### PR TITLE
PWGGA/GammaConv: added AliConversionAodSkimTask

### DIFF
--- a/PWGGA/GammaConv/AliConversionAodSkimTask.cxx
+++ b/PWGGA/GammaConv/AliConversionAodSkimTask.cxx
@@ -1,0 +1,694 @@
+#include <Riostream.h>
+#include <TChain.h>
+#include <TFile.h>
+#include <TGraph.h>
+#include <TH1F.h>
+#include <TKey.h>
+#include <TList.h>
+#include <TMath.h>
+#include <TProfile.h>
+#include <TSystem.h>
+#include <AliAODEvent.h>
+#include <AliAODHandler.h>
+#include <AliAODInputHandler.h>
+#include <AliAODMCHeader.h>
+#include <AliAODMCParticle.h>
+#include <AliAODConversionPhoton.h>
+#include <AliAODVertex.h>
+#include <AliAnalysisManager.h>
+#include <AliLog.h>
+#include "AliConversionAodSkimTask.h"
+#include "TObjectTable.h"
+using namespace std;
+ClassImp(AliConversionAodSkimTask)
+
+AliConversionAodSkimTask::AliConversionAodSkimTask(const char* name) :
+  AliAnalysisTaskSE(name), fClusMinE(-1), fConvMinPt(-1), fConvMinEta(-999.), fConvMaxEta(999.), fConvMinPhi(999.), fConvMaxPhi(999.), fTrackMinPt(-1),fTrackMaxPt(-1), fDoBothMinTrackAndClus(0), fDoBothConvPtAndAcc(0), fCutMC(1), fYCutMC(0.7), fCutMinPt(0), fCutFilterBit(-1), fGammaBr(""),
+  fDoCopyHeader(1),  fDoCopyVZERO(1),  fDoCopyTZERO(1),  fDoCopyVertices(1),  fDoCopyTOF(1), fDoCopyTracklets(1), fDoCopyTracks(1), fDoRemoveTracks(0), fDoCleanTracks(0),
+  fDoRemCovMat(0), fDoRemPid(0), fDoCopyTrigger(1), fDoCopyPTrigger(0), fDoCopyCells(1), fDoCopyPCells(0), fDoCopyClusters(1), fDoCopyDiMuons(0),  fDoCopyTrdTracks(0),
+  fDoCopyV0s(0), fDoCopyCascades(0), fDoCopyZDC(1), fDoCopyConv(0), fDoCopyMC(1), fDoCopyMCHeader(1), fDoVertWoRefs(0), fDoVertMain(0), fDoCleanTracklets(0),
+  fTrials(0), fPyxsec(0), fPytrials(0), fPypthardbin(0), fDoQA(0), fAOD(0), fAODMcHeader(0), fOutputList(0), fHevs(0), fHclus(0), fHtrack(0), fHconvPtBeforeCuts(0), fHconvPtAfterCuts(0), fHconvAccBeforeCuts(0), fHconvAccAfterCuts(0)
+{
+  if (name) {
+    DefineInput(0, TChain::Class());
+    DefineOutput(1, TList::Class());
+  }
+}  
+
+AliConversionAodSkimTask::~AliConversionAodSkimTask()
+{
+  if (fOutputList) {
+    delete fOutputList;
+  }
+  delete fHevs;
+  delete fHclus;
+  delete fHtrack;
+  delete fHconvPtBeforeCuts;
+  delete fHconvPtAfterCuts;
+  delete fHconvAccBeforeCuts;
+  delete fHconvAccAfterCuts;
+}
+
+Bool_t AliConversionAodSkimTask::KeepTrack(AliAODTrack *t)
+{
+  if (!fDoRemoveTracks)
+    return kTRUE;
+  //cout << "Keep tracks " << endl;
+  if (t->IsMuonGlobalTrack())
+    return kFALSE;
+  if (t->Pt()<fCutMinPt)
+    return kFALSE;
+  if (fCutFilterBit!=(UInt_t)-1) {
+    if (t->TestFilterBit(fCutFilterBit)==0)
+      return kFALSE;
+  }
+  return kTRUE;
+}
+
+void AliConversionAodSkimTask::CleanTrack(AliAODTrack *t)
+{
+  if (!fDoCleanTracks)
+    return;
+  //cout << "Clean tracks " << endl;
+  t->SetRAtAbsorberEnd(0);
+  t->SetChi2MatchTrigger(0);
+  t->SetMuonClusterMap(0);
+  t->SetITSMuonClusterMap(0);
+  t->SetMUONtrigHitsMapTrg(0);
+  t->SetMUONtrigHitsMapTrk(0);
+  t->SetMFTClusterPattern(0);
+  t->SetMatchTrigger(0);
+  t->SetIsMuonGlobalTrack(0);
+  t->SetXYAtDCA(-999., -999.);
+  t->SetPxPyPzAtDCA(-999., -999., -999.);
+  if (fDoRemCovMat)
+    t->RemoveCovMatrix();
+  if (fDoRemPid) {
+    AliAODPid *pid = t->GetDetPid();
+    delete pid;
+    t->SetDetPID(0);
+  } else if (t->GetDetPid()) {
+    AliAODPid *pid = t->GetDetPid();
+    AliAODPid *nid = new AliAODPid;
+    nid->SetTPCsignal(pid->GetTPCsignal());
+    nid->SetTPCsignalN(pid->GetTPCsignalN());
+    nid->SetTPCmomentum(pid->GetTPCmomentum());
+    nid->SetTPCTgl(pid->GetTPCTgl());
+    /* Not used and getter not implemented
+       AliTPCdEdxInfo *dedx = new AliTPCdEdxInfo(pid->GetTPCdEdxInfo());
+       nid->SetTPCdEdxInfo(dedx); */
+    nid->SetTOFsignal(pid->GetTOFsignal());
+    Double_t val[5];
+    pid->GetTOFpidResolution(val);
+    nid->SetTOFpidResolution(val);
+    pid->GetIntegratedTimes(val,5);
+    nid->SetIntegratedTimes(val);
+    delete pid;
+    t->SetDetPID(nid);
+  }
+}
+
+void AliConversionAodSkimTask::UserCreateOutputObjects()
+{
+  AliAnalysisManager *man = AliAnalysisManager::GetAnalysisManager();
+  AliAODHandler *oh = (AliAODHandler*)man->GetOutputEventHandler();
+  if (oh) {
+    TFile *fout = oh->GetTree()->GetCurrentFile();
+    fout->SetCompressionLevel(2);
+  }
+
+  fOutputList = new TList;
+  fOutputList->SetOwner();
+  fHevs = new TH1F("hEvs","",2,-0.5,1.5);
+  fOutputList->Add(fHevs);
+  fHclus = new TH1F("hClus",";E (GeV)",200,0,100);
+  fOutputList->Add(fHclus);
+  fHtrack = new TH1F("hTrack",";p_{T} (GeV/c)",200,0,100);
+  fOutputList->Add(fHtrack);
+  if(fDoQA){
+    fHconvPtBeforeCuts = new TH1F("fHconvPtBeforeCuts",";p_{T} (GeV/c)",200,0,100);
+    fOutputList->Add(fHconvPtBeforeCuts);
+    fHconvPtAfterCuts = new TH1F("fHconvPtAfterCuts",";p_{T} (GeV/c)",200,0,100);
+    fOutputList->Add(fHconvPtAfterCuts);
+    fHconvAccBeforeCuts = new TH2F("fHconvAccBeforeCuts",";#eta; #phi",100,-0.9,0.9,100,0.,2*TMath::Pi());
+    fOutputList->Add(fHconvAccBeforeCuts);
+    fHconvAccAfterCuts = new TH2F("fHconvAccAfterCuts",";#eta; #phi",100,-0.9,0.9,100,0.,2*TMath::Pi());
+    fOutputList->Add(fHconvAccAfterCuts);
+  }
+  PostData(1, fOutputList);
+}
+
+void AliConversionAodSkimTask::UserExec(Option_t *)
+{
+  fAOD = dynamic_cast<AliAODEvent*>(InputEvent());
+  if (!fAOD)
+    return;
+
+  AliAnalysisManager *man = AliAnalysisManager::GetAnalysisManager();
+  AliAODHandler *oh = (AliAODHandler*)man->GetOutputEventHandler();
+  if (!oh) {
+    AliFatal(Form("%s: No output handler found", GetName()));
+    return;
+  }
+
+  // check if convcuts were requested but no gammabranch given
+  if ((fConvMinPt > 0) || (fConvMinEta != -999) || (fConvMaxEta != 999) || (fConvMinPhi != -999) || (fConvMaxPhi != 999)){
+     if(!fGammaBr || !fGammaBr.CompareTo("")){
+       AliFatal(Form("%s: Conversion cuts were requested but no fGammaBr was given", GetName()));
+       return;
+     }
+  }
+  
+  oh->SetFillAOD(kFALSE);
+
+  // Accept event only if an EMCal-cluster with a minimum energy of fClusMinE has been found in the event
+  Bool_t storeE = kFALSE;
+  if (fClusMinE>0) {
+    TClonesArray *cls  = fAOD->GetCaloClusters();
+    for (Int_t i=0; i<cls->GetEntriesFast(); ++i) {
+      AliAODCaloCluster *clus = static_cast<AliAODCaloCluster*>(cls->At(i));
+      if (!clus->IsEMCAL())
+        continue;
+      Double_t e = clus->E();
+      fHclus->Fill(e);
+      if (e>fClusMinE) {
+        storeE = kTRUE;
+      }
+    }
+  } else {
+    storeE = kTRUE;
+  }
+
+  // Accept event only if an track with a minimum pT of fTrackMinPt has been found in the event
+  Bool_t storePt = kFALSE;
+  if (fTrackMinPt > 0 ){
+    TClonesArray *tracks = fAOD->GetTracks();
+    for (Int_t i=0;i<tracks->GetEntries();++i) {
+      AliAODTrack *t = static_cast<AliAODTrack*>(tracks->At(i));
+      Double_t pt = t->Pt();
+      fHtrack->Fill(pt);
+      if (pt>fTrackMinPt) {
+        storePt = kTRUE;
+      }
+      if(fTrackMaxPt > 0  &&  fTrackMaxPt < pt){
+        storePt = kFALSE;
+      } 
+    }
+  } else {
+    storePt = kTRUE;
+  }
+
+  // Accept event only if a conversion with a minimum pT of fConvMinPt has been found in the event 
+  Bool_t storeConvPt = kFALSE;
+  Bool_t storeConvAcc = kFALSE; 
+  if ((fConvMinPt > 0) || (fConvMinEta != -999) || (fConvMaxEta != 999) || (fConvMinPhi != -999) || (fConvMaxPhi != 999)){
+    // This is only done if any ConvPt or ConvAcceptance cut was given by user    
+    TClonesArray *convgammas  = dynamic_cast<TClonesArray*>(fAOD->FindListObject(fGammaBr));
+    if(convgammas){
+      for(Int_t i=0;i<convgammas->GetEntriesFast();i++){
+        AliAODConversionPhoton* g =dynamic_cast<AliAODConversionPhoton*>(convgammas->At(i));
+        if(g){
+           Double_t pt = g->Pt();
+           Double_t eta = g->Eta();
+           Double_t phi = g->Phi();
+           if(fDoQA){
+            fHconvPtBeforeCuts->Fill(pt);
+            fHconvAccBeforeCuts->Fill(eta,phi);
+           }
+           if(fConvMinPt > 0){
+              if (pt>fConvMinPt){ // pt cut
+                  storeConvPt = kTRUE;
+              }
+           } else{
+             cout << "stroreconvkTrue" << endl;
+              storeConvPt = kTRUE;
+           }
+           if( (eta>fConvMinEta) && (eta<fConvMaxEta) && (phi>fConvMinPhi) && (phi>fConvMaxPhi)){ // will always be true if no cut was set
+             storeConvAcc = kTRUE;
+           }
+        }
+      }
+    }
+  } else { // neither pt cuts nor acceptance cuts were set
+    storeConvPt = kTRUE;
+    storeConvAcc = kTRUE;
+  }
+
+  Bool_t store = kFALSE;
+  if (fDoBothMinTrackAndClus && fClusMinE>0 && fTrackMinPt > 0){
+    // request that both conditions are full-filled for propagating the event
+    store     = (storeE && storePt);
+  } else if (!fDoBothMinTrackAndClus && fClusMinE>0 && fTrackMinPt > 0){
+    // request that at least one of the conditions is fullfilled
+    store     = (storeE || storePt);
+  } else if (fDoBothConvPtAndAcc && (fConvMinPt >0) && (fConvMinEta!=-999 || fConvMaxEta!=999 || fConvMinPhi!=-999 || fConvMaxPhi!=999)){
+    store     = (storeConvPt && storeConvAcc);
+  } else if (!fDoBothConvPtAndAcc && (fConvMinPt >0) && (fConvMinEta!=-999 || fConvMaxEta!=999 || fConvMinPhi!=-999 || fConvMaxPhi!=999)){
+    store     = (storeConvPt || storeConvAcc);
+  } else if ( fClusMinE>0 ){
+    store     = storeE;
+  } else if ( fTrackMinPt>0 ){
+    store     = storePt;
+  } else if ( fConvMinPt>0 ){
+    store     = storeConvPt;
+  } else if (fConvMinEta!=-999 || fConvMaxEta!=999 || fConvMinPhi!=-999 || fConvMaxPhi!=999){
+    store     = storeConvAcc;
+  } else {
+    store     = kTRUE;
+  }
+
+  if (!store) {
+    ++fTrials;
+    fHevs->Fill(0);
+    return;
+  }
+  
+  fHevs->Fill(1);
+  
+  if(fDoQA){
+    TClonesArray *convgammas  = dynamic_cast<TClonesArray*>(fAOD->FindListObject(fGammaBr));
+    if(convgammas){
+      for(Int_t i=0;i<convgammas->GetEntriesFast();i++){
+        AliAODConversionPhoton* g =dynamic_cast<AliAODConversionPhoton*>(convgammas->At(i));
+        if(g){
+            Double_t pt = g->Pt();
+            Double_t eta = g->Eta();
+            Double_t phi = g->Phi();
+            fHconvPtAfterCuts->Fill(pt);
+            fHconvAccAfterCuts->Fill(eta,phi);
+        }
+      }
+    }
+  }
+
+  oh->SetFillAOD(kTRUE);
+  AliAODEvent *eout = dynamic_cast<AliAODEvent*>(oh->GetAOD());
+  AliAODEvent *evin = dynamic_cast<AliAODEvent*>(InputEvent());
+  TTree *tout = oh->GetTree();
+  if (tout) {
+    TList *lout = tout->GetUserInfo();
+    if (lout->FindObject("alirootVersion")==0) {
+      TList *lin = AliAnalysisManager::GetAnalysisManager()->GetInputEventHandler()->GetUserInfo();
+      TString apver(gSystem->BaseName(gSystem->Getenv("ALICE_PHYSICS")));
+      lout->Add(new TObjString(Form("AodSkim: ver %s, tag %s with settings %s",GetVersion(),apver.Data(),Str())));
+      AliInfo(Form("%s: Set user info %s", GetName(), lout->At(0)->GetName()));
+      for (Int_t jj=0;jj<lin->GetEntries()-1;++jj) {
+        lout->Add(lin->At(jj)->Clone(lin->At(jj)->GetName()));
+      }
+    }
+  }
+
+  if (fDoCopyHeader) {
+    AliAODHeader *out = (AliAODHeader*)eout->GetHeader();
+    AliAODHeader *in  = (AliAODHeader*)evin->GetHeader();
+    *out = *in;
+    out->SetUniqueID(fTrials);
+  }
+
+  if (fDoCopyVZERO) {
+    AliAODVZERO *out = eout->GetVZEROData();
+    AliAODVZERO *in  = evin->GetVZEROData();
+    *out = *in;
+  }
+
+  if (fDoCopyTZERO) {
+    AliAODTZERO *out = eout->GetTZEROData();
+    AliAODTZERO *in  = evin->GetTZEROData();
+    *out = *in;
+  }
+
+  if (fDoCopyVertices) {
+    TClonesArray *out = eout->GetVertices();
+    TClonesArray *in  = evin->GetVertices();
+    if (out->GetEntries()>0) { // just checking if the deletion of previous event worked
+      AliFatal(Form("%s: Previous vertices not deleted. This should not happen!",GetName()));
+    }
+    out->AbsorbObjects(in);
+    Int_t marked=-1;
+    for (Int_t i=0; i<out->GetEntries(); ++i) {
+      AliAODVertex *v = static_cast<AliAODVertex*>(out->At(i));
+      Int_t nc = v->CountRealContributors();
+      Int_t nd = v->GetNDaughters();
+      if (fDoVertWoRefs) {
+      if (nc>0)
+        v->SetNContributors(nc);
+      else
+        v->SetNContributors(nd);
+      }
+      if (fDoVertMain) {
+        TString tmp(v->GetName());
+        if (!tmp.Contains("PrimaryVertex")&&!tmp.Contains("SPDVertex")&&!tmp.Contains("TPCVertex"))
+          continue;
+        marked=i;
+        break;
+      }
+      if (marked>0) {
+        out->RemoveRange(marked,out->GetEntries());
+        out->Compress();
+      }
+    }
+  }
+  if (fDoCopyTOF) {
+    AliTOFHeader *out = const_cast<AliTOFHeader*>(eout->GetTOFHeader());
+    const AliTOFHeader *in = evin->GetTOFHeader();
+    *out = *in;
+  }
+
+  if (fDoCopyTracks) {
+    TClonesArray *out = eout->GetTracks();
+    TClonesArray *in  = evin->GetTracks();
+    if (out->GetEntries()>0) { // just checking if the deletion of previous event worked
+      AliFatal(Form("%s: Previous tracks not deleted. This should not happen!",GetName()));
+    }
+    out->AbsorbObjects(in);
+    for (Int_t i=0;i<out->GetEntries();++i) {
+      AliAODTrack *t = static_cast<AliAODTrack*>(out->At(i));
+      if (KeepTrack(t)) {
+        CleanTrack(t);
+        if (fDoVertMain)
+          t->SetProdVertex(0);
+      } else {
+        t->~AliAODTrack();
+        new ((*out)[i]) AliAODTrack;
+      }
+    }
+  }
+
+  if (fDoCopyTracklets) {
+    AliAODTracklets *out = eout->GetTracklets();
+    AliAODTracklets *in  = evin->GetTracklets();
+    *out = *in;
+    if (fDoCleanTracklets) {
+      Int_t n=in->GetNumberOfTracklets();
+      out->SetTitle(Form("Ntracklets=%d",n));
+      out->DeleteContainer();
+    }
+  }
+
+  if (fDoCopyTrigger) {
+    AliAODCaloTrigger *out = eout->GetCaloTrigger("EMCAL");
+    AliAODCaloTrigger *in  = evin->GetCaloTrigger("EMCAL");
+    *out = *in;
+  }
+
+  if (fDoCopyPTrigger) {
+    AliAODCaloTrigger *out = eout->GetCaloTrigger("PHOS");
+    AliAODCaloTrigger *in  = evin->GetCaloTrigger("PHOS");
+    *out = *in;
+  }
+
+  if (fDoCopyCells) {
+    AliAODCaloCells *out = eout->GetEMCALCells();
+    AliAODCaloCells *in  = evin->GetEMCALCells();
+      *out = *in;
+  }
+
+  if (fDoCopyPCells) {
+    AliAODCaloCells *out = eout->GetPHOSCells();
+    AliAODCaloCells *in  = evin->GetPHOSCells();
+    *out = *in;
+  }
+
+  if (fDoCopyClusters) {
+    TClonesArray *out = eout->GetCaloClusters();
+    TClonesArray *in  = evin->GetCaloClusters();
+    if (out->GetEntries()>0) { // just checking if the deletion of previous event worked
+      AliFatal(Form("%s: Previous clusters not deleted. This should not happen!",GetName()));
+    }
+    out->AbsorbObjects(in);
+  }
+
+  if (fDoCopyTrdTracks) {
+    TClonesArray *out = static_cast<TClonesArray*>(eout->FindListObject("trdTracks"));
+    TClonesArray *in  = static_cast<TClonesArray*>(eout->FindListObject("trdTracks"));
+    if (out->GetEntries()>0) { // just checking if the deletion of previous event worked
+      AliFatal(Form("%s: Previous trdtracks not deleted. This should not happen!",GetName()));
+    }
+    out->AbsorbObjects(in);
+  }
+
+  if (fDoCopyV0s) {
+    TClonesArray *out = eout->GetV0s();
+    TClonesArray *in  = evin->GetV0s();
+    if (out->GetEntries()>0) { // just checking if the deletion of previous event worked
+      AliFatal(Form("%s: Previous v0s not deleted. This should not happen!",GetName()));
+    }
+    out->AbsorbObjects(in);
+  }
+
+  if (fDoCopyCascades) {
+    TClonesArray *out = eout->GetCascades();
+    TClonesArray *in  = evin->GetCascades();
+    if (out->GetEntries()>0) { // just checking if the deletion of previous event worked
+      AliFatal(Form("%s: Previous event not deleted. This should not happen!",GetName()));
+    }
+    out->AbsorbObjects(in);
+  }
+
+  if (fDoCopyZDC) {
+    AliAODZDC *out = eout->GetZDCData();
+    AliAODZDC *in  = evin->GetZDCData();
+    *out = *in;
+  }
+
+  if (fDoCopyDiMuons) {
+    TClonesArray *out = eout->GetDimuons();
+    TClonesArray *in  = evin->GetDimuons();
+    if (out->GetEntries()>0) { // just checking if the deletion of previous event worked
+      AliFatal(Form("%s: Previous dimuons not deleted. This should not happen!",GetName()));
+    }
+    out->AbsorbObjects(in);
+  }
+
+  if (fDoCopyConv) {
+    TClonesArray *out = dynamic_cast<TClonesArray*>(eout->FindListObject(fGammaBr));
+    TClonesArray *in  = dynamic_cast<TClonesArray*>(evin->FindListObject(fGammaBr));
+    if (!in) {
+      evin->GetList()->ls();
+      AliFatal(Form("%s: Could not find conversion branch with name %s!",GetName(), fGammaBr.Data()));
+    }
+    if (in && !out) {
+      out = new TClonesArray("AliAODConversionPhoton",2*in->GetEntries());
+      out->SetName(fGammaBr);
+      oh->AddBranch("TClonesArray", &out);
+    }
+    if (out->GetEntries()>0) { // just checking if the deletion of previous event worked
+      out->Delete();
+    }
+    out->AbsorbObjects(in);
+  }
+
+  if (fDoCopyMC) {
+    TClonesArray *out = static_cast<TClonesArray*>(eout->FindListObject(AliAODMCParticle::StdBranchName()));
+    TClonesArray *in  = static_cast<TClonesArray*>(evin->FindListObject(AliAODMCParticle::StdBranchName()));
+    if (in && !out) {
+      fgAODMCParticles = new TClonesArray("AliAODMCParticle",2*in->GetEntries());
+      fgAODMCParticles->SetName(AliAODMCParticle::StdBranchName());
+      oh->AddBranch("TClonesArray", &fgAODMCParticles);
+      out = static_cast<TClonesArray*>(eout->FindListObject(AliAODMCParticle::StdBranchName()));
+    }
+    if (in && out) {
+      if (out->GetEntries()>0) { // just checking if the deletion of previous event worked
+        AliFatal(Form("%s: Previous mcparticles not deleted. This should not happen!",GetName()));
+      }
+      out->AbsorbObjects(in);
+      if (fCutMC) {
+        for (Int_t i=0;i<out->GetEntriesFast();++i) {
+          AliAODMCParticle *mc = static_cast<AliAODMCParticle*>(in->At(i));
+          if ((mc==0)&&(i==0)) {
+            AliError(Form("%s: No MC info, skipping this event!",GetName()));
+            oh->SetFillAOD(kFALSE);
+            return;
+          }
+          if ((mc==0)||(TMath::Abs(mc->Y())>fYCutMC))
+            new ((*out)[i]) AliAODMCParticle;
+        }
+      }
+    }
+  }
+
+  if (fDoCopyMCHeader) {
+    AliAODMCHeader *out = static_cast<AliAODMCHeader*>(eout->FindListObject(AliAODMCHeader::StdBranchName()));
+    AliAODMCHeader *in  = static_cast<AliAODMCHeader*>(evin->FindListObject(AliAODMCHeader::StdBranchName()));
+    if (in && !out) {
+      fAODMcHeader = new AliAODMCHeader();
+      fAODMcHeader->SetName(AliAODMCHeader::StdBranchName());
+      oh->AddBranch("AliAODMCHeader",&fAODMcHeader);
+      out = static_cast<AliAODMCHeader*>(eout->FindListObject(AliAODMCHeader::StdBranchName()));
+    }
+    if (in && out) {
+      *out = *in;
+      if ((in->GetCrossSection()==0) && (fPyxsec>0)) {
+	out->SetCrossSection(fPyxsec);
+	out->SetTrials(fPytrials);
+	out->SetPtHard(fPypthardbin);
+      }
+    }
+  }
+
+  if (gDebug>10) {
+    Int_t  run = eout->GetRunNumber();
+    AliAODVertex *v=(AliAODVertex*)eout->GetVertices()->At(0);
+    Int_t   vzn = v->GetNContributors();
+    Double_t vz = v->GetZ();
+    cout << "debug run " << run << " " << vzn << " " << vz << endl;
+  }
+
+  fTrials = 0;
+  PostData(1, fOutputList);
+}
+
+Bool_t AliConversionAodSkimTask::UserNotify()
+{
+  TTree *tree = AliAnalysisManager::GetAnalysisManager()->GetTree();
+  if (!tree) {
+    AliError(Form("%s: No current tree!",GetName()));
+    return kFALSE;
+  }
+
+  Float_t xsection    = 0;
+  Float_t trials      = 0;
+  Int_t   pthardbin   = 0;
+
+  TFile *curfile = tree->GetCurrentFile();
+  if (!curfile) {
+    AliError(Form("%s: No current file!",GetName()));
+    return kFALSE;
+  }
+
+  TChain *chain = dynamic_cast<TChain*>(tree);
+  if (chain) tree = chain->GetTree();
+  Int_t nevents = tree->GetEntriesFast();
+
+  Int_t slevel = gErrorIgnoreLevel;
+  gErrorIgnoreLevel = kFatal;
+  Bool_t res = PythiaInfoFromFile(curfile->GetName(), xsection, trials, pthardbin);
+  gErrorIgnoreLevel=slevel;
+
+  if (res) {
+    cout << "AliConversionAodSkimTask " << GetName() << " found xsec info: " << xsection << " " << trials << " " << pthardbin << " " << nevents << endl;
+    fPyxsec      = xsection;
+    fPytrials    = trials;
+    fPypthardbin = pthardbin;
+  }
+
+  return res;
+}
+
+void AliConversionAodSkimTask::Terminate(Option_t *)
+{
+   AliAnalysisManager *man = AliAnalysisManager::GetAnalysisManager();
+   if (man->GetAnalysisType()!=0)
+     return;
+   if (fHevs==0)
+     return;
+   Int_t norm = fHevs->GetEntries();
+   if (norm<1)
+     norm=1;
+   cout << "AliConversionAodSkimTask " << GetName() << " terminated with accepted fraction of events: " << fHevs->GetBinContent(2)/norm
+	<< " (" << fHevs->GetBinContent(2) << "/" << fHevs->GetEntries() << ")" << endl;
+}
+
+Bool_t AliConversionAodSkimTask::PythiaInfoFromFile(const char* currFile, Float_t &xsec, Float_t &trials, Int_t &pthard)
+{
+  TString file(currFile);
+  xsec = 0;
+  trials = 1;
+
+  if (file.Contains(".zip#")) {
+    Ssiz_t pos1 = file.Index("root_archive",12,0,TString::kExact);
+    Ssiz_t pos = file.Index("#",1,pos1,TString::kExact);
+    Ssiz_t pos2 = file.Index(".root",5,TString::kExact);
+    file.Replace(pos+1,pos2-pos1,"");
+  } else {
+    // not an archive take the basename....
+    file.ReplaceAll(gSystem->BaseName(file.Data()),"");
+  }
+  AliDebug(1,Form("File name: %s",file.Data()));
+
+  // Get the pt hard bin
+  TString strPthard(file);
+
+  strPthard.Remove(strPthard.Last('/'));
+  strPthard.Remove(strPthard.Last('/'));
+  if (strPthard.Contains("AOD")) strPthard.Remove(strPthard.Last('/'));
+  strPthard.Remove(0,strPthard.Last('/')+1);
+  if (strPthard.IsDec()) {
+    pthard = strPthard.Atoi();
+  }
+  else {
+    AliWarning(Form("Could not extract file number from path %s", strPthard.Data()));
+    pthard = -1;
+  }
+
+  // problem that we cannot really test the existance of a file in a archive so we have to live with open error message from root
+  TFile *fxsec = TFile::Open(Form("%s%s",file.Data(),"pyxsec.root"));
+
+  if (!fxsec) {
+    // next trial fetch the histgram file
+    fxsec = TFile::Open(Form("%s%s",file.Data(),"pyxsec_hists.root"));
+    if (!fxsec) {
+      // not a severe condition but inciate that we have no information
+      return kFALSE;
+    } else {
+      // find the tlist we want to be independtent of the name so use the Tkey
+      TKey* key = static_cast<TKey*>(fxsec->GetListOfKeys()->At(0));
+      if (!key) {
+        fxsec->Close();
+        return kFALSE;
+      }
+      TList *list = dynamic_cast<TList*>(key->ReadObj());
+      if (!list) {
+        fxsec->Close();
+        return kFALSE;
+      }
+      xsec = static_cast<TProfile*>(list->FindObject("h1Xsec"))->GetBinContent(1);
+      trials = static_cast<TH1F*>(list->FindObject("h1Trials"))->GetBinContent(1);
+      fxsec->Close();
+    }
+  } else { // no tree pyxsec.root
+    TTree *xtree = static_cast<TTree*>(fxsec->Get("Xsection"));
+    if (!xtree) {
+      fxsec->Close();
+      return kFALSE;
+    }
+    UInt_t   ntrials  = 0;
+    Double_t  xsection  = 0;
+    xtree->SetBranchAddress("xsection",&xsection);
+    xtree->SetBranchAddress("ntrials",&ntrials);
+    xtree->GetEntry(0);
+    trials = ntrials;
+    xsec = xsection;
+    fxsec->Close();
+  }
+  return kTRUE;
+}
+
+const char *AliConversionAodSkimTask::Str() const
+{
+  return Form("mine%.2f_%dycut%.2f_%d%d%d%d%d%d%d%d%d%d%d%d%d%d%d%d%d%d%d%d",
+              fClusMinE,
+              fCutMC,
+              fYCutMC,
+              fDoCopyHeader,
+              fDoCopyVZERO,
+              fDoCopyTZERO,
+              fDoCopyVertices,
+              fDoCopyTOF,
+              fDoCopyTracklets,
+              fDoCopyTracks,
+              fDoCopyTrigger,
+              fDoCopyPTrigger,
+              fDoCopyCells,
+              fDoCopyPCells,
+              fDoCopyClusters,
+              fDoCopyDiMuons,
+              fDoCopyTrdTracks,
+              fDoCopyV0s,
+              fDoCopyCascades,
+              fDoCopyZDC,
+              fDoCopyConv,
+              fDoCopyMC,
+              fDoCopyMCHeader);
+}
+

--- a/PWGGA/GammaConv/AliConversionAodSkimTask.h
+++ b/PWGGA/GammaConv/AliConversionAodSkimTask.h
@@ -1,0 +1,136 @@
+#ifndef AliConversionAodSkimTask_H
+#define AliConversionAodSkimTask_H
+
+/// \class AliConversionAodSkimTask
+/// \brief Use to skim AOD files
+///
+/// Class to skim AOD files with the idea to keep the skimmed file as close as possible to the original AOD.
+///
+/// \author C.Loizides
+
+#include <AliAnalysisTaskSE.h>
+#include <TString.h>
+class AliAODMCHeader;
+class TH1F;
+
+class AliConversionAodSkimTask: public AliAnalysisTaskSE
+{
+  public:
+    AliConversionAodSkimTask(const char *name=0);
+    virtual              ~AliConversionAodSkimTask();
+    void                  SetCleanTracklets(Bool_t b)         {fDoCleanTracklets=b;}
+    void                  SetCleanTracks(Bool_t b)            {fDoCleanTracks=b;}
+    void                  SetClusMinE(Double_t v)             {fClusMinE=v;}
+    void                  SetConvMinPt(Double_t v)            {fConvMinPt=v;}
+    void                  SetConvMinEta(Double_t eta)         {fConvMinEta=eta;}
+    void                  SetConvMaxEta(Double_t eta)         {fConvMaxEta=eta;}
+    void                  SetConvMinPhi(Double_t phi)         {fConvMinPhi=phi;}
+    void                  SetConvMaxPhi(Double_t phi)         {fConvMaxPhi=phi;}
+    void                  SetTrackMinPt(Double_t v)           {fTrackMinPt=v;}
+    void                  SetTrackMaxPt(Double_t v)           {fTrackMaxPt=v;}
+    void                  SetDoBothMinTrackAndClus(Bool_t b)  {fDoBothMinTrackAndClus=b;}
+    void                  SetDoBothConvPtAndAcc(Bool_t b)     {fDoBothConvPtAndAcc=b;}
+    void                  SetCopyCascades(Bool_t b)           {fDoCopyCascades=b;}
+    void                  SetCopyCells(Bool_t b)              {fDoCopyCells=b;}
+    void                  SetCopyClusters(Bool_t b)           {fDoCopyClusters=b;}
+    void                  SetCopyConv(Bool_t b)               {fDoCopyConv=b;}
+    void                  SetCopyDiMuons(Bool_t b)            {fDoCopyDiMuons=b;}
+    void                  SetCopyHeader(Bool_t b)             {fDoCopyHeader=b;}
+    void                  SetCopyMC(Bool_t b)                 {fDoCopyMC=b;}
+    void                  SetCopyMCHeader(Bool_t b)           {fDoCopyMCHeader=b;}
+    void                  SetCopyPCells(Bool_t b)             {fDoCopyPCells=b;}
+    void                  SetCopyPTrigger(Bool_t b)           {fDoCopyPTrigger=b;}
+    void                  SetCopyTOF(Bool_t b)                {fDoCopyTOF=b;}
+    void                  SetCopyTZERO(Bool_t b)              {fDoCopyTZERO=b;}
+    void                  SetCopyTracklets(Bool_t b)          {fDoCopyTracklets=b;}
+    void                  SetCopyTracks(Bool_t b)             {fDoCopyTracks=b;}
+    void                  SetCopyTrdTracks(Bool_t b)          {fDoCopyTrdTracks=b;}
+    void                  SetCopyTrigger(Bool_t b)            {fDoCopyTrigger=b;}
+    void                  SetCopyV0s(Bool_t b)                {fDoCopyV0s=b;}
+    void                  SetCopyVZERO(Bool_t b)              {fDoCopyVZERO=b;}
+    void                  SetCopyVertices(Bool_t b)           {fDoCopyVertices=b;}
+    void                  SetCopyZDC(Bool_t b)                {fDoCopyZDC=b;}
+    void                  SetCutFilterBit(UInt_t b)           {fCutFilterBit=b;}
+    void                  SetCutMC(Bool_t b)                  {fCutMC=b;}
+    void                  SetDoVertMain(Bool_t b)             {fDoVertMain=b;}
+    void                  SetDoVertWoRefs(Bool_t b)           {fDoVertWoRefs=b;}
+    void                  SetGammaBrName(TString s)           {fGammaBr=s;}
+    void                  SetMinCutPt(Double_t pt)            {fCutMinPt=pt;}
+    void                  SetRemCovMat(Bool_t b)              {fDoRemCovMat=b;}
+    void                  SetRemPid(Bool_t b)                 {fDoRemPid=b;}
+    void                  SetRemoveTracks(Bool_t b)           {fDoRemoveTracks=b;}
+    void                  SetYCutMC(Double_t v)               {fYCutMC=v;}
+    void                  SetDoQA(Bool_t b)                   {fDoQA=b;}
+    const char           *Str() const;
+  protected:
+    void                  UserCreateOutputObjects();
+    void                  UserExec(Option_t* option);
+    Bool_t                UserNotify();
+    void                  Terminate(Option_t* option);
+    Bool_t                PythiaInfoFromFile(const char *currFile, Float_t &xsec, Float_t &trials, Int_t &pthard);
+    Double_t              fClusMinE;              //  minimum cluster energy to accept event
+    Double_t              fConvMinPt;             //  minimum conversion photon pT to accept event
+    Double_t              fConvMinEta;            //  minimum eta of photon to accept event
+    Double_t              fConvMaxEta;            //  maximum eta of photon to accept event
+    Double_t              fConvMinPhi;            //  minimum phi of photon to accept event
+    Double_t              fConvMaxPhi;            //  maximum phi of photon to accept event
+    Double_t              fTrackMinPt;            //  minimum track pt to accept event
+    Double_t              fTrackMaxPt;            //  maximum track pt to accept event
+    Bool_t                fDoBothMinTrackAndClus; // switch to enable simultaneous filtering for minimum track and cluster cuts
+    Bool_t                fDoBothConvPtAndAcc;    // switch to enable simultaneous filtering for minimum conv pt and conv acceptance cut
+    Bool_t                fCutMC;                 //  if true cut MC particles with |Y|>fYCutMC
+    Double_t              fYCutMC;                //  cut for MC particles (default = 0.7)
+    Double_t              fCutMinPt;              //  minimum pT to keep track
+    UInt_t                fCutFilterBit;          //  filter bit(s) to select
+    TString               fGammaBr;               //  gamma branch name
+    Bool_t                fDoCopyHeader;          //  if true copy header
+    Bool_t                fDoCopyVZERO;           //  if true copy VZERO
+    Bool_t                fDoCopyTZERO;           //  if true copy TZERO
+    Bool_t                fDoCopyVertices;        //  if true copy vertices
+    Bool_t                fDoCopyTOF;             //  if true copy TOF
+    Bool_t                fDoCopyTracklets;       //  if true copy tracklets
+    Bool_t                fDoCopyTracks;          //  if true copy tracks
+    Bool_t                fDoRemoveTracks;        //  if true remove tracks
+    Bool_t                fDoCleanTracks;         //  if true clean tracks
+    Bool_t                fDoRemCovMat;           //  if true remove cov matrix from tracks
+    Bool_t                fDoRemPid;              //  if true remove PID object from tracks
+    Bool_t                fDoCopyTrigger;         //  if true copy trigger (EMC)
+    Bool_t                fDoCopyPTrigger;        //  if true copy trigger (PHS)
+    Bool_t                fDoCopyCells;           //  if true copy cells (EMC)
+    Bool_t                fDoCopyPCells;          //  if true copy cells (PHS)
+    Bool_t                fDoCopyClusters;        //  if true copy clusters
+    Bool_t                fDoCopyDiMuons;         //  if true copy dimuons
+    Bool_t                fDoCopyTrdTracks;       //  if true copy trd tracks
+    Bool_t                fDoCopyV0s;             //  if true copy v0s
+    Bool_t                fDoCopyCascades;        //  if true copy cascades
+    Bool_t                fDoCopyZDC;             //  if true copy zdc
+    Bool_t                fDoCopyConv;            //  if true copy conversions
+    Bool_t                fDoCopyMC;              //  if true copy MC particles
+    Bool_t                fDoCopyMCHeader;        //  if true copy MC header
+    Bool_t                fDoVertWoRefs;          //  if true then do not copy TRefs in vertices
+    Bool_t                fDoVertMain;            //  if true then only copy main vertices
+    Bool_t                fDoCleanTracklets;      //  if true then clean tracklets
+    UInt_t                fTrials;                //! events seen since last acceptance
+    Float_t               fPyxsec;                //! pythia xsection
+    Float_t               fPytrials;              //! pythia trials
+    Int_t                 fPypthardbin;           //! pythia pthard bin
+    Bool_t                fDoQA;                  // do QA
+    AliAODEvent          *fAOD;                   //! input event
+    AliAODMCHeader       *fAODMcHeader;           //! MC header
+    TList                *fOutputList;            //! output list
+    TH1F                 *fHevs;                  //! events processed/accepted
+    TH1F                 *fHclus;                 //! cluster distribution
+    TH1F                 *fHtrack;                //! track distribution
+    TH1F                 *fHconvPtBeforeCuts;       //! conv photon distribution
+    TH1F                 *fHconvPtAfterCuts;        //! conv photon distribution
+    TH2F                 *fHconvAccBeforeCuts;       //! conv photon distribution
+    TH2F                 *fHconvAccAfterCuts;        //! conv photon distribution
+    const char           *GetVersion() const { return "1.4"; }
+    virtual Bool_t        KeepTrack(AliAODTrack *t);
+    virtual void          CleanTrack(AliAODTrack *t);
+
+    AliConversionAodSkimTask(const AliConversionAodSkimTask&);             // not implemented
+    AliConversionAodSkimTask& operator=(const AliConversionAodSkimTask&);  // not implemented
+    ClassDef(AliConversionAodSkimTask, 1); // AliConversionAodSkimTask
+};
+#endif

--- a/PWGGA/GammaConv/CMakeLists.txt
+++ b/PWGGA/GammaConv/CMakeLists.txt
@@ -91,6 +91,7 @@ set(SRCS
     AliPrimaryPionSelector.cxx
     AliConversionCutHandler.cxx
     AliCutHandlerPCM.cxx
+    AliConversionAodSkimTask.cxx
    )
 
 # Headers from sources

--- a/PWGGA/GammaConv/PWGGAGammaConvLinkDef.h
+++ b/PWGGA/GammaConv/PWGGAGammaConvLinkDef.h
@@ -39,6 +39,7 @@
 #pragma link C++ class AliAnalysisTRDEfficiency+;
 #pragma link C++ class AliIdentifiedPrimarySelector+;
 #pragma link C++ class AliIdentifiedPrimaryCuts+;
+#pragma link C++ class AliConversionAodSkimTask+;
 
 
 

--- a/PWGGA/GammaConv/macros/AddTask_AodSkim.C
+++ b/PWGGA/GammaConv/macros/AddTask_AodSkim.C
@@ -1,0 +1,124 @@
+// $Id: AddTaskSkim.C 4586 2013-01-16 15:32:16Z loizides $
+AliConversionAodSkimTask *AddTask_AodSkim( const Double_t mine             = -1,
+                                const Double_t mintrackpt       = -1,
+                                const Double_t minconvpt        = -1,
+                                const Double_t minconveta       = -999,
+                                const Double_t maxconveta       =  999,
+                                const Double_t minconvphi       = -999,
+                                const Double_t maxconvphi       =  999,
+                                const Bool_t doBothMinEandPt    = kFALSE,
+                                const Bool_t doBothConvPtandAcc = kFALSE,
+                                const Double_t ycutmc           = 0.7,
+                                const char *gammabr             = 0,
+                                const UInt_t trigsel            = AliVEvent::kAny,
+                                const Bool_t doCopyTOF          = kTRUE,
+                                const Bool_t doCopyTracklets    = kTRUE,
+                                const Bool_t doCopyTracks       = kTRUE,
+                                const Bool_t doCopyTrigger      = kTRUE,
+                                const Bool_t doCopyPTrigger     = kTRUE,
+                                const Bool_t doCopyCells        = kTRUE,
+                                const Bool_t doCopyPCells       = kTRUE,
+                                const Bool_t doCopyClusters     = kTRUE,
+                                const Bool_t doCopyDiMuons      = kFALSE,
+                                const Bool_t doCopyTrdTracks    = kFALSE,
+                                const Bool_t doCopyCascades     = kFALSE,
+                                const Bool_t doCopyV0s          = kFALSE,
+                                const Bool_t doCopyMC           = kTRUE,
+                                const Bool_t doQA               = kFALSE, // activate additional QA histograms
+                                const char *name=0)
+{
+  AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
+  if (!mgr) {
+    Error("AddTaskAodSkim", "No analysis manager found.");
+    return 0;
+  }
+
+  TString tname(name);
+  if (name==0)
+    tname = Form("aodskim_mine%.1f_trigsel%u",mine,trigsel);
+
+  TString fname(tname);
+  fname += ".root";
+
+  cout << "Calling AddTaskAodSkim with " << endl;
+  cout << "-> mine=" << mine << endl;
+  cout << "-> trigsel=" << trigsel << endl;
+  if (name)
+    cout << "-> name=" << name << endl;
+  else
+    cout << "-> name=0" << endl;
+  cout << "Writing skimmed aod tree to " << fname.Data() << endl;
+
+  AliAODHandler *output = (AliAODHandler*)mgr->GetOutputEventHandler();
+   if (output==0) {
+    AliAODHandler *output = new AliAODHandler;
+    output->SetOutputFileName(fname);
+    output->SetFillAOD(1);
+    output->SetFillAODforRun(1);
+    output->SetFillExtension(0);
+    output->SetTreeBuffSize(30*1024*1024);
+    mgr->SetOutputEventHandler(output);
+  }
+
+  AliAODInputHandler *input = (AliAODInputHandler*)mgr->GetInputEventHandler();
+  AliConversionAodSkimTask *task = new AliConversionAodSkimTask(tname);
+  task->SetClusMinE(mine);
+  task->SetTrackMinPt(mintrackpt);
+  task->SetDoBothMinTrackAndClus(doBothMinEandPt);
+  task->SetDoQA(doQA);
+
+  task->SetConvMinPt(minconvpt);
+  task->SetConvMinEta(minconveta);
+  task->SetConvMaxEta(maxconveta);
+  task->SetConvMinPhi(minconvphi);
+  task->SetConvMaxPhi(maxconvphi);
+  task->SetDoBothConvPtAndAcc(doBothConvPtandAcc);
+  if (gammabr) {
+    task->SetGammaBrName(gammabr);
+    task->SetCopyConv(kTRUE);
+    input->AddFriend((char*)"AliAODGammaConversion.root");
+  } else {
+    task->SetCopyConv(kFALSE);
+  }
+  task->SelectCollisionCandidates(trigsel);
+  task->SetCopyHeader(kTRUE);
+  task->SetCopyVZERO(kTRUE);
+  task->SetCopyTZERO(kTRUE);
+  task->SetCopyVertices(kTRUE);
+  task->SetCopyZDC(kTRUE);
+  if (ycutmc>0) {
+    task->SetCutMC(kTRUE);
+    task->SetYCutMC(ycutmc);
+  } else {
+    task->SetCutMC(kFALSE);
+  }
+  task->SetCopyTOF(doCopyTOF);
+  task->SetCopyTracklets(doCopyTracklets);
+  task->SetCopyTracks(doCopyTracks);
+  task->SetCopyTrigger(doCopyTrigger);
+  task->SetCopyPTrigger(doCopyPTrigger);
+  task->SetCopyCells(doCopyCells);
+  task->SetCopyPCells(doCopyPCells);
+  task->SetCopyClusters(doCopyClusters);
+  task->SetCopyDiMuons(doCopyDiMuons);
+  task->SetCopyTrdTracks(doCopyTrdTracks);
+  task->SetCopyCascades(doCopyCascades);
+  task->SetCopyV0s(doCopyV0s);
+  task->SetCopyMC(doCopyMC);
+  task->SetCopyMCHeader(doCopyMC);
+
+  cout << "Task configured with: " << task->Str() << endl;
+  mgr->AddTask(task);
+
+  AliAnalysisDataContainer *cinput  = mgr->GetCommonInputContainer()  ;
+  TString contName(tname);
+  contName += "_histos";
+  AliAnalysisDataContainer *coutput = mgr->CreateContainer( contName.Data(),
+                                                            TList::Class(),
+                                                            AliAnalysisManager::kOutputContainer,
+                                                            Form("%s_histos.root", tname.Data()));
+  mgr->ConnectInput  (task, 0,  cinput );
+  mgr->ConnectOutput (task, 1, coutput );
+
+  return task;
+}


### PR DESCRIPTION
added AodSkimTask to GammaConv which is based on AliAodSkimTask and offers new functionality to skim for events with conversion photons with minPt and in given acceptance. I decided to create this "new" version in the GammaConv directory due to library linking issues when trying to access conversion photons from within the EMCal libraries. I think in the long run it would be best to use this macro by default.