### PR TITLE
Add option for Trigger Alias

### DIFF
--- a/PWG/EMCAL/EMCALtasks/AliAnalysisTaskEmcalTriggerSelection.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliAnalysisTaskEmcalTriggerSelection.cxx
@@ -29,6 +29,7 @@
 #include <sstream>
 #include <unordered_map>
 #include <TH1.h>
+#include "AliEmcalTriggerAlias.h"
 #include "AliEmcalTriggerDecision.h"
 #include "AliEmcalTriggerDecisionContainer.h"
 #include "AliEmcalTriggerSelection.h"
@@ -321,7 +322,7 @@ void AliAnalysisTaskEmcalTriggerSelection::ConfigureMCPP2012() {
   eg1cuts->SetSelectionMethod(AliEmcalTriggerSelectionCuts::kEnergyOfflineSmeared);
   eg1cuts->SetUseSimpleOfflinePatches(true);
   eg1cuts->SetThreshold(10.);
-  this->AddTriggerSelection(new AliEmcalTriggerSelection("EGA", eg1cuts));
+  this->AddTriggerSelection(new AliEmcalTriggerSelection("EGA", eg1cuts, new AliEmcalTriggerAlias("EGA;EG1")));
 
   AliEmcalTriggerSelectionCuts *ej1cuts = new AliEmcalTriggerSelectionCuts;
   ej1cuts->SetAcceptanceType(AliEmcalTriggerSelectionCuts::kEMCALAcceptance);
@@ -329,7 +330,7 @@ void AliAnalysisTaskEmcalTriggerSelection::ConfigureMCPP2012() {
   ej1cuts->SetSelectionMethod(AliEmcalTriggerSelectionCuts::kEnergyOfflineSmeared);
   ej1cuts->SetUseSimpleOfflinePatches(true);
   ej1cuts->SetThreshold(15.5);
-  this->AddTriggerSelection(new AliEmcalTriggerSelection("EJE", ej1cuts));
+  this->AddTriggerSelection(new AliEmcalTriggerSelection("EJE", ej1cuts, new AliEmcalTriggerAlias("EJE;EJ1")));
 }
 
 void AliAnalysisTaskEmcalTriggerSelection::ConfigurePPB5TeV2013(){

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerAlias.cxx
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerAlias.cxx
@@ -1,0 +1,108 @@
+/************************************************************************************
+ * Copyright (C) 2020, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+#include <iostream>
+#include <memory>
+#include <TObjArray.h>
+#include <TObjString.h>
+#include <TString.h>
+#include "AliEmcalTriggerAlias.h"
+
+ClassImp(PWG::EMCAL::AliEmcalTriggerAlias)
+
+namespace PWG{
+
+namespace EMCAL {
+
+AliEmcalTriggerAlias::AliEmcalTriggerAlias(const char *triggernames):
+  TObject(),
+  fTriggerClasses()
+{
+  fTriggerClasses.SetOwner(true);
+  DecodeTriggerClasses(triggernames);
+}
+
+AliEmcalTriggerAlias::AliEmcalTriggerAlias(const TList &triggernames):
+  TObject(),
+  fTriggerClasses()
+{
+  TIter listiter(&triggernames);
+  fTriggerClasses.SetOwner(true);
+  TObjString *triggerstring(nullptr);
+  while((triggerstring = static_cast<TObjString *>(listiter()))){
+    fTriggerClasses.Add(new TObjString(*triggerstring));
+  }
+}
+
+void AliEmcalTriggerAlias::SetTriggerClasses(const char *triggernames) {
+  fTriggerClasses.Clear();
+  DecodeTriggerClasses(triggernames);
+}
+
+void AliEmcalTriggerAlias::SetTriggerClasses(const TList &triggernames) {
+  fTriggerClasses.Clear();
+  TIter listiter(&triggernames);
+  TObjString *triggerstring(nullptr);
+  while((triggerstring = static_cast<TObjString *>(listiter()))){
+    fTriggerClasses.Add(new TObjString(*triggerstring));
+  }
+}
+
+void AliEmcalTriggerAlias::DecodeTriggerClasses(const char *triggernames) {
+  TString tmpstring(triggernames);
+  std::unique_ptr<TObjArray> separated(tmpstring.Tokenize(";"));
+  TIter listiter(separated.get());
+  TObjString *triggerstring(nullptr);
+  while((triggerstring = static_cast<TObjString *>(listiter()))){
+    fTriggerClasses.Add(new TObjString(*triggerstring));
+  }
+}
+
+bool AliEmcalTriggerAlias::HasTriggerClass(const char *triggername) const {
+  auto found = fTriggerClasses.FindObject(triggername);
+  return found != nullptr;
+}
+
+void AliEmcalTriggerAlias::PrintStream(std::ostream &stream) const {
+  stream << "Alias for: ";
+  TIter listiter(&fTriggerClasses);
+  TObjString *tmpstring(nullptr);
+  bool first = true;
+  while((tmpstring = static_cast<TObjString *>(listiter()))) {
+    if(!first) stream << ",";
+    stream << " " << tmpstring->String();
+    if(first) first = false;
+  }
+}
+    
+}
+
+}
+
+std::ostream & operator<< (std::ostream &in, const PWG::EMCAL::AliEmcalTriggerAlias &alias) {
+  alias.PrintStream(in);
+  return in;
+}

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerAlias.h
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerAlias.h
@@ -1,0 +1,113 @@
+/************************************************************************************
+ * Copyright (C) 2020, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+#ifndef ALIEMCALTRIGGERALIAS_H
+#define ALIEMCALTRIGGERALIAS_H
+
+#include <iosfwd>
+#include <TObject.h>
+#include <TList.h>
+
+// operator<< has to be forward declared carefully to stay in the global namespace so that it works with CINT.
+// For generally how to keep the operator in the global namespace, See: https://stackoverflow.com/a/38801633
+namespace PWG { namespace EMCAL { class AliEmcalTriggerAlias; } }
+std::ostream & operator<< (std::ostream &in, const PWG::EMCAL::AliEmcalTriggerAlias &alias);
+
+namespace PWG {
+
+namespace EMCAL {
+
+/**
+ * @class AliEmcalTriggerAlias
+ * @brief Class for trigger aliases
+ * @ingroup EMCALTRGFW
+ * @author Markus Fasel <markus.fasel@cern.ch>, Oak Ridge National Laboratory
+ * @since Jan. 20, 2020
+ * 
+ * A trigger alias is a collection of trigger classes connected to the same trigger
+ * condition. In case the trigger condition is fulfilled, any of the trigger aliases
+ * is accepted. In order to check for a specific class name check
+ * 
+ * ~~~.{cxx}
+ * AliEmcalTriggerAlias myalias("EGA;EG1");
+ * bool accepted = myalias.HasTriggerClass("EG1");  //true
+ * bool notaccepted = myalias.HasTriggerClass("EG2");  //false
+ * ~~~.{cxx}
+ */
+class AliEmcalTriggerAlias : public TObject {
+public:
+  /**
+   * @brief Constructor, creates a new trigger alias from a list of trigger names
+   * @param triggernames List of the trigger classes handled by the alias, separated by ";"
+   */
+  AliEmcalTriggerAlias(const char *triggernames);
+
+
+  /**
+   * @brief Constructor, creates a new trigger alias from a list of trigger names
+   * @param triggernames List of trigger classes handled
+   */
+  AliEmcalTriggerAlias(const TList &triggernames);
+
+  /**
+   * @brief Destructor
+   */
+  virtual ~AliEmcalTriggerAlias() {}
+
+  /**
+   * @brief check whether trigger name is handled by the trigger alias
+   * @param triggername Name of the trigger class to be checked
+   * @return True if the trigger class is handled, false otherwise
+   */
+  Bool_t HasTriggerClass(const char *triggername) const;
+
+  /**
+   * @brief Set the trigger classes handled by the trigger alias
+   * @param triggernames List of the trigger classes handled by the alias, separated by ";"
+   */
+  void SetTriggerClasses(const char *triggernames);
+
+  /**
+   * @brief Set the trigger classes handled by the trigger alias
+   * @param triggernames List of trigger classes handled
+   */
+  void SetTriggerClasses(const TList &triggernames);
+
+  void PrintStream(std::ostream &stream) const;
+
+private:
+  void DecodeTriggerClasses(const char *triggernames);
+
+  TList    fTriggerClasses;       // List of trigger classes handled by Alias
+
+  ClassDef(AliEmcalTriggerAlias,1)
+};
+
+}
+
+}
+
+#endif

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerDecision.cxx
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerDecision.cxx
@@ -35,8 +35,9 @@ namespace EMCAL{
 
 AliEmcalTriggerDecision::AliEmcalTriggerDecision():
   TNamed(),
-  fMainPatch(NULL),
-  fSelectionCuts(NULL),
+  fMainPatch(nullptr),
+  fSelectionCuts(nullptr),
+  fTriggerAlias(nullptr),
   fAcceptedPatches()
 {
   fAcceptedPatches.SetOwner(kFALSE);
@@ -44,8 +45,9 @@ AliEmcalTriggerDecision::AliEmcalTriggerDecision():
 
 AliEmcalTriggerDecision::AliEmcalTriggerDecision(const char *name, const char *title):
   TNamed(name, title),
-  fMainPatch(NULL),
-  fSelectionCuts(NULL),
+  fMainPatch(nullptr),
+  fSelectionCuts(nullptr),
+  fTriggerAlias(nullptr),
   fAcceptedPatches()
 {
   fAcceptedPatches.SetOwner(kFALSE);

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerDecision.h
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerDecision.h
@@ -36,6 +36,7 @@ namespace PWG {
 
 namespace EMCAL {
 
+class AliEmcalTriggerAlias;
 class AliEmcalTriggerSelectionCuts;
 
 /**
@@ -147,6 +148,13 @@ public:
    */
   virtual ~AliEmcalTriggerDecision();
 
+
+  /**
+   * @brief Get the trigger alias
+   * @return corresponding trigger alias (nullptr if not set)
+   */
+  const AliEmcalTriggerAlias *GetTriggerAlias() const { return fTriggerAlias; }
+
   /**
    * @brief Get the highest energetic trigger patch of the event firing the trigger
    * 
@@ -199,6 +207,12 @@ public:
   Bool_t IsSelected() const { return fMainPatch != NULL; }
 
   /**
+   * @brief Set trigger alias (names of trigger classes corresponding to the trigger condintion)
+   * @param alias Trigger alias object
+   */
+  void SetTriggerAlias(const AliEmcalTriggerAlias *alias) { fTriggerAlias = alias; }
+
+  /**
    * @brief Set the selection cuts used in the trigger selection
    * 
    * Selection cuts specify the trigger patch selection configuration for the
@@ -241,6 +255,7 @@ public:
 protected:
   const AliEMCALTriggerPatchInfo          *fMainPatch;         ///< Main trigger patch which fires the decision
   const AliEmcalTriggerSelectionCuts      *fSelectionCuts;     ///< Pointer to the cuts used for the trigger selection
+  const AliEmcalTriggerAlias              *fTriggerAlias;      ///< Pointer to trigger alias object with names of corresponding classes
   TList                                    fAcceptedPatches;   ///< All trigger patches which are accepted as well
 
   /// \cond CLASSIMP

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerDecisionContainer.cxx
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerDecisionContainer.cxx
@@ -24,6 +24,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
  ************************************************************************************/
+#include "AliEmcalTriggerAlias.h"
 #include "AliEmcalTriggerDecision.h"
 #include "AliEmcalTriggerDecisionContainer.h"
 
@@ -57,7 +58,25 @@ void AliEmcalTriggerDecisionContainer::AddTriggerDecision(AliEmcalTriggerDecisio
 }
 
 const AliEmcalTriggerDecision* AliEmcalTriggerDecisionContainer::FindTriggerDecision(const char* decname) const {
-  return dynamic_cast<const AliEmcalTriggerDecision *>(fContainer.FindObject(decname));
+  const AliEmcalTriggerDecision* result = nullptr, *tmp = nullptr;
+  TIter listiter(&fContainer);
+  while((tmp = static_cast<AliEmcalTriggerDecision *>(listiter()))){
+    auto alias = tmp->GetTriggerAlias();
+    if(alias) {
+      // trigger alias present, check for trigger class
+      if(alias->HasTriggerClass(decname)) {
+        result = tmp;
+        break;
+      }
+    } else {
+      // No trigger alias present, check for name of the trigger decision
+      if(TString(tmp->GetName()) == TString(decname)) {
+        result = tmp;
+        break;
+      }
+    }
+  }
+  return result;
 }
 
 bool AliEmcalTriggerDecisionContainer::IsEventSelected(const char *name)  const {

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerSelection.cxx
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerSelection.cxx
@@ -47,9 +47,10 @@ AliEmcalTriggerSelection::AliEmcalTriggerSelection() :
 {
 }
 
-AliEmcalTriggerSelection::AliEmcalTriggerSelection(const char *name, const AliEmcalTriggerSelectionCuts * const cuts):
+AliEmcalTriggerSelection::AliEmcalTriggerSelection(const char *name, const AliEmcalTriggerSelectionCuts * const cuts, const AliEmcalTriggerAlias *alias):
   TNamed(name, ""),
-  fSelectionCuts(cuts)
+  fSelectionCuts(cuts),
+  fTriggerAlias(alias)
 {
 }
 
@@ -76,11 +77,13 @@ AliEmcalTriggerDecision* AliEmcalTriggerSelection::MakeDecison(const TClonesArra
   }
   if(mainPatch) result->SetMainPatch(mainPatch);
   result->SetSelectionCuts(fSelectionCuts);
+  if(fTriggerAlias) result->SetTriggerAlias(fTriggerAlias);
   return result;
 }
 
 void AliEmcalTriggerSelection::PrintStream(std::ostream &stream) const {
   stream << "  Name of the trigger class: " << GetName() << std::endl;
+  if(fTriggerAlias) stream << fTriggerAlias;
   stream << *fSelectionCuts << std::endl;
 }
 

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerSelection.h
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerSelection.h
@@ -43,6 +43,7 @@ namespace PWG {
 
 namespace EMCAL {
 
+class AliEmcalTriggerAlias;
 class AliEmcalTriggerDecision;
 class AliEmcalTriggerSelectionCuts;
 
@@ -72,15 +73,22 @@ public:
    *
    * Initialises the trigger selection
    *
-   * @param name: name of the trigger selection
-   * @param cuts(optional): selection cuts to be applied
+   * @param name name of the trigger selection
+   * @param cuts(optional) selection cuts to be applied
+   * @param alias(optional) trigger alias
    */
-  AliEmcalTriggerSelection(const char *name, const AliEmcalTriggerSelectionCuts * const cuts);
+  AliEmcalTriggerSelection(const char *name, const AliEmcalTriggerSelectionCuts * const cuts, const AliEmcalTriggerAlias *alias = nullptr);
 
   /**
    * @brief Destructor
    */
   virtual ~AliEmcalTriggerSelection() {}
+
+  /**
+   * @brief Get the trigger alias 
+   * @return Trigger alias (nullptr if not set)
+   */
+  const AliEmcalTriggerAlias *GetTriggerAlias() const { return fTriggerAlias; }
 
   /**
    * @brief Get the selection cuts used in the trigger selection
@@ -93,6 +101,8 @@ public:
    * @param[in] cuts Selection cuts used to fire the trigger
    */
   void SetSelectionCuts(const AliEmcalTriggerSelectionCuts * const cuts) { fSelectionCuts = cuts; }
+
+  void SetTriggerAlias(const AliEmcalTriggerAlias *const alias) { fTriggerAlias = alias; }
 
   /**
    * Perform event selection based on user-defined criteria and create an output trigger decision containing
@@ -117,6 +127,7 @@ public:
   friend std::ostream& ::operator<<(std::ostream &stream, const AliEmcalTriggerSelection &sel);
 protected:
   const AliEmcalTriggerSelectionCuts  *fSelectionCuts;    ///< Cuts used for the trigger patch selection
+  const AliEmcalTriggerAlias *fTriggerAlias;              ///< Trigger alias for the trigger selection
 
   /// \cond CLASSIMP
   ClassDef(AliEmcalTriggerSelection, 1);    // EMCAL trigger selection component
@@ -138,6 +149,7 @@ private:
 
 }
 }
+
 
 
 #endif /* ALIEMCALTRIGGERSELECTION_H */

--- a/PWG/EMCAL/EMCALtrigger/CMakeLists.txt
+++ b/PWG/EMCAL/EMCALtrigger/CMakeLists.txt
@@ -35,6 +35,7 @@ set(SRCS
   AliEmcalTriggerMakerKernel.cxx
   AliEmcalTriggerMakerTask.cxx
   AliEmcalTriggerSetupInfo.cxx
+  AliEmcalTriggerAlias.cxx
   AliEmcalTriggerDecision.cxx
   AliEmcalTriggerDecisionContainer.cxx
   AliEmcalTriggerSelectionCuts.cxx

--- a/PWG/EMCAL/EMCALtrigger/PWGEMCALtriggerLinkDef.h
+++ b/PWG/EMCAL/EMCALtrigger/PWGEMCALtriggerLinkDef.h
@@ -16,6 +16,7 @@
 
 #pragma link C++ namespace PWG;
 #pragma link C++ namespace PWG::EMCAL;
+#pragma link C++ class PWG::EMCAL::AliEmcalTriggerAlias+;
 #pragma link C++ class PWG::EMCAL::AliEmcalTriggerDecision+;
 #pragma link C++ class PWG::EMCAL::AliEmcalTriggerDecisionContainer+;
 #pragma link C++ class PWG::EMCAL::AliEmcalTriggerSelectionCuts++;


### PR DESCRIPTION
Trigger aliases allow to have multiple names for the
same trigger condition. This is of relevance for the
Data period from 2012: The trigger classes were called
EGA and EJE, however in order to port code adapted to
data periods with EG1/EG2 and EJ1/EJ2, it is easier
to identify the trigger with either of the names (EGA/EJE
for backward compatibility, EG1/EG2/EJ1/EJ2 for new
code)