### PR TITLE
Include MC information and minor updates

### DIFF
--- a/PWGHF/correlationHF/AliAnalysisTaskDHFeCorr.cxx
+++ b/PWGHF/correlationHF/AliAnalysisTaskDHFeCorr.cxx
@@ -48,18 +48,27 @@ ClassImp(AliAnalysisTaskDHFeCorr)
 AliAnalysisTaskDHFeCorr::AliAnalysisTaskDHFeCorr() : AliAnalysisTaskSE() {}
 
 AliAnalysisTaskDHFeCorr::AliAnalysisTaskDHFeCorr(const char *name) : AliAnalysisTaskSE(name) {
+
     DefineInput(0, TChain::Class());
-    DefineOutput(1, TList::Class());
-    DefineOutput(2, TList::Class());
-    DefineOutput(3, TList::Class());
-    DefineOutput(4, TTree::Class());
-    DefineOutput(5, TTree::Class());
-    DefineOutput(6, TTree::Class());
+
+    DefineOutput(1, TTree::Class());
+    DefineOutput(2, TTree::Class());
+    DefineOutput(3, TTree::Class());
+    DefineOutput(4, TList::Class());
+    DefineOutput(5, TList::Class());
+    DefineOutput(6, TList::Class());
+    DefineOutput(7, TTree::Class());
+    DefineOutput(8, TTree::Class());
+
 }
 
 //_____________________________________________________________________________
 void AliAnalysisTaskDHFeCorr::UserCreateOutputObjects() {
+    //Additional setup for the task that needs to be done at the time of run time
     fDMesonRequirements.fDMesonCuts->GetPidHF()->SetPidResponse(fInputHandler->GetPIDResponse());
+
+    //Remove the trigger mask from the automatic cuts
+    fEventCuts.OverrideAutomaticTriggerSelection(AliVEvent::kAny);
 
     fOptEvent.SetOwner(kTRUE);
     fOptElectron.SetOwner(kTRUE);
@@ -76,10 +85,15 @@ void AliAnalysisTaskDHFeCorr::UserCreateOutputObjects() {
     if (fIsMC) {
         AddDMesonMCVariables(fDmesonTree);
         AddElectronMCVariables(fElectronTree);
+
+        fElectronTreeMC = std::unique_ptr<TTree>(new TTree("electron_mc", "electron_mc"));
+        fDmesonTreeMC = std::unique_ptr<TTree>(new TTree("dmeson_mc", "dmeson_mc"));
+
+        AddMCTreeVariables(fDmesonTreeMC);
+        AddMCTreeVariables(fElectronTreeMC);
     }
 
-    fEventQABeforeCuts = CreateQAEvents("before", fOptEvent);
-    fEventQAAfterCuts = CreateQAEvents("after", fOptEvent);
+    fEventCuts.AddQAplotsToList(&fOptEvent);
 
     fElectronQABeforeCuts = CreateQAElectrons(fElectronOptConfig, "electron", "before", fOptElectron);
     fElectronQAAfterTrackCuts = CreateQAElectrons(fElectronOptConfig, "electron", "after_track_cuts", fOptElectron);
@@ -91,123 +105,66 @@ void AliAnalysisTaskDHFeCorr::UserCreateOutputObjects() {
     PostOutput();
 }
 
-void AliAnalysisTaskDHFeCorr::AddEventVariables(std::unique_ptr<TTree> &tree) {
-    tree->Branch("RunNumber", &fRunNumber);
-    tree->Branch("EventNumber", &fEventNumber);
-    tree->Branch("VtxZ", &fVtxZ);
-    tree->Branch("Centrality", &fCentrality);
-}
+void AliAnalysisTaskDHFeCorr::UserExec(Option_t *) {
 
+    CheckConfiguration();
+    SetRunAndEventNumber();
 
-void AliAnalysisTaskDHFeCorr::AddElectronVariables(std::unique_ptr<TTree> &tree) {
-    tree->Branch("RunNumber", &fElectron.fRunNumber);
-    tree->Branch("EventNumber", &fElectron.fEventNumber);
-
-    tree->Branch("Pt", &fElectron.fPt);
-    tree->Branch("Eta", &fElectron.fEta);
-    tree->Branch("Phi", &fElectron.fPhi);
-    tree->Branch("ID", &fElectron.fID);
-
-    if (!fReducedElectronInfo) {
-        tree->Branch("Charge", &fElectron.fCharge);
-        tree->Branch("P", &fElectron.fP);
-        tree->Branch("NClsTPC", &fElectron.fNClsTPC);
-        tree->Branch("NClsTPCDeDx", &fElectron.fNClsTPCDeDx);
-        tree->Branch("NITSCls", &fElectron.fNITSCls);
-        tree->Branch("ITSHitFirstLayer", &fElectron.fITSHitFirstLayer);
-        tree->Branch("ITSHitSecondLayer", &fElectron.fITSHitSecondLayer);
-        tree->Branch("DCAxy", &fElectron.fDCAxy);
-        tree->Branch("DCAz", &fElectron.fDCAz);
-        tree->Branch("TPCNSigma", &fElectron.fTPCNSigma);
-        tree->Branch("TOFNSigma", &fElectron.fTOFNSigma);
-        tree->Branch("InvMassPartnersULS", &fElectron.fInvMassPartnersULS);
-        tree->Branch("InvMassPartnersLS", &fElectron.fInvMassPartnersLS);
+    if (!InputEvent()) {
+        PostOutput();
+        return;
     }
-}
 
-void AliAnalysisTaskDHFeCorr::AddDMesonVariables(std::unique_ptr<TTree> &tree,
-                                                 AliAnalysisTaskDHFeCorr::DMeson_t meson_species) {
-    //Event information
-    tree->Branch("RunNumber", &fDmeson.fRunNumber);
-    tree->Branch("EventNumber", &fDmeson.fEventNumber);
-    tree->Branch("ID", &fDmeson.fID);
-    tree->Branch("IsParticleCandidate", &fDmeson.fIsParticleCandidate);
-
-    //Basic information
-    tree->Branch("Pt", &fDmeson.fPt);
-    tree->Branch("Eta", &fDmeson.fEta);
-    tree->Branch("Phi", &fDmeson.fPhi);
-    tree->Branch("Y", &fDmeson.fY);
-    tree->Branch("InvMass", &fDmeson.fInvMass);
-    tree->Branch("ReducedChi2", &fDmeson.fReducedChi2);
-
-    //Topological information
-    tree->Branch("DecayLength", &fDmeson.fDecayLength);
-    tree->Branch("DecayLengthXY", &fDmeson.fDecayLengthXY);
-
-    tree->Branch("NormDecayLength", &fDmeson.fNormDecayLength);
-    tree->Branch("NormDecayLengthXY", &fDmeson.fNormDecayLengthXY);
-
-    tree->Branch("CosP", &fDmeson.fCosP);
-    tree->Branch("CosPXY", &fDmeson.fCosPXY);
-
-    tree->Branch("ImpParXY", &fDmeson.fImpParXY);
-    tree->Branch("DCA", &fDmeson.fDCA);
-
-    tree->Branch("Normd0MeasMinusExp", &fDmeson.fNormd0MeasMinusExp);
-    tree->Branch("PtDaughter", &fDmeson.fPtDaughters);
-    tree->Branch("D0Daughter", &fDmeson.fD0Daughters);
-
-    tree->Branch("IDDaughters", &fDmeson.fIDDaughters);
-
-    //PID
-    tree->Branch("SelectionStatusDefaultPID", &fDmeson.fSelectionStatusDefaultPID);
-
-    tree->Branch("NSigmaTPCDaughters0", &(fDmeson.fNSigmaTPCDaughters[0]));
-    tree->Branch("NSigmaTPCDaughters1", &(fDmeson.fNSigmaTPCDaughters[1]));
-
-    tree->Branch("NSigmaTOFDaughters0", &(fDmeson.fNSigmaTOFDaughters[0]));
-    tree->Branch("NSigmaTOFDaughters1", &(fDmeson.fNSigmaTOFDaughters[1]));
-
-    //Meson depended variables
-    switch (meson_species) {
-        case AliAnalysisTaskDHFeCorr::kD0: {
-            tree->Branch("CosTs", &fDmeson.fCosTs);
-        }
-            break;
-        case AliAnalysisTaskDHFeCorr::kDplus: {
-            tree->Branch("SigmaVertex", &fDmeson.fSigmaVertex);
-            tree->Branch("NSigmaTPCDaughters2", &(fDmeson.fNSigmaTPCDaughters[2]));
-            tree->Branch("NSigmaTOFDaughters2", &(fDmeson.fNSigmaTOFDaughters[2]));
-        }
-            break;
-        case AliAnalysisTaskDHFeCorr::kDstar: {
-            tree->Branch("AngleD0dkpPisoft", &fDmeson.fAngleD0dkpPisoft);
-            tree->Branch("CosTs", &fDmeson.fCosTs);
-        }
-            break;
+    if (!fEventCuts.AcceptEvent(InputEvent())) {
+        PostOutput();
+        return;
     }
+
+    if (fSaveEvent) {
+        fEventInfo = EventInfo();
+        fEventTree->Fill();
+    }
+
+    if (fProcessDMeson)
+        DMesonAnalysis();
+
+    if (fProcessElectron)
+        ElectronAnalysis();
+
+    //Post information to the output
+    PostOutput();
+
 }
 
-void AliAnalysisTaskDHFeCorr::AddElectronMCVariables(std::unique_ptr<TTree> &tree) {
-    tree->Branch("PtMC", &fElectron.fPtMC);
-    tree->Branch("PhiMC", &fElectron.fPhiMC);
-    tree->Branch("EtaMC", &fElectron.fEtaMC);
-    tree->Branch("Origin", &fElectron.fOrigin);
-    tree->Branch("FirstMotherPDG", &fElectron.fFirstMotherPDG);
-    tree->Branch("FirstMotherPt", &fElectron.fFirstMotherPt);
-    tree->Branch("SecondMotherPDG", &fElectron.fSecondMotherPDG);
-    tree->Branch("SecondMotherPt", &fElectron.fSecondMotherPt);
+AliDHFeCorr::AliEvent AliAnalysisTaskDHFeCorr::EventInfo() {
+    AliDHFeCorr::AliEvent event;
+
+    event.fRunNumber = fRunNumber;
+    event.fEventNumber = fEventNumber;
+
+    event.fVtxZ = fEventCuts.GetPrimaryVertex()->GetZ();
+
+    auto multiplicity_selection = dynamic_cast<AliMultSelection *>(InputEvent()->FindListObject("MultSelection"));
+    if (multiplicity_selection) {
+        event.fMultV0MPercentile = multiplicity_selection->GetMultiplicityPercentile("V0M");
+        event.fMultiRefMult08Percentile = multiplicity_selection->GetMultiplicityPercentile("RefMult08");
+        event.fMultiSPDTrackletsPercentile = multiplicity_selection->GetMultiplicityPercentile("SPDTracklets");
+
+        if (multiplicity_selection->GetEstimator("V0M"))
+            event.fMultV0M = multiplicity_selection->GetEstimator("V0M")->GetValue();
+        if (multiplicity_selection->GetEstimator("RefMult08"))
+            event.fMultiRefMult08 = multiplicity_selection->GetEstimator("RefMult08")->GetValue();
+        if (multiplicity_selection->GetEstimator("SPDTracklets"))
+            event.fMultiSPDTracklets = multiplicity_selection->GetEstimator("SPDTracklets")->GetValue();
+    }
+
+    return event;
 }
 
-void AliAnalysisTaskDHFeCorr::AddDMesonMCVariables(std::unique_ptr<TTree> &tree) {
-    tree->Branch("PtMC", &fDmeson.fPtMC);
-    tree->Branch("IsD", &fDmeson.fIsD);
-    tree->Branch("IsParticle", &fDmeson.fIsParticle);
-    tree->Branch("IsPrompt", &fDmeson.fIsPrompt);
-}
 
 std::vector<AliDHFeCorr::AliElectron> AliAnalysisTaskDHFeCorr::ElectronAnalysis() {
+
+    // Reconstructed candidates
     auto aod_event = dynamic_cast<AliAODEvent *>(InputEvent());
 
     std::vector<AliDHFeCorr::AliElectron> tracks;
@@ -224,8 +181,6 @@ std::vector<AliDHFeCorr::AliElectron> AliAnalysisTaskDHFeCorr::ElectronAnalysis(
     auto selected_tracks = FilterElectronsTracking(fElectronRequirements, tracks);
     auto selected_electrons = FilterElectronsPID(fElectronRequirements, selected_tracks);
 
-    FillElectronMCInfo(selected_electrons);
-
     auto selected_partner_tracks = FilterElectronsTracking(fPartnerElectronRequirements, tracks);
     auto partner_electrons = FilterElectronsPID(fPartnerElectronRequirements, selected_partner_tracks);
 
@@ -234,15 +189,108 @@ std::vector<AliDHFeCorr::AliElectron> AliAnalysisTaskDHFeCorr::ElectronAnalysis(
             FindNonHFe(electron, partner_electrons);
     }
 
-    //fill the electron (track) QA before applying the cuts
-    FillElectronQA(tracks, fElectronQABeforeCuts);
-    //fill the electron QA after track selection
-    FillElectronQA(selected_tracks, fElectronQAAfterTrackCuts);
-    //fill the electron QA after applying the cuts
-    FillElectronQA(selected_electrons, fElectronQAAfterCuts);
+    if (fSaveHistograms) {
+        //fill the electron (track) QA before applying the cuts
+        FillElectronQA(tracks, fElectronQABeforeCuts);
+        //fill the electron QA after track selection
+        FillElectronQA(selected_tracks, fElectronQAAfterTrackCuts);
+        //fill the electron QA after applying the cuts
+        FillElectronQA(selected_electrons, fElectronQAAfterCuts);
+    }
+
+    if (fIsMC) {
+        auto mc_e_from_c_b = FindHFParticleInMC(11); // Also might include D->pi0->e for example
+        auto hfe_mc = FilterHFeInMCParticles(mc_e_from_c_b); // Only includes c and b meson/baryons-> e X
+        FillTreeFromStdContainer(hfe_mc, &fMCParticle, fElectronTreeMC);
+    }
+
+    FillTreeFromStdContainer(selected_electrons, &fElectron, fElectronTree);
 
     return selected_electrons;
 }
+
+
+std::vector<AliDHFeCorr::AliParticleMC> AliAnalysisTaskDHFeCorr::FindHFParticleInMC(int pdg) {
+    pdg = abs(pdg);
+
+    std::vector<AliDHFeCorr::AliParticleMC> mc_particles;
+
+    const auto mc_information = dynamic_cast<TClonesArray *>(InputEvent()->GetList()->FindObject(
+            AliAODMCParticle::StdBranchName()));
+
+    for (int i(0); i < mc_information->GetEntriesFast(); i++) {
+        auto particle = dynamic_cast<AliAODMCParticle *>(mc_information->At(i));
+
+        if (abs(particle->GetPdgCode()) != pdg)
+            continue;
+
+        auto origin = AliVertexingHFUtils::CheckOrigin(mc_information, particle, true);
+
+        if (!(origin == 4 || origin == 5))
+            continue;
+
+        AliDHFeCorr::AliParticleMC particle_to_save;
+        particle_to_save.fRunNumber = fRunNumber;
+        particle_to_save.fEventNumber = fEventNumber;
+        particle_to_save.fLabel = particle->GetLabel();
+        particle_to_save.fMCParticle = particle;
+        particle_to_save.fE = particle->E();
+        particle_to_save.fPt = particle->Pt();
+        particle_to_save.fEta = particle->Eta();
+        particle_to_save.fPhi = particle->Phi();
+        particle_to_save.fXv = particle->Xv();
+        particle_to_save.fYv = particle->Yv();
+        particle_to_save.fZv = particle->Zv();
+        particle_to_save.fTv = particle->Tv();
+        particle_to_save.fCharge = particle->Charge();
+        particle_to_save.fPDGCode = particle->PdgCode();
+        particle_to_save.fOrigin = origin;
+
+        mc_particles.push_back(particle_to_save);
+
+    }
+
+    //Sorted by construction
+    return mc_particles;
+}
+
+std::vector<AliDHFeCorr::AliParticleMC> AliAnalysisTaskDHFeCorr::FilterHFeInMCParticles(
+        std::vector<AliDHFeCorr::AliParticleMC> &electrons) {
+
+    std::vector<AliDHFeCorr::AliParticleMC> hfe;
+    hfe.reserve(electrons.size());
+
+    const auto mc_information = dynamic_cast<TClonesArray *>(InputEvent()->GetList()->FindObject(
+            AliAODMCParticle::StdBranchName()));
+
+    for (auto &mc_electron: electrons) {
+        if (IsHFe(mc_electron.fMCParticle, mc_information))
+            hfe.push_back(mc_electron);
+    }
+
+    hfe.shrink_to_fit();
+
+    return hfe;
+}
+
+bool AliAnalysisTaskDHFeCorr::IsHFe(AliAODMCParticle *particle, TClonesArray *mc_information) {
+
+    if (abs(particle->PdgCode()) != 11)
+        return false;
+
+    if (particle->GetMother() < 0)
+        return false;
+
+    if (!mc_information)
+        throw std::runtime_error("The program is trying to access MC information, but the mc info is not present.");
+
+    auto mother = dynamic_cast<AliAODMCParticle *>(mc_information->At(particle->GetMother()));
+    auto abs_pdg_mother = abs(mother->PdgCode());
+
+    return (abs_pdg_mother > 400 && abs_pdg_mother < 600) || (abs_pdg_mother > 4000 && abs_pdg_mother < 6000);
+
+}
+
 
 std::vector<AliDHFeCorr::AliDMeson> AliAnalysisTaskDHFeCorr::DMesonAnalysis() {
     auto aod_event = dynamic_cast<AliAODEvent *>(InputEvent());
@@ -255,71 +303,29 @@ std::vector<AliDHFeCorr::AliDMeson> AliAnalysisTaskDHFeCorr::DMesonAnalysis() {
     //Select D mesons
     auto selected_d_mesons = FilterDmesons(d_mesons, fDMesonRequirements, aod_event, fgkDMesonPDG.at(fDmesonSpecies));
 
-    FillDmesonQA(d_mesons, fDMesonQABeforeCuts, fDmesonSpecies);
-    FillDmesonQA(selected_d_mesons, fDMesonQAAfterCuts, fDmesonSpecies);
+    if (fSaveHistograms) {
+        FillDmesonQA(d_mesons, fDMesonQABeforeCuts, fDmesonSpecies);
+        FillDmesonQA(selected_d_mesons, fDMesonQAAfterCuts, fDmesonSpecies);
+    }
 
     FillDmesonMCInfo(selected_d_mesons, fDmesonSpecies);
+
+    if (fIsMC) {
+        auto d_mc = FindHFParticleInMC(fgkDMesonPDG.at(fDmesonSpecies));
+        FillTreeFromStdContainer(d_mc, &fMCParticle, fDmesonTreeMC);
+
+        if (fIsEffMode)
+            selected_d_mesons = FilterTrueDMesons(selected_d_mesons);
+    }
+
+    FillTreeFromStdContainer(selected_d_mesons, &fDmeson, fDmesonTree);
+
 
     return selected_d_mesons;
 }
 
 //_____________________________________________________________________________
-void AliAnalysisTaskDHFeCorr::UserExec(Option_t *) {
-    CheckConfiguration();
-    SetRunAndEventNumber();
 
-    //Set Global event variables
-    fVtxZ = InputEvent()->GetPrimaryVertex()->GetZ();
-
-    auto multiplicity_selection = dynamic_cast<AliMultSelection *>(InputEvent()->FindListObject("MultSelection"));
-    if (multiplicity_selection)
-        fCentrality = multiplicity_selection->GetMultiplicityPercentile(fEventSelection.fMultiEstimator);
-
-    auto aod_event = dynamic_cast<AliAODEvent *>(InputEvent());
-    if (!aod_event)
-        return;
-
-    FillEventQA(fEventQABeforeCuts);
-
-    if (!IsSelectedEvent(aod_event, fEventSelection)) {
-        PostOutput();
-        return;
-    }
-
-    auto selected_d_mesons = DMesonAnalysis();
-    auto selected_electrons = ElectronAnalysis();
-
-    //In case no D meson AND electron is present, the event is not saved at all
-    if ((selected_d_mesons.empty()) && (selected_electrons.empty())) {
-        PostOutput();
-        return;
-    }
-
-    if (!fIsEffMode && !fKeepAllCandidates) {
-        //Ignores event in case no electron and D meson is found, depending on the configuration
-        if ((selected_d_mesons.empty()) || (selected_electrons.empty())) {
-            PostOutput();
-            return;
-        }
-    }
-
-    //Fill the plots in case both D meson and electron is found the event
-    FillEventQA(fEventQAAfterCuts);
-
-    if (fIsEffMode && fIsMC) {
-        selected_d_mesons = FilterTrueDMesons(selected_d_mesons);
-    }
-
-    FillElectronTree(selected_electrons);
-    FillDMesonTree(selected_d_mesons);
-    fEventTree->Fill();
-
-    //Post information to the output
-    PostOutput();
-
-    //increase the number of the event used for the Trees
-    fEventNumber++;
-}
 
 void AliAnalysisTaskDHFeCorr::CheckConfiguration() const {
     auto event_list = InputEvent()->GetList();
@@ -359,7 +365,7 @@ void AliAnalysisTaskDHFeCorr::FillElectronInformation(std::vector<AliDHFeCorr::A
         candidate.fEta = track->Eta();
         candidate.fPhi = track->Phi();
 
-        candidate.fNClsTPC = track->GetTPCNcls();
+        candidate.fNCrossedRowsTPC = track->GetTPCNCrossedRows();
         candidate.fNClsTPCDeDx = track->GetTPCsignalN();
         candidate.fNITSCls = track->GetITSNcls();
 
@@ -379,6 +385,8 @@ void AliAnalysisTaskDHFeCorr::FillElectronInformation(std::vector<AliDHFeCorr::A
         candidate.fTPCNSigma = pid_response->NumberOfSigmasTPC(track, AliPID::kElectron);
         candidate.fTOFNSigma = pid_response->NumberOfSigmasTOF(track, AliPID::kElectron);
     }
+
+    FillAllElectronsMCInfo(electrons);
 }
 
 std::vector<AliDHFeCorr::AliElectron>
@@ -397,7 +405,7 @@ AliAnalysisTaskDHFeCorr::FilterElectronsTracking(AliDHFeCorr::AliElectronSelecti
         if (!candidate.fTrack->TestFilterBit(electronSelection.fFilterBit))
             continue;
 
-        if (candidate.fNClsTPC < electronSelection.fTPCClsMin)
+        if (candidate.fNCrossedRowsTPC < electronSelection.fNCrossedRowsTPCMin)
             continue;
 
         if (candidate.fNClsTPCDeDx < electronSelection.fTPCClsDeDxMin)
@@ -437,14 +445,14 @@ AliAnalysisTaskDHFeCorr::FilterElectronsPID(AliDHFeCorr::AliElectronSelection el
                 (candidate.fTOFNSigma > electronSelection.fTOFNSigmaMax))
                 continue;
         }
-        selected_electrons.push_back(AliDHFeCorr::AliElectron(candidate));
+        selected_electrons.push_back(candidate);
     }
 
     selected_electrons.shrink_to_fit();
     return selected_electrons;
 }
 
-void AliAnalysisTaskDHFeCorr::FillElectronMCInfo(std::vector<AliDHFeCorr::AliElectron> &electrons) {
+void AliAnalysisTaskDHFeCorr::FillAllElectronsMCInfo(std::vector<AliDHFeCorr::AliElectron> &electrons) {
     const auto mc_information = dynamic_cast<TClonesArray *>(InputEvent()->GetList()->FindObject(
             AliAODMCParticle::StdBranchName()));
 
@@ -465,6 +473,7 @@ void AliAnalysisTaskDHFeCorr::FillElectronMCInfo(std::vector<AliDHFeCorr::AliEle
         candidate.fPhiMC = mc_part->Phi();
         candidate.fPDG = mc_part->PdgCode();
         candidate.fOrigin = AliVertexingHFUtils::CheckOrigin(mc_information, mc_part, true);
+        candidate.fLabel = label;
 
         if (mc_part->GetMother() > 0) {
             const auto mc_mother = dynamic_cast<AliAODMCParticle *>(mc_information->At(mc_part->GetMother()));
@@ -503,6 +512,8 @@ void AliAnalysisTaskDHFeCorr::FillDmesonMCInfo(std::vector<AliDHFeCorr::AliDMeso
             continue;
 
         candidate.fIsD = kTRUE;
+        candidate.fLabel = label;
+
         const auto mc_part = dynamic_cast<AliAODMCParticle *>(mc_information->At(label));
         candidate.fPtMC = mc_part->Pt();
         const auto origin = AliVertexingHFUtils::CheckOrigin(mc_information, mc_part, true); //Prompt = 4, FeedDown = 5
@@ -515,6 +526,7 @@ void AliAnalysisTaskDHFeCorr::FillDmesonMCInfo(std::vector<AliDHFeCorr::AliDMeso
         }
     }
 }
+
 
 std::vector<AliDHFeCorr::AliDMeson>
 AliAnalysisTaskDHFeCorr::FilterTrueDMesons(const std::vector<AliDHFeCorr::AliDMeson> &d_mesons) {
@@ -552,12 +564,27 @@ void AliAnalysisTaskDHFeCorr::SetRunAndEventNumber() {
 
 
 void AliAnalysisTaskDHFeCorr::PostOutput() {
-    PostData(1, &fOptEvent);
-    PostData(2, &fOptElectron);
-    PostData(3, &fOptDMeson);
-    PostData(4, fElectronTree.get());
-    PostData(5, fDmesonTree.get());
-    PostData(6, fEventTree.get());
+    if (fProcessElectron) {
+        PostData(1, fElectronTree.get());
+    }
+    if (fProcessDMeson) {
+        PostData(2, fDmesonTree.get());
+    }
+
+    if (fSaveEvent) {
+        PostData(3, fEventTree.get());
+    }
+
+    if (fSaveHistograms) {
+        PostData(4, &fOptEvent);
+        PostData(5, &fOptElectron);
+        PostData(6, &fOptDMeson);
+    }
+
+    if (fIsMC) {
+        PostData(7, fElectronTreeMC.get());
+        PostData(8, fDmesonTreeMC.get());
+    }
 }
 
 
@@ -565,7 +592,7 @@ void AliAnalysisTaskDHFeCorr::FillElectronQA(const std::vector<AliDHFeCorr::AliE
                                              AliDHFeCorr::AliElectronQAHistograms &histograms) {
     for (const auto &electron: tracks) {
         histograms.fPtEtaPhi->Fill(electron.fPt, electron.fEta, electron.fPhi);
-        histograms.fTPCNCls->Fill(electron.fNClsTPC);
+        histograms.fTPCNCls->Fill(electron.fNCrossedRowsTPC);
         histograms.fTPCNClsDeDx->Fill(electron.fNClsTPCDeDx);
         histograms.fITSCls->Fill(electron.fNITSCls);
         histograms.fDCAz->Fill(electron.fDCAz);
@@ -609,23 +636,12 @@ void AliAnalysisTaskDHFeCorr::FillDmesonQA(const std::vector<AliDHFeCorr::AliDMe
     }
 }
 
-void AliAnalysisTaskDHFeCorr::FillEventQA(AliDHFeCorr::AliEventQAHistograms &histograms) {
-    histograms.fNEvents->Fill(0);
-    histograms.fVertexZ->Fill(fVtxZ);
-    histograms.fCentrality->Fill(fCentrality);
-}
-
 void AliAnalysisTaskDHFeCorr::FindNonHFe(AliDHFeCorr::AliElectron &main_electron,
                                          const std::vector<AliDHFeCorr::AliElectron> &partners) const {
 
-    //Reset all the vectors and reserve 10 (it should not have too many partners)
-    std::vector<Float_t> inv_mass_uls, inv_mass_ls;
+    std::vector<Float_t> inv_mass_uls, inv_mass_ls, pt_uls, pt_ls;
+    std::vector<UShort_t> n_cross_row_uls, n_cross_row_ls;
     std::vector<UInt_t> id_uls, id_ls;
-
-    inv_mass_uls.reserve(10);
-    inv_mass_ls.reserve(10);
-    id_uls.reserve(10);
-    id_ls.reserve(10);
 
     //Set the magnetic field
     AliKFParticle::SetField(InputEvent()->GetMagneticField());
@@ -634,6 +650,7 @@ void AliAnalysisTaskDHFeCorr::FindNonHFe(AliDHFeCorr::AliElectron &main_electron
     const auto charge_main = track_main->Charge();
 
     int pdg_main = 11; //electron pdg is always 11
+
     if (charge_main > 0.) { //change sign in case it is a positron
         pdg_main = -1 * pdg_main;
     }
@@ -674,40 +691,32 @@ void AliAnalysisTaskDHFeCorr::FindNonHFe(AliDHFeCorr::AliElectron &main_electron
 
         //If the pair arrived here, it fulfils all the requirements, so it will be saved
         if ((charge_main * charge_partner) > 0) { //++ or --, Like-sign pair
+            pt_ls.push_back(track_partner->Pt());
+            n_cross_row_ls.push_back(static_cast<UShort_t >(track_partner->GetTPCNCrossedRows()));
             inv_mass_ls.push_back(pair_mass);
             id_ls.push_back(static_cast<unsigned int &&>(TMath::Abs(track_partner->GetID())));
+
         } else {
+            pt_uls.push_back(track_partner->Pt());
+            n_cross_row_uls.push_back(static_cast<UShort_t >(track_partner->GetTPCNCrossedRows()));
             inv_mass_uls.push_back(pair_mass);
             id_uls.push_back(static_cast<unsigned int &&>(TMath::Abs(track_partner->GetID())));
         }
     }
 
-    inv_mass_uls.shrink_to_fit();
-    inv_mass_ls.shrink_to_fit();
-    id_uls.shrink_to_fit();
-    id_ls.shrink_to_fit();
-
     main_electron.fInvMassPartnersULS = inv_mass_uls;
     main_electron.fInvMassPartnersLS = inv_mass_ls;
+
     main_electron.fPartnersULSID = id_uls;
     main_electron.fPartnersLSID = id_ls;
 
+    main_electron.fCrossedRowsTPCPartnersLS = n_cross_row_ls;
+    main_electron.fCrossedRowsTPCPartnersULS = n_cross_row_uls;
+    main_electron.fPtPartnersULS = pt_uls;
+    main_electron.fPtPartnersLS = pt_ls;
+
 }
 
-void AliAnalysisTaskDHFeCorr::FillElectronTree(const std::vector<AliDHFeCorr::AliElectron> &tracks) {
-    for (const auto &electron: tracks) {
-        fElectron = AliDHFeCorr::AliElectron(electron);
-        fElectronTree->Fill();
-    }
-}
-
-
-void AliAnalysisTaskDHFeCorr::FillDMesonTree(const std::vector<AliDHFeCorr::AliDMeson> &d_mesons) {
-    for (const auto &dmeson: d_mesons) {
-        fDmeson = AliDHFeCorr::AliDMeson(dmeson);
-        fDmesonTree->Fill();
-    }
-}
 
 std::vector<Float_t> AliAnalysisTaskDHFeCorr::MakeBins(Float_t start, Float_t end, Int_t n_bins) {
     const auto step = (end - start) / n_bins;
@@ -746,6 +755,18 @@ std::vector<AliDHFeCorr::AliDMeson> AliAnalysisTaskDHFeCorr::FillDMesonInfo(cons
         const auto reco_candidate = cand.fRecoObj;
         if (!reco_candidate)
             continue;
+
+        //Preselect to save  time
+        TObjArray arrTracks(cand.fRecoObj->GetNProngs());
+        for (Int_t itrack = 0; itrack < cand.fRecoObj->GetNProngs(); itrack++) {
+            AliAODTrack *tr = vertexing_HF.GetProng(aod_event, cand.fRecoObj, itrack);
+            arrTracks.AddAt(tr, itrack);
+        }
+
+        if (!dmeson_selection.fDMesonCuts->PreSelect(arrTracks)) {
+            continue;
+        }
+
         //Fill missing info not saved in the AOD
         switch (meson_species) {
             case AliAnalysisTaskDHFeCorr::kD0: {
@@ -771,11 +792,9 @@ std::vector<AliDHFeCorr::AliDMeson> AliAnalysisTaskDHFeCorr::FillDMesonInfo(cons
             }
             default: {
                 throw std::invalid_argument("The D meson requested is not defined in the task");
-                break;
             }
         }
         //avoid a lot of computational time by rejecting minimum Pt here
-        //Reject in case the pt is smaller than the minimum fPtMin
         if (reco_candidate->Pt() < dmeson_selection.fPtMin)
             continue;
 
@@ -839,7 +858,6 @@ std::vector<AliDHFeCorr::AliDMeson> AliAnalysisTaskDHFeCorr::FillDMesonInfo(cons
 
         for (int j = 0; j < n_prongs; j++) {
 
-            //TO DO: UNDERSTAND IT IS NOT SAVING THE pid_info_tpc_prong WITH 2X THE NUMBER OF id_daughter_alipid
             const auto track = dynamic_cast<AliAODTrack *>(reco_cand->GetDaughter(j));
             id_daughters.push_back(TMath::Abs(track->GetID()));
 
@@ -949,18 +967,6 @@ AliAnalysisTaskDHFeCorr::FilterDmesons(const std::vector<AliDHFeCorr::AliDMeson>
     return d_mesons;
 }
 
-bool AliAnalysisTaskDHFeCorr::IsSelectedEvent(AliAODEvent *event, const AliDHFeCorr::AliEventSelection &selection) {
-    if (!event)
-        return false;
-    if ((fVtxZ < selection.fVertexZMin) || (fVtxZ > selection.fVertexZMax))
-        return false;
-
-    if (fCentrality < selection.fMultMin || fCentrality > selection.fMultMax)
-        return false;
-
-    return true;
-}
-
 bool AliAnalysisTaskDHFeCorr::FulfilPixelSelection(const AliDHFeCorr::AliElectron &track, Int_t requirement) {
     const bool hasHitFirstLayer = track.fITSHitFirstLayer;
     const bool hasHitSecondLayer = track.fITSHitSecondLayer;
@@ -977,13 +983,12 @@ bool AliAnalysisTaskDHFeCorr::FulfilPixelSelection(const AliDHFeCorr::AliElectro
         return kTRUE;
     if (!hasHitFirstLayer && hasHitSecondLayer && (requirement == kExclusiveSecond))
         return kTRUE;
-    if (hasHitFirstLayer && !hasHitSecondLayer && (requirement == kExclusiveFirst))
-        return kTRUE;
 
-    return kFALSE;
+    return hasHitFirstLayer && !hasHitSecondLayer && (requirement == kExclusiveFirst);
 }
 
-AliAnalysisTaskDHFeCorr *AliAnalysisTaskDHFeCorr::AddTask(const std::string &name, const std::string &config_file) {
+AliAnalysisTaskDHFeCorr *AliAnalysisTaskDHFeCorr::AddTask(const std::string &name,
+                                                          const std::string &config_file, Int_t trigger) {
     AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
     if (!mgr) {
         std::cout << "It was not possible to connect to the AnalysisManager. Returning null pointer." << std::endl;
@@ -1005,8 +1010,7 @@ AliAnalysisTaskDHFeCorr *AliAnalysisTaskDHFeCorr::AddTask(const std::string &nam
         std::cout << "Failed to configure the task. Please check the config file and error above." << std::endl;
         return nullptr;
     }
-
-    task->SelectCollisionCandidates(AliVEvent::kINT7);
+    task->SelectCollisionCandidates(trigger);
 
     mgr->AddTask(task);
 
@@ -1015,20 +1019,33 @@ AliAnalysisTaskDHFeCorr *AliAnalysisTaskDHFeCorr::AddTask(const std::string &nam
     std::string fileName = static_cast<std::string>(AliAnalysisManager::GetCommonFileName());
     fileName += ":DHFeCorrelation_" + name;
 
-    mgr->ConnectOutput(task, 1, mgr->CreateContainer("EventsQA", TList::Class(), AliAnalysisManager::kOutputContainer,
-                                                     fileName.c_str()));
-    mgr->ConnectOutput(task, 2, mgr->CreateContainer("ElectronQA", TList::Class(), AliAnalysisManager::kOutputContainer,
-                                                     fileName.c_str()));
-    mgr->ConnectOutput(task, 3, mgr->CreateContainer("DMesonQA", TList::Class(), AliAnalysisManager::kOutputContainer,
-                                                     fileName.c_str()));
-    mgr->ConnectOutput(task, 4,
+    mgr->ConnectOutput(task, 1,
                        mgr->CreateContainer("ElectronTree", TTree::Class(), AliAnalysisManager::kOutputContainer,
                                             fileName.c_str()));
-    mgr->ConnectOutput(task, 5, mgr->CreateContainer("DMesonTree", TTree::Class(), AliAnalysisManager::kOutputContainer,
+
+    mgr->ConnectOutput(task, 2, mgr->CreateContainer("DMesonTree", TTree::Class(), AliAnalysisManager::kOutputContainer,
                                                      fileName.c_str()));
 
-    mgr->ConnectOutput(task, 6, mgr->CreateContainer("EventTree", TTree::Class(), AliAnalysisManager::kOutputContainer,
+    mgr->ConnectOutput(task, 3, mgr->CreateContainer("EventTree", TTree::Class(), AliAnalysisManager::kOutputContainer,
                                                      fileName.c_str()));
+
+    mgr->ConnectOutput(task, 4, mgr->CreateContainer("EventsQA", TList::Class(), AliAnalysisManager::kOutputContainer,
+                                                     fileName.c_str()));
+
+    mgr->ConnectOutput(task, 5, mgr->CreateContainer("ElectronQA", TList::Class(), AliAnalysisManager::kOutputContainer,
+                                                     fileName.c_str()));
+
+    mgr->ConnectOutput(task, 6, mgr->CreateContainer("DMesonQA", TList::Class(), AliAnalysisManager::kOutputContainer,
+                                                     fileName.c_str()));
+
+    mgr->ConnectOutput(task, 7,
+                       mgr->CreateContainer("ElectronTreeMC", TTree::Class(), AliAnalysisManager::kOutputContainer,
+                                            fileName.c_str()));
+
+    mgr->ConnectOutput(task, 8,
+                       mgr->CreateContainer("DMesonTreeMC", TTree::Class(), AliAnalysisManager::kOutputContainer,
+                                            fileName.c_str()));
+
 
     return task;
 }
@@ -1045,8 +1062,12 @@ bool AliAnalysisTaskDHFeCorr::Configure(std::string config_file, std::string con
     //Read the global task settings
     fYAMLConfig.GetProperty("mc_mode", fIsMC, true);
     fYAMLConfig.GetProperty("calculate_only_efficiency", fIsEffMode, true);
-    fYAMLConfig.GetProperty("keep_all_candidates", fKeepAllCandidates, true);
     fYAMLConfig.GetProperty("reduced_electron_info", fReducedElectronInfo, true);
+
+    fYAMLConfig.GetProperty("process_electron", fProcessElectron, true);
+    fYAMLConfig.GetProperty("process_dmeson", fProcessDMeson, true);
+    fYAMLConfig.GetProperty("save_event", fSaveEvent, true);
+
 
     std::string meson_species;
     fYAMLConfig.GetProperty("d_meson_species", meson_species, true);
@@ -1059,9 +1080,6 @@ bool AliAnalysisTaskDHFeCorr::Configure(std::string config_file, std::string con
                 << exp.what() << std::endl;
         return false;
     }
-
-    if (!ConfigureEventSelection("event", fEventSelection))
-        return false;
 
     if (!ConfigureElectrons("main_electron", fElectronRequirements))
         return false;
@@ -1083,21 +1101,6 @@ bool AliAnalysisTaskDHFeCorr::Configure(std::string config_file, std::string con
     return true;
 }
 
-bool
-AliAnalysisTaskDHFeCorr::ConfigureEventSelection(const std::string &name,
-                                                 AliDHFeCorr::AliEventSelection &event_selection) {
-    std::cout << "Configuring event selection for: " << name << std::endl;
-
-    AliDHFeCorr::Utils::GetPropertyRange<Float_t>(fYAMLConfig, {name, "properties", "zvxt_range"},
-                                                  event_selection.fVertexZMin, event_selection.fVertexZMax, true);
-
-    fYAMLConfig.GetProperty({name, "multiplicity", "estimator"}, event_selection.fMultiEstimator, true);
-
-    AliDHFeCorr::Utils::GetPropertyRange<Float_t>(fYAMLConfig, {name, "multiplicity", "multiplicity_range"},
-                                                  event_selection.fMultMin, event_selection.fMultMax, true);
-    return true;
-
-}
 
 bool
 AliAnalysisTaskDHFeCorr::ConfigureElectrons(const std::string &name,
@@ -1125,8 +1128,8 @@ AliAnalysisTaskDHFeCorr::ConfigureElectrons(const std::string &name,
         return false;
     }
 
-    //min_TPC_cls
-    fYAMLConfig.GetProperty({name, "track", "min_TPC_cls"}, electron_selection.fTPCClsMin, true);
+    //min_TPC_crossedrows
+    fYAMLConfig.GetProperty({name, "track", "min_TPC_crossedrows"}, electron_selection.fNCrossedRowsTPCMin, true);
     //min_TPC_cls_dedx
     fYAMLConfig.GetProperty({name, "track", "min_TPC_cls_dedx"}, electron_selection.fTPCClsDeDxMin, true);
     //min_ITS_hits
@@ -1225,26 +1228,6 @@ bool AliAnalysisTaskDHFeCorr::ConfigureDMesonOpt(const std::string &name,
 }
 
 void AliAnalysisTaskDHFeCorr::Terminate(Option_t *) {}
-
-AliDHFeCorr::AliEventQAHistograms AliAnalysisTaskDHFeCorr::CreateQAEvents(const std::string &stage, TList &opt_list) {
-    AliDHFeCorr::AliEventQAHistograms qa_hists;
-
-    qa_hists.fNEvents = std::unique_ptr<TH1F>(new TH1F((std::string("NEvents_") + stage).c_str(),
-                                                       (std::string("NEvents_") + stage).c_str(),
-                                                       10, 0., 10.));
-    qa_hists.fVertexZ = std::unique_ptr<TH1F>(new TH1F((std::string("VertexZ_") + stage).c_str(),
-                                                       (std::string("VertexZ_") + stage).c_str(),
-                                                       120, -15., 15.));
-    qa_hists.fCentrality = std::unique_ptr<TH1F>(new TH1F((std::string("Centrality_") + stage).c_str(),
-                                                          (std::string("Centrality_") + stage).c_str(),
-                                                          120, -10, 110));
-
-    opt_list.Add(qa_hists.fNEvents.get());
-    opt_list.Add(qa_hists.fVertexZ.get());
-    opt_list.Add(qa_hists.fCentrality.get());
-
-    return qa_hists;
-}
 
 AliDHFeCorr::AliDMesonQAHistos
 AliAnalysisTaskDHFeCorr::CreateQADMeson(AliDHFeCorr::AliConfigureDMesonOpt config, const std::string &type_particle,
@@ -1378,5 +1361,146 @@ float AliAnalysisTaskDHFeCorr::GetMaxd0MeasMinusExp(AliAODRecoDecayHF *candidate
             d_d0_max = norm_dd0;
     }
     return d_d0_max;
+}
+
+void AliAnalysisTaskDHFeCorr::AddEventVariables(std::unique_ptr<TTree> &tree) {
+    tree->Branch("RunNumber", &fEventInfo.fRunNumber);
+    tree->Branch("EventNumber", &fEventInfo.fEventNumber);
+    tree->Branch("MultV0M", &fEventInfo.fMultV0M);
+    tree->Branch("MultiRefMult08", &fEventInfo.fMultiRefMult08);
+    tree->Branch("MultiSPDTracklets", &fEventInfo.fMultiSPDTracklets);
+    tree->Branch("MultV0MPercentile", &fEventInfo.fMultV0MPercentile);
+    tree->Branch("MultiRefMult08Percentile", &fEventInfo.fMultiRefMult08Percentile);
+    tree->Branch("MultiSPDTrackletsPercentile", &fEventInfo.fMultiSPDTrackletsPercentile);
+}
+
+
+void AliAnalysisTaskDHFeCorr::AddElectronVariables(std::unique_ptr<TTree> &tree) {
+    tree->Branch("RunNumber", &fElectron.fRunNumber);
+    tree->Branch("EventNumber", &fElectron.fEventNumber);
+
+    tree->Branch("Pt", &fElectron.fPt);
+    tree->Branch("Eta", &fElectron.fEta);
+    tree->Branch("Phi", &fElectron.fPhi);
+    tree->Branch("ID", &fElectron.fID);
+
+    if (!fReducedElectronInfo) {
+        tree->Branch("Charge", &fElectron.fCharge);
+        tree->Branch("P", &fElectron.fP);
+        tree->Branch("NCrossedRowsTPC", &fElectron.fNCrossedRowsTPC);
+        tree->Branch("NClsTPCDeDx", &fElectron.fNClsTPCDeDx);
+        tree->Branch("NITSCls", &fElectron.fNITSCls);
+        tree->Branch("ITSHitFirstLayer", &fElectron.fITSHitFirstLayer);
+        tree->Branch("ITSHitSecondLayer", &fElectron.fITSHitSecondLayer);
+        tree->Branch("DCAxy", &fElectron.fDCAxy);
+        tree->Branch("DCAz", &fElectron.fDCAz);
+        tree->Branch("TPCNSigma", &fElectron.fTPCNSigma);
+        tree->Branch("TOFNSigma", &fElectron.fTOFNSigma);
+        tree->Branch("InvMassPartnersULS", &fElectron.fInvMassPartnersULS);
+        tree->Branch("InvMassPartnersLS", &fElectron.fInvMassPartnersLS);
+        tree->Branch("PtPartnersULS", &fElectron.fPtPartnersULS);
+        tree->Branch("PtPartnersLS", &fElectron.fPtPartnersLS);
+        tree->Branch("CrossedRowsTPCPartnersULS", &fElectron.fCrossedRowsTPCPartnersULS);
+        tree->Branch("CrossedRowsTPCPartnersLS", &fElectron.fCrossedRowsTPCPartnersLS);
+    }
+}
+
+void AliAnalysisTaskDHFeCorr::AddDMesonVariables(std::unique_ptr<TTree> &tree,
+                                                 AliAnalysisTaskDHFeCorr::DMeson_t meson_species) {
+    //Event information
+    tree->Branch("RunNumber", &fDmeson.fRunNumber);
+    tree->Branch("EventNumber", &fDmeson.fEventNumber);
+    tree->Branch("ID", &fDmeson.fID);
+    tree->Branch("IsParticleCandidate", &fDmeson.fIsParticleCandidate);
+
+    //Basic information
+    tree->Branch("Pt", &fDmeson.fPt);
+    tree->Branch("Eta", &fDmeson.fEta);
+    tree->Branch("Phi", &fDmeson.fPhi);
+    tree->Branch("Y", &fDmeson.fY);
+    tree->Branch("InvMass", &fDmeson.fInvMass);
+    tree->Branch("ReducedChi2", &fDmeson.fReducedChi2);
+
+    //Topological information
+    tree->Branch("DecayLength", &fDmeson.fDecayLength);
+    tree->Branch("DecayLengthXY", &fDmeson.fDecayLengthXY);
+
+    tree->Branch("NormDecayLength", &fDmeson.fNormDecayLength);
+    tree->Branch("NormDecayLengthXY", &fDmeson.fNormDecayLengthXY);
+
+    tree->Branch("CosP", &fDmeson.fCosP);
+    tree->Branch("CosPXY", &fDmeson.fCosPXY);
+
+    tree->Branch("ImpParXY", &fDmeson.fImpParXY);
+    tree->Branch("DCA", &fDmeson.fDCA);
+
+    tree->Branch("Normd0MeasMinusExp", &fDmeson.fNormd0MeasMinusExp);
+    tree->Branch("PtDaughter", &fDmeson.fPtDaughters);
+    tree->Branch("D0Daughter", &fDmeson.fD0Daughters);
+
+    tree->Branch("IDDaughters", &fDmeson.fIDDaughters);
+
+    //PID
+    tree->Branch("SelectionStatusDefaultPID", &fDmeson.fSelectionStatusDefaultPID);
+
+    tree->Branch("NSigmaTPCDaughters0", &(fDmeson.fNSigmaTPCDaughters[0]));
+    tree->Branch("NSigmaTPCDaughters1", &(fDmeson.fNSigmaTPCDaughters[1]));
+
+    tree->Branch("NSigmaTOFDaughters0", &(fDmeson.fNSigmaTOFDaughters[0]));
+    tree->Branch("NSigmaTOFDaughters1", &(fDmeson.fNSigmaTOFDaughters[1]));
+
+    //Meson depended variables
+    switch (meson_species) {
+        case AliAnalysisTaskDHFeCorr::kD0: {
+            tree->Branch("CosTs", &fDmeson.fCosTs);
+        }
+            break;
+        case AliAnalysisTaskDHFeCorr::kDplus: {
+            tree->Branch("SigmaVertex", &fDmeson.fSigmaVertex);
+            tree->Branch("NSigmaTPCDaughters2", &(fDmeson.fNSigmaTPCDaughters[2]));
+            tree->Branch("NSigmaTOFDaughters2", &(fDmeson.fNSigmaTOFDaughters[2]));
+        }
+            break;
+        case AliAnalysisTaskDHFeCorr::kDstar: {
+            tree->Branch("AngleD0dkpPisoft", &fDmeson.fAngleD0dkpPisoft);
+            tree->Branch("CosTs", &fDmeson.fCosTs);
+        }
+            break;
+    }
+}
+
+void AliAnalysisTaskDHFeCorr::AddElectronMCVariables(std::unique_ptr<TTree> &tree) {
+    tree->Branch("PtMC", &fElectron.fPtMC);
+    tree->Branch("Label", &fElectron.fLabel);
+    tree->Branch("Origin", &fElectron.fOrigin);
+    tree->Branch("FirstMotherPDG", &fElectron.fFirstMotherPDG);
+    tree->Branch("FirstMotherPt", &fElectron.fFirstMotherPt);
+    tree->Branch("SecondMotherPDG", &fElectron.fSecondMotherPDG);
+    tree->Branch("SecondMotherPt", &fElectron.fSecondMotherPt);
+}
+
+void AliAnalysisTaskDHFeCorr::AddMCTreeVariables(std::unique_ptr<TTree> &tree) {
+    tree->Branch("RunNumber", &fMCParticle.fRunNumber);
+    tree->Branch("EventNumber", &fMCParticle.fEventNumber);
+    tree->Branch("Label", &fMCParticle.fLabel);
+    tree->Branch("E", &fMCParticle.fE);
+    tree->Branch("Pt", &fMCParticle.fPt);
+    tree->Branch("Eta", &fMCParticle.fEta);
+    tree->Branch("Phi", &fMCParticle.fPhi);
+    tree->Branch("Xv", &fMCParticle.fXv);
+    tree->Branch("Yv", &fMCParticle.fYv);
+    tree->Branch("Zv", &fMCParticle.fZv);
+    tree->Branch("Tv", &fMCParticle.fTv);
+    tree->Branch("Charge", &fMCParticle.fCharge);
+    tree->Branch("PDGCode", &fMCParticle.fPDGCode);
+    tree->Branch("fOrigin", &fMCParticle.fOrigin);
+}
+
+void AliAnalysisTaskDHFeCorr::AddDMesonMCVariables(std::unique_ptr<TTree> &tree) {
+    tree->Branch("PtMC", &fDmeson.fPtMC);
+    tree->Branch("Label", &fDmeson.fLabel);
+    tree->Branch("IsD", &fDmeson.fIsD);
+    tree->Branch("IsParticle", &fDmeson.fIsParticle);
+    tree->Branch("IsPrompt", &fDmeson.fIsPrompt);
 }
 

--- a/PWGHF/correlationHF/AliAnalysisTaskDHFeCorr.h
+++ b/PWGHF/correlationHF/AliAnalysisTaskDHFeCorr.h
@@ -10,12 +10,7 @@
  *
  * The configuration is done using a yaml file. The following parameters can be adjusted:
  *
- * -# Event selection: corresponds to the yaml parameter 'event'. All the selected events use the trigger kINT7 for
- * the moment.
- *   - Vertex Z: corresponds to the yaml parameter 'zvxt_range'. The value should of the format [min,max].
- *   - Multiplicity: corresponds to the yaml parameters 'estimator' and 'multiplicity_range'. The value of 'estimator'
- *   should be also defined added to AliAnalysisTaskDHFeCorr::fgkMultiplicityEstimators. The values allowed are set
- * using 'multiplicity_range' in the format [min,max].
+ * -# Event selection: Only default event selection for period used. Obtained from AliEventCuts.
  *
  * -# D-meson selection: corresponds to the yaml parameter 'D_meson' and the sub parameter 'selection'. The cuts are
  * implemented in the standard D-meson selection framework, with the AliRDHFCuts as the base class.
@@ -43,8 +38,8 @@
  *     AliAnalysisTaskDHFeCorr::ITSPixel_t
  *     - The DCA maximum values can be set using 'dca_z' and 'dca_xy'
  *   - Particle identification, under 'PID' sub parameter
- *     - TPC N sigma selection: set the maximun and minimum with 'TPC_selection'
- *     - TOF N sigma selection: set the maximun and minimum with 'TOF_selection'. It can be turned on and off by
+ *     - TPC N sigma selection: set the maximum and minimum with 'TPC_selection'
+ *     - TOF N sigma selection: set the maximum and minimum with 'TOF_selection'. It can be turned on and off by
  *     'require_TOF'.
  */
 #ifndef AliAnalysisTaskDHFeCorr_H
@@ -65,9 +60,14 @@
 #include "AliYAMLConfiguration.h"
 #include "AliRDHFCuts.h"
 #include "AliAODRecoDecayHF.h"
+#include "AliEventCuts.h"
 
+//Forward declarations
 class TClonesArray;
 
+class AliAODMCParticle;
+
+// STD includes
 #include <vector>
 #include <memory>
 #include <string>
@@ -76,62 +76,79 @@ class TClonesArray;
 namespace AliDHFeCorr {
 
     typedef struct AliDMeson {
-        public:
-            AliAODRecoDecayHF *fRecoObj{nullptr};
-            Int_t fRunNumber{0}; ///<PID of the grid job used to create the tree
-            Int_t fEventNumber{0}; ///< Number of the event
-            UInt_t fID{0}; ///< D meson id in the event
-            Bool_t fIsParticleCandidate{kFALSE}; ///< Particle hypotheses at reconstruction level
+    public:
+        AliAODRecoDecayHF *fRecoObj{nullptr};
+        Int_t fRunNumber{0}; ///<PID of the grid job used to create the tree
+        Int_t fEventNumber{0}; ///< Number of the event
+        UInt_t fID{0}; ///< D meson id in the event
+        Bool_t fIsParticleCandidate{kFALSE}; ///< Particle hypotheses at reconstruction level
+        UInt_t fLabel{0};
 
-            //Basic Information
-            Float_t fPt{-999.};
-            Float_t fEta{-999.};
-            Float_t fPhi{-999.};
-            Float_t fY{-999.};
-            Float_t fInvMass{0.};
-            Float_t fReducedChi2{-999.};
+        //Basic Information
+        Float_t fPt{-999.};
+        Float_t fEta{-999.};
+        Float_t fPhi{-999.};
+        Float_t fY{-999.};
+        Float_t fInvMass{0.};
+        Float_t fReducedChi2{-999.};
 
-            // Topologic information
-            Float_t fDecayLength{-999.};
-            Float_t fDecayLengthXY{-999.};
+        // Topologic information
+        Float_t fDecayLength{-999.};
+        Float_t fDecayLengthXY{-999.};
 
-            Float_t fNormDecayLength{-999.};
-            Float_t fNormDecayLengthXY{-999.};
+        Float_t fNormDecayLength{-999.};
+        Float_t fNormDecayLengthXY{-999.};
 
-            Float_t fCosP{-999.};
-            Float_t fCosPXY{-999.};
+        Float_t fCosP{-999.};
+        Float_t fCosPXY{-999.};
 
-            Float_t fImpParXY{-999.};
-            Float_t fDCA{-999.};
+        Float_t fImpParXY{-999.};
+        Float_t fDCA{-999.};
 
-            //D0 and D+, D*+ shared information
-            Float_t fNormd0MeasMinusExp{-999.};
-            UChar_t fSelectionStatusDefaultPID{99}; ///< Default PID selection status
+        //D0 and D+, D*+ shared information
+        Float_t fNormd0MeasMinusExp{-999.};
+        UChar_t fSelectionStatusDefaultPID{99}; ///< Default PID selection status
 
-            //D0 information (also used by the D*, since it has a D0)
-            Float_t fCosTs{-999.};
+        //D0 information (also used by the D*, since it has a D0)
+        Float_t fCosTs{-999.};
 
-            //D+ information
-            Float_t fSigmaVertex{-999.};
+        //D+ information
+        Float_t fSigmaVertex{-999.};
 
-            //D* information
-            Float_t fAngleD0dkpPisoft{-999.};
+        //D* information
+        Float_t fAngleD0dkpPisoft{-999.};
 
-            //Single-track information
-            std::vector<Float_t> fPtDaughters;
-            std::vector<Float_t> fD0Daughters;
-            std::vector<UInt_t> fIDDaughters; ///< ID obtained using GetID()
+        //Single-track information
+        std::vector<Float_t> fPtDaughters;
+        std::vector<Float_t> fD0Daughters;
+        std::vector<UInt_t> fIDDaughters; ///< ID obtained using GetID()
 
-            std::array<std::vector<Float_t>, 3> fNSigmaTPCDaughters; ///< The PID TPC response (n )sigma
-            std::array<std::vector<Float_t>, 3> fNSigmaTOFDaughters; ///< The PID TOF response (n sigma)
+        std::array<std::vector<Float_t>, 3> fNSigmaTPCDaughters; ///< The PID TPC response (n )sigma
+        std::array<std::vector<Float_t>, 3> fNSigmaTOFDaughters; ///< The PID TOF response (n sigma)
 
-            //MC Level information
-            Float_t fPtMC{-999.};///< Transverse momentum (MC information)
-            Bool_t fIsD{kFALSE}; // Is it signal or background? (MC information)
-            Bool_t fIsParticle{kFALSE}; //is it a D0 or D0bar? (MC information)
-            Bool_t fIsPrompt{kFALSE}; // Does it comes from charm? (MC information)
+        //MC Level information
+        Float_t fPtMC{-999.};///< Transverse momentum (MC information)
+        Bool_t fIsD{kFALSE}; // Is it signal or background? (MC information)
+        Bool_t fIsParticle{kFALSE}; //is it a D0 or D0bar? (MC information)
+        Bool_t fIsPrompt{kFALSE}; // Does it comes from charm? (MC information)
 
     } AliDMeson;
+
+    typedef struct AliEvent {
+        UInt_t fRunNumber{0};
+        UInt_t fEventNumber{0};
+
+        Float_t fVtxZ{-999.};
+
+        Float_t fMultV0M{-999.};
+        Float_t fMultiRefMult08{-999.};
+        Float_t fMultiSPDTracklets{-999.};
+
+        Float_t fMultV0MPercentile{-999.};
+        Float_t fMultiRefMult08Percentile{-999.};
+        Float_t fMultiSPDTrackletsPercentile{-999.};
+
+    } AliEvent;
 
     typedef struct AliElectron {
     public:
@@ -147,7 +164,7 @@ namespace AliDHFeCorr {
         Float_t fEta{-999.};
         Float_t fPhi{-999.};
 
-        UShort_t fNClsTPC{999};
+        UShort_t fNCrossedRowsTPC{999};
         UShort_t fNClsTPCDeDx{999};
         UChar_t fNITSCls{99};
 
@@ -159,16 +176,24 @@ namespace AliDHFeCorr {
         Float_t fTPCNSigma{-999.};
         Float_t fTOFNSigma{-999.};
 
+        //Partner variables
         std::vector<Float_t> fInvMassPartnersULS; //mass of the ULS partners
         std::vector<Float_t> fInvMassPartnersLS; //mass of the LS partners
+        std::vector<Float_t> fPtPartnersULS; //Pt of the ULS partners
+        std::vector<Float_t> fPtPartnersLS; //Pt of the LS partners
+        std::vector<UShort_t> fCrossedRowsTPCPartnersULS; //Pt of the LS partners
+        std::vector<UShort_t> fCrossedRowsTPCPartnersLS; //Pt of the LS partners
+
+
         std::vector<UInt_t> fPartnersULSID; //unique ID of the ULS partners
         std::vector<UInt_t> fPartnersLSID; //unique ID of the LS partners
 
         //MC information
+        UInt_t fLabel{0};
         Float_t fPtMC{-999.};
         Float_t fPhiMC{-999.};
         Float_t fEtaMC{-999.};
-        Char_t fOrigin{0}; // track origin from AliVertexingHFUtils::CheckOrigin
+        UShort_t fOrigin{0}; // track origin from AliVertexingHFUtils::CheckOrigin
         Int_t fPDG{0};
 
         Int_t fFirstMotherPDG{0};
@@ -179,15 +204,28 @@ namespace AliDHFeCorr {
 
     } AliElectron;
 
-    //Structs to hold the selection values ("cuts")
-    typedef struct AliEventSelection {
-        Float_t fVertexZMin{-10.};
-        Float_t fVertexZMax{10.};
+    typedef struct AliParticleMC {
+        AliAODMCParticle *fMCParticle{nullptr};
+        UInt_t fRunNumber{0};
+        UInt_t fEventNumber{0};
 
-        Float_t fMultMin{0.};
-        Float_t fMultMax{101.};
-        std::string fMultiEstimator = "VOM";
-    } AliEventSelection;
+        UInt_t fLabel{0};
+
+        Float_t fE{-999.};
+        Float_t fPt{-999.};
+        Float_t fEta{-999.};
+        Float_t fPhi{-999.};
+
+        Float_t fXv{-999.};
+        Float_t fYv{-999.};
+        Float_t fZv{-999.};
+        Float_t fTv{-999.};
+
+        Char_t fCharge{99};
+        Int_t fPDGCode{-999};
+        UShort_t fOrigin{99};
+
+    } AliParticleMC;
 
     typedef struct AliElectronSelection {
         //Track selection
@@ -198,7 +236,7 @@ namespace AliDHFeCorr {
 
         AliAODTrack::AODTrkFilterBits_t fFilterBit{AliAODTrack::kTrkGlobalNoDCA};
 
-        Int_t fTPCClsMin{0};
+        Int_t fNCrossedRowsTPCMin{0};
         Int_t fTPCClsDeDxMin{0};
         Int_t fITSClsMin{0};
 
@@ -217,7 +255,7 @@ namespace AliDHFeCorr {
     } AliElectronSelection;
 
     typedef struct AliPhotonSelection {
-        Float_t fInvMassMax{0.3};
+        Float_t fInvMassMax{0.2};
         Float_t fReducedChi2Max{3.};
     } AliPhotonSelection;
 
@@ -229,12 +267,6 @@ namespace AliDHFeCorr {
     } AliDMesonSelection;
 
     //Structs to hold QA plots
-    typedef struct AliEventQAHistograms {
-        std::unique_ptr<TH1F> fNEvents;
-        std::unique_ptr<TH1F> fVertexZ;
-        std::unique_ptr<TH1F> fCentrality;
-
-    } AliEventQAHistograms;
 
     typedef struct AliElectronQAHistograms {
         //Tracking
@@ -342,7 +374,8 @@ public:
     virtual ~AliAnalysisTaskDHFeCorr() = default;
 
     static AliAnalysisTaskDHFeCorr *AddTask(const std::string &name = "DHFeCorrelation",
-                                            const std::string &config_file = "$ALICE_PHYSICS/PWGHF/correlationHF/macros/default_config_d_hfe.yaml");
+                                            const std::string &config_file = "$ALICE_PHYSICS/PWGHF/correlationHF/macros/default_config_d_hfe.yaml",
+                                            Int_t trigger = AliVEvent::kINT7);
 
     virtual void UserCreateOutputObjects();
 
@@ -407,7 +440,16 @@ public:
     bool Configure(std::string config_file, std::string config_name = "custom_config",
                    std::string default_file = "$ALICE_PHYSICS/PWGHF/correlationHF/macros/default_config_d_hfe.yaml");
 
+    bool isFSaveHistograms() const {
+        return fSaveHistograms;
+    }
+
+    bool isFIsMc() const {
+        return fIsMC;
+    }
+
 private:
+    //Output variables that will be saved to the ROOT file
     TList fOptEvent; ///< List with histograms from the event QA
     TList fOptElectron; ///< List with with histograms from the electron QA
     TList fOptDMeson; ///< List with with histograms from the D meson QA
@@ -416,28 +458,62 @@ private:
     std::unique_ptr<TTree> fElectronTree; ///< Tree with the electron information
     std::unique_ptr<TTree> fDmesonTree; ///< Tree with the D meson information
 
-    std::string fCurrentFile;
+    std::unique_ptr<TTree> fElectronTreeMC; ///< Tree with the MC electron information
+    std::unique_ptr<TTree> fDmesonTreeMC; ///< Tree with the MC D meson information
 
+    //Event Properties. Create a new struct?
     UInt_t fRunNumber{0}; ///< Run number
     UInt_t fEventNumber{0}; ///< Unique number for each event
-    int fDirNum{-1};
 
     Float_t fVtxZ{-999.}; ///< Vertex Z
-    Float_t fCentrality{-1.}; ///< Centrality
+    Float_t fCentrality{-999.};
 
+
+    //Values used to determine the unique event ID
+    int fDirNum{-1};
+    std::string fCurrentFile;
+
+    //Stores the current electron and D meson to save in the tree
     AliDHFeCorr::AliElectron fElectron; ///< Electron information that will be used in the fElectronTree
     AliDHFeCorr::AliDMeson fDmeson;///< D meson information that will be used in the fDmesonTree
+    AliDHFeCorr::AliParticleMC fMCParticle; ////<  Used to hold data about the MC information (D and e)
+    AliDHFeCorr::AliEvent fEventInfo; ////<  Used to hold data about the Event
 
+
+    //Task Configuration
     bool fIsMC{false}; ///< Flag for MC analysis
+    bool fSaveHistograms{false}; ///< Set false to produce only trees (usefull to save space)
     bool fIsEffMode{false}; ///< Fills only the trees with true D mesons and electrons
-    bool fKeepAllCandidates{true}; ///< Keep all candidates (even if no electron is present)
+
+    bool fProcessElectron{true};
+    bool fProcessDMeson{true};
+    bool fSaveEvent{true};
+
     bool fReducedElectronInfo{false}; ///< Keep only basic information (pt, eta, phi)
+
     DMeson_t fDmesonSpecies{kD0}; ///< The D meson species (D0, D+ or D*)
+
+    AliEventCuts fEventCuts;
+
+    AliDHFeCorr::AliElectronSelection fElectronRequirements; ///< Electron selection configuration
+    AliDHFeCorr::AliElectronSelection fPartnerElectronRequirements; ///< Partner selection configuration
+    AliDHFeCorr::AliConfigureElectronOpt fElectronOptConfig; ///< Electron output (histograms) configuration
+
+    AliDHFeCorr::AliPhotonSelection fPhotonSelection; //<< Photon (electron pair) selection configuration
+
+    AliDHFeCorr::AliDMesonSelection fDMesonRequirements; ///< Electron selection configuration
+    AliDHFeCorr::AliConfigureDMesonOpt fDMesonOptConfig; ///< Electron output (histograms) configuration
+
+    AliDHFeCorr::AliElectronQAHistograms fElectronQABeforeCuts; //! QA histograms for electrons before the selection
+    AliDHFeCorr::AliElectronQAHistograms fElectronQAAfterTrackCuts; //! QA histograms for electrons before the selection
+    AliDHFeCorr::AliElectronQAHistograms fElectronQAAfterCuts;  //! QA histograms for electrons after the selection
+
+    AliDHFeCorr::AliDMesonQAHistos fDMesonQABeforeCuts; //! QA histograms for D mesons before the selection
+    AliDHFeCorr::AliDMesonQAHistos fDMesonQAAfterCuts;  //! QA histograms for D mesons before the selection
+
 
     //YAML configuration
     PWG::Tools::AliYAMLConfiguration fYAMLConfig; //<< YAML config object, used to set the parameters of the task
-
-    bool ConfigureEventSelection(const std::string &name, AliDHFeCorr::AliEventSelection &event_selection);
 
     bool ConfigureElectrons(const std::string &name, AliDHFeCorr::AliElectronSelection &electron_selection);
 
@@ -451,6 +527,7 @@ private:
 
     void CheckConfiguration() const;
 
+    //Tree creation
     void AddEventVariables(std::unique_ptr<TTree> &tree);
 
     void AddElectronVariables(std::unique_ptr<TTree> &tree);
@@ -461,30 +538,8 @@ private:
 
     void AddDMesonMCVariables(std::unique_ptr<TTree> &tree);
 
-    AliDHFeCorr::AliEventSelection fEventSelection; ///<< Event selection configuration
+    void AddMCTreeVariables(std::unique_ptr<TTree> &tree);
 
-    AliDHFeCorr::AliElectronSelection fElectronRequirements; ///<< Electron selection configuration
-    AliDHFeCorr::AliElectronSelection fPartnerElectronRequirements; ///<< Partner selection configuration
-    AliDHFeCorr::AliConfigureElectronOpt fElectronOptConfig; ///<< Electron output (histograms) configuration
-
-    AliDHFeCorr::AliPhotonSelection fPhotonSelection; //<< Photon (electron pair) selection configuration
-
-    AliDHFeCorr::AliDMesonSelection fDMesonRequirements; ///<< Electron selection configuration 
-    AliDHFeCorr::AliConfigureDMesonOpt fDMesonOptConfig; ///<< Electron output (histograms) configuration
-
-    //QA histograms
-    AliDHFeCorr::AliEventQAHistograms fEventQABeforeCuts; //! QA histograms for events before the selection
-    AliDHFeCorr::AliEventQAHistograms fEventQAAfterCuts; //! QA histograms for events after the selection
-
-    AliDHFeCorr::AliElectronQAHistograms fElectronQABeforeCuts; //! QA histograms for electrons before the selection
-    AliDHFeCorr::AliElectronQAHistograms fElectronQAAfterTrackCuts; //! QA histograms for electrons before the selection
-    AliDHFeCorr::AliElectronQAHistograms fElectronQAAfterCuts;  //! QA histograms for electrons after the selection
-
-    AliDHFeCorr::AliDMesonQAHistos fDMesonQABeforeCuts; //! QA histograms for D mesons before the selection
-    AliDHFeCorr::AliDMesonQAHistos fDMesonQAAfterCuts;  //! QA histograms for D mesons before the selection
-
-    //Functions for the QA
-    static AliDHFeCorr::AliEventQAHistograms CreateQAEvents(const std::string &stage, TList &opt_list);
 
     static AliDHFeCorr::AliElectronQAHistograms CreateQAElectrons(AliDHFeCorr::AliConfigureElectronOpt config,
                                                                   const std::string &type_particle,
@@ -494,48 +549,58 @@ private:
     CreateQADMeson(AliDHFeCorr::AliConfigureDMesonOpt config, const std::string &type_particle,
                    const std::string &stage, TList &opt_list);
 
-    void FillEventQA(AliDHFeCorr::AliEventQAHistograms &histograms);
-
-    void FillElectronQA(const std::vector<AliDHFeCorr::AliElectron> &tracks,
-                        AliDHFeCorr::AliElectronQAHistograms &histograms);
+    static void FillElectronQA(const std::vector<AliDHFeCorr::AliElectron> &tracks,
+                               AliDHFeCorr::AliElectronQAHistograms &histograms);
 
     static void FillDmesonQA(const std::vector<AliDHFeCorr::AliDMeson> &d_mesons,
                              AliDHFeCorr::AliDMesonQAHistos &histogram, DMeson_t meson_species);
 
-    void SetRunAndEventNumber();
 
-    void PostOutput(); //< Function to post the data
-
+    //
     static float GetMaxd0MeasMinusExp(AliAODRecoDecayHF *candidate, float b_field);
 
     static std::vector<Float_t> MakeBins(Float_t start, Float_t end, Int_t n_bins);
 
+
+    //Functions used to control the flow of the task
+    void SetRunAndEventNumber();
+
+    void PostOutput(); //< Function to post the data
+
     //Analysis steps
+
+    AliDHFeCorr::AliEvent EventInfo();
+
+    //Electron Analysis
     std::vector<AliDHFeCorr::AliElectron> ElectronAnalysis();
-
-    std::vector<AliDHFeCorr::AliDMeson> DMesonAnalysis();
-
-    //Select Events
-    bool IsSelectedEvent(AliAODEvent *event, const AliDHFeCorr::AliEventSelection &selection);
-
-    //Filter Electrons, Partner Electrons
-    static bool FulfilPixelSelection(const AliDHFeCorr::AliElectron &track, Int_t requirement);
 
     void FillElectronInformation(std::vector<AliDHFeCorr::AliElectron> &electrons);
 
-    std::vector<AliDHFeCorr::AliElectron>
+    static bool FulfilPixelSelection(const AliDHFeCorr::AliElectron &track, Int_t requirement);
+
+    static std::vector<AliDHFeCorr::AliElectron>
     FilterElectronsTracking(AliDHFeCorr::AliElectronSelection electronSelection,
                             const std::vector<AliDHFeCorr::AliElectron> &electrons);
 
-    std::vector<AliDHFeCorr::AliElectron> FilterElectronsPID(AliDHFeCorr::AliElectronSelection electronSelection,
-                                                             const std::vector<AliDHFeCorr::AliElectron> &electrons);
+    static std::vector<AliDHFeCorr::AliElectron> FilterElectronsPID(AliDHFeCorr::AliElectronSelection electronSelection,
+                                                                    const std::vector<AliDHFeCorr::AliElectron> &electrons);
 
-    void FillElectronMCInfo(std::vector<AliDHFeCorr::AliElectron> &electrons);
+    void FillAllElectronsMCInfo(std::vector<AliDHFeCorr::AliElectron> &electrons);
 
-    //Filter D mesons
-    std::vector<AliDHFeCorr::AliDMeson>
-    FillDMesonInfo(const TClonesArray *dmeson_candidates, DMeson_t meson_species,
-                   AliDHFeCorr::AliDMesonSelection &dmeson_selection) const;
+    void FindNonHFe(AliDHFeCorr::AliElectron &main_electron,
+                    const std::vector<AliDHFeCorr::AliElectron> &partners) const;
+
+    std::vector<AliDHFeCorr::AliParticleMC> FindHFParticleInMC(int pdg);
+
+    static bool IsHFe(AliAODMCParticle *particle, TClonesArray *mc_information);
+
+    std::vector<AliDHFeCorr::AliParticleMC> FilterHFeInMCParticles(std::vector<AliDHFeCorr::AliParticleMC> &electrons);
+
+    //DMeson analysis
+    std::vector<AliDHFeCorr::AliDMeson> DMesonAnalysis();
+
+    std::vector<AliDHFeCorr::AliDMeson> FillDMesonInfo(const TClonesArray *dmeson_candidates, DMeson_t meson_species,
+                                                       AliDHFeCorr::AliDMesonSelection &dmeson_selection) const;
 
     void FillDmesonMCInfo(std::vector<AliDHFeCorr::AliDMeson> &d_mesons,
                           AliAnalysisTaskDHFeCorr::DMeson_t meson_species) const;
@@ -546,17 +611,22 @@ private:
     FilterDmesons(const std::vector<AliDHFeCorr::AliDMeson> &dmeson_candidates,
                   const AliDHFeCorr::AliDMesonSelection &selectionDMeson, AliAODEvent *aod_event, int pdg_dmeson);
 
-    //Select ULS and LS pairs
-    void
-    FindNonHFe(AliDHFeCorr::AliElectron &main_electron, const std::vector<AliDHFeCorr::AliElectron> &partners) const;
+    template<typename T>
+    void FillTreeFromStdContainer(std::vector<T> &items, T *item_to_fill, std::unique_ptr<TTree> &tree);
 
-    //Save to tree
-    void FillElectronTree(const std::vector<AliDHFeCorr::AliElectron> &tracks);
 
-    void FillDMesonTree(const std::vector<AliDHFeCorr::AliDMeson> &d_mesons);
-
-ClassDef(AliAnalysisTaskDHFeCorr, 2);
+ClassDef(AliAnalysisTaskDHFeCorr, 4);
 
 };
+
+template<class T>
+void AliAnalysisTaskDHFeCorr::FillTreeFromStdContainer(std::vector<T> &items, T *item_to_fill,
+                                                       std::unique_ptr<TTree> &tree) {
+
+    for (const auto &item: items) {
+        *item_to_fill = item;
+        tree->Fill();
+    }
+}
 
 #endif

--- a/PWGHF/correlationHF/macros/AddTaskDHFeCorr.C
+++ b/PWGHF/correlationHF/macros/AddTaskDHFeCorr.C
@@ -1,6 +1,6 @@
 #include "AliAnalysisTaskDHFeCorr.h"
 #include <string>
 
-AliAnalysisTaskDHFeCorr* AddTaskDHFeCorr(std::string name, std::string config_file){
-    return AliAnalysisTaskDHFeCorr::AddTask(name,config_file);
+AliAnalysisTaskDHFeCorr *AddTaskDHFeCorr(std::string name, std::string config_file, Int_t trigger = AliVEvent::kINT7) {
+    return AliAnalysisTaskDHFeCorr::AddTask(name, config_file, trigger);
 }

--- a/PWGHF/correlationHF/macros/default_config_d_hfe.yaml
+++ b/PWGHF/correlationHF/macros/default_config_d_hfe.yaml
@@ -1,7 +1,12 @@
 # General task configuration
 mc_mode: false
 calculate_only_efficiency: false #ignore background, saves space in MC
-keep_all_candidates: true #ignores the requirement of having both D meson and electron in the same event
+
+process_electron: true
+process_dmeson: true
+save_event: true
+
+
 reduced_electron_info: false #saves only Pt, Eta and Phi
 
 d_meson_species: 'D0'
@@ -25,7 +30,7 @@ main_electron:
         pt_range: [0.5,10.0]
         eta_range: [-0.8,0.8] 
         filter_bit: kTrkGlobal #as defined in AliAODTrack
-        min_TPC_cls: 70
+        min_TPC_crossedrows: 0
         min_TPC_cls_dedx: 0
         min_ITS_hits: 2
         pixel_req: kAny #check possibilities in AliAnalysisTaskDHFeCorr::ITSPixel_t
@@ -38,10 +43,10 @@ main_electron:
 
 partner_electron:
     track:
-        pt_range: [0.2,100.0]
+      pt_range: [0.15,100.0]
         eta_range: [-0.8,0.8] 
         filter_bit: kTrkGlobalNoDCA #as defined in AliAODTrack
-        min_TPC_cls: 60
+      min_TPC_crossedrows: 0
         min_TPC_cls_dedx: 0
         min_ITS_hits: 2
         pixel_req: kAny #check possibilities in AliAnalysisTaskDHFeCorr::ITSPixel_t


### PR DESCRIPTION
The following things were included:
- Save MC information at generated level for HFe and D mesons.
- Added possibility to turn on/off the processing of D, electrons and events
- Added more information for the Events
- Removed TPC N clusters in favor of TPC crossed rows for electrons
- Change event selection to use AliEventCuts
- Added variables for systematics of NHFe subtraction
- Optimised some of the default values to reduce size
