### PR TITLE
AO2d links from event array to lower hierarchy arrays

### DIFF
--- a/RUN3/AliAnalysisTaskAO2Dconverter.cxx
+++ b/RUN3/AliAnalysisTaskAO2Dconverter.cxx
@@ -150,7 +150,11 @@ void AliAnalysisTaskAO2Dconverter::UserCreateOutputObjects()
   TTree* tEvents = CreateTree(kEvents);
   tEvents->SetAutoFlush(fNumberOfEventsPerCluster);
   if (fTreeStatus[kEvents]) {
+    TString sstart = TString::Format("fStart[%d]/I", kTrees);
+    TString sentries = TString::Format("fNentries[%d]/I", kTrees);
     tEvents->Branch("fRunNumber", &vtx.fRunNumber, "fRunNumber/I");
+    tEvents->Branch("fStart", vtx.fStart, sstart.Data());
+    tEvents->Branch("fNentries", vtx.fNentries, sentries.Data());
     tEvents->Branch("fEventId", &vtx.fEventId, "fEventId/l");
     tEvents->Branch("fX", &vtx.fX, "fX/F");
     tEvents->Branch("fY", &vtx.fY, "fY/F");
@@ -183,6 +187,8 @@ void AliAnalysisTaskAO2Dconverter::UserCreateOutputObjects()
   tTracks->SetAutoFlush(fNumberOfEventsPerCluster);
   if (fTreeStatus[kTracks]) {
     tTracks->Branch("fCollisionsID", &tracks.fCollisionsID, "fCollisionsID/I");
+//    tTracks->Branch("fTOFclsIndex", &tracks.fTOFclsIndex, "fTOFclsIndex/I");
+//    tTracks->Branch("fNTOFcls", &tracks.fNTOFcls, "fNTOFcls/I");
     tTracks->Branch("fX", &tracks.fX, "fX/F");
     tTracks->Branch("fAlpha", &tracks.fAlpha, "fAlpha/F");
     tTracks->Branch("fY", &tracks.fY, "fY/F");
@@ -256,6 +262,8 @@ void AliAnalysisTaskAO2Dconverter::UserCreateOutputObjects()
   tMuon->SetAutoFlush(fNumberOfEventsPerCluster);
   if (fTreeStatus[kMuon]) {
     tMuon->Branch("fCollisionsID", &muons.fCollisionsID, "fCollisionsID/I");
+//    tMuon->Branch("fClusterIndex", &muons.fClusterIndex, "fClusterIndex/I");
+//    tMuon->Branch("fNclusters", &muons.fNclusters, "fNclusters/I");
     tMuon->Branch("fInverseBendingMomentum", &muons.fInverseBendingMomentum, "fInverseBendingMomentum/F");
     tMuon->Branch("fThetaX", &muons.fThetaX, "fThetaX/F");
     tMuon->Branch("fThetaY", &muons.fThetaY, "fThetaY/F");
@@ -742,7 +750,7 @@ void AliAnalysisTaskAO2Dconverter::UserExec(Option_t *)
 
     // In case we need connection to clusters, activate next lines
     // muons.fClusterIndex += muons.fNclusters;
-    // muons.muons.fNclusters = nmucl_filled;
+    // muons.fNclusters = nmucl_filled;
 
     FillTree(kMuon);
     if (fTreeStatus[kMuon]) nmu_filled++;

--- a/RUN3/AliAnalysisTaskAO2Dconverter.h
+++ b/RUN3/AliAnalysisTaskAO2Dconverter.h
@@ -105,6 +105,10 @@ private:
   // Data structures
 
   struct {
+    // Start indices and numbers of elements for data in the other trees matching this vertex.
+    // Needed for random access of collision-related data, allowing skipping data discarded by the user
+    Int_t     fStart[kTrees]    = {0}; /// Start entry indices for data in the other trees matching this vertex
+    Int_t     fNentries[kTrees] = {0}; /// Numbers of entries for data in the other trees matching this vertex
     // Event data
     Int_t     fRunNumber;       /// Run Number (added in case of multirun skimming)
     ULong64_t fEventId = 0u;    /// Event (collision) unique id. Contains period, orbit and bunch crossing numbers
@@ -135,6 +139,9 @@ private:
     // Track data
 
     Int_t   fCollisionsID;    /// The index of the collision vertex in the TF, to which the track is attached
+    // In case we need connection to TOF clusters, activate next lines
+    // Int_t   fTOFclsIndex;     /// The index of the associated TOF cluster
+    // Int_t   fNTOFcls;         /// The number of TOF clusters
 
     // Coordinate system parameters
     Float_t fX = -999.f;     /// X coordinate for the point of parametrisation
@@ -268,7 +275,10 @@ private:
   struct {
     // MUON track data
 
-    Int_t   fCollisionsID;            /// The index of the collision vertex, to which the muon is attached
+    Int_t   fCollisionsID;           /// The index of the collision vertex, to which the muon is attached
+    // In case we need connection to muon clusters, activate next lines
+    // Int_t   fClusterIndex;        /// The index of the associated MUON clusters
+    // Int_t   fNclusters;           /// The number of MUON clusters
 
     /// Parameters at vertex
     Float_t fInverseBendingMomentum; ///< Inverse bending momentum (GeV/c ** -1) times the charge 
@@ -292,7 +302,7 @@ private:
   } muons;                        //! structure to keep muons information
 
   struct {
-    // Muon clister data
+    // Muon cluster data
     
     Int_t   fMuonsID; /// The index of the muon track to which the clusters are attached
     Float_t fX;         ///< cluster X position


### PR DESCRIPTION
To use AO2D format in current analysis tasks, the event data needs to be aggregated from separate arrays. Now there is no connection allowing to see which segment of the arrays belong to a given event. The PR adds 2 arrays of indices to the O2events tree for each entry. The first array contains the start indices of the event data in the trees of tracks, v0s, cascades, ..., while the second array contains the number of entries to be read. Adding these arrays only increase the total file size by 0.015%.