### PR TITLE
Add hadRej PID for withSDD data sets

### DIFF
--- a/PWGDQ/dielectron/macrosLMEE/Config_acapon.C
+++ b/PWGDQ/dielectron/macrosLMEE/Config_acapon.C
@@ -123,7 +123,13 @@ AliDielectron* Config_acapon(TString cutDefinition,
       die->GetPairFilter().AddCuts(LMcutlib->GetPairCuts(LMEECutLib::kCutSet1));
     }
   }
-
+  // kCutSet1 with hadron band rejection
+  else if(cutDefinition == "kCutSet4"){
+    die->GetTrackFilter().AddCuts(LMcutlib->GetTrackCuts(LMEECutLib::kCutSet1, LMEECutLib::kScheidCuts));
+    if(applyPairCuts){
+      die->GetPairFilter().AddCuts(LMcutlib->GetPairCuts(LMEECutLib::kCutSet1));
+    }
+  }
   // ######## PID Cut variation settings #################
   // These variations use the kCutSet1 track cuts and only vary PID
   else if(cutDefinition == "kPIDcut1"){

--- a/PWGDQ/dielectron/macrosLMEE/Config_acapon_Efficiency.C
+++ b/PWGDQ/dielectron/macrosLMEE/Config_acapon_Efficiency.C
@@ -175,6 +175,12 @@ AliAnalysisFilter* SetupTrackCutsAndSettings(TString cutDefinition, Bool_t wSDD)
     anaFilter->SetName(cutDefinition);
     anaFilter->Print();
   }
+  else if(cutDefinition == "kCutSet4"){ // Hadron band rejection for wSDD data
+    std::cout << "Setting up kCutSet4" << std::endl;
+    anaFilter->AddCuts(LMcutlib->GetTrackCuts(LMEECutLib::kCutSet1, LMEECutLib::kScheidCuts));
+    anaFilter->SetName(cutDefinition);
+    anaFilter->Print();
+  }
   else if(cutDefinition == "kTheoPID"){ // PID cut set from a Run 1 pPb analysis. Standard track cuts
     std::cout << "Setting up Theo PID. Standard track cuts." << std::endl;
     anaFilter->AddCuts(LMcutlib->GetTrackCuts(LMEECutLib::kCutSet1, LMEECutLib::kTheoPID));

--- a/PWGDQ/dielectron/macrosLMEE/LMEECutLib_acapon.C
+++ b/PWGDQ/dielectron/macrosLMEE/LMEECutLib_acapon.C
@@ -141,7 +141,7 @@ class LMEECutLib {
 void LMEECutLib::SetEtaCorrectionTPC(AliDielectron *die, Int_t corrXdim, Int_t corrYdim, Int_t corrZdim){
 
   std::cout << "starting LMEECutLib::SetEtaCorrectionTPC()\n";
-  TString localPath = "/home/aaron/Data/diElec_outputs/PIDcalibration/";
+  TString localPath = "~/Data/diElec_outputs/PIDcalibration/";
   TString fileName;
   if(wSDD == kTRUE){
     fileName = "outputTPC.root";
@@ -172,7 +172,7 @@ void LMEECutLib::SetEtaCorrectionITS(AliDielectron *die, Int_t corrXdim, Int_t c
     return;
   }
   std::cout << "starting LMEECutLib::SetEtaCorrectionITS()\n";
-  TString localPath = "/home/aaron/Data/diElec_outputs/PIDcalibration/";
+  TString localPath = "~/Data/diElec_outputs/PIDcalibration/";
   TString fileName = "outputITS";
   if(hasMC){
     fileName.Append("_MC.root");
@@ -201,7 +201,7 @@ void LMEECutLib::SetEtaCorrectionITS(AliDielectron *die, Int_t corrXdim, Int_t c
 void LMEECutLib::SetEtaCorrectionTOF(AliDielectron *die, Int_t corrXdim, Int_t corrYdim, Int_t corrZdim, Bool_t hasMC){
 
   std::cout << "starting LMEECutLib::SetEtaCorrectionTOF()\n";
-  TString localPath = "/home/aaron/Data/diElec_outputs/PIDcalibration/";
+  TString localPath = "~/Data/diElec_outputs/PIDcalibration/";
   TString fileName = "outputTOF";
   if(hasMC){
     if(wSDD == kTRUE){
@@ -243,7 +243,7 @@ static TH3D LMEECutLib::SetEtaCorrectionTPCTTree( Int_t corrXdim, Int_t corrYdim
   ::Info("LMEECutLib_acapon", " >>>>>>>>>>>>>>>>>>>>>> SetEtaCorrectionTPC() >>>>>>>>>>>>>>>>>>>>>> ");
 
   std::cout << "starting LMEECutLib::SetEtaCorrectionTPC()\n";
-  TString localPath = "/home/aaron/Data/diElec_outputs/PIDcalibration/";
+  TString localPath = "~/Data/diElec_outputs/PIDcalibration/";
   TString fileName;
   if(wSDD == kTRUE){
     fileName = "outputTPC.root";
@@ -358,7 +358,7 @@ TH3D LMEECutLib::SetEtaCorrectionITSTTree( Int_t corrXdim, Int_t corrYdim, Int_t
   ::Info("LMEECutLib_acapon", " >>>>>>>>>>>>>>>>>>>>>> SetEtaCorrectionITSTTree() >>>>>>>>>>>>>>>>>>>>>> ");
 
   std::cout << "starting LMEECutLib::SetEtaCorrectionITSTTree()\n";
-  TString localPath = "/home/aaron/Data/diElec_outputs/PIDcalibration/";
+  TString localPath = "~/Data/diElec_outputs/PIDcalibration/";
   TString fileName = "outputITS";
   if(hasMC){
     fileName.Append("_MC.root");
@@ -470,7 +470,7 @@ static TH3D LMEECutLib::SetEtaCorrectionTOFTTree( Int_t corrXdim, Int_t corrYdim
   ::Info("LMEECutLib_acapon", " >>>>>>>>>>>>>>>>>>>>>> SetEtaCorrectionTOFTTree() >>>>>>>>>>>>>>>>>>>>>> ");
 
   std::cout << "starting LMEECutLib::SetEtaCorrectionTOFTTree()\n";
-  TString localPath = "/home/aaron/Data/diElec_outputs/PIDcalibration/";
+  TString localPath = "~/Data/diElec_outputs/PIDcalibration/";
   TString fileName = "outputTOF";
   if(hasMC){
     if(wSDD == kTRUE){

--- a/PWGDQ/dielectron/macrosLMEE/LMEECutLib_acapon.C
+++ b/PWGDQ/dielectron/macrosLMEE/LMEECutLib_acapon.C
@@ -141,7 +141,7 @@ class LMEECutLib {
 void LMEECutLib::SetEtaCorrectionTPC(AliDielectron *die, Int_t corrXdim, Int_t corrYdim, Int_t corrZdim){
 
   std::cout << "starting LMEECutLib::SetEtaCorrectionTPC()\n";
-  TString localPath = "/home/aaron/Data/diElec_framework_output/PIDcalibration/";
+  TString localPath = "/home/aaron/Data/diElec_outputs/PIDcalibration/";
   TString fileName;
   if(wSDD == kTRUE){
     fileName = "outputTPC.root";
@@ -172,7 +172,7 @@ void LMEECutLib::SetEtaCorrectionITS(AliDielectron *die, Int_t corrXdim, Int_t c
     return;
   }
   std::cout << "starting LMEECutLib::SetEtaCorrectionITS()\n";
-  TString localPath = "/home/aaron/Data/diElec_framework_output/PIDcalibration/";
+  TString localPath = "/home/aaron/Data/diElec_outputs/PIDcalibration/";
   TString fileName = "outputITS";
   if(hasMC){
     fileName.Append("_MC.root");
@@ -201,7 +201,7 @@ void LMEECutLib::SetEtaCorrectionITS(AliDielectron *die, Int_t corrXdim, Int_t c
 void LMEECutLib::SetEtaCorrectionTOF(AliDielectron *die, Int_t corrXdim, Int_t corrYdim, Int_t corrZdim, Bool_t hasMC){
 
   std::cout << "starting LMEECutLib::SetEtaCorrectionTOF()\n";
-  TString localPath = "/home/aaron/Data/diElec_framework_output/PIDcalibration/";
+  TString localPath = "/home/aaron/Data/diElec_outputs/PIDcalibration/";
   TString fileName = "outputTOF";
   if(hasMC){
     if(wSDD == kTRUE){
@@ -243,7 +243,7 @@ static TH3D LMEECutLib::SetEtaCorrectionTPCTTree( Int_t corrXdim, Int_t corrYdim
   ::Info("LMEECutLib_acapon", " >>>>>>>>>>>>>>>>>>>>>> SetEtaCorrectionTPC() >>>>>>>>>>>>>>>>>>>>>> ");
 
   std::cout << "starting LMEECutLib::SetEtaCorrectionTPC()\n";
-  TString localPath = "/home/aaron/Data/diElec_framework_output/PIDcalibration/";
+  TString localPath = "/home/aaron/Data/diElec_outputs/PIDcalibration/";
   TString fileName;
   if(wSDD == kTRUE){
     fileName = "outputTPC.root";
@@ -358,7 +358,7 @@ TH3D LMEECutLib::SetEtaCorrectionITSTTree( Int_t corrXdim, Int_t corrYdim, Int_t
   ::Info("LMEECutLib_acapon", " >>>>>>>>>>>>>>>>>>>>>> SetEtaCorrectionITSTTree() >>>>>>>>>>>>>>>>>>>>>> ");
 
   std::cout << "starting LMEECutLib::SetEtaCorrectionITSTTree()\n";
-  TString localPath = "/home/aaron/Data/diElec_framework_output/PIDcalibration/";
+  TString localPath = "/home/aaron/Data/diElec_outputs/PIDcalibration/";
   TString fileName = "outputITS";
   if(hasMC){
     fileName.Append("_MC.root");
@@ -470,7 +470,7 @@ static TH3D LMEECutLib::SetEtaCorrectionTOFTTree( Int_t corrXdim, Int_t corrYdim
   ::Info("LMEECutLib_acapon", " >>>>>>>>>>>>>>>>>>>>>> SetEtaCorrectionTOFTTree() >>>>>>>>>>>>>>>>>>>>>> ");
 
   std::cout << "starting LMEECutLib::SetEtaCorrectionTOFTTree()\n";
-  TString localPath = "/home/aaron/Data/diElec_framework_output/PIDcalibration/";
+  TString localPath = "/home/aaron/Data/diElec_outputs/PIDcalibration/";
   TString fileName = "outputTOF";
   if(hasMC){
     if(wSDD == kTRUE){


### PR DESCRIPTION
- Cut setting added which uses standard kCutSet1 track cuts, but implements hadron band rejection ePID scheme.
- Local PID correction map paths updated