### PR TITLE
Always use time range cut in 2018 Pb-Pb

### DIFF
--- a/OADB/AliEventCuts.cxx
+++ b/OADB/AliEventCuts.cxx
@@ -771,6 +771,8 @@ void AliEventCuts::SetupPbPb2018() {
     fTriggerMask = AliVEvent::kINT7 | AliVEvent::kCentral | AliVEvent::kSemiCentral;
   }
 
+  fUseTimeRangeCut = true;
+
 }
 
 void AliEventCuts::SetupRun2PbPb() {


### PR DESCRIPTION
Since anyway in unaffected periods it does not hurt.