### PR TITLE
PWGHF: Container name fix for ITS2-ITS3 setup

### DIFF
--- a/PWGHF/treeHF/macros/AddTaskHFTreeCreator.C
+++ b/PWGHF/treeHF/macros/AddTaskHFTreeCreator.C
@@ -19,7 +19,8 @@ AliAnalysisTaskSEHFTreeCreator *AddTaskHFTreeCreator(Bool_t readMC=kFALSE,
                                                      Bool_t fillParticleTree = kFALSE,
                                                      Bool_t fillTrackletTree = kFALSE,
                                                      Int_t fillNJetTrees = 0,
-                                                     Bool_t fillJetConstituentTrees = kFALSE)
+                                                     Bool_t fillJetConstituentTrees = kFALSE,
+                                                     Bool_t isITSUpgradeProd = kFALSE)
 {
     //
     //
@@ -133,7 +134,7 @@ AliAnalysisTaskSEHFTreeCreator *AddTaskHFTreeCreator(Bool_t readMC=kFALSE,
     task->SetPIDoptLc2V0bachelorTree(pidOpt);
     task->SetPIDoptLbTree(pidOpt);
     task->SetTreeSingleTrackVarsOpt(singletrackvarsopt);
-    if(fillTreeBs || fillTreeLb || fillTreeBplus){
+    if(fillTreeBs || fillTreeLb || fillTreeBplus || isITSUpgradeProd){
       task->SetITSUpgradeProduction(kTRUE);
       task->SetITSUpgradePreSelect(kTRUE);
       task->SetStoreOnlyHIJINGBackground(kTRUE);
@@ -210,7 +211,7 @@ AliAnalysisTaskSEHFTreeCreator *AddTaskHFTreeCreator(Bool_t readMC=kFALSE,
     AliAnalysisDataContainer *cinput = mgr->CreateContainer(inname,TChain::Class(),AliAnalysisManager::kInputContainer);
     TString outputfile = AliAnalysisManager::GetCommonFileName();
     outputfile += ":PWGHF_TreeCreator";
-    if(fillTreeLb || fillTreeBs || fillTreeBplus){
+    if(fillTreeLb || fillTreeBs || fillTreeBplus || isITSUpgradeProd){
       //Needed to run ITS2 production together with ITS2+ITS3 improver
       outputfile += finDirname;
     }


### PR DESCRIPTION
The TTreeCreator -> ITS3Improver -> TTreeCreator setup we use on trains only worked for beauty hadrons. Added an extra argument in AddTask, so we can use same setup also for the other particles.