### PR TITLE
PWG/EMCAL: Implemented shaper nonlinearity correction

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.h
+++ b/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.h
@@ -147,6 +147,7 @@ public:
   void     SetNonLinearityFunction(Int_t fun)            { fNonLinearityFunction = fun     ; InitNonLinearityParam() ; }
   void     SetNonLinearityThreshold(Int_t threshold)     { fNonLinearThreshold = threshold ; } //only for Alexie's non linearity correction
   Int_t    GetNonLinearityThreshold()              const { return fNonLinearThreshold      ; }
+  void     SetUseTowerShaperNonlinarityCorrection(Bool_t doCorr)     { fUseShaperNonlin = doCorr ; }
 
   //-----------------------------------------------------
   // MC clusters energy smearing
@@ -168,6 +169,7 @@ public:
 
   // Energy recalibration
   Bool_t   IsRecalibrationOn()                     const { return fRecalibration ; }
+  Float_t  CorrectShaperNonLin(Float_t Emeas, Float_t EcalibHG) ; // shaper energy nonlinearity
   void     SwitchOffRecalibration()                      { fRecalibration = kFALSE ; }
   void     SwitchOnRecalibration()                       { fRecalibration = kTRUE  ; 
                                                            if(!fEMCALRecalibrationFactors)InitEMCALRecalibrationFactors() ; }
@@ -522,6 +524,7 @@ private:
   Int_t      fNonLinearityFunction;      ///< Non linearity function choice, see enum NonlinearityFunctions
   Float_t    fNonLinearityParams[10];    ///< Parameters for the non linearity function
   Int_t	     fNonLinearThreshold;        ///< Non linearity threshold value for kBeamTest non linearity function 
+  Bool_t     fUseShaperNonlin;        ///< Shaper non linearity correction for towers
   
   // Energy smearing for MC
   Bool_t     fSmearClusterEnergy;        ///< Smear cluster energy, to be done only for simulated data to match real data

--- a/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.h
+++ b/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.h
@@ -625,7 +625,7 @@ private:
   Bool_t     fMCGenerToAcceptForTrack;   ///<  Activate the removal of tracks entering the track matching that come from a particular generator
   
   /// \cond CLASSIMP
-  ClassDef(AliEMCALRecoUtils, 32) ;
+  ClassDef(AliEMCALRecoUtils, 33) ;
   /// \endcond
 
 };

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellBadChannel.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellBadChannel.cxx
@@ -81,9 +81,9 @@ void AliEmcalCorrectionCellBadChannel::UserCreateOutputObjects()
   AliEmcalCorrectionComponent::UserCreateOutputObjects();
 
   if (fCreateHisto){
-    fCellEnergyDistBefore = new TH1F("hCellEnergyDistBefore","hCellEnergyDistBefore;E_{cell} (GeV)",1000,0,10);
+    fCellEnergyDistBefore = new TH1F("hCellEnergyDistBefore","hCellEnergyDistBefore;E_{cell} (GeV)",7000,0,70);
     fOutput->Add(fCellEnergyDistBefore);
-    fCellEnergyDistAfter = new TH1F("hCellEnergyDistAfter","hCellEnergyDistAfter;E_{cell} (GeV)",1000,0,10);
+    fCellEnergyDistAfter = new TH1F("hCellEnergyDistAfter","hCellEnergyDistAfter;E_{cell} (GeV)",7000,0,70);
     fOutput->Add(fCellEnergyDistAfter);
   }
 }

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEmulateCrosstalk.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEmulateCrosstalk.cxx
@@ -151,9 +151,9 @@ void AliEmcalCorrectionCellEmulateCrosstalk::UserCreateOutputObjects()
   AliEmcalCorrectionComponent::UserCreateOutputObjects();
 
   if (fCreateHisto){
-    fCellEnergyDistBefore = new TH1F("hCellEnergyDistBefore","hCellEnergyDistBefore;E_{cell} (GeV)",1000,0,10);
+    fCellEnergyDistBefore = new TH1F("hCellEnergyDistBefore","hCellEnergyDistBefore;E_{cell} (GeV)",7000,0,70);
     fOutput->Add(fCellEnergyDistBefore);
-    fCellEnergyDistAfter = new TH1F("hCellEnergyDistAfter","hCellEnergyDistAfter;E_{cell} (GeV)",1000,0,10);
+    fCellEnergyDistAfter = new TH1F("hCellEnergyDistAfter","hCellEnergyDistAfter;E_{cell} (GeV)",7000,0,70);
     fOutput->Add(fCellEnergyDistAfter);
   }
 }

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEnergy.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEnergy.cxx
@@ -28,6 +28,7 @@ AliEmcalCorrectionCellEnergy::AliEmcalCorrectionCellEnergy() :
   ,fUseAutomaticRecalib(1)
   ,fUseAutomaticRunDepRecalib(1)
   ,fUseNewRunDepTempCalib(0)
+  ,fUseShaperCorrection(0)
   ,fCustomRecalibFilePath("")
   ,fLoad1DRecalibFactors(0)
 {
@@ -55,6 +56,9 @@ Bool_t AliEmcalCorrectionCellEnergy::Initialize()
   // check the YAML configuration if the Run2 calibration is requested (default is false)
   GetProperty("enableNewTempCalib",fUseNewRunDepTempCalib);
 
+  // check the YAML configuration if the shaper nonlinearity correction is requested (default is false)
+  GetProperty("enableShaperCorrection",fUseShaperCorrection);
+
   // check the YAML configuration if a custom energy calibration is requested (default is empty string "")
   GetProperty("customRecalibFilePath",fCustomRecalibFilePath);
 
@@ -79,9 +83,9 @@ void AliEmcalCorrectionCellEnergy::UserCreateOutputObjects()
   AliEmcalCorrectionComponent::UserCreateOutputObjects();
 
   if (fCreateHisto){
-    fCellEnergyDistBefore = new TH1F("hCellEnergyDistBefore","hCellEnergyDistBefore;E_{cell} (GeV)",1000,0,10);
+    fCellEnergyDistBefore = new TH1F("hCellEnergyDistBefore","hCellEnergyDistBefore;E_{cell} (GeV)",7000,0,70);
     fOutput->Add(fCellEnergyDistBefore);
-    fCellEnergyDistAfter = new TH1F("hCellEnergyDistAfter","hCellEnergyDistAfter;E_{cell} (GeV)",1000,0,10);
+    fCellEnergyDistAfter = new TH1F("hCellEnergyDistAfter","hCellEnergyDistAfter;E_{cell} (GeV)",7000,0,70);
     fOutput->Add(fCellEnergyDistAfter);
   }
 }
@@ -488,6 +492,10 @@ Bool_t AliEmcalCorrectionCellEnergy::CheckIfRunChanged()
         AliWarning(Form("No Temperature recalibration available: %d - %s", fEventManager.InputEvent()->GetRunNumber(), fFilepass.Data()));
       }
     }
+  }
+  if(fUseShaperCorrection)
+  {
+    fRecoUtils->SetUseTowerShaperNonlinarityCorrection(kTRUE);
   }
   return runChanged;
 }

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEnergy.h
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEnergy.h
@@ -45,6 +45,7 @@ private:
   Bool_t                 fUseAutomaticRecalib;       ///< On by default the check in the OADB of the energy recalibration
   Bool_t                 fUseAutomaticRunDepRecalib; ///< On by default the check in the OADB of the run dependent energy recalibration
   Bool_t                 fUseNewRunDepTempCalib;     ///< Off by default the check in the OADB of the new run dependent temp calib Run1/Run2
+  Bool_t                 fUseShaperCorrection;       ///< Off by default the correction for the shaper nonlinearity
   TString                fCustomRecalibFilePath;     ///< Empty string by default the path to the OADB file of the custom energy recalibration
   Bool_t                 fLoad1DRecalibFactors;      ///< Flag to load 1D energy recalibration factors
   

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEnergy.h
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEnergy.h
@@ -56,7 +56,7 @@ private:
   static RegisterCorrectionComponent<AliEmcalCorrectionCellEnergy> reg;
 
   /// \cond CLASSIMP
-  ClassDef(AliEmcalCorrectionCellEnergy, 5); // EMCal cell energy correction component
+  ClassDef(AliEmcalCorrectionCellEnergy, 6); // EMCal cell energy correction component
   /// \endcond
 };
 

--- a/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
+++ b/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
@@ -60,6 +60,7 @@ CellEnergy:                                         # Cell Energy correction com
     enabled: false                                  # Whether to enable the task
     createHistos: false                             # Whether the task should create output histograms
     enableNewTempCalib: false                       # Whether the new temperature calibration parmeters should be used (available for Run1 and Run2)
+    enableShaperCorrection: false                   # Correct all cells >50 GeV for the shaper detector effect (to be used with special testbeam nonlinearity)
     customRecalibFilePath: ""                       # Full path including .root file for custom recalibration object
     load1DRecalibFactors: false                     # Flag to load a 1D energy recalibration histogram
     cellsNames:                                     # Names of the cells input objects which should be attached to the correction


### PR DESCRIPTION
This PR adds the possibility to correct low gain cells for the shaper nonlinearity. The pol6 for this correction was obtained by Martin in the EMCal lab and was presented here: https://indico.cern.ch/event/885500/contributions/3732586/attachments/1980636/3298179/TB_20200203.pdf

In a later commit, also the nonlinearity function that has to be applied on cluster level will be made available.