### PR TITLE
In case of MC Do not fill in TTree not flagged candidates

### DIFF
--- a/PWGHF/vertexingHF/vHFML/AliAnalysisTaskSEDplus.cxx
+++ b/PWGHF/vertexingHF/vHFML/AliAnalysisTaskSEDplus.cxx
@@ -1360,8 +1360,9 @@ void AliAnalysisTaskSEDplus::UserExec(Option_t * /*option*/)
 
             fMLhandler->SetCandidateType(issignal, isbkg, isprompt, isFD, kFALSE);
             fMLhandler->SetVariables(d, aod->GetMagneticField(), 0, Pid_HF);
-            fMLhandler->FillTree();
-
+            if(!(fReadMC && !issignal && !isbkg && !isprompt && !isFD))
+              fMLhandler->FillTree();
+    
             PostData(4, fMLtree);
           }
         }

--- a/PWGHF/vertexingHF/vHFML/AliAnalysisTaskSEDs.cxx
+++ b/PWGHF/vertexingHF/vHFML/AliAnalysisTaskSEDs.cxx
@@ -1195,7 +1195,8 @@ void AliAnalysisTaskSEDs::UserExec(Option_t * /*option*/)
 
         fMLhandler->SetCandidateType(issignal, isbkg, isprompt, isFD, isrefl);
         fMLhandler->SetVariables(d, aod->GetMagneticField(), AliHFMLVarHandlerDstoKKpi::kKKpi, Pid_HF);
-        fMLhandler->FillTree();
+        if(!(fReadMC && !issignal && !isbkg && !isprompt && !isFD && !isrefl))
+          fMLhandler->FillTree();
       }
 
       if (isPhipiKK)
@@ -1229,7 +1230,8 @@ void AliAnalysisTaskSEDs::UserExec(Option_t * /*option*/)
 
         fMLhandler->SetCandidateType(issignal, isbkg, isprompt, isFD, isrefl);
         fMLhandler->SetVariables(d, aod->GetMagneticField(), AliHFMLVarHandlerDstoKKpi::kpiKK, Pid_HF);
-        fMLhandler->FillTree();
+        if(!(fReadMC && !issignal && !isbkg && !isprompt && !isFD && !isrefl))
+          fMLhandler->FillTree();
       }
     }
 


### PR DESCRIPTION
This is to avoid the storage of injected background candidates in TTree in case of PbPb MC samples