### PR TITLE
Major overhaul of tree creation for S0/RT Analyses

### DIFF
--- a/PWGLF/SPECTRA/CMakeLists.txt
+++ b/PWGLF/SPECTRA/CMakeLists.txt
@@ -90,8 +90,12 @@ set(SRCS
   PiKaPr/TPCTOFfits/AliAnalysisPIDTrack.cxx
   PiKaPr/TPCTOFfits/AliAnalysisPIDV0.cxx
   PiKaPr/TPCTOFfits/AliAnalysisTaskTPCTOFPID.cxx
+  PiKaPr/TPCTOFCascades/AliAnalysisPIDCascadeEvent.cxx
+  PiKaPr/TPCTOFCascades/AliAnalysisPIDCascadeParticle.cxx
+  PiKaPr/TPCTOFCascades/AliAnalysisPIDCascadeTrack.cxx
+  PiKaPr/TPCTOFCascades/AliAnalysisPIDCascadeV0.cxx
   PiKaPr/TPCTOFCascades/AliAnalysisPIDCascade.cxx
-  PiKaPr/TPCTOFCascades/AliAnalysisTaskTPCTOFCascade.cxx
+  PiKaPr/TPCTOFCascades/AliAnalysisTaskTPCTOFCascade.cxx  
   PiKaPr/TOF/pp13/AliAnalysisTaskTOFppSpectra.cxx
   PiKaPr/TOF/pp13/AliAnalysisTaskTOFMC.cxx
   PiKaPr/TOF/pp7/TOFSpectrappAnalysis.cxx

--- a/PWGLF/SPECTRA/PWGLFspectraLinkDef.h
+++ b/PWGLF/SPECTRA/PWGLFspectraLinkDef.h
@@ -90,9 +90,13 @@
 #pragma link C++ class AliMultiplictyLoaderTask+;
 
 #pragma link C++ class AliAnalysisPIDEvent+;
+#pragma link C++ class AliAnalysisPIDCascadeEvent+;
 #pragma link C++ class AliAnalysisPIDParticle+;
+#pragma link C++ class AliAnalysisPIDCascadeParticle+;
 #pragma link C++ class AliAnalysisPIDTrack+;
+#pragma link C++ class AliAnalysisPIDCascadeTrack+;
 #pragma link C++ class AliAnalysisPIDV0+;
+#pragma link C++ class AliAnalysisPIDCascadeV0+;
 #pragma link C++ class AliAnalysisPIDCascade+;
 #pragma link C++ class AliAnalysisTaskTPCTOFPID+;
 #pragma link C++ class AliAnalysisTaskTPCTOFCascade+;

--- a/PWGLF/SPECTRA/PiKaPr/TPCTOFCascades/AliAnalysisPIDCascade.cxx
+++ b/PWGLF/SPECTRA/PiKaPr/TPCTOFCascades/AliAnalysisPIDCascade.cxx
@@ -1,6 +1,6 @@
 #include "AliAnalysisPIDCascade.h"
-#include "AliAnalysisPIDV0.h"
-#include "AliAnalysisPIDTrack.h"
+#include "AliAnalysisPIDCascadeV0.h"
+#include "AliAnalysisPIDCascadeTrack.h"
 AliAnalysisPIDCascade::AliAnalysisPIDCascade():
   TObject(),
   fInvMXi(0),
@@ -16,14 +16,14 @@ AliAnalysisPIDCascade::AliAnalysisPIDCascade():
   fCascPdg(0),
   fCascPrimary(kFALSE)
 {
-  fBachAnalysisPIDTrack = new AliAnalysisPIDTrack();
-  fV0AnalysisPIDV0 = new AliAnalysisPIDV0();
+  fBachAnalysisPIDCascadeTrack = new AliAnalysisPIDCascadeTrack();
+  fV0AnalysisPIDCascadeV0 = new AliAnalysisPIDCascadeV0();
 };
 
 AliAnalysisPIDCascade::AliAnalysisPIDCascade(const AliAnalysisPIDCascade &source):
   TObject(source),
-  fV0AnalysisPIDV0(source.fV0AnalysisPIDV0),
-  fBachAnalysisPIDTrack(source.fBachAnalysisPIDTrack),
+  fV0AnalysisPIDCascadeV0(source.fV0AnalysisPIDCascadeV0),
+  fBachAnalysisPIDCascadeTrack(source.fBachAnalysisPIDCascadeTrack),
   fInvMXi(source.fInvMXi),
   fInvMO(source.fInvMO),
   fCascRadius(source.fCascRadius),
@@ -41,8 +41,8 @@ AliAnalysisPIDCascade::AliAnalysisPIDCascade(const AliAnalysisPIDCascade &source
 AliAnalysisPIDCascade &AliAnalysisPIDCascade::operator=(const AliAnalysisPIDCascade &source) {
   if(&source == this) return *this;
   TObject::operator=(source);
-  fV0AnalysisPIDV0 = source.fV0AnalysisPIDV0;
-  fBachAnalysisPIDTrack = source.fBachAnalysisPIDTrack;
+  fV0AnalysisPIDCascadeV0 = source.fV0AnalysisPIDCascadeV0;
+  fBachAnalysisPIDCascadeTrack = source.fBachAnalysisPIDCascadeTrack;
   fInvMXi = source.fInvMXi;
   fInvMO = source.fInvMO;
   fCascRadius = source.fCascRadius;
@@ -57,9 +57,9 @@ AliAnalysisPIDCascade &AliAnalysisPIDCascade::operator=(const AliAnalysisPIDCasc
   fCascPrimary = source.fCascPrimary;
   return *this;
 };
-void AliAnalysisPIDCascade::Update(AliAnalysisPIDV0* V0, AliAnalysisPIDTrack* BachTrack, Double_t *InvMasses, Double_t CascRadius,  Double_t CascDCA, Double_t CascCosinePA, Double_t PtCasc, Double_t EtaCasc, Double_t CascDCAPV, Int_t Charge, Double_t V0DCA, Int_t CascPdg, Bool_t CascPrimary) {
-  fV0AnalysisPIDV0 = V0;
-  fBachAnalysisPIDTrack = BachTrack;
+void AliAnalysisPIDCascade::Update(AliAnalysisPIDCascadeV0* V0, AliAnalysisPIDCascadeTrack* BachTrack, Double_t *InvMasses, Double_t CascRadius,  Double_t CascDCA, Double_t CascCosinePA, Double_t PtCasc, Double_t EtaCasc, Double_t CascDCAPV, Int_t Charge, Double_t V0DCA, Int_t CascPdg, Bool_t CascPrimary) {
+  fV0AnalysisPIDCascadeV0 = V0;
+  fBachAnalysisPIDCascadeTrack = BachTrack;
   fInvMXi=InvMasses[0];
   fInvMO=InvMasses[1];
   fCascRadius = CascRadius;
@@ -75,8 +75,8 @@ void AliAnalysisPIDCascade::Update(AliAnalysisPIDV0* V0, AliAnalysisPIDTrack* Ba
 };
 AliAnalysisPIDCascade::~AliAnalysisPIDCascade()
 {
-  delete fV0AnalysisPIDV0;
-  delete fBachAnalysisPIDTrack;
+  delete fV0AnalysisPIDCascadeV0;
+  delete fBachAnalysisPIDCascadeTrack;
 };
 
 Double_t AliAnalysisPIDCascade::CalculateCascDCAPV() {

--- a/PWGLF/SPECTRA/PiKaPr/TPCTOFCascades/AliAnalysisPIDCascade.h
+++ b/PWGLF/SPECTRA/PiKaPr/TPCTOFCascades/AliAnalysisPIDCascade.h
@@ -1,11 +1,11 @@
 #ifndef ALIANALYSISPIDCascade__H
 #define ALIANALYSISPIDCascade__H
 #include "TObject.h"
-#include "AliAnalysisPIDTrack.h"
-#include "AliAnalysisPIDV0.h"
+#include "AliAnalysisPIDCascadeTrack.h"
+#include "AliAnalysisPIDCascadeV0.h"
 
-class AliAnalysisPIDTrack;
-class AliAnalysisPIDV0;
+class AliAnalysisPIDCascadeTrack;
+class AliAnalysisPIDCascadeV0;
 class AliAnalysisPIDCascade:
 public TObject
 {
@@ -14,10 +14,10 @@ public TObject
   AliAnalysisPIDCascade(const AliAnalysisPIDCascade &source); //copy const
   AliAnalysisPIDCascade &operator=(const AliAnalysisPIDCascade &source); // operator =
   virtual ~AliAnalysisPIDCascade();
-  void Update(AliAnalysisPIDV0* V0, AliAnalysisPIDTrack* BachTrack, Double_t *InvMasses, Double_t CascRadius, Double_t CascDCA,  Double_t CascCosinePA, Double_t PtCasc, Double_t EtaCasc, Double_t CascDCAPV, Int_t Charge, Double_t V0DCA, Int_t CascPdg, Bool_t CascPrimary);
+  void Update(AliAnalysisPIDCascadeV0* V0, AliAnalysisPIDCascadeTrack* BachTrack, Double_t *InvMasses, Double_t CascRadius, Double_t CascDCA,  Double_t CascCosinePA, Double_t PtCasc, Double_t EtaCasc, Double_t CascDCAPV, Int_t Charge, Double_t V0DCA, Int_t CascPdg, Bool_t CascPrimary);
 
-  AliAnalysisPIDV0    *GetV0()  { return fV0AnalysisPIDV0;};
-  AliAnalysisPIDTrack *GetBachAnalysisTrack() { return fBachAnalysisPIDTrack; };
+  AliAnalysisPIDCascadeV0    *GetV0()  { return fV0AnalysisPIDCascadeV0;};
+  AliAnalysisPIDCascadeTrack *GetBachAnalysisTrack() { return fBachAnalysisPIDCascadeTrack; };
   Double_t GetIMXi()         { return fInvMXi; }; //M Xi
   Double_t GetIMO()          { return fInvMO; }; //M Omega
   Double_t GetCascRadius()   { return fCascRadius; };
@@ -33,8 +33,8 @@ public TObject
   Bool_t GetCascPrimary() {return fCascPrimary;};
 
  protected:  
-  AliAnalysisPIDV0 * fV0AnalysisPIDV0;
-  AliAnalysisPIDTrack *fBachAnalysisPIDTrack;
+  AliAnalysisPIDCascadeV0 * fV0AnalysisPIDCascadeV0;
+  AliAnalysisPIDCascadeTrack *fBachAnalysisPIDCascadeTrack;
   Double_t fInvMXi,fInvMO;
   Double_t fCascRadius;
   Double_t fCascDCA, fCascCosinePA;

--- a/PWGLF/SPECTRA/PiKaPr/TPCTOFCascades/AliAnalysisPIDCascadeEvent.cxx
+++ b/PWGLF/SPECTRA/PiKaPr/TPCTOFCascades/AliAnalysisPIDCascadeEvent.cxx
@@ -1,0 +1,239 @@
+#include "AliAnalysisPIDCascadeEvent.h"
+#include "AliVEvent.h"
+
+ClassImp(AliAnalysisPIDCascadeEvent)
+
+//___________________________________________________________
+
+//___________________________________________________________
+
+AliTOFPIDResponse AliAnalysisPIDCascadeEvent::fgTOFResponse;
+
+Float_t AliAnalysisPIDCascadeEvent::fgVertexZ_cuts[2] = {-10., 10.}; /* min,max */
+
+const Char_t *AliAnalysisPIDCascadeEvent::fgkCentralityEstimatorName[AliAnalysisPIDCascadeEvent::kNCentralityEstimators] = {
+  "V0M",
+  "V0A",
+  "V0C",
+  "TRK",
+  "TKL",
+  "CL1",
+  "ZNA"
+};
+
+Int_t AliAnalysisPIDCascadeEvent::fgFlagToCheck = 205;
+
+//___________________________________________________________
+
+AliAnalysisPIDCascadeEvent::AliAnalysisPIDCascadeEvent() :
+  TObject(),
+  fIsCollisionCandidate(kFALSE),
+  fIsEventSelected(0),
+  fIsPileupFromSPD(kFALSE),
+  fHasVertex(kFALSE),
+  fVertexZ(-999.0),
+  fCentralityQuality(0),
+  fReferenceMultiplicity(0),
+  fV0Mmultiplicity(0.),
+  fMCMultiplicity(0),
+  fEventFlags(0),
+  fMagneticField(0.),
+  fRunNo(0)
+{
+  /*
+   * default constructor
+   */
+}
+
+//___________________________________________________________
+
+AliAnalysisPIDCascadeEvent::AliAnalysisPIDCascadeEvent(const AliAnalysisPIDCascadeEvent &source) :
+  TObject(source),
+  fIsCollisionCandidate(source.fIsCollisionCandidate),
+  fIsEventSelected(source.fIsEventSelected),
+  fIsPileupFromSPD(source.fIsPileupFromSPD),
+  fHasVertex(source.fHasVertex),
+  fVertexZ(source.fVertexZ),
+  fCentralityQuality(source.fCentralityQuality),
+  fReferenceMultiplicity(0),
+  fV0Mmultiplicity(source.fV0Mmultiplicity),
+  fMCMultiplicity(source.fMCMultiplicity),
+  fEventFlags(source.fEventFlags),
+  fMagneticField(source.fMagneticField),
+  fRunNo(source.fRunNo)
+{
+  /*
+   * copy constructor
+   */
+
+    fReferenceMultiplicity = source.fReferenceMultiplicity;
+    fV0Mmultiplicity = source.fV0Mmultiplicity;
+}
+
+//___________________________________________________________
+
+AliAnalysisPIDCascadeEvent &
+AliAnalysisPIDCascadeEvent::operator=(const AliAnalysisPIDCascadeEvent &source)
+{
+  /*
+   * operator=
+   */
+
+  if (&source == this) return *this;
+  TObject::operator=(source);
+
+  fIsCollisionCandidate = source.fIsCollisionCandidate;
+  fIsEventSelected = source.fIsEventSelected;
+  fIsPileupFromSPD = source.fIsPileupFromSPD;
+  fHasVertex = source.fHasVertex;
+  fVertexZ = source.fVertexZ;
+  fCentralityQuality = source.fCentralityQuality;
+  fReferenceMultiplicity = source.fReferenceMultiplicity;
+  fV0Mmultiplicity = source.fV0Mmultiplicity;
+  fMCMultiplicity = source.fMCMultiplicity;
+  fEventFlags = source.fEventFlags;
+  fMagneticField=source.fMagneticField;
+  fRunNo=source.fRunNo;
+  return *this;
+}
+
+//___________________________________________________________
+
+AliAnalysisPIDCascadeEvent::~AliAnalysisPIDCascadeEvent()
+{
+  /*
+   * default destructor
+   */
+
+}
+
+//___________________________________________________________
+
+
+void
+AliAnalysisPIDCascadeEvent::Reset()
+{
+  /*
+   * reset
+   */
+
+  fIsCollisionCandidate = kFALSE;
+  fIsEventSelected = 0;
+  fIsPileupFromSPD = kFALSE;
+  fHasVertex = 0.;
+  fVertexZ = -999.;
+  fCentralityQuality = 0;
+  fReferenceMultiplicity = 0;
+  fMCMultiplicity = 0;
+  fV0Mmultiplicity = 0;
+  fEventFlags = 0;
+  fMagneticField=0;
+  fRunNo=0;
+}
+
+//___________________________________________________________
+
+//___________________________________________________________
+
+Bool_t
+AliAnalysisPIDCascadeEvent::AcceptEvent(Bool_t CheckVertex, Int_t type) const
+{
+  /*
+   * accept event proton-proton
+   */
+
+  if (!fIsCollisionCandidate) return kFALSE;
+  if (fCentralityQuality != 0) return kFALSE;
+  if (!(fIsEventSelected & AliVEvent::kINT7)) return kFALSE;
+  if((fEventFlags&fgFlagToCheck)!=fgFlagToCheck) return kFALSE;
+  if(CheckVertex)
+    if(!AcceptVertex()) return kFALSE;
+  if (type > 0) {
+    if (fIsPileupFromSPD) return kFALSE;
+    if (!(fIsEventSelected & AliVEvent::kMB)) return kFALSE;
+  };
+
+
+  return kTRUE;
+}
+
+//___________________________________________________________
+
+Bool_t
+AliAnalysisPIDCascadeEvent::AcceptVertex() const
+{
+  /*
+   * accept vertex
+   */
+
+  if (!HasVertex()) return kFALSE;
+  if (fVertexZ < fgVertexZ_cuts[0] || fVertexZ > fgVertexZ_cuts[1]) return kFALSE;
+  return kTRUE;
+}
+
+//___________________________________________________________
+
+//___________________________________________________________
+
+//___________________________________________________________
+
+//___________________________________________________________
+
+//___________________________________________________________
+
+//___________________________________________________________
+
+//___________________________________________________________
+
+//___________________________________________________________
+
+//___________________________________________________________
+
+//___________________________________________________________
+
+//___________________________________________________________
+
+//___________________________________________________________
+
+//___________________________________________________________
+
+//___________________________________________________________
+
+//___________________________________________________________
+
+//___________________________________________________________
+
+//___________________________________________________________
+
+//___________________________________________________________
+void AliAnalysisPIDCascadeEvent::SetCheckFlag(Int_t newval) {
+  if(newval>kAll||newval<0) {
+    printf("Flag value %i not defined!\n",newval);
+    return;
+  };
+  fgFlagToCheck = newval;
+};
+void AliAnalysisPIDCascadeEvent::AddCheckFlag(EventFlags_t av) {
+  fgFlagToCheck = fgFlagToCheck|av;
+};
+void AliAnalysisPIDCascadeEvent::RemoveCheckFlag(EventFlags_t av) {
+  Int_t flagmask = kAll-av;
+  fgFlagToCheck = fgFlagToCheck&flagmask;
+};
+Bool_t AliAnalysisPIDCascadeEvent::CheckFlag() {
+  return (fEventFlags&fgFlagToCheck)==fgFlagToCheck;
+};
+void AliAnalysisPIDCascadeEvent::PrintEventSelection() {
+  printf("AliAnalysisPIDCascadeEvent::AcceptEvent() requires:\n");
+  printf("Vertex position: %f..%f\n",fgVertexZ_cuts[0],fgVertexZ_cuts[1]);
+  printf("Trigger class: kINT7\n");
+  printf("Not pileup in SPD:   %s\n",(fgFlagToCheck&kNotPileupInSPD)?"Yes":"No");
+  printf("Not pileup in MV:    %s\n",(fgFlagToCheck&kNotPileupInMV)?"Yes":"No");
+  printf("Not pileup in MB:    %s\n",(fgFlagToCheck&kNotPileupInMB)?"Yes":"No");
+  printf("INEL > 0:            %s\n",(fgFlagToCheck&kINELgtZERO)?"Yes":"No");
+  printf("No inconsistent VTX: %s\n",(fgFlagToCheck&kNoInconsistentVtx)?"Yes":"No");
+  printf("No assym. in V0:     %s\n",(fgFlagToCheck&kNoV0Asym)?"Yes":"No");
+  printf("2015 pp vertex cut:  %s\n",(fgFlagToCheck&kVertexSelected2015pp)?"Yes":"No");
+  printf("Req. SPD & TRK vtx.: %s\n",(fgFlagToCheck&kSPDandTrkVtxExists)?"Yes":"No");
+  printf("Check proximity cut: %s\n",(fgFlagToCheck&kPassProximityCut)?"Yes":"No");
+};

--- a/PWGLF/SPECTRA/PiKaPr/TPCTOFCascades/AliAnalysisPIDCascadeEvent.h
+++ b/PWGLF/SPECTRA/PiKaPr/TPCTOFCascades/AliAnalysisPIDCascadeEvent.h
@@ -1,0 +1,131 @@
+#ifndef ALIANALYSISPIDCASCADEVENT_H
+#define ALIANALYSISPIDCASCADEVENT_H
+
+#include "TObject.h"
+#include "AliTOFPIDResponse.h"
+#include "TF1.h"
+
+class AliAnalysisPIDCascadeEvent :
+public TObject
+{
+
+ public:
+
+  AliAnalysisPIDCascadeEvent(); // default constructor
+  AliAnalysisPIDCascadeEvent(const AliAnalysisPIDCascadeEvent &source); // copy constructor
+  AliAnalysisPIDCascadeEvent &operator=(const AliAnalysisPIDCascadeEvent &source); // operator=
+  virtual ~AliAnalysisPIDCascadeEvent(); // default destructor
+  Bool_t IsCollisionCandidate() const {return fIsCollisionCandidate;}; // getter
+  Bool_t HasVertex() const {return fHasVertex;}; // getter
+  Float_t GetVertexZ() const {return fVertexZ;}; // getter
+  UChar_t GetCentralityQuality() const {return fCentralityQuality;}; // getter
+  Int_t GetReferenceMultiplicity()  {return fReferenceMultiplicity;}; // getter
+
+  void SetIsCollisionCandidate(Bool_t value) {fIsCollisionCandidate = value;}; // setter
+  void SetIsEventSelected(UInt_t value) {fIsEventSelected = value;}; // setter
+  void SetIsPileupFromSPD(Bool_t value) {fIsPileupFromSPD = value;}; // setter
+  void SetHasVertex(Bool_t value) {fHasVertex = value;}; // setter
+  void SetVertexZ(Float_t value) {fVertexZ = value;}; // setter
+  void SetCentralityQuality(UChar_t value) {fCentralityQuality = value;}; // setter
+  void SetReferenceMultiplicity(Int_t value) {fReferenceMultiplicity = value; };// setter
+  void SetMCMultiplicity(Int_t value) {fMCMultiplicity = value;}; // setter
+
+  void SetV0Mmultiplicity(Float_t multi) { fV0Mmultiplicity = multi;}; // setter
+  void SetRefMult08(Float_t multi) { fRefMult08 = multi;}; // setter
+  void SetRefMult05(Float_t multi) { fRefMult05 = multi;}; // setter
+  void SetSPDTracklets(Float_t multi) { fSPDTracklets = multi;}; // setter
+
+  void SetEventFlags(Int_t NewFlag) { fEventFlags = NewFlag; };
+  Int_t GetEventFlags() { return fEventFlags; };
+  Bool_t HasEventFlag(Int_t CheckFlag) { return (fEventFlags&CheckFlag)==CheckFlag; };
+  void SetMagneticField(Double_t MagneticFieldValue) { fMagneticField = MagneticFieldValue; };
+  void SetRunNumber(Int_t RunNo) { fRunNo = RunNo; };
+
+
+  void Reset(); // reset
+
+  Bool_t AcceptEvent(Bool_t CheckVertex=kTRUE, Int_t type = 0) const; // accept event proton-proton
+  Bool_t AcceptVertex() const; // accept vertex
+
+  Float_t GetV0Mmultiplicity() { return fV0Mmultiplicity;}; //getter
+  Float_t GetRefMult08() { return fRefMult08;};
+  Float_t GetRefMult05() { return fRefMult05;};
+  Float_t GetSPDTracklets() { return fSPDTracklets;};
+
+  Int_t GetMCMultiplicity() {return fMCMultiplicity; }; // getter
+  Bool_t IsPileup() {return fIsPileupFromSPD; }; // getter
+  Double_t GetMagneticField() { return fMagneticField;};
+  Int_t GetRunNumber() { return fRunNo; };
+
+  enum ECentralityEstimator_t {
+    kCentEst_V0M, /* V0 multiplicity */
+    kCentEst_V0A, /* V0A multiplicity */
+    kCentEst_V0C, /* V0C multiplicity */
+    kCentEst_TRK, /* N. of tracks */
+    kCentEst_TKL, /* N. of tracklets */
+    kCentEst_CL1, /*  N. of clusters in layer 1 */
+    kCentEst_ZNA, /* ZNA */
+    kNCentralityEstimators
+  };
+  enum EventFlags_t {
+    kNotPileupInSPD = 1,
+    kNotPileupInMV = 2,
+    kNotPileupInMB = 4,
+    kINELgtZERO = 8,
+    kNoInconsistentVtx = 16,
+    kNoV0Asym = 32,
+    kVertexSelected2015pp=64,
+    kSPDandTrkVtxExists=128,
+    kPassProximityCut=256,
+    kAll = 511
+  };
+  static const Char_t *fgkCentralityEstimatorName[kNCentralityEstimators]; // centrality estimator name
+  static void SetVertexZCuts(Float_t min, Float_t max) {fgVertexZ_cuts[0] = min; fgVertexZ_cuts[1] = max;}; // setter
+  static void SetCheckFlag(Int_t);
+  static void AddCheckFlag(EventFlags_t);
+  static void RemoveCheckFlag(EventFlags_t);
+  static Int_t GetCheckFlag() { return fgFlagToCheck; };
+  Bool_t CheckFlag();
+  static void PrintEventSelection();
+  /*** tools ***/
+  static AliTOFPIDResponse fgTOFResponse; // TOF PID response
+
+ private:
+
+  /*** global event info ***/
+  Bool_t fIsCollisionCandidate; // is collision candidate
+  UInt_t fIsEventSelected; // is event selected
+  Bool_t fIsPileupFromSPD; // is pile-up from SPD
+  Bool_t fHasVertex; // has vertex
+  Float_t fVertexZ; // vertex z
+  UChar_t fCentralityQuality; // centrality quality
+  Int_t fReferenceMultiplicity; // reference multiplicity in eta 0.8
+  Float_t fV0Mmultiplicity;
+  Float_t fRefMult08;
+  Float_t fRefMult05;
+  Float_t fSPDTracklets;
+  //  Float_t fV0CellAmplitude[64];
+  Int_t fMCMultiplicity; // MC multiplicity
+  /*** TPC event info ***/
+  /*** TOF event info ***/
+  /*** T0 event info ***/
+  /*** MC info ***/
+  //Some flags from PPVsMultUtils class
+  Int_t fEventFlags;
+  Double_t fMagneticField;
+  Int_t fRunNo;
+
+
+
+  /*** cuts ***/
+  static Float_t fgVertexZ_cuts[2]; // min,max
+
+  /*** other ***/
+
+  /*** corrections ***/
+  static Int_t fgFlagToCheck; //! check flag
+
+  ClassDef(AliAnalysisPIDCascadeEvent, 1);
+};
+
+#endif /* ALIANALYSISPIDCASCADEEVENT_H */

--- a/PWGLF/SPECTRA/PiKaPr/TPCTOFCascades/AliAnalysisPIDCascadeParticle.cxx
+++ b/PWGLF/SPECTRA/PiKaPr/TPCTOFCascades/AliAnalysisPIDCascadeParticle.cxx
@@ -1,0 +1,163 @@
+#include "AliAnalysisPIDCascadeParticle.h"
+#include "TParticle.h"
+#include "AliPID.h"
+#include "TDatabasePDG.h"
+#include "TParticlePDG.h"
+#include "TMath.h"
+
+ClassImp(AliAnalysisPIDCascadeParticle)
+
+//___________________________________________________________
+
+TLorentzVector AliAnalysisPIDCascadeParticle::fgLorentzVector;
+
+//___________________________________________________________
+
+Double_t
+AliAnalysisPIDCascadeParticle::GetY() const
+{
+
+  fgLorentzVector.SetPtEtaPhiM(fPt, fEta, fPhi, GetMass());
+  return fgLorentzVector.Rapidity();
+}
+
+//___________________________________________________________
+
+Int_t
+AliAnalysisPIDCascadeParticle::GetSign() const
+{
+
+  TDatabasePDG *dbpdg = TDatabasePDG::Instance();
+  TParticlePDG *ppdg = dbpdg->GetParticle(fPdgCode);
+  if (!ppdg)
+    return 0;
+  return TMath::Nint(ppdg->Charge());
+}
+
+//___________________________________________________________
+
+Int_t
+AliAnalysisPIDCascadeParticle::GetPID() const
+{
+  /*
+   * get PID
+   */
+
+  for (Int_t ipart = 0; ipart < AliPID::kSPECIES; ipart++)
+    if (TMath::Abs(fPdgCode) == AliPID::ParticleCode(ipart))
+      return ipart;
+  return -1;
+
+}
+
+//___________________________________________________________
+
+Double_t
+AliAnalysisPIDCascadeParticle::GetMass() const
+{
+  /*
+   * get mass
+   */
+
+  if (GetPID() == -1)
+    return 0.;
+  return AliPID::ParticleMass(GetPID());
+}
+
+//___________________________________________________________
+
+AliAnalysisPIDCascadeParticle::AliAnalysisPIDCascadeParticle() :
+  TObject(),
+  fLabel(0),
+  fPt(0.),
+  fEta(0.),
+  fPhi(0.),
+  fPdgCode(0),
+  fMotherPdgCode(0)
+{
+  /*
+   * default constructor
+   */
+}
+
+//___________________________________________________________
+
+AliAnalysisPIDCascadeParticle::AliAnalysisPIDCascadeParticle(const AliAnalysisPIDCascadeParticle &source) :
+  TObject(source),
+  fLabel(source.fLabel),
+  fPt(source.fPt),
+  fEta(source.fEta),
+  fPhi(source.fPhi),
+  fPdgCode(source.fPdgCode),
+  fMotherPdgCode(source.fMotherPdgCode)
+{
+  /*
+   * copy constructor
+   */
+}
+
+//___________________________________________________________
+
+AliAnalysisPIDCascadeParticle &
+AliAnalysisPIDCascadeParticle::operator=(const AliAnalysisPIDCascadeParticle &source)
+{
+  /*
+   * operator=
+   */
+
+  if (&source == this) return *this;
+  TObject::operator=(source);
+
+  fLabel = source.fLabel;
+  fPt = source.fPt;
+  fEta = source.fEta;
+  fPhi = source.fPhi;
+  fPdgCode = source.fPdgCode;
+  fMotherPdgCode = source.fMotherPdgCode;
+  return *this;
+}
+
+//___________________________________________________________
+
+AliAnalysisPIDCascadeParticle::~AliAnalysisPIDCascadeParticle()
+{
+  /*
+   * default destructor
+   */
+}
+
+//___________________________________________________________
+
+void
+AliAnalysisPIDCascadeParticle::Reset()
+{
+  /*
+   * reset
+   */
+
+  fLabel = 0;
+  fPt = 0.;
+  fEta = 0.;
+  fPhi = 0.;
+  fPdgCode = 0;
+  fMotherPdgCode = 0;
+
+}
+
+//___________________________________________________________
+
+void
+AliAnalysisPIDCascadeParticle::Update(TParticle *particle, Int_t label, Int_t MotherPdg)
+{
+  /*
+   * update
+   */
+
+  fLabel = label;
+  fMotherPdgCode = MotherPdg;
+  fPt = particle->Pt();
+  fEta = particle->Eta();
+  fPhi = particle->Phi();
+  fPdgCode = particle->GetPdgCode();
+
+}

--- a/PWGLF/SPECTRA/PiKaPr/TPCTOFCascades/AliAnalysisPIDCascadeParticle.h
+++ b/PWGLF/SPECTRA/PiKaPr/TPCTOFCascades/AliAnalysisPIDCascadeParticle.h
@@ -1,0 +1,49 @@
+#ifndef ALIANALYSISPIDPARTICLE_H
+#define ALIANALYSISPIDPARTICLE_H
+
+#include "TObject.h"
+#include "TLorentzVector.h"
+
+class TParticle;
+
+class AliAnalysisPIDCascadeParticle :
+public TObject
+{
+
+ public:
+
+  AliAnalysisPIDCascadeParticle(); // default constructor
+  AliAnalysisPIDCascadeParticle(const AliAnalysisPIDCascadeParticle &source); // copy constructor
+  AliAnalysisPIDCascadeParticle &operator=(const AliAnalysisPIDCascadeParticle &source); // operator=
+  virtual ~AliAnalysisPIDCascadeParticle(); // default destructor
+
+  Int_t GetLabel() const {return fLabel;} // get label
+  Float_t GetPt() const {return fPt;}; // get pt
+  Float_t GetEta() const {return fEta;}; // get eta
+  Float_t GetPhi() const {return fPhi;}; // get phi
+  Int_t GetPdgCode() const {return fPdgCode;}; // get PDG code
+  Int_t GetMotherPdgCode() const {return fMotherPdgCode; }; //get mother PDG code
+  Double_t GetY() const; // get Y
+  Int_t GetSign() const; // get sign
+  Int_t GetPID() const; // get MC PID
+  Double_t GetMass() const; // get mass
+
+  void Reset(); // reset
+  void Update(TParticle *particle, Int_t label, Int_t MotherPDG); // update
+
+ private:
+
+  Int_t fLabel; // label
+  Float_t fPt; // pt
+  Float_t fEta; // eta
+  Float_t fPhi; // phi
+  Int_t fPdgCode; // PDG code
+  Int_t fMotherPdgCode; //Mother PDG code
+
+  /*** tools ***/
+  static TLorentzVector fgLorentzVector;
+
+  ClassDef(AliAnalysisPIDCascadeParticle, 1);
+};
+
+#endif /* ALIANALYSISPIDCASCADEPARTICLE_H */

--- a/PWGLF/SPECTRA/PiKaPr/TPCTOFCascades/AliAnalysisPIDCascadeTrack.cxx
+++ b/PWGLF/SPECTRA/PiKaPr/TPCTOFCascades/AliAnalysisPIDCascadeTrack.cxx
@@ -1,0 +1,531 @@
+#include "AliAnalysisPIDCascadeTrack.h"
+#include "AliAnalysisPIDCascadeEvent.h"
+//#include "AliStack.h"
+#include "AliTrackReference.h"
+#include "AliMCEvent.h"
+#include "TParticle.h"
+#include "TDatabasePDG.h"
+#include "TParticlePDG.h"
+#include "TFile.h"
+#include "TH2F.h"
+#include "TF1.h"
+#include "TMath.h"
+#include "AliPIDResponse.h"
+#include "AliLog.h"
+
+ClassImp(AliAnalysisPIDCascadeTrack)
+
+//___________________________________________________________
+
+Float_t AliAnalysisPIDCascadeTrack::fgMatchTrackDeltaX = 10.;
+Float_t AliAnalysisPIDCascadeTrack::fgMatchTrackDeltaZ = 10;
+
+//___________________________________________________________
+
+TLorentzVector AliAnalysisPIDCascadeTrack::fgLorentzVector;
+AliTPCPIDResponse *AliAnalysisPIDCascadeTrack::fgTPCResponse = NULL;
+AliTOFPIDResponse *AliAnalysisPIDCascadeTrack::fgTOFResponse = NULL;
+TH2F *AliAnalysisPIDCascadeTrack::hTOFtuned_th[AliPID::kSPECIES] = {
+  NULL, NULL, NULL, NULL, NULL
+};
+
+
+Float_t
+AliAnalysisPIDCascadeTrack::GetY(Float_t mass) const
+{
+  
+  fgLorentzVector.SetPtEtaPhiM(fPt, fEta, fPhi, mass);
+  return fgLorentzVector.Rapidity();
+}
+
+//___________________________________________________________
+
+AliAnalysisPIDCascadeTrack::AliAnalysisPIDCascadeTrack() :
+  //General
+  TObject(),
+  fP(),
+  fPt(),
+  fEta(),
+  fPhi(),
+  fSign(0.),
+  fStatus(0x0),
+  fLabel(0),
+  fImpactParameter(),
+  //TPC
+  fTPCdEdx(0.),
+  fTPCdEdxN(0),
+  //TOF
+  fTOFIndex(0),
+  fTOFLength(0.),
+  fTOFDeltaX(0.),
+  fTOFDeltaZ(0.),
+  fTOFLabel(),
+  //MC
+  fMCPrimary(kFALSE),
+  fMCPdgCode(0),
+  fMCMotherPrimary(kFALSE),
+  fMCMotherPdgCode(0),
+  fMCMotherLabel(0),
+  fMCPrimaryPdgCode(0),
+  fMCPrimaryLabel(0),
+  fMCTOFMatchPrimary(kFALSE),
+  fMCTOFMatchPdgCode(0),
+  fMCTOFMatchLevel(-1),
+  fMCTOFTime(0.),
+  fMCTOFLength(0.),
+  fMCSecondaryWeak(kFALSE),
+  fMCSecondaryMaterial(kFALSE),
+//PID
+  nSigmaPionTPC(0.),
+  nSigmaKaonTPC(0.),
+  nSigmaProtonTPC(0.),
+  nSigmaPionTOF(0.),
+  nSigmaKaonTOF(0.),
+  nSigmaProtonTOF(0.),
+  fTrackCutFlag(0)
+{
+  /*
+   * default constructor
+   */
+
+  Double_t bbParam[6] = { /* R+ fit on minimum-bias PbPb (run 138275, pass2) */
+    5.22879e+01,
+    2.80863e-02,
+    2.58364e+01,
+    5.15102e-07,
+    2.42169e+00,
+    5.38930e+00
+  };
+  
+  if (!fgTPCResponse) {
+    fgTPCResponse = new AliTPCPIDResponse();
+    fgTPCResponse->SetMip(bbParam[0]);
+    fgTPCResponse->SetBetheBlochParameters(bbParam[1], bbParam[2], bbParam[3], bbParam[4], bbParam[5]);
+  }
+
+  /* reset */
+  Reset();
+}
+
+//___________________________________________________________
+AliAnalysisPIDCascadeTrack::AliAnalysisPIDCascadeTrack(const AliAnalysisPIDCascadeTrack &source) :
+  //General
+  TObject(source),
+  fP(source.fP),
+  fPt(source.fPt),
+  fEta(source.fEta),
+  fPhi(source.fPhi),
+  fSign(source.fSign),
+  fStatus(source.fStatus),
+  fLabel(source.fLabel),
+  fImpactParameter(),
+  //TPC
+  fTPCdEdx(source.fTPCdEdx),
+  fTPCdEdxN(source.fTPCdEdxN),
+  //TOF
+  fTOFIndex(source.fTOFIndex),
+  fTOFLength(source.fTOFLength),
+  fTOFDeltaX(source.fTOFDeltaX),
+  fTOFDeltaZ(source.fTOFDeltaZ),
+  fTOFLabel(),
+  //MC
+  fMCPrimary(source.fMCPrimary),
+  fMCPdgCode(source.fMCPdgCode),
+  fMCMotherPrimary(source.fMCMotherPrimary),
+  fMCMotherPdgCode(source.fMCMotherPdgCode),
+  fMCMotherLabel(source.fMCMotherLabel),
+  fMCPrimaryPdgCode(source.fMCPrimaryPdgCode),
+  fMCPrimaryLabel(source.fMCPrimaryLabel),
+  fMCTOFMatchPrimary(source.fMCTOFMatchPrimary),
+  fMCTOFMatchPdgCode(source.fMCTOFMatchPdgCode),
+  fMCTOFMatchLevel(source.fMCTOFMatchLevel),
+  fMCTOFTime(source.fMCTOFTime),
+  fMCTOFLength(source.fMCTOFLength),
+  fMCSecondaryWeak(source.fMCSecondaryWeak),
+  fMCSecondaryMaterial(source.fMCSecondaryMaterial),
+//PID
+  nSigmaPionTPC(source.nSigmaPionTPC),
+  nSigmaKaonTPC(source.nSigmaKaonTPC),
+  nSigmaProtonTPC(source.nSigmaProtonTPC),
+  nSigmaPionTOF(source.nSigmaPionTOF),
+  nSigmaKaonTOF(source.nSigmaKaonTOF),
+  nSigmaProtonTOF(source.nSigmaProtonTOF),
+  fTrackCutFlag(source.fTrackCutFlag)
+{
+  /*
+   * copy constructor
+   */
+
+  for (Int_t i = 0; i < 2; i++) fImpactParameter[i] = source.fImpactParameter[i];
+  for (Int_t i = 0; i < 3; i++) fTOFLabel[i] = source.fTOFLabel[i];
+
+}
+
+//___________________________________________________________
+
+AliAnalysisPIDCascadeTrack &
+AliAnalysisPIDCascadeTrack::operator=(const AliAnalysisPIDCascadeTrack &source)
+{
+  /*
+   * operator=
+   */
+
+  if (&source == this) return *this;
+  TObject::operator=(source);
+  //General
+  fP = source.fP;
+  fPt = source.fPt;
+  fEta = source.fEta;
+  fPhi = source.fPhi;
+  fSign = source.fSign;
+  fStatus = source.fStatus;
+  fLabel = source.fLabel;
+  for (Int_t i = 0; i < 2; i++) fImpactParameter[i] = source.fImpactParameter[i];
+  //TPC
+  fTPCdEdx = source.fTPCdEdx;
+  fTPCdEdxN = source.fTPCdEdxN;
+  //TOF
+  fTOFIndex = source.fTOFIndex;
+  fTOFLength = source.fTOFLength;
+  fTOFDeltaX = source.fTOFDeltaX;
+  fTOFDeltaZ = source.fTOFDeltaZ;
+  for (Int_t i = 0; i < 3; i++) fTOFLabel[i] = source.fTOFLabel[i];
+  //MC
+  fMCPrimary = source.fMCPrimary;
+  fMCPdgCode = source.fMCPdgCode;
+  fMCMotherPrimary = source.fMCMotherPrimary;
+  fMCMotherPdgCode = source.fMCMotherPdgCode;
+  fMCMotherLabel = source.fMCMotherLabel;
+  fMCPrimaryPdgCode = source.fMCPrimaryPdgCode;
+  fMCPrimaryLabel = source.fMCPrimaryLabel;
+  fMCTOFMatchPrimary = source.fMCTOFMatchPrimary;
+  fMCTOFMatchPdgCode = source.fMCTOFMatchPdgCode;
+  fMCTOFMatchLevel = source.fMCTOFMatchLevel;
+  fMCTOFTime = source.fMCTOFTime;
+  fMCTOFLength = source.fMCTOFLength;
+  fMCSecondaryWeak = source.fMCSecondaryWeak;
+  fMCSecondaryMaterial = source.fMCSecondaryMaterial;
+  //PID
+  nSigmaPionTPC = source.nSigmaPionTPC;
+  nSigmaKaonTPC = source.nSigmaKaonTPC;
+  nSigmaProtonTPC = source.nSigmaProtonTPC;
+  nSigmaPionTOF = source.nSigmaPionTOF;
+  nSigmaKaonTOF = source.nSigmaKaonTOF;
+  nSigmaProtonTOF = source.nSigmaProtonTOF;
+  fTrackCutFlag = source.fTrackCutFlag;
+
+  return *this;
+}
+
+//___________________________________________________________
+
+AliAnalysisPIDCascadeTrack::~AliAnalysisPIDCascadeTrack()
+{
+  /*
+   * default destructor
+   */
+
+}
+
+void
+AliAnalysisPIDCascadeTrack::Reset()
+{
+  /*
+   * reset
+   */
+  //General
+  fP = 0.;
+  fPt = 0.;
+  fEta = 0.;
+  fPhi = 0.;
+  fSign = 0.;
+  fStatus = 0;
+  fLabel = 0;
+  for (Int_t i = 0; i < 2; i++) fImpactParameter[i] = 0.;
+  //TPC
+  fTPCdEdx = 0.;
+  fTPCdEdxN = 0;
+  //TOF
+  fTOFIndex = 0;
+  fTOFLength = 0.;
+  fTOFDeltaX = 0.;
+  fTOFDeltaZ = 0.;
+  for (Int_t i = 0; i < 3; i++) fTOFLabel[i] = 0;
+  //MC
+  fMCPrimary = kFALSE;
+  fMCPdgCode = 0;
+  fMCMotherPrimary = kFALSE;
+  fMCMotherPdgCode = 0;
+  fMCMotherLabel = 0;
+  fMCPrimaryPdgCode = 0;
+  fMCPrimaryLabel = 0;
+  fMCTOFMatchPrimary = kFALSE;
+  fMCTOFMatchPdgCode = 0;
+  fMCTOFMatchLevel = -1;
+  fMCTOFTime = 0.;
+  fMCTOFLength = 0.;
+  fMCSecondaryWeak = 0.;
+  fMCSecondaryMaterial = 0.;
+  //PID
+  nSigmaPionTPC = 0.;
+  nSigmaKaonTPC = 0;
+  nSigmaProtonTPC = 0;
+  nSigmaPionTOF = 0;
+  nSigmaKaonTOF = 0;
+  nSigmaProtonTOF = 0;
+  fTrackCutFlag = 0;
+  
+}
+
+//___________________________________________________________
+
+void
+AliAnalysisPIDCascadeTrack::Update(AliESDtrack *track, AliMCEvent *mcevent, AliPIDResponse *PIDRes, Int_t TrackCutFlag)
+{
+  /*
+   * update
+   */
+
+  fP = track->P();
+  fPt = track->Pt();
+  fEta = track->Eta();
+  fPhi = track->Phi();
+  fSign = track->GetSign();
+  fStatus = track->GetStatus();
+  fLabel = track->GetLabel();
+  track->GetImpactParameters(&fImpactParameter[0],&fImpactParameter[1]);
+  fTPCdEdx = track->GetTPCsignal();
+  fTPCdEdxN = track->GetTPCsignalN();
+
+  nSigmaPionTPC = PIDRes->NumberOfSigmasTPC(track,AliPID::kPion);
+  nSigmaKaonTPC = PIDRes->NumberOfSigmasTPC(track,AliPID::kKaon);
+  nSigmaProtonTPC = PIDRes->NumberOfSigmasTPC(track,AliPID::kProton);
+  nSigmaPionTOF = PIDRes->NumberOfSigmasTOF(track,AliPID::kPion);
+  nSigmaKaonTOF = PIDRes->NumberOfSigmasTOF(track,AliPID::kKaon);
+
+  fTOFLength = track->GetIntegratedLength();
+  fTOFDeltaX = track->GetTOFsignalDx();
+  fTOFDeltaZ = track->GetTOFsignalDz();
+  track->GetTOFLabel(fTOFLabel);
+  fTrackCutFlag = TrackCutFlag;
+  /* info from track references */
+  fMCTOFTime = 0.;
+  fMCTOFLength = 0.;
+  if (mcevent && fTOFLabel[0] > 0) {
+    TParticle *particle;
+    TClonesArray *arrayTR;
+    AliTrackReference *trackRef;
+    mcevent->GetParticleAndTR(fTOFLabel[0], particle, arrayTR);
+    if(arrayTR) {
+      for (Int_t itr = 0; itr < arrayTR->GetEntries(); itr++) {
+	trackRef = (AliTrackReference *)arrayTR->At(itr);
+	if (!trackRef || trackRef->DetectorId() != AliTrackReference::kTOF) continue;
+	fMCTOFTime = trackRef->GetTime() * 1.e12; /* s -> ps */
+	fMCTOFLength = trackRef->GetLength();
+	/* break as soon as we get it */
+	break;
+      }
+    }
+  }
+  /* info from stack */
+  fMCPrimary = kFALSE;
+  fMCPdgCode = 0;
+  fMCMotherPrimary = kFALSE;
+  fMCMotherPdgCode = 0;
+  fMCPrimaryPdgCode = 0;
+  fMCSecondaryWeak = kFALSE;
+  fMCSecondaryMaterial = kFALSE;
+  if (mcevent) {
+    Int_t index = TMath::Abs(fLabel);
+    if (index < 0) {
+      printf("index = %d\n", index);
+      return;
+    }
+    TParticle *particle = mcevent->Particle(index);
+    fMCPrimary = mcevent->IsPhysicalPrimary(index);
+    fMCSecondaryWeak = mcevent->IsSecondaryFromWeakDecay(index);
+    fMCSecondaryMaterial = mcevent->IsSecondaryFromMaterial(index);
+    fMCPdgCode = particle->GetPdgCode();
+    Int_t indexm = particle->GetFirstMother();
+    if (indexm < 0) {
+      fMCMotherPrimary = kFALSE;
+      fMCMotherPdgCode = 0;
+    }
+    else {
+      TParticle *particlem = mcevent->Particle(indexm);
+      fMCMotherPrimary = mcevent->IsPhysicalPrimary(indexm);
+      fMCMotherPdgCode = particlem->GetPdgCode();
+      fMCMotherLabel = indexm;
+    }
+    if (fMCPrimary) {
+      fMCPrimaryPdgCode = fMCPdgCode;
+      fMCPrimaryLabel = fLabel;
+    } else {
+      Bool_t primary = kFALSE;
+      while (!primary) {
+	if (indexm < 0) {
+	  fMCPrimaryPdgCode = 0;
+	  break;
+	}
+	TParticle *particlem = mcevent->Particle(indexm);
+	primary = mcevent->IsPhysicalPrimary(indexm);
+	if (primary) {
+	  fMCPrimaryPdgCode = particlem->GetPdgCode();
+	  fMCPrimaryLabel = indexm;
+	} else
+	  indexm = particlem->GetFirstMother();
+      }
+    }
+    
+    /* check TOF match */
+    fMCTOFMatchPrimary = kFALSE;
+    fMCTOFMatchPdgCode = 0;
+    fMCTOFMatchLevel = -1;
+    if (fTOFLabel[0] > 0) {
+      index = fTOFLabel[0];
+      particle = mcevent->Particle(index);
+      fMCTOFMatchPrimary = mcevent->IsPhysicalPrimary(index);
+      fMCTOFMatchPdgCode = particle->GetPdgCode();
+      Int_t tracklabel = TMath::Abs(fLabel);
+      Int_t matchlevel = -1;
+      for (Int_t ilevel = 0; index > 0; ilevel++) {
+	if (index == tracklabel) {
+	  matchlevel = ilevel;
+	  break;
+	}
+	index = mcevent->Particle(index)->GetFirstMother();
+      }
+      fMCTOFMatchLevel = matchlevel;
+    }
+    
+  }
+  fTimeZeroSigma = 0.;
+  
+}
+
+//___________________________________________________________
+
+Bool_t
+AliAnalysisPIDCascadeTrack::HasTPCPID() const
+{
+  /*
+   * has TPC PID
+   */
+
+  /* check PID signal */
+  if (fTPCdEdx <= 0. || fTPCdEdxN == 0) return kFALSE;
+  return kTRUE;
+}
+  
+//___________________________________________________________
+
+Bool_t
+AliAnalysisPIDCascadeTrack::HasTOFPID(TH1 *henabled) const
+{
+  /*
+   * has TOF PID
+   */
+
+  /* check channel enabled */
+  if (henabled && henabled->GetBinContent(fTOFIndex + 1) == 0) return kFALSE;
+  
+  /* check TOF matched track */
+  if (!(fStatus & AliESDtrack::kTOFout)||
+      !(fStatus & AliESDtrack::kTIME)) return kFALSE;
+  /* check integrated length */
+  if (fTOFLength < 350.) return kFALSE;
+  /* check deltax and deltaz */
+  if (TMath::Abs(fTOFDeltaX) > fgMatchTrackDeltaX ||
+      TMath::Abs(fTOFDeltaZ) > fgMatchTrackDeltaZ) return kFALSE;
+  return kTRUE;
+}
+  
+//___________________________________________________________  
+//___________________________________________________________
+//___________________________________________________________
+//___________________________________________________________
+
+Int_t
+AliAnalysisPIDCascadeTrack::GetMCPID() const
+{
+  /*
+   * get MC PID
+   */
+
+  for (Int_t ipart = 0; ipart < AliPID::kSPECIES; ipart++)
+    if (TMath::Abs(fMCPdgCode) == AliPID::ParticleCode(ipart))
+      return ipart;
+  return -1;
+
+}
+
+//___________________________________________________________
+
+Int_t
+AliAnalysisPIDCascadeTrack::GetMCCharge() const
+{
+  /*
+   * get MC charge
+   */
+  
+  TDatabasePDG *dbpdg = TDatabasePDG::Instance();
+  TParticlePDG *pdg = dbpdg->GetParticle(fMCPdgCode);
+  if (!pdg) return 0;
+  return (Int_t)TMath::Sign(1., pdg->Charge());
+};
+
+//___________________________________________________________
+//___________________________________________________________
+
+// Bool_t
+// AliAnalysisPIDCascadeTrack::AcceptTrack(Bool_t selPrimaries)
+// {
+//   /*
+//    * accept track
+//    */
+
+//   /* check charge */
+//   if (fSign == 0.) return kFALSE;
+//   /* check eta */
+//   if (TMath::Abs(fEta) > fgEtaCut) return kFALSE;
+//   if (TMath::Abs(fEta) < fgEtaReject) return kFALSE;
+//   /* check max DCA to vertex Z */
+//   if (TMath::Abs(fImpactParameter[1]) > fgMaxDCAToVertexZCut) return kFALSE;
+//   /* check max DCA to vertex XY */
+//   if (selPrimaries) {
+//     Float_t maxdca = fgMaxDCAToVertexXYPtDepFormula->Eval(fPt);
+//     if (TMath::Abs(fImpactParameter[0]) > maxdca) return kFALSE;
+//   }
+//   /* check max chi2 per cluster TPC */
+//   Float_t chi2 = fTPCchi2 / (Float_t)fTPCNcls;
+//   if (chi2 > fgMaxChi2PerClusterTPC) return kFALSE;
+//   /* check min N clusters TPC */
+//   if (fgAcceptTrackClusterCut != 1) {
+//     if (fTPCNcls < fgMinNClustersTPC) return kFALSE;
+//   }
+//   if (fgAcceptTrackClusterCut == 1) {
+//     /* check min N crossed rows TPC */
+//     if (fTPCNcr < fgMinNCrossedRowsTPC) return kFALSE;
+//     /* check min crossed rows over findable clusters ratio */
+//     Float_t crratio = 1.;
+//     if (fTPCNclsF > 0) crratio = fTPCNcr / fTPCNclsF;
+//     if (crratio < fgMinRatioCrossedRowsOverFindableClustersTPC) return kFALSE;
+//   }
+//   /* check accept track status cut */
+//   if (fgAcceptTrackStatusCut && (fStatus & fgAcceptTrackStatusCut) == 0) return kFALSE;
+//   /* check reject track status cut */
+//   if (fgRejectTrackStatusCut && (fStatus & fgRejectTrackStatusCut) != 0) return kFALSE;
+//   /* reject ITS fakes if requested */
+//   if (fgRejectITSFakes && fITSFakeFlag) return kFALSE;
+
+//   /* accept track */
+//   return kTRUE;
+// }
+
+// Bool_t AliAnalysisPIDCascadeTrack::CheckExtraCuts(Float_t minTPCNcr, Float_t maxChi2PerFindableCluster, Float_t maxDCAz) {
+//   if(fTPCNcr<minTPCNcr) return kFALSE;
+//   if(fTPCNclsF<=0) return kFALSE;
+//   if(fTPCchi2/fTPCNclsF > maxChi2PerFindableCluster) return kFALSE;
+//   if(TMath::Abs(fImpactParameter[1])>maxDCAz) return kFALSE;
+//   return kTRUE;
+// };

--- a/PWGLF/SPECTRA/PiKaPr/TPCTOFCascades/AliAnalysisPIDCascadeTrack.h
+++ b/PWGLF/SPECTRA/PiKaPr/TPCTOFCascades/AliAnalysisPIDCascadeTrack.h
@@ -1,0 +1,166 @@
+#ifndef ALIANALYSISPIDCASCADETRACK_H
+#define ALIANALYSISPIDCASCADETRACK_H
+
+#include "TObject.h"
+#include "TMath.h"
+#include "TLorentzVector.h"
+//#include "AliTOFGeometry.h"
+//#include "AliTOFcalibHisto.h"
+#include "AliTPCPIDResponse.h"
+#include "AliTOFPIDResponse.h"
+#include "AliAnalysisPIDCascadeEvent.h"
+#include "AliESDtrack.h"
+#include "AliPID.h"
+#include "TF1.h"
+#include "AliPIDResponse.h"
+
+//class AliStack;
+class AliMCEvent;
+class TH2F;
+class TH1;
+
+class AliAnalysisPIDCascadeTrack :
+public TObject
+{
+
+ public:
+
+  AliAnalysisPIDCascadeTrack();//default constructor
+  AliAnalysisPIDCascadeTrack(const AliAnalysisPIDCascadeTrack &source); //copy constructor
+  AliAnalysisPIDCascadeTrack &operator=(const AliAnalysisPIDCascadeTrack &source);
+  virtual ~AliAnalysisPIDCascadeTrack(); //default destructor.
+
+  
+  //General Track Info
+  Float_t GetP() const {return fP;}; // get p
+  Float_t GetPt() const {return fPt;}; // get pt
+  Float_t GetEta() const {return fEta;}; // get eta
+  Float_t GetPhi() const {return fPhi;}; // get phi
+  Float_t GetY(Float_t mass) const; // get Y
+  Double_t GetSign() const {return fSign;}; // get sign
+  ULong64_t GetStatus() const {return fStatus;}; // get status
+  Int_t GetLabel() const {return fLabel;}; // get label
+  Float_t GetImpactParameter(Int_t i) const {return fImpactParameter[i];}; // get impact parameter
+  //TPC Info
+  Float_t GetTPCdEdx() const {return fTPCdEdx;}; // get TPC dEdx
+  UShort_t GetTPCdEdxN() const {return fTPCdEdxN;}; // get TPC dEdx clusters
+
+  //TOF Info
+  Int_t GetTOFIndex() const {return fTOFIndex;}; // get TOF index
+
+ Float_t GetTOFLength() const {return fTOFLength;}; // get TOF length
+  Int_t GetTOFLabel(Int_t i) const {return fTOFLabel[i];}; // get TOF label
+  Float_t GetTOFDeltaX() const {return fTOFDeltaX;}; // get TOF deltaX
+  Float_t GetTOFDeltaZ() const {return fTOFDeltaZ;}; // get TOF deltaZ
+  //MC Info
+  Bool_t IsMCPrimary() const {return fMCPrimary;}; // is MC primary
+  Bool_t IsMCSecondaryWeakDecay() const {return fMCSecondaryWeak;}; // is MC weak decay
+  Bool_t IsMCSecondaryMaterial() const {return fMCSecondaryMaterial;}; // is MC material
+  Bool_t IsMCPrimary(Int_t ipart) const {return (fMCPrimary && TMath::Abs(fMCPdgCode) == AliPID::ParticleCode(ipart));}; // is MC primary
+  Int_t GetMCPdgCode() const {return fMCPdgCode;}; // get MC PDG code
+  Int_t GetMCMotherPdgCode() const {return fMCMotherPdgCode;}; // get MC mother PDG code
+  Int_t GetMCMotherPrimary() const {return fMCMotherPrimary;}; // get MC mother primary
+  Int_t GetMCMotherLabel() const {return fMCMotherLabel; }; //get MC mother label
+  Int_t GetMCPrimaryPdgCode() const {return fMCPrimaryPdgCode;}; // get MC PDG code of primary (grand)mother
+  Int_t GetMCPrimaryLabel() const {return fMCPrimaryLabel; }; //get MC label of primary (grand)mother
+  Bool_t IsMCTOFMatchPrimary() const {return fMCTOFMatchPrimary;};
+  Int_t GetMCTOFMatchPdgCode() const {return fMCTOFMatchPdgCode;};
+  Int_t GetMCTOFMatchLevel() const {return fMCTOFMatchLevel;};
+  Float_t GetMCTOFTime() const {return fMCTOFTime;};
+  Float_t GetMCTOFLength() const {return fMCTOFLength;};
+
+
+  void Reset(); // reset
+  void Update(AliESDtrack *track, AliMCEvent *mcevent, AliPIDResponse *PIDRes, Int_t TrackCutFlag); // update
+  Bool_t HasTOFMatch() const {return (fStatus & AliESDtrack::kTOFout);}; // has TOF match
+  Bool_t HasTPCPID() const; // has TPC PID
+  Bool_t HasTOFPID(TH1 *henabled = NULL) const; // has TOF PID
+  Int_t GetMCPID() const; // get MC PID
+  Int_t GetMCCharge() const; // get MC charge
+  Bool_t IsTOFout() const {return fStatus & AliESDtrack::kTOFout;}; // is TOF out
+  Float_t GetNSigmaPionTPC() {return nSigmaPionTPC;};
+  Float_t GetNSigmaKaonTPC() {return nSigmaKaonTPC;};
+  Float_t GetNSigmaProtonTPC() {return nSigmaProtonTPC;};
+  Float_t GetNSigmaPionTOF() {return nSigmaPionTOF;};
+  Float_t GetNSigmaKaonTOF() {return nSigmaKaonTOF;};
+  Float_t GetNSigmaProtonTOF() {return nSigmaProtonTOF;};
+  Int_t GetTrackCutFlag() {return fTrackCutFlag; };
+
+  // Bool_t IsAcceptedByTrackCuts(Int_t CutFlag) { return GetTrackCutFlag()&CutFlag;};
+
+
+  static AliTOFPIDResponse *GetTOFResponse() {return fgTOFResponse;}; // getter
+  static AliTPCPIDResponse *GetTPCResponse() {return fgTPCResponse;}; // getter
+  static void SetTOFResponse(AliTOFPIDResponse *value) {fgTOFResponse = value;}; // setter
+  static void SetTPCResponse(AliTPCPIDResponse *value) {fgTPCResponse = value;}; // setter
+  static void UpdateTOFResponse(AliAnalysisPIDCascadeEvent *analysisEvent); // update TOF response
+
+  //Bool_t AcceptTrack(Bool_t selPrimaries = kTRUE); // accept track
+
+  static void SetMatchTrackDeltaX(Float_t value) {fgMatchTrackDeltaX = value;}; // setter
+  static void SetMatchTrackDeltaZ(Float_t value) {fgMatchTrackDeltaZ = value;}; // setter
+  static AliTPCPIDResponse *fgTPCResponse;
+  static AliTOFPIDResponse *fgTOFResponse;
+
+
+ private:
+
+  /*** global track info ***/
+  Float_t fP; // p
+  Float_t fPt; // pt
+  Float_t fEta; // eta
+  Float_t fPhi; // phi
+  Double_t fSign; // sign
+  ULong64_t fStatus; // status
+  Int_t fLabel; // label
+  Float_t fImpactParameter[2]; // impact parameters
+  /*** TPC PID info ***/
+  Float_t fTPCdEdx; // dEdx
+  UShort_t fTPCdEdxN; // dEdx clusters
+  /*** TOF PID info ***/
+  Int_t fTOFIndex; // index
+  Float_t fTOFLength; // track length
+  Float_t fTOFDeltaX; // TOF deltaX
+  Float_t fTOFDeltaZ; // TOF deltaZ
+  Int_t fTOFLabel[3]; // TOF label
+  /*** MC info ***/
+  Bool_t fMCPrimary; // MC primary flag
+  Int_t fMCPdgCode; // MC PDG code
+  Bool_t fMCMotherPrimary; // MC mother primary flag
+  Int_t fMCMotherPdgCode; // MC mother PDG code
+  Int_t fMCMotherLabel; // MC mother label
+  Int_t fMCPrimaryPdgCode; // MC PDG code of primary (grand)mother
+  Int_t fMCPrimaryLabel; // MC label of primary (grand)mother
+  Bool_t fMCTOFMatchPrimary; // MC TOF match primary flag
+  Int_t fMCTOFMatchPdgCode; // MC TOF match PDG code
+  Short_t fMCTOFMatchLevel; // MC TOF match level
+  Float_t fMCTOFTime; // MC TOF time
+  Float_t fMCTOFLength; // MC TOF length
+  Bool_t fMCSecondaryWeak;
+  Bool_t fMCSecondaryMaterial;
+  /*** PID info ***/
+  Float_t nSigmaPionTPC;
+  Float_t nSigmaKaonTPC;
+  Float_t nSigmaProtonTPC;
+  Float_t nSigmaPionTOF;
+  Float_t nSigmaKaonTOF;
+  Float_t nSigmaProtonTOF;
+  Int_t fTrackCutFlag;
+
+  /*** cut paramters */
+  static Float_t fgMatchTrackDeltaX; // match track deltaX
+  static Float_t fgMatchTrackDeltaZ; // match track deltaZ
+
+  /*** tools ***/
+  static TLorentzVector fgLorentzVector;
+  //static AliTOFGeometry fgTOFGeometry;
+  //  static AliTOFcalibHisto fgTOFcalibHisto;
+  //  static Bool_t fgTOFcalibHistoFlag;
+  static TH2F *hTOFtuned_th[AliPID::kSPECIES];
+
+  Float_t fTimeZeroSigma; //!
+
+  ClassDef(AliAnalysisPIDCascadeTrack, 1);
+};
+
+#endif /* ALIANALYSISPIDCASCADETRACK_H */

--- a/PWGLF/SPECTRA/PiKaPr/TPCTOFCascades/AliAnalysisPIDCascadeV0.cxx
+++ b/PWGLF/SPECTRA/PiKaPr/TPCTOFCascades/AliAnalysisPIDCascadeV0.cxx
@@ -1,0 +1,77 @@
+#include "AliAnalysisPIDCascadeV0.h"
+
+AliAnalysisPIDCascadeV0::AliAnalysisPIDCascadeV0():
+  TObject(),
+  fPosAnalysisPIDCascadeTrack(),
+  fNegAnalysisPIDCascadeTrack(),
+  fInvMK0s(0),
+  fInvML(0),
+  fInvMAL(0),
+  fRadius(0),
+  fDCAV0Daughters(0),
+  fV0CosinePA(0),
+  fPt(0),
+  fEta(0),
+  fDCAPV(-999)
+{
+};
+AliAnalysisPIDCascadeV0::AliAnalysisPIDCascadeV0(const AliAnalysisPIDCascadeV0 &source):
+  TObject(source),
+  fPosAnalysisPIDCascadeTrack(source.fPosAnalysisPIDCascadeTrack),
+  fNegAnalysisPIDCascadeTrack(source.fNegAnalysisPIDCascadeTrack),
+  fInvMK0s(source.fInvMK0s),
+  fInvML(source.fInvML),
+  fInvMAL(source.fInvMAL),
+  fRadius(source.fRadius) ,
+  fDCAV0Daughters(source.fDCAV0Daughters),
+  fV0CosinePA(source.fV0CosinePA),
+  fPt(source.fPt),
+  fEta(source.fEta),
+  fDCAPV(source.fDCAPV)
+{
+};
+AliAnalysisPIDCascadeV0 &AliAnalysisPIDCascadeV0::operator=(const AliAnalysisPIDCascadeV0 &source) {
+  if(&source == this) return *this;
+  TObject::operator=(source);
+  fPosAnalysisPIDCascadeTrack = source.fPosAnalysisPIDCascadeTrack;
+  fNegAnalysisPIDCascadeTrack = source.fNegAnalysisPIDCascadeTrack;
+  fInvMK0s = source.fInvMK0s;
+  fInvML = source.fInvML;
+  fInvMAL = source.fInvMAL;
+  fRadius = source.fRadius;
+  fDCAV0Daughters = source.fDCAV0Daughters;
+  fV0CosinePA = source.fV0CosinePA;
+  fPt = source.fPt;
+  fEta = source.fEta;
+  fDCAPV = source.fDCAPV;
+  return *this;
+};
+void AliAnalysisPIDCascadeV0::Update(AliAnalysisPIDCascadeTrack *PosTrack, AliAnalysisPIDCascadeTrack *NegTrack, Double_t *InvMasses, Double_t Radius, Double_t DaughterDCA, Double_t CosinePA, Double_t pT, Double_t Eta, Double_t DCAPV) {
+  fPosAnalysisPIDCascadeTrack = PosTrack;
+  fNegAnalysisPIDCascadeTrack = NegTrack;
+  fInvMK0s=InvMasses[0];
+  fInvML=InvMasses[1];
+  fInvMAL=InvMasses[2];
+  fRadius = Radius; 
+  fDCAV0Daughters = DaughterDCA;
+  fV0CosinePA = CosinePA;
+  fPt = pT;
+  fEta = Eta;
+  fDCAPV = DCAPV;
+};
+AliAnalysisPIDCascadeV0::~AliAnalysisPIDCascadeV0()
+{
+  delete fPosAnalysisPIDCascadeTrack;
+  delete fNegAnalysisPIDCascadeTrack;
+};
+Int_t AliAnalysisPIDCascadeV0::GetMCPdgCode() {
+  if(!fPosAnalysisPIDCascadeTrack || !fNegAnalysisPIDCascadeTrack) return 0;
+  if(fPosAnalysisPIDCascadeTrack->GetMCMotherPdgCode()==0) return 0;
+  if(fPosAnalysisPIDCascadeTrack->GetMCMotherPdgCode()==fNegAnalysisPIDCascadeTrack->GetMCMotherPdgCode())
+    if(fPosAnalysisPIDCascadeTrack->GetMCMotherLabel()==fNegAnalysisPIDCascadeTrack->GetMCMotherLabel())
+      return fPosAnalysisPIDCascadeTrack->GetMCMotherPdgCode();
+  return 0;
+};
+Double_t AliAnalysisPIDCascadeV0::CalculateDCAPV() {
+  return fRadius * ( TMath::Sqrt(1. - fV0CosinePA * fV0CosinePA));
+};

--- a/PWGLF/SPECTRA/PiKaPr/TPCTOFCascades/AliAnalysisPIDCascadeV0.h
+++ b/PWGLF/SPECTRA/PiKaPr/TPCTOFCascades/AliAnalysisPIDCascadeV0.h
@@ -1,0 +1,41 @@
+#ifndef ALIANALYSISPIDCASCADEV0__H
+#define ALIANALYSISPIDCASCADEV0__H
+#include "TObject.h"
+#include "AliAnalysisPIDCascadeTrack.h"
+
+class AliAnalysisPIDCascadeTrack;
+class AliAnalysisPIDCascadeV0:
+public TObject
+{
+ public:
+  AliAnalysisPIDCascadeV0();
+  AliAnalysisPIDCascadeV0(const AliAnalysisPIDCascadeV0 &source); //copy const
+  AliAnalysisPIDCascadeV0 &operator=(const AliAnalysisPIDCascadeV0 &source); // operator =
+  virtual ~AliAnalysisPIDCascadeV0();
+  void Update(AliAnalysisPIDCascadeTrack *PosTrack, AliAnalysisPIDCascadeTrack *NegTrack, Double_t *InvMasses, Double_t Radius, Double_t DaughterDCA, Double_t CosinePA, Double_t pT, Double_t Eta, Double_t DCAPV);
+  AliAnalysisPIDCascadeTrack *GetPosAnalysisTrack() { return fPosAnalysisPIDCascadeTrack; };
+  AliAnalysisPIDCascadeTrack *GetNegAnalysisTrack() { return fNegAnalysisPIDCascadeTrack; };
+  Double_t GetRadius() { return fRadius; };
+  Double_t GetIMK0s() { return fInvMK0s; }; //M K0s
+  Double_t GetIML() { return fInvML; }; //M Lambda
+  Double_t GetIMAL() { return fInvMAL; };//M Antilambda
+  Double_t GetDCAV0Daughters() { return fDCAV0Daughters; };
+  Double_t GetV0CosinePA() { return fV0CosinePA; };
+  Double_t GetPt() { return fPt; };
+  Double_t GetEta() { return fEta; };
+  Int_t GetMCPdgCode();
+  Double_t GetDCAPV() { return fDCAPV; };
+  Double_t CalculateDCAPV();
+ protected:  
+  AliAnalysisPIDCascadeTrack *fPosAnalysisPIDCascadeTrack;
+  AliAnalysisPIDCascadeTrack *fNegAnalysisPIDCascadeTrack;
+  Double_t fInvMK0s,fInvML,fInvMAL;
+  Double_t fRadius;
+  Double_t fDCAV0Daughters, fV0CosinePA;
+  Double_t fPt;
+  //Int_t fMCPdgCode;
+  Double_t fEta;
+  Double_t fDCAPV;
+  ClassDef(AliAnalysisPIDCascadeV0, 1);
+};
+#endif

--- a/PWGLF/SPECTRA/PiKaPr/TPCTOFCascades/AliAnalysisTaskTPCTOFCascade.cxx
+++ b/PWGLF/SPECTRA/PiKaPr/TPCTOFCascades/AliAnalysisTaskTPCTOFCascade.cxx
@@ -863,6 +863,9 @@ AliAnalysisTaskTPCTOFCascade::UserExec(Option_t *option)
     SPDTracklets = ams->GetMultiplicityPercentile("SPDTracklets");
   }
 
+  fAnalysisEvent->SetRefMult08(RefMult08);
+  fAnalysisEvent->SetRefMult05(RefMult05);
+  fAnalysisEvent->SetSPDTracklets(SPDTracklets);
   /*** MC PRIMARY PARTICLES ***/
 
   Int_t mcmulti = 0;

--- a/PWGLF/SPECTRA/PiKaPr/TPCTOFCascades/AliAnalysisTaskTPCTOFCascade.cxx
+++ b/PWGLF/SPECTRA/PiKaPr/TPCTOFCascades/AliAnalysisTaskTPCTOFCascade.cxx
@@ -20,9 +20,9 @@
 #include "TParticle.h"
 #include "TDatabasePDG.h"
 #include "TParticlePDG.h"
-#include "AliAnalysisPIDTrack.h"
-#include "AliAnalysisPIDParticle.h"
-#include "AliAnalysisPIDEvent.h"
+#include "AliAnalysisPIDCascadeTrack.h"
+#include "AliAnalysisPIDCascadeParticle.h"
+#include "AliAnalysisPIDCascadeEvent.h"
 #include "TClonesArray.h"
 #include "AliAnalysisManager.h"
 #include "AliAODHandler.h"
@@ -37,7 +37,7 @@
 #include "AliESDVertex.h"
 #include "AliESDv0.h"
 #include "AliESDcascade.h"
-#include "AliAnalysisPIDV0.h"
+#include "AliAnalysisPIDCascadeV0.h"
 #include "AliAnalysisPIDCascade.h"
 #include "AliAODVertex.h"
 #include "AliKFParticle.h"
@@ -82,13 +82,13 @@ AliAnalysisTaskTPCTOFCascade::AliAnalysisTaskTPCTOFCascade() :
   fVertexZ(0.),
   fMCTimeZero(0.),
   fCentrality(NULL),
-  fAnalysisEvent(new AliAnalysisPIDEvent()),
-  fAnalysisTrackArray(new TClonesArray("AliAnalysisPIDTrack")),
-  fAnalysisTrack(new AliAnalysisPIDTrack()),
-  fAnalysisParticleArray(new TClonesArray("AliAnalysisPIDParticle")),
-  fAnalysisParticle(new AliAnalysisPIDParticle()),
-  fAnalysisV0TrackArray(new TClonesArray("AliAnalysisPIDV0")),
-  fAnalysisV0Track(new AliAnalysisPIDV0()),
+  fAnalysisEvent(new AliAnalysisPIDCascadeEvent()),
+  fAnalysisTrackArray(new TClonesArray("AliAnalysisPIDCascadeTrack")),
+  fAnalysisTrack(new AliAnalysisPIDCascadeTrack()),
+  fAnalysisParticleArray(new TClonesArray("AliAnalysisPIDCascadeParticle")),
+  fAnalysisParticle(new AliAnalysisPIDCascadeParticle()),
+  fAnalysisV0TrackArray(new TClonesArray("AliAnalysisPIDCascadeV0")),
+  fAnalysisV0Track(new AliAnalysisPIDCascadeV0()),
   fAnalysisCascadeTrackArray(new TClonesArray("AliAnalysisPIDCascade")),
   fAnalysisCascadeTrack(new AliAnalysisPIDCascade()),
   fTOFcalib(new AliTOFcalib()),
@@ -160,13 +160,13 @@ AliAnalysisTaskTPCTOFCascade::AliAnalysisTaskTPCTOFCascade(Bool_t isMC) :
   fVertexZ(0.),
   fMCTimeZero(0.),
   fCentrality(NULL),
-  fAnalysisEvent(new AliAnalysisPIDEvent()),
-  fAnalysisTrackArray(new TClonesArray("AliAnalysisPIDTrack")),
-  fAnalysisTrack(new AliAnalysisPIDTrack()),
-  fAnalysisParticleArray(new TClonesArray("AliAnalysisPIDParticle")),
-  fAnalysisParticle(new AliAnalysisPIDParticle()),
-  fAnalysisV0TrackArray(new TClonesArray("AliAnalysisPIDV0")),
-  fAnalysisV0Track(new AliAnalysisPIDV0()),
+  fAnalysisEvent(new AliAnalysisPIDCascadeEvent()),
+  fAnalysisTrackArray(new TClonesArray("AliAnalysisPIDCascadeTrack")),
+  fAnalysisTrack(new AliAnalysisPIDCascadeTrack()),
+  fAnalysisParticleArray(new TClonesArray("AliAnalysisPIDCascadeParticle")),
+  fAnalysisParticle(new AliAnalysisPIDCascadeParticle()),
+  fAnalysisV0TrackArray(new TClonesArray("AliAnalysisPIDCascadeV0")),
+  fAnalysisV0Track(new AliAnalysisPIDCascadeV0()),
   fAnalysisCascadeTrackArray(new TClonesArray("AliAnalysisPIDCascade")),
   fAnalysisCascadeTrack(new AliAnalysisPIDCascade()),
   fTOFcalib(new AliTOFcalib()),
@@ -251,7 +251,7 @@ AliAnalysisTaskTPCTOFCascade::UserCreateOutputObjects()
   OpenFile(2);
   /* output tree */
   fPIDTree = new TTree("PIDTree","PIDTree");
-  fPIDTree->Branch("AnalysisEvent", "AliAnalysisPIDEvent", &fAnalysisEvent);  
+  fPIDTree->Branch("AnalysisEvent", "AliAnalysisPIDCascadeEvent", &fAnalysisEvent);  
   fPIDTree->Branch("AnalysisTrack", "TClonesArray", &fAnalysisTrackArray); 
   fPIDTree->Branch("AnalysisV0Track","TClonesArray",&fAnalysisV0TrackArray);
   fPIDTree->Branch("AnalysisCascadeTrack","TClonesArray",&fAnalysisCascadeTrackArray);
@@ -610,10 +610,10 @@ void AliAnalysisTaskTPCTOFCascade::ProcessV0s() {
       BestPrimaryVert*/
 
     /*Done w/ calculation*/
-    AliAnalysisPIDV0* v0Tree = new ((*fAnalysisV0TrackArray)[fAnalysisV0TrackArray->GetEntries()]) AliAnalysisPIDV0();
+    AliAnalysisPIDCascadeV0* v0Tree = new ((*fAnalysisV0TrackArray)[fAnalysisV0TrackArray->GetEntries()]) AliAnalysisPIDCascadeV0();
     
-    AliAnalysisPIDTrack *pTrack = new AliAnalysisPIDTrack();
-    AliAnalysisPIDTrack *nTrack = new AliAnalysisPIDTrack();
+    AliAnalysisPIDCascadeTrack *pTrack = new AliAnalysisPIDCascadeTrack();
+    AliAnalysisPIDCascadeTrack *nTrack = new AliAnalysisPIDCascadeTrack();
     pTrack->Update(pEsdTrack, fMCEvent, fPIDResponse, GetTrackCutsFlag(pEsdTrack));
     nTrack->Update(nEsdTrack, fMCEvent, fPIDResponse, GetTrackCutsFlag(nEsdTrack));
 
@@ -699,16 +699,6 @@ void AliAnalysisTaskTPCTOFCascade::ProcessCascades() {
     if (temp_p->Pt()<0.15||temp_n->Pt()<0.15||temp_b->Pt()<0.15)
       continue;
 /////////////////////////////////////////////////////////////////////////////
-    //PID cuts & Mass Estimations
-    // Bachelor
-    // Double_t nSigmaBachK = TMath::Abs(fPIDResponse->NumberOfSigmasTPC(temp_b, AliPID::kKaon));
-    // Double_t nSigmaBachPi = TMath::Abs(fPIDResponse->NumberOfSigmasTPC(temp_b, AliPID::kPion));
-    // // Negative V0 daughter
-    // Double_t nSigmaPiNeg = TMath::Abs(fPIDResponse->NumberOfSigmasTPC(temp_n, AliPID::kPion));
-    // Double_t nSigmaPNeg = TMath::Abs(fPIDResponse->NumberOfSigmasTPC(temp_n,AliPID::kProton));
-    // // Positive V0 daughter
-    // Double_t nSigmaPiPos = TMath::Abs(fPIDResponse->NumberOfSigmasTPC(temp_p,AliPID::kPion));
-    // Double_t nSigmaPPos = TMath::Abs(fPIDResponse->NumberOfSigmasTPC(temp_p,AliPID::kProton));
 /////////////////////////////////////////////////////////////////////////////
     if(temp_b->GetSign()<0){
       casc->ChangeMassHypothesis(lV0quality, 3312); //Xi-
@@ -764,11 +754,11 @@ void AliAnalysisTaskTPCTOFCascade::ProcessCascades() {
      AliAnalysisPIDCascade* Cascade = new ((*fAnalysisCascadeTrackArray)[ArrayCounter]) AliAnalysisPIDCascade();
      ArrayCounter++;
         
-     AliAnalysisPIDTrack* bTrack = (AliAnalysisPIDTrack*)Cascade->GetBachAnalysisTrack();
-     AliAnalysisPIDV0* V0 = (AliAnalysisPIDV0*)Cascade->GetV0();
+     AliAnalysisPIDCascadeTrack* bTrack = (AliAnalysisPIDCascadeTrack*)Cascade->GetBachAnalysisTrack();
+     AliAnalysisPIDCascadeV0* V0 = (AliAnalysisPIDCascadeV0*)Cascade->GetV0();
      
-     AliAnalysisPIDTrack* pTrack = new AliAnalysisPIDTrack();
-     AliAnalysisPIDTrack* nTrack = new AliAnalysisPIDTrack();
+     AliAnalysisPIDCascadeTrack* pTrack = new AliAnalysisPIDCascadeTrack();
+     AliAnalysisPIDCascadeTrack* nTrack = new AliAnalysisPIDCascadeTrack();
 
      bTrack->Update(temp_b,fMCEvent,fPIDResponse, GetTrackCutsFlag(temp_b));
      pTrack->Update(temp_p,fMCEvent,fPIDResponse, GetTrackCutsFlag(temp_p));
@@ -841,38 +831,37 @@ AliAnalysisTaskTPCTOFCascade::UserExec(Option_t *option)
     V0MPercentile = -999;
   else {
     V0MPercentile = ams->GetMultiplicityPercentile("V0M");
-    if(ams->GetThisEventIsNotPileup()) EventSelectionFlag += AliAnalysisPIDEvent::kNotPileupInSPD;
-    if(ams->GetThisEventIsNotPileupMV()) EventSelectionFlag += AliAnalysisPIDEvent::kNotPileupInMV;
-    if(ams->GetThisEventIsNotPileupInMultBins()) EventSelectionFlag += AliAnalysisPIDEvent::kNotPileupInMB;
-    if(ams->GetThisEventINELgtZERO()) EventSelectionFlag+=AliAnalysisPIDEvent::kINELgtZERO;
-    if(ams->GetThisEventHasNoInconsistentVertices()) EventSelectionFlag+=AliAnalysisPIDEvent::kNoInconsistentVtx;
-    if(ams->GetThisEventIsNotAsymmetricInVZERO()) EventSelectionFlag+=AliAnalysisPIDEvent::kNoV0Asym;
+    if(ams->GetThisEventIsNotPileup()) EventSelectionFlag += AliAnalysisPIDCascadeEvent::kNotPileupInSPD;
+    if(ams->GetThisEventIsNotPileupMV()) EventSelectionFlag += AliAnalysisPIDCascadeEvent::kNotPileupInMV;
+    if(ams->GetThisEventIsNotPileupInMultBins()) EventSelectionFlag += AliAnalysisPIDCascadeEvent::kNotPileupInMB;
+    if(ams->GetThisEventINELgtZERO()) EventSelectionFlag+=AliAnalysisPIDCascadeEvent::kINELgtZERO;
+    if(ams->GetThisEventHasNoInconsistentVertices()) EventSelectionFlag+=AliAnalysisPIDCascadeEvent::kNoInconsistentVtx;
+    if(ams->GetThisEventIsNotAsymmetricInVZERO()) EventSelectionFlag+=AliAnalysisPIDCascadeEvent::kNoV0Asym;
   };
   Bool_t lSPDandTrkVtxExists=kFALSE;
   Bool_t lPassProximityCut=kTRUE;
-  if(SelectVertex2015pp(fESDEvent,kTRUE,&lSPDandTrkVtxExists,&lPassProximityCut)) EventSelectionFlag+=AliAnalysisPIDEvent::kVertexSelected2015pp;
-  if(lSPDandTrkVtxExists) EventSelectionFlag+=AliAnalysisPIDEvent::kSPDandTrkVtxExists;
-  if(lPassProximityCut) EventSelectionFlag+=AliAnalysisPIDEvent::kPassProximityCut;
+  if(SelectVertex2015pp(fESDEvent,kTRUE,&lSPDandTrkVtxExists,&lPassProximityCut)) EventSelectionFlag+=AliAnalysisPIDCascadeEvent::kVertexSelected2015pp;
+  if(lSPDandTrkVtxExists) EventSelectionFlag+=AliAnalysisPIDCascadeEvent::kSPDandTrkVtxExists;
+  if(lPassProximityCut) EventSelectionFlag+=AliAnalysisPIDCascadeEvent::kPassProximityCut;
   fAnalysisEvent->SetV0Mmultiplicity(V0MPercentile);
   fAnalysisEvent->SetEventFlags(EventSelectionFlag);
-  AliVVZERO *v0 = fESDEvent->GetVZEROData();
-  for(Int_t i=0;i<32;i++) fAnalysisEvent->SetV0CellAmplitude(i,v0->GetMultiplicityV0A(i));
-  for(Int_t i=32;i<64;i++) fAnalysisEvent->SetV0CellAmplitude(i,v0->GetMultiplicityV0C(i-32));
+  //  AliVVZERO *v0 = fESDEvent->GetVZEROData();
+  // for(Int_t i=0;i<32;i++) fAnalysisEvent->SetV0CellAmplitude(i,v0->GetMultiplicityV0A(i));
+  // for(Int_t i=32;i<64;i++) fAnalysisEvent->SetV0CellAmplitude(i,v0->GetMultiplicityV0C(i-32));
   
   Float_t RefMult08 = -1000;
   Float_t RefMult05 = -1000;
   Float_t SPDTracklets = -1000;
-
+  if(!ams){ 
+   RefMult08 = -999;
+   RefMult05 = -999;
+   SPDTracklets = -999;
+  }
   if(ams){
     RefMult08 = ams->GetMultiplicityPercentile("RefMult08");
     RefMult05 = ams->GetMultiplicityPercentile("RefMult05");
     SPDTracklets = ams->GetMultiplicityPercentile("SPDTracklets");
   }
-
-  fAnalysisEvent->SetV0CellAmplitude(0, RefMult08);
-  fAnalysisEvent->SetV0CellAmplitude(1, RefMult05);
-  fAnalysisEvent->SetV0CellAmplitude(2, SPDTracklets);
-
 
   /*** MC PRIMARY PARTICLES ***/
 
@@ -922,7 +911,7 @@ AliAnalysisTaskTPCTOFCascade::UserExec(Option_t *option)
 
       /* update and add analysis particle */
       fAnalysisParticle->Update(particle, ipart, lMotherPDG);
-      new ((*fAnalysisParticleArray)[fAnalysisParticleArray->GetEntries()]) AliAnalysisPIDParticle(*fAnalysisParticle);
+      new ((*fAnalysisParticleArray)[fAnalysisParticleArray->GetEntries()]) AliAnalysisPIDCascadeParticle(*fAnalysisParticle);
     } /* end of loop over primary particles */
 
     
@@ -937,19 +926,9 @@ AliAnalysisTaskTPCTOFCascade::UserExec(Option_t *option)
   fAnalysisEvent->SetIsPileupFromSPD(fIsPileupFromSPD);
   fAnalysisEvent->SetHasVertex(fHasVertex);
   fAnalysisEvent->SetVertexZ(fVertexZ);
-  fAnalysisEvent->SetMCTimeZero(fMCTimeZero);
+  // fAnalysisEvent->SetMCTimeZero(fMCTimeZero);
   fAnalysisEvent->SetRunNumber(fRunNumber);
   fAnalysisEvent->SetMagneticField(fESDEvent->GetMagneticField());
-				
-  /* update TOF event info */
-  for (Int_t i = 0; i < 10; i++) {
-    fAnalysisEvent->SetTimeZeroTOF(i, fESDpid->GetTOFResponse().GetT0bin(i));
-    fAnalysisEvent->SetTimeZeroTOFSigma(i, fESDpid->GetTOFResponse().GetT0binRes(i));
-  }
-  /* update T0 event info */
-  for (Int_t i = 0; i < 3; i++)
-    fAnalysisEvent->SetTimeZeroT0(i, fESDEvent->GetT0TOF(i));
-
 
   Int_t refmulti;
   refmulti = AliESDtrackCuts::GetReferenceMultiplicity(fESDEvent, AliESDtrackCuts::kTrackletsITSTPC,0.8);  
@@ -976,22 +955,20 @@ AliAnalysisTaskTPCTOFCascade::UserExec(Option_t *option)
     const AliESDVertex *vtx = fESDEvent->GetPrimaryVertexTracks();
     if(!vtx || !vtx->GetStatus())
       vtx = fESDEvent->GetPrimaryVertexSPD();
-    if(vtx) {
-      if(vtx->GetStatus()) {
-	Double_t ChiConstrained = track->GetChi2TPCConstrainedVsGlobal(vtx);
-	fAnalysisTrack->SetChi2TPCConstrainedVsGlobal(ChiConstrained);
-      } else
-	fAnalysisTrack->SetChi2TPCConstrainedVsGlobal(-8);
-    };
-    if(track->IsEMCAL()) {
-      AliVCluster *lvcl = fESDEvent->GetCaloCluster(track->GetEMCALcluster());
-      if(lvcl)
-	fAnalysisTrack->SetEMCalPars(lvcl->E(),track->GetTrackPOnEMCal());
-    };
-    new ((*fAnalysisTrackArray)[fAnalysisTrackArray->GetEntries()]) AliAnalysisPIDTrack(*fAnalysisTrack);
-    //fAnalysisV0Track = (V0Track*)fAnalysisTrack;
-    /*fAnalysisV0Track->SetExtraParam(3);
-      new ((*fAnalysisV0TrackArray)[fAnalysisV0TrackArray->GetEntries()]) V0Track(*fAnalysisV0Track);*/
+    // if(vtx) {
+    //   if(vtx->GetStatus()) {
+    // 	Double_t ChiConstrained = track->GetChi2TPCConstrainedVsGlobal(vtx);
+    // 	fAnalysisTrack->SetChi2TPCConstrainedVsGlobal(ChiConstrained);
+    //   } else
+    // 	fAnalysisTrack->SetChi2TPCConstrainedVsGlobal(-8);
+    // };
+    // if(track->IsEMCAL()) {
+    //   AliVCluster *lvcl = fESDEvent->GetCaloCluster(track->GetEMCALcluster());
+    //   if(lvcl)
+    // 	fAnalysisTrack->SetEMCalPars(lvcl->E(),track->GetTrackPOnEMCal());
+    // };
+    new ((*fAnalysisTrackArray)[fAnalysisTrackArray->GetEntries()]) AliAnalysisPIDCascadeTrack(*fAnalysisTrack);
+
     
 
   } /* end of loop over ESD tracks */

--- a/PWGLF/SPECTRA/PiKaPr/TPCTOFCascades/AliAnalysisTaskTPCTOFCascade.h
+++ b/PWGLF/SPECTRA/PiKaPr/TPCTOFCascades/AliAnalysisTaskTPCTOFCascade.h
@@ -13,7 +13,7 @@ class AliESDpid;
 class AliESDtrack;
 class AliESDv0;
 class AliESDVertex;
-class AliAnalysisPIDV0;
+class AliAnalysisPIDCascadeV0;
 class AliAnalysisPIDCascade;
 class AliAODVertex;
 class AliTOFcalib;
@@ -23,9 +23,9 @@ class TH1F;
 class TH2F;
 class TH1D;
 class TObjArray;
-class AliAnalysisPIDEvent;
-class AliAnalysisPIDTrack;
-class AliAnalysisPIDParticle;
+class AliAnalysisPIDCascadeEvent;
+class AliAnalysisPIDCascadeTrack;
+class AliAnalysisPIDCascadeParticle;
 class TClonesArray;
 class AliCentrality;
 class AliPIDResponse;
@@ -121,13 +121,13 @@ public AliAnalysisTaskSE
   Float_t fMCTimeZero; // MC time-zero
   AliCentrality *fCentrality; // centrality
   
-  AliAnalysisPIDEvent *fAnalysisEvent; // analysis event
+  AliAnalysisPIDCascadeEvent *fAnalysisEvent; // analysis event
   TClonesArray *fAnalysisTrackArray; // analysis track array
-  AliAnalysisPIDTrack *fAnalysisTrack; // analysis track
+  AliAnalysisPIDCascadeTrack *fAnalysisTrack; // analysis track
   TClonesArray *fAnalysisParticleArray; // analysis particle array
-  AliAnalysisPIDParticle *fAnalysisParticle; // analysis particle
+  AliAnalysisPIDCascadeParticle *fAnalysisParticle; // analysis particle
   TClonesArray *fAnalysisV0TrackArray; //V0 track array
-  AliAnalysisPIDV0 *fAnalysisV0Track; //V0 track object
+  AliAnalysisPIDCascadeV0 *fAnalysisV0Track; //V0 track object
   TClonesArray *fAnalysisCascadeTrackArray; //Cascade track array
   AliAnalysisPIDCascade *fAnalysisCascadeTrack; //Cascade track object
 


### PR DESCRIPTION
Major changes to the Lund Trees used in the pp@13 TeV S0/RT analyses.
New classes are added (modifications from old classes) that contain only the relevant information needed for these analyses. More complete trees can be found at TPCTOFfits (albeit without cascades).

An alternative version of the AT will be created in the near future that contains all of the previous capabilities.