### PR TITLE
AliAnalysisTaskGFWFlow bypassing calculations

### DIFF
--- a/PWGCF/FLOW/GF/AliAnalysisTaskGFWFlow.cxx
+++ b/PWGCF/FLOW/GF/AliAnalysisTaskGFWFlow.cxx
@@ -61,7 +61,8 @@ AliAnalysisTaskGFWFlow::AliAnalysisTaskGFWFlow():
   fRunNo(-1),
   fCurrSystFlag(0),
   fAddQA(kFALSE),
-  fQAList(0)
+  fQAList(0),
+  fBypassCalculations(kFALSE)
 {
 };
 AliAnalysisTaskGFWFlow::AliAnalysisTaskGFWFlow(const char *name, Bool_t ProduceWeights, Bool_t IsMC, Bool_t AddQA):
@@ -88,7 +89,8 @@ AliAnalysisTaskGFWFlow::AliAnalysisTaskGFWFlow(const char *name, Bool_t ProduceW
   fRunNo(-1),
   fCurrSystFlag(0),
   fAddQA(AddQA),
-  fQAList(0)
+  fQAList(0),
+  fBypassCalculations(kFALSE)
 {
   if(!fProduceWeights) DefineInput(1,TList::Class());
   DefineOutput(1,(fProduceWeights?TList::Class():AliGFWFlowContainer::Class()));
@@ -307,6 +309,7 @@ void AliAnalysisTaskGFWFlow::UserExec(Option_t*) {
   Double_t vz = fAOD->GetPrimaryVertex()->GetZ();
   Int_t vtxb = GetVtxBit(fAOD);
   if(!vtxb) return; //If no vertex pass, then do not consider further
+  if(fBypassCalculations) return;
   //fFlowEvent->SetRunNumber(fAOD->GetRunNumber());
   const AliAODVertex* vtx = dynamic_cast<const AliAODVertex*>(fAOD->GetPrimaryVertex());
   Double_t POSvtx[] = {0.,0.,0.};

--- a/PWGCF/FLOW/GF/AliAnalysisTaskGFWFlow.h
+++ b/PWGCF/FLOW/GF/AliAnalysisTaskGFWFlow.h
@@ -54,6 +54,7 @@ class AliAnalysisTaskGFWFlow : public AliAnalysisTaskSE {
   void CreateCorrConfigs();
   void SetTriggerType(AliVEvent::EOfflineTriggerTypes newval) { fTriggerType = newval; };
   Bool_t CheckTriggerVsCentrality(Double_t l_cent); //Hard cuts on centrality for special triggers
+  void SetBypassCalculations(Bool_t newval) { fBypassCalculations = newval; };
  protected:
   AliEventCuts fEventCuts, fEventCutsForPU;
  private:
@@ -84,6 +85,7 @@ class AliAnalysisTaskGFWFlow : public AliAnalysisTaskSE {
   Int_t fCurrSystFlag;
   Bool_t fAddQA; // Add AliEventSelection QA plots
   TList *fQAList;
+  Bool_t fBypassCalculations; //Flag to bypass all the calculations, so only event selection is performed (for QA)
   Int_t AcceptedEventCount;
   Int_t GetVtxBit(AliAODEvent *mev);
   Int_t GetParticleBit(AliVParticle *mpa);


### PR DESCRIPTION
Adding a flag to bypass all the calculations (and so only the QA is done)