### PR TITLE
Changing the method of selecting b->e for MC DCA

### DIFF
--- a/PWGHF/hfe/AliAnalysisTaskHFEBESpectraEMC.h
+++ b/PWGHF/hfe/AliAnalysisTaskHFEBESpectraEMC.h
@@ -339,6 +339,8 @@ private:
     TH1F                *fDHadpT;//!
     TH1F                *fDMesonpT;//!
     TH1F                *fD0pT;//!
+    TH1F                *fDPluspT;//!
+    TH1F                *fDspT;//!
     TH1F                *fLambdaCpT;//!
     
     TH2F                *fDElecDCA;//!


### PR DESCRIPTION
- Changing the method of selecting b->e and c->e for MC DCA templates by going back to the first B hadron

- Extending the electron THnsparse to 60 GeV/c