### PR TITLE
Allow Individual V0RadiusMin/Max cut and V0CPA cut

### DIFF
--- a/PWG/DevNanoAOD/AliAnalysisNanoAODCuts.cxx
+++ b/PWG/DevNanoAOD/AliAnalysisNanoAODCuts.cxx
@@ -81,7 +81,6 @@ Bool_t AliAnalysisNanoAODV0Cuts::IsSelected(TObject* obj)
 
   if (fv0EtaMax > 0 && TMath::Abs(v0->Eta()) > fv0EtaMax)
     return false;
-
   if (fTransverseRadiusMin > 0 || fCPAMin > 0) {
     const AliAODEvent* evt = static_cast<const AliAODEvent*>(static_cast<AliAODTrack *>(v0->GetDaughter(0))->GetEvent());
     if (!evt)
@@ -92,7 +91,7 @@ Bool_t AliAnalysisNanoAODV0Cuts::IsSelected(TObject* obj)
     Float_t zvP = evt->GetPrimaryVertex()->GetZ();
     Double_t vecTarget[3] = { xvP, yvP, zvP };
     Float_t TransverseRadius = v0->DecayLengthXY(vecTarget);
-    if (TransverseRadius > fTransverseRadiusMax || TransverseRadius < fTransverseRadiusMin)
+    if ((fTransverseRadiusMin > 0 || fTransverseRadiusMax > 0) && (TransverseRadius > fTransverseRadiusMax || TransverseRadius < fTransverseRadiusMin))
       return false;
     if (fCPAMin > 0 && v0->CosPointingAngle(vecTarget) < fCPAMin)
       return false;

--- a/PWG/DevNanoAOD/AliAnalysisNanoAODCuts.cxx
+++ b/PWG/DevNanoAOD/AliAnalysisNanoAODCuts.cxx
@@ -92,7 +92,8 @@ Bool_t AliAnalysisNanoAODV0Cuts::IsSelected(TObject* obj)
     Float_t zvP = evt->GetPrimaryVertex()->GetZ();
     Double_t vecTarget[3] = { xvP, yvP, zvP };
     Float_t TransverseRadius = v0->DecayLengthXY(vecTarget);
-    if ((fTransverseRadiusMin > 0 || fTransverseRadiusMax > 0) && (TransverseRadius > fTransverseRadiusMax || TransverseRadius < fTransverseRadiusMin))
+    if ((fTransverseRadiusMin > 0 && TransverseRadius < fTransverseRadiusMin) 
+    || (fTransverseRadiusMax > 0 && TransverseRadius > fTransverseRadiusMax))
       return false;
     if (fCPAMin > 0 && v0->CosPointingAngle(vecTarget) < fCPAMin)
       return false;

--- a/PWG/DevNanoAOD/AliAnalysisNanoAODCuts.cxx
+++ b/PWG/DevNanoAOD/AliAnalysisNanoAODCuts.cxx
@@ -81,6 +81,7 @@ Bool_t AliAnalysisNanoAODV0Cuts::IsSelected(TObject* obj)
 
   if (fv0EtaMax > 0 && TMath::Abs(v0->Eta()) > fv0EtaMax)
     return false;
+  
   if (fTransverseRadiusMin > 0 || fCPAMin > 0) {
     const AliAODEvent* evt = static_cast<const AliAODEvent*>(static_cast<AliAODTrack *>(v0->GetDaughter(0))->GetEvent());
     if (!evt)

--- a/PWG/DevNanoAOD/AliAnalysisNanoAODCuts.cxx
+++ b/PWG/DevNanoAOD/AliAnalysisNanoAODCuts.cxx
@@ -81,7 +81,7 @@ Bool_t AliAnalysisNanoAODV0Cuts::IsSelected(TObject* obj)
 
   if (fv0EtaMax > 0 && TMath::Abs(v0->Eta()) > fv0EtaMax)
     return false;
-  
+
   if (fTransverseRadiusMin > 0 || fCPAMin > 0) {
     const AliAODEvent* evt = static_cast<const AliAODEvent*>(static_cast<AliAODTrack *>(v0->GetDaughter(0))->GetEvent());
     if (!evt)

--- a/PWGLF/RESONANCES/PostProcessing/Sigma1385/AliAnalysisTaskSigma1385PM.cxx
+++ b/PWGLF/RESONANCES/PostProcessing/Sigma1385/AliAnalysisTaskSigma1385PM.cxx
@@ -237,7 +237,7 @@ AliAnalysisTaskSigma1385PM::~AliAnalysisTaskSigma1385PM() {}
 //___________________________________________________________________
 void AliAnalysisTaskSigma1385PM::SetCutOpen() {
   // Pion cuts
-  SetFilterbitSigmaStarPion(1);
+  SetFilterbitSigmaStarPion(32);
   SetMaxNsigSigmaStarPion(5);
   SetMaxEtaSigmaStarPion(0.8);
   SetMaxVertexZSigmaStarPion(99);
@@ -246,8 +246,8 @@ void AliAnalysisTaskSigma1385PM::SetCutOpen() {
   // Lambda cuts
   SetMaxNsigV0Proton(5);
   SetMaxNsigV0Pion(5);
-  SetMaxDCAPVV0PosDaughter(99);
-  SetMaxDCAPVV0NegDaughter(99);
+  SetMaxDCAPVV0PosDaughter(0);
+  SetMaxDCAPVV0NegDaughter(0);
   SetMaxDCAV0daughters(999);
   SetMaxDCAPVV0(999);
   SetMinCPAV0(0.9);


### PR DESCRIPTION
Previously, if we put the V0CPA cut, it returned always false.