### PR TITLE
Silence error message of failed grooming in case of purely charged/ne…

### DIFF
--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalSoftDropResponse.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalSoftDropResponse.cxx
@@ -760,7 +760,7 @@ bool AliAnalysisTaskEmcalSoftDropResponse::Run()
     }
     catch (...)
     {
-      AliErrorStream() << "Error in softdrop evaluation - jet will be ignored" << std::endl;
+      if(fUseChargedConstituents && fUseNeutralConstituents) AliErrorStream() << "Error in softdrop evaluation - jet will be ignored" << std::endl;
       if(fForceBeamType != kpp) {
         fHistManager.FillTH1(Form("hSkippedJetsPart_%d", fCentBin), partjet->Pt());
         fHistManager.FillTH1(Form("hSkippedJetsDet_%d", fCentBin), detjet->Pt());


### PR DESCRIPTION
…utral jets

In case only using charged / neutral constituents for the
SoftDrop jets with NEF=1/0 lead to jets with 0
constituent. Those jets should be discarded in the
SoftDrop, and the error message should be skipped.