### PR TITLE
Link against fastjet

### DIFF
--- a/JETAN/FASTJETAN/CMakeLists.txt
+++ b/JETAN/FASTJETAN/CMakeLists.txt
@@ -44,19 +44,12 @@ if(FASTJET_FOUND)
     include_directories(SYSTEM ${FASTJET_INCLUDE_DIR})
     link_directories(${FASTJET_LIBS_DIR})
     add_definitions(${FASTJET_DEFINITIONS})
-
-    if(ROOT_VERSION_MAJOR EQUAL 6)
-      set(EXTRADEFINITIONS "-I${FASTJET_INCLUDE_DIR} -rml libfastjetcontribfragile -rml libfastjetplugins -rml libsiscone_spherical -rml libsiscone -rml libfastjettools -rml libfastjet")
-      if (";${FASTJET_LIBS};" MATCHES ";CGAL;")
-	set(EXTRADEFINITIONS "${EXTRADEFINITIONS} -rml libCGAL")
-      endif()
-    endif(ROOT_VERSION_MAJOR EQUAL 6)
 endif(FASTJET_FOUND)
 
 # Generate the dictionary
 # It will create G_ARG1.cxx and G_ARG1.h / ARG1 = function first argument
 get_directory_property(incdirs INCLUDE_DIRECTORIES)
-generate_dictionary("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}" "${EXTRADEFINITIONS}")
+generate_dictionary("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}" "${FASTJET_ROOTDICT_OPTS}")
 
 # Generate the ROOT map
 # Dependecies

--- a/PWGCF/Correlations/JCORRAN/Pro/CMakeLists.txt
+++ b/PWGCF/Correlations/JCORRAN/Pro/CMakeLists.txt
@@ -100,7 +100,7 @@ add_library(${MODULE}-object OBJECT ${SRCS} G__${MODULE}.cxx)
 
 # Add a library to the project using the object
 add_library_tested(${MODULE} SHARED $<TARGET_OBJECTS:${MODULE}-object>)
-target_link_libraries(${MODULE} ${ALIROOT_DEPENDENCIES} ${ROOT_DEPENDENCIES})
+target_link_libraries(${MODULE} ${LIBDEPS})
 
 # Setting the correct headers for the object as gathered from the dependencies
 target_include_directories(${MODULE}-object PUBLIC $<TARGET_PROPERTY:${MODULE},INCLUDE_DIRECTORIES>)

--- a/PWGDQ/dielectronJet/CMakeLists.txt
+++ b/PWGDQ/dielectronJet/CMakeLists.txt
@@ -91,7 +91,7 @@ add_target_parfile(${MODULE} "${SRCS}" "${HDRS}" "${MODULE}LinkDef.h" "${LIBDEPS
 add_library(${MODULE}-object OBJECT ${SRCS} G__${MODULE}.cxx)
 # Add a library to the project using the object
 add_library_tested(${MODULE} SHARED $<TARGET_OBJECTS:${MODULE}-object>)
-target_link_libraries(${MODULE} ${ALIPHYSICS_DEPENCIES} ${ALIROOT_DEPENDENCIES} ${ROOT_DEPENDENCIES})
+target_link_libraries(${MODULE} ${ALIPHYSICS_DEPENCIES} ${ALIROOT_DEPENDENCIES} ${ROOT_DEPENDENCIES} ${FASTJET_LIBS})
 
 # Setting the correct headers for the object as gathered from the dependencies
 target_include_directories(${MODULE}-object PUBLIC $<TARGET_PROPERTY:${MODULE},INCLUDE_DIRECTORIES>)

--- a/PWGDQ/reducedTree/CMakeLists.txt
+++ b/PWGDQ/reducedTree/CMakeLists.txt
@@ -98,7 +98,7 @@ add_target_parfile(${MODULE} "${SRCS}" "${HDRS}" "${MODULE}LinkDef.h" "${LIBDEPS
 add_library(${MODULE}-object OBJECT ${SRCS} G__${MODULE}.cxx)
 # Add a library to the project using the object
 add_library_tested(${MODULE} SHARED $<TARGET_OBJECTS:${MODULE}-object>)
-target_link_libraries(${MODULE} ${ALIROOT_DEPENDENCIES} ${ROOT_DEPENDENCIES})
+target_link_libraries(${MODULE} ${ALIROOT_DEPENDENCIES} ${ROOT_DEPENDENCIES} ${FASTJET_LIBS})
 
 # Setting the correct headers for the object as gathered from the dependencies
 target_include_directories(${MODULE}-object PUBLIC $<TARGET_PROPERTY:${MODULE},INCLUDE_DIRECTORIES>)

--- a/PWGHF/jetsHF/CMakeLists.txt
+++ b/PWGHF/jetsHF/CMakeLists.txt
@@ -89,7 +89,7 @@ endif(FASTJET_FOUND)
 # Generate the dictionary
 # It will create G_ARG1.cxx and G_ARG1.h / ARG1 = function first argument
 get_directory_property(incdirs INCLUDE_DIRECTORIES)
-generate_dictionary("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
+generate_dictionary("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}" "${FASTJET_ROOTDICT_OPTS}")
 
 set(ROOT_DEPENDENCIES Core EG Gpad Hist MathCore Physics Tree)
 set(ALIROOT_DEPENDENCIES ANALYSIS ANALYSISalice AOD ESD PWGJETFW STEERBase PWGTools PWGHFvertexingHF)
@@ -108,7 +108,7 @@ add_target_parfile(${MODULE} "${SRCS}" "${HDRS}" "${MODULE}LinkDef.h" "${LIBDEPS
 add_library(${MODULE}-object OBJECT ${SRCS} G__${MODULE}.cxx)
 # Add a library to the project using the object
 add_library_tested(${MODULE} SHARED $<TARGET_OBJECTS:${MODULE}-object>)
-target_link_libraries(${MODULE} ${ALIROOT_DEPENDENCIES} ${ROOT_DEPENDENCIES})
+target_link_libraries(${MODULE} ${ALIROOT_DEPENDENCIES} ${ROOT_DEPENDENCIES} ${FASTJET_LIBS})
 
 # Setting the correct headers for the object as gathered from the dependencies
 target_include_directories(${MODULE}-object PUBLIC $<TARGET_PROPERTY:${MODULE},INCLUDE_DIRECTORIES>)

--- a/PWGJE/EMCALJetTasks/CMakeLists.txt
+++ b/PWGJE/EMCALJetTasks/CMakeLists.txt
@@ -355,7 +355,7 @@ add_target_parfile(${MODULE} "${SRCS}" "${HDRS}" "${MODULE}LinkDef.h" "${LIBDEPS
 add_library(${MODULE}-object OBJECT ${SRCS} G__${MODULE}.cxx)
 # Add a library to the project using the object
 add_library_tested(${MODULE} SHARED $<TARGET_OBJECTS:${MODULE}-object>)
-target_link_libraries(${MODULE} ${ALIROOT_DEPENDENCIES} ${ROOT_DEPENDENCIES} ${ROOUNFOLD_DEPENDENCIES})
+target_link_libraries(${MODULE} ${LIBDEPS})
 
 # Setting the correct headers for the object as gathered from the dependencies
 target_include_directories(${MODULE}-object PUBLIC $<TARGET_PROPERTY:${MODULE},INCLUDE_DIRECTORIES>)

--- a/PWGJE/FlavourJetTasks/CMakeLists.txt
+++ b/PWGJE/FlavourJetTasks/CMakeLists.txt
@@ -95,7 +95,7 @@ add_target_parfile(${MODULE} "${SRCS}" "${HDRS}" "${MODULE}LinkDef.h" "${LIBDEPS
 add_library(${MODULE}-object OBJECT ${SRCS} G__${MODULE}.cxx)
 # Add a library to the project using the object
 add_library_tested(${MODULE} SHARED $<TARGET_OBJECTS:${MODULE}-object>)
-target_link_libraries(${MODULE} ${ALIROOT_DEPENDENCIES} ${ROOT_DEPENDENCIES})
+target_link_libraries(${MODULE} ${ALIROOT_DEPENDENCIES} ${ROOT_DEPENDENCIES} ${FASTJET_LIBS})
 
 # Setting the correct headers for the object as gathered from the dependencies
 target_include_directories(${MODULE}-object PUBLIC $<TARGET_PROPERTY:${MODULE},INCLUDE_DIRECTORIES>)

--- a/cmake/FindFASTJET.cmake
+++ b/cmake/FindFASTJET.cmake
@@ -213,9 +213,6 @@ if(FASTJET)
     if(ROOT_VERSION_MAJOR GREATER 5)
         # ROOT 6+: additional options required for dictionary generation.
         set(FASTJET_ROOTDICT_OPTS "-I${FASTJET_INCLUDE_DIR}")
-        foreach(fjl ${fjlibs};${fjextralibs})
-            set(FASTJET_ROOTDICT_OPTS "${FASTJET_ROOTDICT_OPTS} -rml lib${fjl}")
-        endforeach()
     else(ROOT_VERSION_MAJOR GREATER 5)
         if(NOT FASTJET_VERSION VERSION_LESS "3.2.0")
             # Disable some C++11 constructs on ROOT 5 and FastJet >= 3.2.0


### PR DESCRIPTION
- link properly against fastjet instead of using ROOT auto-loading
- ensures correct loading of dependencies by linker, not depending on LD_LIBRARY_PATH

NB: still testing ..