### PR TITLE
Mt mult binning

### DIFF
--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCollConfig.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCollConfig.cxx
@@ -11,9 +11,9 @@ AliFemtoDreamCollConfig::AliFemtoDreamCollConfig()
     : TNamed(),
       fMultBinning(false),
       fCentBinning(false),
-      fkTandMultBinning(false),
       fkTBinning(false),
       fmTBinning(false),
+      fkTandMultBinning(false),
       fPtQA(false),
       fMassQA(false),
       fMomentumResolution(false),
@@ -41,8 +41,9 @@ AliFemtoDreamCollConfig::AliFemtoDreamCollConfig()
       fCorrelationRange(0.),
       fkTCentrality(false),
       fmTdEtadPhi(false),
-      fAncestors(false),
+      fmTMultBinning(false),
       fEst(AliFemtoDreamEvent::kSPD),
+      fAncestors(false),
       fDeltaEtaMax(0.f),
       fDeltaPhiMax(0.f),
       fDoDeltaEtaDeltaPhiCut(false),
@@ -55,9 +56,9 @@ AliFemtoDreamCollConfig::AliFemtoDreamCollConfig(
     : TNamed(config),
       fMultBinning(config.fMultBinning),
       fCentBinning(config.fCentBinning),
-      fkTandMultBinning(config.fkTandMultBinning),
       fkTBinning(config.fkTBinning),
       fmTBinning(config.fmTBinning),
+      fkTandMultBinning(config.fkTandMultBinning),
       fPtQA(config.fPtQA),
       fMassQA(config.fMassQA),
       fMomentumResolution(config.fMomentumResolution),
@@ -85,8 +86,9 @@ AliFemtoDreamCollConfig::AliFemtoDreamCollConfig(
       fCorrelationRange(config.fCorrelationRange),
       fkTCentrality(config.fkTCentrality),
       fmTdEtadPhi(config.fmTdEtadPhi),
-      fAncestors(config.fAncestors),
+      fmTMultBinning(config.fmTMultBinning),
       fEst(config.fEst),
+      fAncestors(config.fAncestors),
       fDeltaEtaMax(config.fDeltaEtaMax),
       fDeltaPhiMax(config.fDeltaPhiMax),
       fDoDeltaEtaDeltaPhiCut(config.fDoDeltaEtaDeltaPhiCut),
@@ -99,9 +101,9 @@ AliFemtoDreamCollConfig::AliFemtoDreamCollConfig(const char *name,
     : TNamed(name, title),
       fMultBinning(false),
       fCentBinning(false),
-      fkTandMultBinning(false),
       fkTBinning(false),
       fmTBinning(false),
+      fkTandMultBinning(false),
       fPtQA(false),
       fMassQA(false),
       fMomentumResolution(false),
@@ -129,8 +131,9 @@ AliFemtoDreamCollConfig::AliFemtoDreamCollConfig(const char *name,
       fCorrelationRange(0.),
       fkTCentrality(false),
       fmTdEtadPhi(false),
-      fAncestors(false),
+      fmTMultBinning(false),
       fEst(AliFemtoDreamEvent::kSPD),
+      fAncestors(false),
       fDeltaEtaMax(0.f),
       fDeltaPhiMax(0.f),
       fDoDeltaEtaDeltaPhiCut(false),
@@ -142,9 +145,9 @@ AliFemtoDreamCollConfig& AliFemtoDreamCollConfig::operator=(
     TNamed::operator=(config);
     this->fMultBinning = config.fMultBinning;
     this->fCentBinning = config.fCentBinning;
-    this->fkTandMultBinning = config.fkTandMultBinning;
     this->fkTBinning = config.fkTBinning;
     this->fmTBinning = config.fmTBinning;
+    this->fkTandMultBinning = config.fkTandMultBinning;
     this->fPtQA = config.fPtQA;
     this->fMassQA = config.fMassQA;
     this->fMomentumResolution = config.fMomentumResolution;
@@ -172,8 +175,9 @@ AliFemtoDreamCollConfig& AliFemtoDreamCollConfig::operator=(
     this->fCorrelationRange = config.fCorrelationRange;
     this->fkTCentrality = config.fkTCentrality;
     this->fmTdEtadPhi = config.fmTdEtadPhi;
-    this->fAncestors = config.fAncestors;
+    this->fmTMultBinning = config.fmTMultBinning; 
     this->fEst = config.fEst;
+    this->fAncestors = config.fAncestors;
     this->fDeltaEtaMax = config.fDeltaEtaMax;
     this->fDeltaPhiMax = config.fDeltaPhiMax;
     this->fDoDeltaEtaDeltaPhiCut = config.fDoDeltaEtaDeltaPhiCut;
@@ -295,9 +299,8 @@ std::vector<int> AliFemtoDreamCollConfig::GetCentBins() {
   }
   return fCentBins;
 }
-void AliFemtoDreamCollConfig::SetmTdEtadPhiBins(std::vector<float> mTBins) {
-  //Set Bins for the deta dphi mT Binning
-  fmTdEtadPhi = true;
+void AliFemtoDreamCollConfig::SetmTBins(std::vector<float> mTBins) {
+  //Set Bins for the deta dphi and multiplicity mT Binning 
   fmTBins = mTBins;
 }
 std::vector<float> AliFemtoDreamCollConfig::GetmTBins() {

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCollConfig.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCollConfig.h
@@ -85,9 +85,16 @@ class AliFemtoDreamCollConfig : public TNamed {
     fMode = mode;
   }
   ;
-    void SetAncestors(bool doIt) {
+  void SetAncestors(bool doIt) {
     fAncestors = doIt;
   }
+  void SetDomTMultBinning(bool doIt) {
+    fmTMultBinning = doIt; 
+  };
+  void SetDomTdEtadPhiBinning(bool doIt) {
+    fmTdEtadPhi = doIt; 
+  }
+    ;
   void SetZBins(std::vector<float> ZBins);
   void SetMultBins(std::vector<int> MultBins);
   void SetPDGCodes(std::vector<int> PDGCodes);
@@ -95,7 +102,7 @@ class AliFemtoDreamCollConfig : public TNamed {
   void SetMinKRel(std::vector<float> minKRel);
   void SetMaxKRel(std::vector<float> maxKRel);
   void SetCentBins(std::vector<int> CentBins);
-  void SetmTdEtadPhiBins(std::vector<float> mTBins);
+  void SetmTBins(std::vector<float> mTBins);
   //TODO: should be renamed since besides the QA it also specifies the
   // number of tracks to compare when doing the CPR cut
   void SetExtendedQAPairs(std::vector<int> whichPairs);
@@ -187,6 +194,10 @@ class AliFemtoDreamCollConfig : public TNamed {
   bool GetdPhidEtamTPlots() {
     return (fdPhidEtaPlots && fmTdEtadPhi);
   }
+  bool GetmTMultBinning() {
+    return fmTMultBinning;
+  }
+  ;  
   bool GetMinimalBookingME() {
     return fMinimalBookingME;
   }
@@ -267,7 +278,6 @@ class AliFemtoDreamCollConfig : public TNamed {
   bool GetDoDeltaEtaDeltaPhiCut() const {
     return fDoDeltaEtaDeltaPhiCut;
   }
-
  private:
   bool fMultBinning;            //
   bool fCentBinning;            //
@@ -282,7 +292,6 @@ class AliFemtoDreamCollConfig : public TNamed {
   bool fdPhidEtaPlotsSmallK;    //
   bool fMixedEventStatistics;   //
   bool fGetTheControlSampel;    //
-  bool fAncestors;              //
   AliFemtoDreamCollConfig::UncorrelatedMode fMode;  //
   bool fMinimalBookingME;       //
   bool fMinimalBookingSample;   //
@@ -302,12 +311,14 @@ class AliFemtoDreamCollConfig : public TNamed {
   float fCorrelationRange;	      //
   bool fkTCentrality;           //
   bool fmTdEtadPhi;             //
+  bool fmTMultBinning; //
   AliFemtoDreamEvent::MultEstimator fEst;  //
+  bool fAncestors;              //
   float fDeltaEtaMax;           //
   float fDeltaPhiMax;           //
   bool fDoDeltaEtaDeltaPhiCut;  //
   bool fCoutVariables;
-  ClassDef(AliFemtoDreamCollConfig,16);
+  ClassDef(AliFemtoDreamCollConfig,17);
 };
 
 #endif /* ALIFEMTODREAMCOLLCONFIG_H_ */

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCorrHists.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCorrHists.cxx
@@ -260,6 +260,7 @@ AliFemtoDreamCorrHists::AliFemtoDreamCorrHists(AliFemtoDreamCollConfig *conf,
   fDokTCentralityBins = conf->GetDokTCentralityBinning();
   fDokTandMultBinning = conf->GetDokTandMultBinning();
   fDomTBinning = conf->GetDomTBinning();
+  fmTMultPlots = conf->GetmTMultBinning(); 
   fPtQA = conf->GetDoPtQA();
   fMassQA = conf->GetDoMassQA();
   fPDGCode = conf->GetPDGCodes();
@@ -426,6 +427,13 @@ AliFemtoDreamCorrHists::AliFemtoDreamCorrHists(AliFemtoDreamCollConfig *conf,
     fSameEventmTDist = nullptr;
     fMixedEventmTDist = nullptr;
   }
+  if (fmTMultPlots) {
+    fSameEventmTMultDist = new TH2F**[nHists];
+    fMixedEventmTMultDist = new TH2F**[nHists];
+  } else {
+    fSameEventmTMultDist = nullptr; 
+    fMixedEventmTMultDist = nullptr;
+  }
   if (fPtQA) {
     fPtQADist = new TH2F*[nHists];
     fPtQADistSEPartOne = new TH2F*[nHists];
@@ -467,21 +475,21 @@ AliFemtoDreamCorrHists::AliFemtoDreamCorrHists(AliFemtoDreamCollConfig *conf,
     fdEtadPhiSEmT = nullptr;
     fdEtadPhiMEmT = nullptr;
   }
-    if (fAncestors) {
-      fSameEventDistCommon = new TH1F*[nHists];
-      fSameEventDistNonCommon = new TH1F*[nHists];
-      if (fdPhidEtaPlots) {
+  if (fAncestors) {
+    fSameEventDistCommon = new TH1F*[nHists];
+    fSameEventDistNonCommon = new TH1F*[nHists];
+    if (fdPhidEtaPlots) {
       fdEtadPhiSECommon = new TH2F*[nHists];
       fdEtadPhiSENonCommon = new TH2F*[nHists];
-      }
-      if (fDoMultBinning) {
-       fSameEventMultDistCommon = new TH2F*[nHists];
-       fSameEventMultDistNonCommon = new TH2F*[nHists];
-      }
-      if (fDomTBinning) {
-       fSameEventmTDistCommon = new TH2F*[nHists];
-       fSameEventmTDistNonCommon = new TH2F*[nHists];
-      }
+    }
+    if (fDoMultBinning) {
+      fSameEventMultDistCommon = new TH2F*[nHists];
+      fSameEventMultDistNonCommon = new TH2F*[nHists];
+    }
+    if (fDomTBinning) {
+      fSameEventmTDistCommon = new TH2F*[nHists];
+      fSameEventmTDistNonCommon = new TH2F*[nHists];
+    }
   } else {
     fSameEventDistCommon = nullptr;
     fSameEventDistNonCommon = nullptr;
@@ -637,7 +645,27 @@ AliFemtoDreamCorrHists::AliFemtoDreamCorrHists(AliFemtoDreamCollConfig *conf,
           fPairs[Counter]->Add(fMixedEventkTCentDist[Counter][iCent]);
         }
       }
+      if (fillHists && fmTMultPlots) {
+	fSameEventmTMultDist[Counter] = new TH2F*[nmTBins];
+	fMixedEventmTMultDist[Counter] = new TH2F*[nmTBins]; 
+	for (unsigned int imT = 0; imT < nmTBins; ++imT) {
+	  TString SameEventmTMultName =
+	    TString::Format("SEmTMult_%d_Particle%d_Particle%d", imT, iPar1, iPar2);
+	  fSameEventmTMultDist[Counter][imT] = new TH2F(SameEventmTMultName.Data(),
+							SameEventmTMultName.Data(),
+							*itNBins, *itKMin, *itKMax,
+							multbins, 1, multbins + 1); 
+	  fPairs[Counter]->Add(fSameEventmTMultDist[Counter][imT]);
 
+	  TString MixedEventmTMultName =
+	    TString::Format("MEmTMult_%d_Particle%d_Particle%d", imT, iPar1, iPar2);
+	  fMixedEventmTMultDist[Counter][imT] = new TH2F(MixedEventmTMultName.Data(),
+							 MixedEventmTMultName.Data(),
+							 *itNBins, *itKMin, *itKMax,
+							 multbins, 1, multbins + 1); 
+	  fPairs[Counter]->Add(fMixedEventmTMultDist[Counter][imT]);
+	}
+      } 
       if (fillHists && fDomTBinning) {
         TString SamemTEventName = TString::Format("SEmTDist_Particle%d_Particle%d", iPar1,
                                        iPar2);
@@ -1368,7 +1396,7 @@ void AliFemtoDreamCorrHists::FillSameEventmTMultDist(int iHist, float mT, int iM
       TString WarnMe = TString::Format("mT Bin for %.2f not found", mT);
       AliWarning(WarnMe.Data());
     } else {
-    
+      fSameEventmTMultDist[iHist][pos]->Fill(RelK, iMult); 
     }
   } 
 }
@@ -1385,6 +1413,8 @@ void AliFemtoDreamCorrHists::FillMixedEventmTMultDist(int iHist, float mT, int i
     if (pos >= fmTBins.size()) {
       TString WarnMe = TString::Format("mT Bin for %.2f not found", mT);
       AliWarning(WarnMe.Data());
-    } 
+    } else {
+      fMixedEventmTMultDist[iHist][pos]->Fill(RelK, iMult); 
+    }
   } 
 }

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCorrHists.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCorrHists.cxx
@@ -28,6 +28,7 @@ AliFemtoDreamCorrHists::AliFemtoDreamCorrHists()
       fSameEventkTDist(nullptr),
       fSameEventkTandMultDist(nullptr),
       fSameEventkTCentDist(nullptr),
+      fSameEventmTMultDist(nullptr), 
       fPtQADist(nullptr),
       fPtQADistSEPartOne(nullptr),
       fPtQADistSEPartTwo(nullptr),
@@ -44,6 +45,7 @@ AliFemtoDreamCorrHists::AliFemtoDreamCorrHists()
       fMixedEventkTDist(nullptr),
       fMixedEventkTandMultDist(nullptr),
       fMixedEventkTCentDist(nullptr),
+      fMixedEventmTMultDist(nullptr),
       fPairCounterME(nullptr),
       fMomResolutionSE(nullptr),
       fMomResolutionSEAll(nullptr),
@@ -76,6 +78,7 @@ AliFemtoDreamCorrHists::AliFemtoDreamCorrHists()
       fDokTandMultBinning(false),
       fDokTBinning(false),
       fDomTBinning(false),
+      fmTMultPlots(false),
       fPtQA(false),
       fMassQA(false),
       fDokTCentralityBins(false),
@@ -84,7 +87,7 @@ AliFemtoDreamCorrHists::AliFemtoDreamCorrHists()
       fmTDetaDPhi(false),
       fAncestors(false),
       fPDGCode(),
-      fmTdEtadPhiBins(),
+      fmTBins(),
       fWhichPairs(),
       fCentBins(0) {
 }
@@ -106,6 +109,7 @@ AliFemtoDreamCorrHists::AliFemtoDreamCorrHists(
       fSameEventkTDist(hists.fSameEventkTDist),
       fSameEventkTandMultDist(hists.fSameEventkTandMultDist),
       fSameEventkTCentDist(hists.fSameEventkTCentDist),
+      fSameEventmTMultDist(hists.fSameEventmTMultDist),
       fPtQADist(hists.fPtQADist),
       fPtQADistSEPartOne(hists.fPtQADistSEPartOne),
       fPtQADistSEPartTwo(hists.fPtQADistSEPartTwo),
@@ -122,6 +126,7 @@ AliFemtoDreamCorrHists::AliFemtoDreamCorrHists(
       fMixedEventkTDist(hists.fMixedEventkTDist),
       fMixedEventkTandMultDist(hists.fMixedEventkTandMultDist),
       fMixedEventkTCentDist(hists.fMixedEventkTCentDist),
+      fMixedEventmTMultDist(hists.fMixedEventmTMultDist),
       fPairCounterME(hists.fPairCounterME),
       fMomResolutionSE(hists.fMomResolutionSE),
       fMomResolutionSEAll(hists.fMomResolutionSEAll),
@@ -154,6 +159,7 @@ AliFemtoDreamCorrHists::AliFemtoDreamCorrHists(
       fDokTandMultBinning(hists.fDokTandMultBinning),
       fDokTBinning(hists.fDokTBinning),
       fDomTBinning(hists.fDomTBinning),
+      fmTMultPlots(hists.fmTMultPlots),
       fPtQA(hists.fPtQA),
       fMassQA(hists.fMassQA),
       fDokTCentralityBins(hists.fDokTCentralityBins),
@@ -162,7 +168,7 @@ AliFemtoDreamCorrHists::AliFemtoDreamCorrHists(
       fmTDetaDPhi(hists.fmTDetaDPhi),
       fAncestors(hists.fAncestors),
       fPDGCode(hists.fPDGCode),
-      fmTdEtadPhiBins(hists.fmTdEtadPhiBins),
+      fmTBins(hists.fmTBins),
       fWhichPairs(hists.fWhichPairs),
       fCentBins(hists.fCentBins) {
 }
@@ -184,6 +190,7 @@ AliFemtoDreamCorrHists::AliFemtoDreamCorrHists(AliFemtoDreamCollConfig *conf,
       fSameEventkTDist(nullptr),
       fSameEventkTandMultDist(nullptr),
       fSameEventkTCentDist(nullptr),
+      fSameEventmTMultDist(nullptr),
       fPtQADist(nullptr),
       fPtQADistSEPartOne(nullptr),
       fPtQADistSEPartTwo(nullptr),
@@ -200,6 +207,7 @@ AliFemtoDreamCorrHists::AliFemtoDreamCorrHists(AliFemtoDreamCollConfig *conf,
       fMixedEventkTDist(nullptr),
       fMixedEventkTandMultDist(nullptr),
       fMixedEventkTCentDist(nullptr),
+      fMixedEventmTMultDist(nullptr),
       fPairCounterME(nullptr),
       fMomResolutionSE(nullptr),
       fMomResolutionSEAll(nullptr),
@@ -229,9 +237,10 @@ AliFemtoDreamCorrHists::AliFemtoDreamCorrHists(AliFemtoDreamCollConfig *conf,
       fSameEventmTDistNonCommon(nullptr),
       fDoMultBinning(false),
       fDoCentBinning(false),
-      fDokTBinning(false),
       fDokTandMultBinning(false),
+      fDokTBinning(false),
       fDomTBinning(false),
+      fmTMultPlots(false),
       fPtQA(false),
       fMassQA(false),
       fDokTCentralityBins(false),
@@ -240,7 +249,7 @@ AliFemtoDreamCorrHists::AliFemtoDreamCorrHists(AliFemtoDreamCollConfig *conf,
       fmTDetaDPhi(false),
       fAncestors(false),
       fPDGCode(),
-      fmTdEtadPhiBins(),
+      fmTBins(),
       fWhichPairs(),
       fCentBins(0) {
 //  fMinimalBooking=MinimalBooking;
@@ -278,8 +287,8 @@ AliFemtoDreamCorrHists::AliFemtoDreamCorrHists(AliFemtoDreamCollConfig *conf,
   std::vector<float>::iterator itKMin = kRelMin.begin();
   std::vector<float> kRelMax = conf->GetMaxKRel();
   std::vector<float>::iterator itKMax = kRelMax.begin();
-  fmTdEtadPhiBins = conf->GetmTBins();
-  const unsigned int nmTBins = fmTdEtadPhiBins.size();
+  fmTBins = conf->GetmTBins();
+  const unsigned int nmTBins = fmTBins.size();
   if (fDokTandMultBinning) {
     if (multbins == 0) {
       AliWarning("Did you set the Multiplicity bins, since their size is 0?\n");
@@ -673,7 +682,7 @@ AliFemtoDreamCorrHists::AliFemtoDreamCorrHists(AliFemtoDreamCollConfig *conf,
           for (unsigned int imT = 0; imT < nmTBins; ++imT) {
             TString SameEventdPhidEtaName = TString::Format(
                 "SEdPhidEtaDist_Particle%d_Particle%d_imT%.2f", iPar1, iPar2,
-                fmTdEtadPhiBins[imT]);
+                fmTBins[imT]);
             fdEtadPhiSEmT[Counter][imT] = new TH2F(SameEventdPhidEtaName.Data(),
                                                    SameEventdPhidEtaName.Data(),
                                                    80, -2., 2., 84,
@@ -685,7 +694,7 @@ AliFemtoDreamCorrHists::AliFemtoDreamCorrHists(AliFemtoDreamCollConfig *conf,
 
             TString MixedEventdPhidEtaName = TString::Format(
                 "MEdPhidEtaDist_Particle%d_Particle%d_imT%.2f", iPar1, iPar2,
-                fmTdEtadPhiBins[imT]);
+                fmTBins[imT]);
             fdEtadPhiMEmT[Counter][imT] = new TH2F(
                 MixedEventdPhidEtaName.Data(), MixedEventdPhidEtaName.Data(),
                 80, -2., 2., 84, -2 * TMath::Pi() / 3, 2 * TMath::Pi());
@@ -1116,12 +1125,13 @@ AliFemtoDreamCorrHists &AliFemtoDreamCorrHists::operator=(
     this->fSameEventCentDist = hists.fSameEventCentDist;
     this->fSameEventmTDist = hists.fSameEventmTDist;
     this->fSameEventkTDist = hists.fSameEventkTDist;
+    this->fSameEventkTandMultDist = hists.fSameEventkTandMultDist;
+    this->fSameEventkTCentDist = hists.fSameEventkTCentDist;
+    this->fSameEventmTMultDist = hists.fSameEventmTMultDist; 
     this->fPtQADist = hists.fPtQADist;
     this->fMassQADistPart1 = hists.fMassQADistPart1;
     this->fMassQADistPart2 = hists.fMassQADistPart2;
     this->fPairInvMassQAD = hists.fPairInvMassQAD;
-    this->fSameEventkTandMultDist = hists.fSameEventkTandMultDist;
-    this->fSameEventkTCentDist = hists.fSameEventkTCentDist;
     this->fPairCounterSE = hists.fPairCounterSE;
     this->fMixedEventDist = hists.fMixedEventDist;
     this->fMixedEventMultDist = hists.fMixedEventMultDist;
@@ -1130,6 +1140,7 @@ AliFemtoDreamCorrHists &AliFemtoDreamCorrHists::operator=(
     this->fMixedEventkTDist = hists.fMixedEventkTDist;
     this->fMixedEventkTandMultDist = hists.fMixedEventkTandMultDist;
     this->fMixedEventkTCentDist = hists.fMixedEventkTCentDist;
+    this->fMixedEventmTMultDist = hists.fMixedEventmTMultDist; 
     this->fPairCounterME = hists.fPairCounterME;
     this->fMomResolutionME = hists.fMomResolutionME;
     this->fMomResolutionDist = hists.fMomResolutionDist;
@@ -1290,14 +1301,14 @@ void AliFemtoDreamCorrHists::FilldPhidEtaSE(int iHist, float dPhi, float dEta,
                                             float mT) {
   if (fmTDetaDPhi && fdPhidEtaPlots) {
     unsigned int pos = 0;
-    for (auto it : fmTdEtadPhiBins) {
+    for (auto it : fmTBins) {
       if (it > TMath::Abs(mT)) {
         break;
       } else {
         pos++;
       }
     }
-    if (pos >= fmTdEtadPhiBins.size()) {
+    if (pos >= fmTBins.size()) {
       TString WarnMe = TString::Format("mT Bin for %.2f not found", mT);
       AliWarning(WarnMe.Data());
     } else {
@@ -1311,14 +1322,14 @@ void AliFemtoDreamCorrHists::FilldPhidEtaME(int iHist, float dPhi, float dEta,
                                             float mT) {
   if (fmTDetaDPhi && fdPhidEtaPlots) {
     unsigned int pos = 0;
-    for (auto it : fmTdEtadPhiBins) {
+    for (auto it : fmTBins) {
       if (it > TMath::Abs(mT)) {
         break;
       } else {
         pos++;
       }
     }
-    if (pos >= fmTdEtadPhiBins.size()) {
+    if (pos >= fmTBins.size()) {
       TString WarnMe = TString::Format("mT Bin for %.2f not found", mT);
       AliWarning(WarnMe.Data());
     } else {
@@ -1341,4 +1352,39 @@ void AliFemtoDreamCorrHists::FilldPhidEtaSENonCommon(int iHist, float dPhi, floa
   if (fdPhidEtaPlots) {
     fdEtadPhiSENonCommon[iHist]->Fill(dEta, dPhi);
   }
+}
+
+void AliFemtoDreamCorrHists::FillSameEventmTMultDist(int iHist, float mT, int iMult, float RelK) {
+  if (fmTMultPlots) {
+    unsigned int pos = 0;
+    for (auto it : fmTBins) {
+      if (it > TMath::Abs(mT)) {
+        break;
+      } else {
+        pos++;
+      }
+    }
+    if (pos >= fmTBins.size()) {
+      TString WarnMe = TString::Format("mT Bin for %.2f not found", mT);
+      AliWarning(WarnMe.Data());
+    } else {
+    
+    }
+  } 
+}
+void AliFemtoDreamCorrHists::FillMixedEventmTMultDist(int iHist, float mT, int iMult, float RelK) {
+  if (fmTMultPlots) { 
+    unsigned int pos = 0;
+    for (auto it : fmTBins) {
+      if (it > TMath::Abs(mT)) {
+        break;
+      } else {
+        pos++;
+      }
+    }
+    if (pos >= fmTBins.size()) {
+      TString WarnMe = TString::Format("mT Bin for %.2f not found", mT);
+      AliWarning(WarnMe.Data());
+    } 
+  } 
 }

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCorrHists.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCorrHists.h
@@ -67,7 +67,10 @@ class AliFemtoDreamCorrHists {
     return fmTDetaDPhi;
   }
   ;
-    bool GetDoAncestorsPlots() {
+  bool GetDomTMultPlots() {
+    return fmTMultPlots;
+  }
+  bool GetDoAncestorsPlots() {
     return fAncestors;
   }
   void FillSameEventDist(int i, float RelK) {
@@ -101,6 +104,7 @@ class AliFemtoDreamCorrHists {
     if (fSameEventmTDist[i])
       fSameEventmTDist[i]->Fill(RelK, mT);
   }
+  void FillSameEventmTMultDist(int i, float mT, int iMult, float RelK);
   void FillMixedEventDist(int i, float RelK) {
     fMixedEventDist[i]->Fill(RelK);
   }
@@ -180,6 +184,7 @@ class AliFemtoDreamCorrHists {
     if (fMixedEventmTDist[i])
       fMixedEventmTDist[i]->Fill(RelK, mT);
   }
+  void FillMixedEventmTMultDist(int i, float mT, int iMult, float RelK);
   void FillPartnersSE(int hist, int nPart1, int nPart2) {
     if (!fMinimalBooking)
       fPairCounterSE[hist]->Fill(nPart1, nPart2);
@@ -316,6 +321,7 @@ class AliFemtoDreamCorrHists {
   TH2F **fSameEventkTDist;
   TH2F ***fSameEventkTandMultDist;
   TH2F ***fSameEventkTCentDist;
+  TH2F ***fSameEventmTMultDist;
   TH2F **fPtQADist;
   TH2F **fPtQADistSEPartOne;
   TH2F **fPtQADistSEPartTwo;
@@ -332,6 +338,7 @@ class AliFemtoDreamCorrHists {
   TH2F **fMixedEventkTDist;
   TH2F ***fMixedEventkTandMultDist;
   TH2F ***fMixedEventkTCentDist;
+  TH2F ***fMixedEventmTMultDist;
   TH2F **fPairCounterME;
   TH2F **fMomResolutionSE;
   TH2F **fMomResolutionSEAll;
@@ -368,6 +375,7 @@ class AliFemtoDreamCorrHists {
   bool fDokTandMultBinning;
   bool fDokTBinning;
   bool fDomTBinning;
+  bool fmTMultPlots;
   bool fPtQA;
   bool fMassQA;
   bool fDokTCentralityBins;
@@ -376,10 +384,10 @@ class AliFemtoDreamCorrHists {
   bool fmTDetaDPhi;
   bool fAncestors;
   std::vector<int> fPDGCode;
-  std::vector<float> fmTdEtadPhiBins;
+  std::vector<float> fmTBins;
   std::vector<unsigned int> fWhichPairs;
-  std::vector<int> fCentBins;ClassDef(AliFemtoDreamCorrHists,9)
-  ;
+  std::vector<int> fCentBins;
+  ClassDef(AliFemtoDreamCorrHists,10);
 };
 
 #endif /* ALIFEMTODREAMCORRHISTS_H_ */

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCorrHists.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCorrHists.h
@@ -257,36 +257,36 @@ class AliFemtoDreamCorrHists {
   }
 
   void FillSameEventDistCommon(int i, float RelK) {
-  if (!fMinimalBooking) {
-   if (fAncestors)
-    fSameEventDistCommon[i]->Fill(RelK);
-  }
-  }
-  ;
-    void FillSameEventDistNonCommon(int i, float RelK) {
-   if (!fMinimalBooking) {
-     if (fAncestors)
-    fSameEventDistNonCommon[i]->Fill(RelK);
-   }
+    if (!fMinimalBooking) {
+      if (fAncestors)
+	fSameEventDistCommon[i]->Fill(RelK);
+    }
   }
   ;
-    void FillSameEventMultDistCommon(int i, int iMult, float RelK) {
-         if (!fMinimalBooking) {
-    if (fSameEventMultDistCommon[i])
-      fSameEventMultDistCommon[i]->Fill(RelK, iMult);
-         }
+  void FillSameEventDistNonCommon(int i, float RelK) {
+    if (!fMinimalBooking) {
+      if (fAncestors)
+	fSameEventDistNonCommon[i]->Fill(RelK);
+    }
   }
-    void FillSameEventMultDistNonCommon(int i, int iMult, float RelK) {
-         if (!fMinimalBooking) {
-    if (fSameEventMultDistNonCommon[i])
-      fSameEventMultDistNonCommon[i]->Fill(RelK, iMult);
-         }
+  ;
+  void FillSameEventMultDistCommon(int i, int iMult, float RelK) {
+    if (!fMinimalBooking) {
+      if (fSameEventMultDistCommon[i])
+	fSameEventMultDistCommon[i]->Fill(RelK, iMult);
+    }
   }
-    void FillSameEventmTDistCommon(int i, float mT, float RelK) {
+  void FillSameEventMultDistNonCommon(int i, int iMult, float RelK) {
+    if (!fMinimalBooking) {
+      if (fSameEventMultDistNonCommon[i])
+	fSameEventMultDistNonCommon[i]->Fill(RelK, iMult);
+    }
+  }
+  void FillSameEventmTDistCommon(int i, float mT, float RelK) {
     if (fSameEventmTDistCommon[i])
       fSameEventmTDistCommon[i]->Fill(RelK, mT);
   }
-    void FillSameEventmTDistNonCommon(int i, float mT, float RelK) {
+  void FillSameEventmTDistNonCommon(int i, float mT, float RelK) {
     if (fSameEventmTDistNonCommon[i])
       fSameEventmTDistNonCommon[i]->Fill(RelK, mT);
   }

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCorrHists.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCorrHists.h
@@ -359,7 +359,7 @@ class AliFemtoDreamCorrHists {
   TH2F ***fdEtadPhiMEmT;
   TH1F **fEffMixingDepth;
   TH1F **fSameEventDistCommon;
-  TH1F **fSameEventDistNonCommon;
+  TH1F **fSameEventDistNonCommon;   
   TH2F **fdEtadPhiSECommon;
   TH2F **fdEtadPhiSENonCommon;
   TH2F **fSameEventMultDistCommon;

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamHigherPairMath.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamHigherPairMath.cxx
@@ -38,6 +38,8 @@ AliFemtoDreamHigherPairMath::AliFemtoDreamHigherPairMath(
       fBField(-99.),
       fRejPairs(samp.fRejPairs),
       fDoDeltaEtaDeltaPhiCut(samp.fDoDeltaEtaDeltaPhiCut),
+      fDeltaPhiSqMax(samp.fDeltaPhiSqMax),
+      fDeltaEtaSqMax(samp.fDeltaEtaSqMax),
       fDeltaPhiEtaMax(samp.fDeltaPhiEtaMax),
       fRandom(),
       fPi(TMath::Pi()) {
@@ -51,6 +53,10 @@ AliFemtoDreamHigherPairMath& AliFemtoDreamHigherPairMath::operator=(
   fHists = math.fHists;
   fWhichPairs = math.fWhichPairs;
   fBField = math.fBField;
+  fRejPairs = math.fRejPairs;
+  fDoDeltaEtaDeltaPhiCut = math.fDoDeltaEtaDeltaPhiCut;
+  fDeltaPhiSqMax = math.fDeltaPhiSqMax;
+  fDeltaEtaSqMax = math.fDeltaEtaSqMax; 
   fDeltaPhiEtaMax = math.fDeltaPhiEtaMax;
   fRandom = math.fRandom;
   fPi = TMath::Pi();
@@ -60,7 +66,6 @@ AliFemtoDreamHigherPairMath& AliFemtoDreamHigherPairMath::operator=(
 bool AliFemtoDreamHigherPairMath::PassesPairSelection(
     int iHC, AliFemtoDreamBasePart& part1, AliFemtoDreamBasePart& part2,
     float RelativeK, bool SEorME, bool Recalculate) {
-  bool outBool = true;
   //Method calculates the average separation between two tracks
   //at different radii within the TPC and rejects pairs which a
   //too low separation
@@ -168,6 +173,10 @@ float AliFemtoDreamHigherPairMath::FillSameEvent(int iHC, int Mult, float cent,
     fHists->FillSameEventkTandMultDist(iHC, RelativePairkT(PartOne, PartTwo),
                                        RelativeK, Mult + 1);
   }
+  if (fillHists && fHists->GetDomTMultPlots()) {
+    fHists->FillSameEventmTMultDist(iHC, RelativePairmT(PartOne, PartTwo), Mult + 1, 
+				   RelativeK); 
+  }   
   if (fillHists && fHists->GetDoPtQA()) {
     fHists->FillPtQADist(iHC, RelativeK, Part1Momentum.Pt(),
                          Part2Momentum.Pt());
@@ -178,13 +187,20 @@ float AliFemtoDreamHigherPairMath::FillSameEvent(int iHC, int Mult, float cent,
     bool isAlabama = CommonAncestors(part1,part2);
     if (isAlabama) {
       fHists->FillSameEventDistCommon(iHC, RelativeK);
-      if (fHists->GetDoMultBinning()) fHists->FillSameEventMultDistCommon(iHC, Mult + 1, RelativeK);
-      if (fHists->GetDomTBinning()) fHists->FillSameEventmTDistCommon(iHC, RelativePairmT(PartOne, PartTwo), RelativeK);
+      if (fHists->GetDoMultBinning()) {
+	fHists->FillSameEventMultDistCommon(iHC, Mult + 1, RelativeK);
+      }
+      if (fHists->GetDomTBinning()) {
+	fHists->FillSameEventmTDistCommon(iHC, RelativePairmT(PartOne, PartTwo), RelativeK);
+      }
     } else {
       fHists->FillSameEventDistNonCommon(iHC, RelativeK);
-      if (fHists->GetDoMultBinning()) fHists->FillSameEventMultDistNonCommon(iHC, Mult + 1, RelativeK);
-      if (fHists->GetDomTBinning()) fHists->FillSameEventmTDistNonCommon(iHC, RelativePairmT(PartOne, PartTwo), RelativeK);
-
+      if (fHists->GetDoMultBinning()) {
+	fHists->FillSameEventMultDistNonCommon(iHC, Mult + 1, RelativeK);
+      }
+      if (fHists->GetDomTBinning()) {
+	fHists->FillSameEventmTDistNonCommon(iHC, RelativePairmT(PartOne, PartTwo), RelativeK);
+      }
     }
   }
   return RelativeK;
@@ -248,6 +264,10 @@ float AliFemtoDreamHigherPairMath::FillMixedEvent(
     fHists->FillMixedEventkTandMultDist(iHC, RelativePairkT(PartOne, PartTwo),
                                         RelativeK, Mult + 1);
   }
+  if (fillHists && fHists->GetDomTMultPlots()) {
+    fHists->FillMixedEventmTMultDist(iHC, RelativePairmT(PartOne, PartTwo), Mult + 1, 
+				   RelativeK); 
+  }   
   if (fillHists && fHists->GetDoPtQA()) {
     fHists->FillPtMEOneQADist(iHC, Part1Momentum.Pt(), Mult + 1);
     fHists->FillPtMETwoQADist(iHC, Part2Momentum.Pt(), Mult + 1);
@@ -482,7 +502,7 @@ bool AliFemtoDreamHigherPairMath::DeltaEtaDeltaPhi(int Hist,
     TString outMessage =
         TString::Format(
             "For pair number %u your number of Daughters 1 (%u) and Radii 1 (%u) do not correspond \n",
-            Hist, nDaug1, part1.GetPhiAtRaidius().size());
+            Hist, nDaug1, (unsigned int)part1.GetPhiAtRaidius().size());
     AliWarning(outMessage.Data());
   }
   unsigned int nDaug2 = (unsigned int) DoThisPair % 10;
@@ -491,7 +511,7 @@ bool AliFemtoDreamHigherPairMath::DeltaEtaDeltaPhi(int Hist,
     TString outMessage =
         TString::Format(
             "For pair number %u your number of Daughters 2 (%u) and Radii 2 (%u) do not correspond \n",
-            Hist, nDaug2, part2.GetPhiAtRaidius().size());
+            Hist, nDaug2, (unsigned int)part2.GetPhiAtRaidius().size());
     AliWarning(outMessage.Data());
   }
   std::vector<float> eta1 = part1.GetEta();

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamZVtxMultContainer.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamZVtxMultContainer.cxx
@@ -59,7 +59,6 @@ void AliFemtoDreamZVtxMultContainer::SetEvent(
 void AliFemtoDreamZVtxMultContainer::PairParticlesSE(
     std::vector<std::vector<AliFemtoDreamBasePart>> &Particles,
     AliFemtoDreamHigherPairMath *HigherMath, int iMult, float cent) {
-  float RelativeK = 0;
   int HistCounter = 0;
   //First loop over all the different Species
   auto itPDGPar1 = fPDGParticleSpecies.begin();
@@ -120,7 +119,6 @@ void AliFemtoDreamZVtxMultContainer::PairParticlesSE(
 void AliFemtoDreamZVtxMultContainer::PairParticlesME(
     std::vector<std::vector<AliFemtoDreamBasePart>> &Particles,
     AliFemtoDreamHigherPairMath *HigherMath, int iMult, float cent) {
-  float RelativeK = 0;
   int HistCounter = 0;
   auto itPDGPar1 = fPDGParticleSpecies.begin();
   //First loop over all the different Species

--- a/PWGCF/FEMTOSCOPY/macros/AddTaskFemtoLoton.C
+++ b/PWGCF/FEMTOSCOPY/macros/AddTaskFemtoLoton.C
@@ -95,7 +95,7 @@ AliAnalysisTaskSE *AddTaskFemtoLoton(int trigger = 0, bool fullBlastQA = false,
   std::vector<float> kMax;
   std::vector<int> pairQA;
   std::vector<bool> closeRejection;
-  std::vector<float> mTBins = {1.0, 1.14, 1.26, 999.};
+  std::vector<float> mTBins = {1.14, 1.26, 999.};
   //pairs:
   //pp                0
   //p bar p           1

--- a/PWGCF/FEMTOSCOPY/macros/AddTaskFemtoLoton.C
+++ b/PWGCF/FEMTOSCOPY/macros/AddTaskFemtoLoton.C
@@ -95,6 +95,7 @@ AliAnalysisTaskSE *AddTaskFemtoLoton(int trigger = 0, bool fullBlastQA = false,
   std::vector<float> kMax;
   std::vector<int> pairQA;
   std::vector<bool> closeRejection;
+  std::vector<float> mTBins = {1.0, 1.14, 1.26, 999.};
   //pairs:
   //pp                0
   //p bar p           1
@@ -130,7 +131,8 @@ AliAnalysisTaskSE *AddTaskFemtoLoton(int trigger = 0, bool fullBlastQA = false,
   config->SetDeltaEtaMax(0.017);
   config->SetDeltaPhiMax(0.017);
   config->SetExtendedQAPairs(pairQA);
-
+  config->SetmTBins(mTBins);
+  config->SetDomTMultBinning(true);
   if (phiSpinning == 0) {
     config->SetMixingDepth(10);
     config->SetUseEventMixing(true);

--- a/PWGCF/FEMTOSCOPY/macros/AddTaskFemtoLoton.C
+++ b/PWGCF/FEMTOSCOPY/macros/AddTaskFemtoLoton.C
@@ -182,7 +182,22 @@ AliAnalysisTaskSE *AddTaskFemtoLoton(int trigger = 0, bool fullBlastQA = false,
   MultBins.push_back(92);
   MultBins.push_back(96);
   MultBins.push_back(100);
-
+  MultBins.push_back(104);
+  MultBins.push_back(108);
+  MultBins.push_back(112);
+  MultBins.push_back(116);
+  MultBins.push_back(120);
+  MultBins.push_back(124);
+  MultBins.push_back(128);
+  MultBins.push_back(132);
+  MultBins.push_back(136);
+  MultBins.push_back(140);
+  MultBins.push_back(144);
+  MultBins.push_back(148);
+  MultBins.push_back(152);
+  MultBins.push_back(156);
+  MultBins.push_back(160);
+        
   config->SetMultBins(MultBins);
 
   std::vector<float> ZVtxBins;


### PR DESCRIPTION
Adds the distribution of multiplicity and kstar for several mT bins. Can be activated via the event collection config with SetDomTMultBinning. The bins can be defined in a std::vector<float> via SetmTBins. 