### PR TITLE
PWGGA/GammaConv: properly derived AliConversionAodSkimTask 

### DIFF
--- a/PWGGA/GammaConv/AliConversionAodSkimTask.cxx
+++ b/PWGGA/GammaConv/AliConversionAodSkimTask.cxx
@@ -62,7 +62,7 @@ void AliConversionAodSkimTask::UserCreateOutputObjects()
   {
     if (strcmp(obj->ClassName(), "AliV0ReaderV1") == 0)
     {
-      AliFatal("Skim task is running but detected V0Reader running in addition. This will cause problems due to relabelling already done now by the V0Reader!");
+      AliFatal("Skim task is running but detected V0Reader running in addition! This will cause problems due to relabelling already done now by the V0Reader!");
     }
   }
 

--- a/PWGGA/GammaConv/AliConversionAodSkimTask.cxx
+++ b/PWGGA/GammaConv/AliConversionAodSkimTask.cxx
@@ -23,11 +23,8 @@ using namespace std;
 ClassImp(AliConversionAodSkimTask)
 
 AliConversionAodSkimTask::AliConversionAodSkimTask(const char* name) :
-  AliAnalysisTaskSE(name), fClusMinE(-1), fConvMinPt(-1), fConvMinEta(-999.), fConvMaxEta(999.), fConvMinPhi(999.), fConvMaxPhi(999.), fTrackMinPt(-1),fTrackMaxPt(-1), fDoBothMinTrackAndClus(0), fDoBothConvPtAndAcc(0), fCutMC(1), fYCutMC(0.7), fCutMinPt(0), fCutFilterBit(-1), fGammaBr(""),
-  fDoCopyHeader(1),  fDoCopyVZERO(1),  fDoCopyTZERO(1),  fDoCopyVertices(1),  fDoCopyTOF(1), fDoCopyTracklets(1), fDoCopyTracks(1), fDoRemoveTracks(0), fDoCleanTracks(0),
-  fDoRemCovMat(0), fDoRemPid(0), fDoCopyTrigger(1), fDoCopyPTrigger(0), fDoCopyCells(1), fDoCopyPCells(0), fDoCopyClusters(1), fDoCopyDiMuons(0),  fDoCopyTrdTracks(0),
-  fDoCopyV0s(0), fDoCopyCascades(0), fDoCopyZDC(1), fDoCopyConv(0), fDoCopyMC(1), fDoCopyMCHeader(1), fDoVertWoRefs(0), fDoVertMain(0), fDoCleanTracklets(0),
-  fTrials(0), fPyxsec(0), fPytrials(0), fPypthardbin(0), fDoQA(0), fAOD(0), fAODMcHeader(0), fOutputList(0), fHevs(0), fHclus(0), fHtrack(0), fHconvPtBeforeCuts(0), fHconvPtAfterCuts(0), fHconvAccBeforeCuts(0), fHconvAccAfterCuts(0)
+  AliAodSkimTask(name), fConvMinPt(-1), fConvMinEta(-999.), fConvMaxEta(999.), fConvMinPhi(999.), fConvMaxPhi(999.),fDoBothConvPtAndAcc(0),
+  fDoQA(0),fHconvPtBeforeCuts(0), fHconvPtAfterCuts(0), fHconvAccBeforeCuts(0), fHconvAccAfterCuts(0)
 {
   if (name) {
     DefineInput(0, TChain::Class());
@@ -49,65 +46,6 @@ AliConversionAodSkimTask::~AliConversionAodSkimTask()
   delete fHconvAccAfterCuts;
 }
 
-Bool_t AliConversionAodSkimTask::KeepTrack(AliAODTrack *t)
-{
-  if (!fDoRemoveTracks)
-    return kTRUE;
-  //cout << "Keep tracks " << endl;
-  if (t->IsMuonGlobalTrack())
-    return kFALSE;
-  if (t->Pt()<fCutMinPt)
-    return kFALSE;
-  if (fCutFilterBit!=(UInt_t)-1) {
-    if (t->TestFilterBit(fCutFilterBit)==0)
-      return kFALSE;
-  }
-  return kTRUE;
-}
-
-void AliConversionAodSkimTask::CleanTrack(AliAODTrack *t)
-{
-  if (!fDoCleanTracks)
-    return;
-  //cout << "Clean tracks " << endl;
-  t->SetRAtAbsorberEnd(0);
-  t->SetChi2MatchTrigger(0);
-  t->SetMuonClusterMap(0);
-  t->SetITSMuonClusterMap(0);
-  t->SetMUONtrigHitsMapTrg(0);
-  t->SetMUONtrigHitsMapTrk(0);
-  t->SetMFTClusterPattern(0);
-  t->SetMatchTrigger(0);
-  t->SetIsMuonGlobalTrack(0);
-  t->SetXYAtDCA(-999., -999.);
-  t->SetPxPyPzAtDCA(-999., -999., -999.);
-  if (fDoRemCovMat)
-    t->RemoveCovMatrix();
-  if (fDoRemPid) {
-    AliAODPid *pid = t->GetDetPid();
-    delete pid;
-    t->SetDetPID(0);
-  } else if (t->GetDetPid()) {
-    AliAODPid *pid = t->GetDetPid();
-    AliAODPid *nid = new AliAODPid;
-    nid->SetTPCsignal(pid->GetTPCsignal());
-    nid->SetTPCsignalN(pid->GetTPCsignalN());
-    nid->SetTPCmomentum(pid->GetTPCmomentum());
-    nid->SetTPCTgl(pid->GetTPCTgl());
-    /* Not used and getter not implemented
-       AliTPCdEdxInfo *dedx = new AliTPCdEdxInfo(pid->GetTPCdEdxInfo());
-       nid->SetTPCdEdxInfo(dedx); */
-    nid->SetTOFsignal(pid->GetTOFsignal());
-    Double_t val[5];
-    pid->GetTOFpidResolution(val);
-    nid->SetTOFpidResolution(val);
-    pid->GetIntegratedTimes(val,5);
-    nid->SetIntegratedTimes(val);
-    delete pid;
-    t->SetDetPID(nid);
-  }
-}
-
 void AliConversionAodSkimTask::UserCreateOutputObjects()
 {
   AliAnalysisManager *man = AliAnalysisManager::GetAnalysisManager();
@@ -115,6 +53,25 @@ void AliConversionAodSkimTask::UserCreateOutputObjects()
   if (oh) {
     TFile *fout = oh->GetTree()->GetCurrentFile();
     fout->SetCompressionLevel(2);
+  }
+
+  // Before running skim, check if the V0Reader is running
+  TIter next(man->GetTasks());
+  TObject *obj;
+  while ((obj = next()))
+  {
+    if (strcmp(obj->ClassName(), "AliV0ReaderV1") == 0)
+    {
+      AliFatal("Skim task is running but detected V0Reader running in addition. This will cause problems due to relabelling already done now by the V0Reader!");
+    }
+  }
+
+  // check if convcuts were requested but no gammabranch given
+  if ((fConvMinPt > 0) || (fConvMinEta != -999) || (fConvMaxEta != 999) || (fConvMinPhi != -999) || (fConvMaxPhi != 999)){
+     if(!fGammaBr || !fGammaBr.CompareTo("")){
+       AliFatal(Form("%s: Conversion cuts were requested but no fGammaBr was given", GetName()));
+       return;
+     }
   }
 
   fOutputList = new TList;
@@ -138,29 +95,8 @@ void AliConversionAodSkimTask::UserCreateOutputObjects()
   PostData(1, fOutputList);
 }
 
-void AliConversionAodSkimTask::UserExec(Option_t *)
+Bool_t AliConversionAodSkimTask::SelectEvent()
 {
-  fAOD = dynamic_cast<AliAODEvent*>(InputEvent());
-  if (!fAOD)
-    return;
-
-  AliAnalysisManager *man = AliAnalysisManager::GetAnalysisManager();
-  AliAODHandler *oh = (AliAODHandler*)man->GetOutputEventHandler();
-  if (!oh) {
-    AliFatal(Form("%s: No output handler found", GetName()));
-    return;
-  }
-
-  // check if convcuts were requested but no gammabranch given
-  if ((fConvMinPt > 0) || (fConvMinEta != -999) || (fConvMaxEta != 999) || (fConvMinPhi != -999) || (fConvMaxPhi != 999)){
-     if(!fGammaBr || !fGammaBr.CompareTo("")){
-       AliFatal(Form("%s: Conversion cuts were requested but no fGammaBr was given", GetName()));
-       return;
-     }
-  }
-  
-  oh->SetFillAOD(kFALSE);
-
   // Accept event only if an EMCal-cluster with a minimum energy of fClusMinE has been found in the event
   Bool_t storeE = kFALSE;
   if (fClusMinE>0) {
@@ -220,7 +156,6 @@ void AliConversionAodSkimTask::UserExec(Option_t *)
                   storeConvPt = kTRUE;
               }
            } else{
-             cout << "stroreconvkTrue" << endl;
               storeConvPt = kTRUE;
            }
            if( (eta>fConvMinEta) && (eta<fConvMaxEta) && (phi>fConvMinPhi) && (phi>fConvMaxPhi)){ // will always be true if no cut was set
@@ -257,14 +192,6 @@ void AliConversionAodSkimTask::UserExec(Option_t *)
     store     = kTRUE;
   }
 
-  if (!store) {
-    ++fTrials;
-    fHevs->Fill(0);
-    return;
-  }
-  
-  fHevs->Fill(1);
-  
   if(fDoQA){
     TClonesArray *convgammas  = dynamic_cast<TClonesArray*>(fAOD->FindListObject(fGammaBr));
     if(convgammas){
@@ -280,262 +207,7 @@ void AliConversionAodSkimTask::UserExec(Option_t *)
       }
     }
   }
-
-  oh->SetFillAOD(kTRUE);
-  AliAODEvent *eout = dynamic_cast<AliAODEvent*>(oh->GetAOD());
-  AliAODEvent *evin = dynamic_cast<AliAODEvent*>(InputEvent());
-  TTree *tout = oh->GetTree();
-  if (tout) {
-    TList *lout = tout->GetUserInfo();
-    if (lout->FindObject("alirootVersion")==0) {
-      TList *lin = AliAnalysisManager::GetAnalysisManager()->GetInputEventHandler()->GetUserInfo();
-      TString apver(gSystem->BaseName(gSystem->Getenv("ALICE_PHYSICS")));
-      lout->Add(new TObjString(Form("AodSkim: ver %s, tag %s with settings %s",GetVersion(),apver.Data(),Str())));
-      AliInfo(Form("%s: Set user info %s", GetName(), lout->At(0)->GetName()));
-      for (Int_t jj=0;jj<lin->GetEntries()-1;++jj) {
-        lout->Add(lin->At(jj)->Clone(lin->At(jj)->GetName()));
-      }
-    }
-  }
-
-  if (fDoCopyHeader) {
-    AliAODHeader *out = (AliAODHeader*)eout->GetHeader();
-    AliAODHeader *in  = (AliAODHeader*)evin->GetHeader();
-    *out = *in;
-    out->SetUniqueID(fTrials);
-  }
-
-  if (fDoCopyVZERO) {
-    AliAODVZERO *out = eout->GetVZEROData();
-    AliAODVZERO *in  = evin->GetVZEROData();
-    *out = *in;
-  }
-
-  if (fDoCopyTZERO) {
-    AliAODTZERO *out = eout->GetTZEROData();
-    AliAODTZERO *in  = evin->GetTZEROData();
-    *out = *in;
-  }
-
-  if (fDoCopyVertices) {
-    TClonesArray *out = eout->GetVertices();
-    TClonesArray *in  = evin->GetVertices();
-    if (out->GetEntries()>0) { // just checking if the deletion of previous event worked
-      AliFatal(Form("%s: Previous vertices not deleted. This should not happen!",GetName()));
-    }
-    out->AbsorbObjects(in);
-    Int_t marked=-1;
-    for (Int_t i=0; i<out->GetEntries(); ++i) {
-      AliAODVertex *v = static_cast<AliAODVertex*>(out->At(i));
-      Int_t nc = v->CountRealContributors();
-      Int_t nd = v->GetNDaughters();
-      if (fDoVertWoRefs) {
-      if (nc>0)
-        v->SetNContributors(nc);
-      else
-        v->SetNContributors(nd);
-      }
-      if (fDoVertMain) {
-        TString tmp(v->GetName());
-        if (!tmp.Contains("PrimaryVertex")&&!tmp.Contains("SPDVertex")&&!tmp.Contains("TPCVertex"))
-          continue;
-        marked=i;
-        break;
-      }
-      if (marked>0) {
-        out->RemoveRange(marked,out->GetEntries());
-        out->Compress();
-      }
-    }
-  }
-  if (fDoCopyTOF) {
-    AliTOFHeader *out = const_cast<AliTOFHeader*>(eout->GetTOFHeader());
-    const AliTOFHeader *in = evin->GetTOFHeader();
-    *out = *in;
-  }
-
-  if (fDoCopyTracks) {
-    TClonesArray *out = eout->GetTracks();
-    TClonesArray *in  = evin->GetTracks();
-    if (out->GetEntries()>0) { // just checking if the deletion of previous event worked
-      AliFatal(Form("%s: Previous tracks not deleted. This should not happen!",GetName()));
-    }
-    out->AbsorbObjects(in);
-    for (Int_t i=0;i<out->GetEntries();++i) {
-      AliAODTrack *t = static_cast<AliAODTrack*>(out->At(i));
-      if (KeepTrack(t)) {
-        CleanTrack(t);
-        if (fDoVertMain)
-          t->SetProdVertex(0);
-      } else {
-        t->~AliAODTrack();
-        new ((*out)[i]) AliAODTrack;
-      }
-    }
-  }
-
-  if (fDoCopyTracklets) {
-    AliAODTracklets *out = eout->GetTracklets();
-    AliAODTracklets *in  = evin->GetTracklets();
-    *out = *in;
-    if (fDoCleanTracklets) {
-      Int_t n=in->GetNumberOfTracklets();
-      out->SetTitle(Form("Ntracklets=%d",n));
-      out->DeleteContainer();
-    }
-  }
-
-  if (fDoCopyTrigger) {
-    AliAODCaloTrigger *out = eout->GetCaloTrigger("EMCAL");
-    AliAODCaloTrigger *in  = evin->GetCaloTrigger("EMCAL");
-    *out = *in;
-  }
-
-  if (fDoCopyPTrigger) {
-    AliAODCaloTrigger *out = eout->GetCaloTrigger("PHOS");
-    AliAODCaloTrigger *in  = evin->GetCaloTrigger("PHOS");
-    *out = *in;
-  }
-
-  if (fDoCopyCells) {
-    AliAODCaloCells *out = eout->GetEMCALCells();
-    AliAODCaloCells *in  = evin->GetEMCALCells();
-      *out = *in;
-  }
-
-  if (fDoCopyPCells) {
-    AliAODCaloCells *out = eout->GetPHOSCells();
-    AliAODCaloCells *in  = evin->GetPHOSCells();
-    *out = *in;
-  }
-
-  if (fDoCopyClusters) {
-    TClonesArray *out = eout->GetCaloClusters();
-    TClonesArray *in  = evin->GetCaloClusters();
-    if (out->GetEntries()>0) { // just checking if the deletion of previous event worked
-      AliFatal(Form("%s: Previous clusters not deleted. This should not happen!",GetName()));
-    }
-    out->AbsorbObjects(in);
-  }
-
-  if (fDoCopyTrdTracks) {
-    TClonesArray *out = static_cast<TClonesArray*>(eout->FindListObject("trdTracks"));
-    TClonesArray *in  = static_cast<TClonesArray*>(eout->FindListObject("trdTracks"));
-    if (out->GetEntries()>0) { // just checking if the deletion of previous event worked
-      AliFatal(Form("%s: Previous trdtracks not deleted. This should not happen!",GetName()));
-    }
-    out->AbsorbObjects(in);
-  }
-
-  if (fDoCopyV0s) {
-    TClonesArray *out = eout->GetV0s();
-    TClonesArray *in  = evin->GetV0s();
-    if (out->GetEntries()>0) { // just checking if the deletion of previous event worked
-      AliFatal(Form("%s: Previous v0s not deleted. This should not happen!",GetName()));
-    }
-    out->AbsorbObjects(in);
-  }
-
-  if (fDoCopyCascades) {
-    TClonesArray *out = eout->GetCascades();
-    TClonesArray *in  = evin->GetCascades();
-    if (out->GetEntries()>0) { // just checking if the deletion of previous event worked
-      AliFatal(Form("%s: Previous event not deleted. This should not happen!",GetName()));
-    }
-    out->AbsorbObjects(in);
-  }
-
-  if (fDoCopyZDC) {
-    AliAODZDC *out = eout->GetZDCData();
-    AliAODZDC *in  = evin->GetZDCData();
-    *out = *in;
-  }
-
-  if (fDoCopyDiMuons) {
-    TClonesArray *out = eout->GetDimuons();
-    TClonesArray *in  = evin->GetDimuons();
-    if (out->GetEntries()>0) { // just checking if the deletion of previous event worked
-      AliFatal(Form("%s: Previous dimuons not deleted. This should not happen!",GetName()));
-    }
-    out->AbsorbObjects(in);
-  }
-
-  if (fDoCopyConv) {
-    TClonesArray *out = dynamic_cast<TClonesArray*>(eout->FindListObject(fGammaBr));
-    TClonesArray *in  = dynamic_cast<TClonesArray*>(evin->FindListObject(fGammaBr));
-    if (!in) {
-      evin->GetList()->ls();
-      AliFatal(Form("%s: Could not find conversion branch with name %s!",GetName(), fGammaBr.Data()));
-    }
-    if (in && !out) {
-      out = new TClonesArray("AliAODConversionPhoton",2*in->GetEntries());
-      out->SetName(fGammaBr);
-      oh->AddBranch("TClonesArray", &out);
-    }
-    if (out->GetEntries()>0) { // just checking if the deletion of previous event worked
-      out->Delete();
-    }
-    out->AbsorbObjects(in);
-  }
-
-  if (fDoCopyMC) {
-    TClonesArray *out = static_cast<TClonesArray*>(eout->FindListObject(AliAODMCParticle::StdBranchName()));
-    TClonesArray *in  = static_cast<TClonesArray*>(evin->FindListObject(AliAODMCParticle::StdBranchName()));
-    if (in && !out) {
-      fgAODMCParticles = new TClonesArray("AliAODMCParticle",2*in->GetEntries());
-      fgAODMCParticles->SetName(AliAODMCParticle::StdBranchName());
-      oh->AddBranch("TClonesArray", &fgAODMCParticles);
-      out = static_cast<TClonesArray*>(eout->FindListObject(AliAODMCParticle::StdBranchName()));
-    }
-    if (in && out) {
-      if (out->GetEntries()>0) { // just checking if the deletion of previous event worked
-        AliFatal(Form("%s: Previous mcparticles not deleted. This should not happen!",GetName()));
-      }
-      out->AbsorbObjects(in);
-      if (fCutMC) {
-        for (Int_t i=0;i<out->GetEntriesFast();++i) {
-          AliAODMCParticle *mc = static_cast<AliAODMCParticle*>(in->At(i));
-          if ((mc==0)&&(i==0)) {
-            AliError(Form("%s: No MC info, skipping this event!",GetName()));
-            oh->SetFillAOD(kFALSE);
-            return;
-          }
-          if ((mc==0)||(TMath::Abs(mc->Y())>fYCutMC))
-            new ((*out)[i]) AliAODMCParticle;
-        }
-      }
-    }
-  }
-
-  if (fDoCopyMCHeader) {
-    AliAODMCHeader *out = static_cast<AliAODMCHeader*>(eout->FindListObject(AliAODMCHeader::StdBranchName()));
-    AliAODMCHeader *in  = static_cast<AliAODMCHeader*>(evin->FindListObject(AliAODMCHeader::StdBranchName()));
-    if (in && !out) {
-      fAODMcHeader = new AliAODMCHeader();
-      fAODMcHeader->SetName(AliAODMCHeader::StdBranchName());
-      oh->AddBranch("AliAODMCHeader",&fAODMcHeader);
-      out = static_cast<AliAODMCHeader*>(eout->FindListObject(AliAODMCHeader::StdBranchName()));
-    }
-    if (in && out) {
-      *out = *in;
-      if ((in->GetCrossSection()==0) && (fPyxsec>0)) {
-	out->SetCrossSection(fPyxsec);
-	out->SetTrials(fPytrials);
-	out->SetPtHard(fPypthardbin);
-      }
-    }
-  }
-
-  if (gDebug>10) {
-    Int_t  run = eout->GetRunNumber();
-    AliAODVertex *v=(AliAODVertex*)eout->GetVertices()->At(0);
-    Int_t   vzn = v->GetNContributors();
-    Double_t vz = v->GetZ();
-    cout << "debug run " << run << " " << vzn << " " << vz << endl;
-  }
-
-  fTrials = 0;
-  PostData(1, fOutputList);
+  return store;
 }
 
 Bool_t AliConversionAodSkimTask::UserNotify()
@@ -587,81 +259,6 @@ void AliConversionAodSkimTask::Terminate(Option_t *)
      norm=1;
    cout << "AliConversionAodSkimTask " << GetName() << " terminated with accepted fraction of events: " << fHevs->GetBinContent(2)/norm
 	<< " (" << fHevs->GetBinContent(2) << "/" << fHevs->GetEntries() << ")" << endl;
-}
-
-Bool_t AliConversionAodSkimTask::PythiaInfoFromFile(const char* currFile, Float_t &xsec, Float_t &trials, Int_t &pthard)
-{
-  TString file(currFile);
-  xsec = 0;
-  trials = 1;
-
-  if (file.Contains(".zip#")) {
-    Ssiz_t pos1 = file.Index("root_archive",12,0,TString::kExact);
-    Ssiz_t pos = file.Index("#",1,pos1,TString::kExact);
-    Ssiz_t pos2 = file.Index(".root",5,TString::kExact);
-    file.Replace(pos+1,pos2-pos1,"");
-  } else {
-    // not an archive take the basename....
-    file.ReplaceAll(gSystem->BaseName(file.Data()),"");
-  }
-  AliDebug(1,Form("File name: %s",file.Data()));
-
-  // Get the pt hard bin
-  TString strPthard(file);
-
-  strPthard.Remove(strPthard.Last('/'));
-  strPthard.Remove(strPthard.Last('/'));
-  if (strPthard.Contains("AOD")) strPthard.Remove(strPthard.Last('/'));
-  strPthard.Remove(0,strPthard.Last('/')+1);
-  if (strPthard.IsDec()) {
-    pthard = strPthard.Atoi();
-  }
-  else {
-    AliWarning(Form("Could not extract file number from path %s", strPthard.Data()));
-    pthard = -1;
-  }
-
-  // problem that we cannot really test the existance of a file in a archive so we have to live with open error message from root
-  TFile *fxsec = TFile::Open(Form("%s%s",file.Data(),"pyxsec.root"));
-
-  if (!fxsec) {
-    // next trial fetch the histgram file
-    fxsec = TFile::Open(Form("%s%s",file.Data(),"pyxsec_hists.root"));
-    if (!fxsec) {
-      // not a severe condition but inciate that we have no information
-      return kFALSE;
-    } else {
-      // find the tlist we want to be independtent of the name so use the Tkey
-      TKey* key = static_cast<TKey*>(fxsec->GetListOfKeys()->At(0));
-      if (!key) {
-        fxsec->Close();
-        return kFALSE;
-      }
-      TList *list = dynamic_cast<TList*>(key->ReadObj());
-      if (!list) {
-        fxsec->Close();
-        return kFALSE;
-      }
-      xsec = static_cast<TProfile*>(list->FindObject("h1Xsec"))->GetBinContent(1);
-      trials = static_cast<TH1F*>(list->FindObject("h1Trials"))->GetBinContent(1);
-      fxsec->Close();
-    }
-  } else { // no tree pyxsec.root
-    TTree *xtree = static_cast<TTree*>(fxsec->Get("Xsection"));
-    if (!xtree) {
-      fxsec->Close();
-      return kFALSE;
-    }
-    UInt_t   ntrials  = 0;
-    Double_t  xsection  = 0;
-    xtree->SetBranchAddress("xsection",&xsection);
-    xtree->SetBranchAddress("ntrials",&ntrials);
-    xtree->GetEntry(0);
-    trials = ntrials;
-    xsec = xsection;
-    fxsec->Close();
-  }
-  return kTRUE;
 }
 
 const char *AliConversionAodSkimTask::Str() const

--- a/PWGGA/GammaConv/AliConversionAodSkimTask.h
+++ b/PWGGA/GammaConv/AliConversionAodSkimTask.h
@@ -8,129 +8,44 @@
 ///
 /// \author C.Loizides
 
-#include <AliAnalysisTaskSE.h>
+#include <AliAodSkimTask.h>
 #include <TString.h>
 class AliAODMCHeader;
 class TH1F;
 
-class AliConversionAodSkimTask: public AliAnalysisTaskSE
+class AliConversionAodSkimTask: public AliAodSkimTask
 {
   public:
     AliConversionAodSkimTask(const char *name=0);
     virtual              ~AliConversionAodSkimTask();
-    void                  SetCleanTracklets(Bool_t b)         {fDoCleanTracklets=b;}
-    void                  SetCleanTracks(Bool_t b)            {fDoCleanTracks=b;}
-    void                  SetClusMinE(Double_t v)             {fClusMinE=v;}
     void                  SetConvMinPt(Double_t v)            {fConvMinPt=v;}
     void                  SetConvMinEta(Double_t eta)         {fConvMinEta=eta;}
     void                  SetConvMaxEta(Double_t eta)         {fConvMaxEta=eta;}
     void                  SetConvMinPhi(Double_t phi)         {fConvMinPhi=phi;}
     void                  SetConvMaxPhi(Double_t phi)         {fConvMaxPhi=phi;}
-    void                  SetTrackMinPt(Double_t v)           {fTrackMinPt=v;}
-    void                  SetTrackMaxPt(Double_t v)           {fTrackMaxPt=v;}
-    void                  SetDoBothMinTrackAndClus(Bool_t b)  {fDoBothMinTrackAndClus=b;}
     void                  SetDoBothConvPtAndAcc(Bool_t b)     {fDoBothConvPtAndAcc=b;}
-    void                  SetCopyCascades(Bool_t b)           {fDoCopyCascades=b;}
-    void                  SetCopyCells(Bool_t b)              {fDoCopyCells=b;}
-    void                  SetCopyClusters(Bool_t b)           {fDoCopyClusters=b;}
-    void                  SetCopyConv(Bool_t b)               {fDoCopyConv=b;}
-    void                  SetCopyDiMuons(Bool_t b)            {fDoCopyDiMuons=b;}
-    void                  SetCopyHeader(Bool_t b)             {fDoCopyHeader=b;}
-    void                  SetCopyMC(Bool_t b)                 {fDoCopyMC=b;}
-    void                  SetCopyMCHeader(Bool_t b)           {fDoCopyMCHeader=b;}
-    void                  SetCopyPCells(Bool_t b)             {fDoCopyPCells=b;}
-    void                  SetCopyPTrigger(Bool_t b)           {fDoCopyPTrigger=b;}
-    void                  SetCopyTOF(Bool_t b)                {fDoCopyTOF=b;}
-    void                  SetCopyTZERO(Bool_t b)              {fDoCopyTZERO=b;}
-    void                  SetCopyTracklets(Bool_t b)          {fDoCopyTracklets=b;}
-    void                  SetCopyTracks(Bool_t b)             {fDoCopyTracks=b;}
-    void                  SetCopyTrdTracks(Bool_t b)          {fDoCopyTrdTracks=b;}
-    void                  SetCopyTrigger(Bool_t b)            {fDoCopyTrigger=b;}
-    void                  SetCopyV0s(Bool_t b)                {fDoCopyV0s=b;}
-    void                  SetCopyVZERO(Bool_t b)              {fDoCopyVZERO=b;}
-    void                  SetCopyVertices(Bool_t b)           {fDoCopyVertices=b;}
-    void                  SetCopyZDC(Bool_t b)                {fDoCopyZDC=b;}
-    void                  SetCutFilterBit(UInt_t b)           {fCutFilterBit=b;}
-    void                  SetCutMC(Bool_t b)                  {fCutMC=b;}
-    void                  SetDoVertMain(Bool_t b)             {fDoVertMain=b;}
-    void                  SetDoVertWoRefs(Bool_t b)           {fDoVertWoRefs=b;}
-    void                  SetGammaBrName(TString s)           {fGammaBr=s;}
-    void                  SetMinCutPt(Double_t pt)            {fCutMinPt=pt;}
-    void                  SetRemCovMat(Bool_t b)              {fDoRemCovMat=b;}
-    void                  SetRemPid(Bool_t b)                 {fDoRemPid=b;}
-    void                  SetRemoveTracks(Bool_t b)           {fDoRemoveTracks=b;}
-    void                  SetYCutMC(Double_t v)               {fYCutMC=v;}
     void                  SetDoQA(Bool_t b)                   {fDoQA=b;}
     const char           *Str() const;
   protected:
     void                  UserCreateOutputObjects();
-    void                  UserExec(Option_t* option);
     Bool_t                UserNotify();
     void                  Terminate(Option_t* option);
-    Bool_t                PythiaInfoFromFile(const char *currFile, Float_t &xsec, Float_t &trials, Int_t &pthard);
-    Double_t              fClusMinE;              //  minimum cluster energy to accept event
+    Bool_t                SelectEvent();
     Double_t              fConvMinPt;             //  minimum conversion photon pT to accept event
     Double_t              fConvMinEta;            //  minimum eta of photon to accept event
     Double_t              fConvMaxEta;            //  maximum eta of photon to accept event
     Double_t              fConvMinPhi;            //  minimum phi of photon to accept event
     Double_t              fConvMaxPhi;            //  maximum phi of photon to accept event
-    Double_t              fTrackMinPt;            //  minimum track pt to accept event
-    Double_t              fTrackMaxPt;            //  maximum track pt to accept event
-    Bool_t                fDoBothMinTrackAndClus; // switch to enable simultaneous filtering for minimum track and cluster cuts
     Bool_t                fDoBothConvPtAndAcc;    // switch to enable simultaneous filtering for minimum conv pt and conv acceptance cut
-    Bool_t                fCutMC;                 //  if true cut MC particles with |Y|>fYCutMC
-    Double_t              fYCutMC;                //  cut for MC particles (default = 0.7)
-    Double_t              fCutMinPt;              //  minimum pT to keep track
-    UInt_t                fCutFilterBit;          //  filter bit(s) to select
-    TString               fGammaBr;               //  gamma branch name
-    Bool_t                fDoCopyHeader;          //  if true copy header
-    Bool_t                fDoCopyVZERO;           //  if true copy VZERO
-    Bool_t                fDoCopyTZERO;           //  if true copy TZERO
-    Bool_t                fDoCopyVertices;        //  if true copy vertices
-    Bool_t                fDoCopyTOF;             //  if true copy TOF
-    Bool_t                fDoCopyTracklets;       //  if true copy tracklets
-    Bool_t                fDoCopyTracks;          //  if true copy tracks
-    Bool_t                fDoRemoveTracks;        //  if true remove tracks
-    Bool_t                fDoCleanTracks;         //  if true clean tracks
-    Bool_t                fDoRemCovMat;           //  if true remove cov matrix from tracks
-    Bool_t                fDoRemPid;              //  if true remove PID object from tracks
-    Bool_t                fDoCopyTrigger;         //  if true copy trigger (EMC)
-    Bool_t                fDoCopyPTrigger;        //  if true copy trigger (PHS)
-    Bool_t                fDoCopyCells;           //  if true copy cells (EMC)
-    Bool_t                fDoCopyPCells;          //  if true copy cells (PHS)
-    Bool_t                fDoCopyClusters;        //  if true copy clusters
-    Bool_t                fDoCopyDiMuons;         //  if true copy dimuons
-    Bool_t                fDoCopyTrdTracks;       //  if true copy trd tracks
-    Bool_t                fDoCopyV0s;             //  if true copy v0s
-    Bool_t                fDoCopyCascades;        //  if true copy cascades
-    Bool_t                fDoCopyZDC;             //  if true copy zdc
-    Bool_t                fDoCopyConv;            //  if true copy conversions
-    Bool_t                fDoCopyMC;              //  if true copy MC particles
-    Bool_t                fDoCopyMCHeader;        //  if true copy MC header
-    Bool_t                fDoVertWoRefs;          //  if true then do not copy TRefs in vertices
-    Bool_t                fDoVertMain;            //  if true then only copy main vertices
-    Bool_t                fDoCleanTracklets;      //  if true then clean tracklets
-    UInt_t                fTrials;                //! events seen since last acceptance
-    Float_t               fPyxsec;                //! pythia xsection
-    Float_t               fPytrials;              //! pythia trials
-    Int_t                 fPypthardbin;           //! pythia pthard bin
     Bool_t                fDoQA;                  // do QA
-    AliAODEvent          *fAOD;                   //! input event
-    AliAODMCHeader       *fAODMcHeader;           //! MC header
-    TList                *fOutputList;            //! output list
-    TH1F                 *fHevs;                  //! events processed/accepted
-    TH1F                 *fHclus;                 //! cluster distribution
-    TH1F                 *fHtrack;                //! track distribution
+
     TH1F                 *fHconvPtBeforeCuts;       //! conv photon distribution
     TH1F                 *fHconvPtAfterCuts;        //! conv photon distribution
     TH2F                 *fHconvAccBeforeCuts;       //! conv photon distribution
     TH2F                 *fHconvAccAfterCuts;        //! conv photon distribution
-    const char           *GetVersion() const { return "1.4"; }
-    virtual Bool_t        KeepTrack(AliAODTrack *t);
-    virtual void          CleanTrack(AliAODTrack *t);
 
     AliConversionAodSkimTask(const AliConversionAodSkimTask&);             // not implemented
     AliConversionAodSkimTask& operator=(const AliConversionAodSkimTask&);  // not implemented
-    ClassDef(AliConversionAodSkimTask, 1); // AliConversionAodSkimTask
+    ClassDef(AliConversionAodSkimTask, 2); // AliConversionAodSkimTask
 };
 #endif


### PR DESCRIPTION
- AliConversionAodSkimTask is now properly derived from the original AliAodSkimTask, including the user exec. From now on, tasks can override the SelectEvent() to influence the selection of events selected for the skim and all copying is handeled by AliAodSkimTask
- intorduced a check that ensures that the V0Reader is not running in the analysis manager during skimming by accident. When relabelling by default with the V0Reader while skimming, the trains running on the skimmed dataset will fail to read the V0 candidates when attempting to relabel again. 