### PR TITLE
New background scheme (swapping method)

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskOmegaToPiZeroGamma.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskOmegaToPiZeroGamma.cxx
@@ -848,6 +848,12 @@ void AliAnalysisTaskOmegaToPiZeroGamma::UserCreateOutputObjects(){
       if(fReconMethod!=2 && fReconMethod!=5) fHistoMotherMatchedInvMassPt[iCut]->Sumw2();
       if(fDoPiZeroGammaAngleCut) fHistoMotherAngleCutRejectedInvMassPt[iCut]->Sumw2();
       if(fReconMethod<2) fHistoPhotonPairMatchedInvMassPt[iCut]->Sumw2();
+    }
+    if(((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->DoGammaSwappForBg()) {
+      fHistoMotherSwappingBackInvMassPt[iCut]->Sumw2();
+      fHistoMotherSwappingBackInvMassECalib[iCut]->Sumw2();
+    }
+    else {
       fHistoDiffPi0SameGammaBackInvMassPt[iCut]->Sumw2();
       fHistoSamePi0DiffGammaBackInvMassPt[iCut]->Sumw2();
     }
@@ -2123,9 +2129,9 @@ void AliAnalysisTaskOmegaToPiZeroGamma::ProcessAODMCParticles()
 
         if(gamma2 && pi0){
           fHistoMCOmegaDecayChannels[fiCut]->Fill(1,fWeightJetJetMC);
-          fHistoMCAllOmegaInvMassPt[fiCut]->Fill(TMath::Sqrt((particle->E())*(particle->E())-(particle->P())*(particle->P())),particle->Pt(),fWeightJetJetMC);
+          fHistoMCAllOmegaInvMassPt[fiCut]->Fill(((particle->GetCalcMass()) ? particle->GetCalcMass() : particle->M()),particle->Pt(),fWeightJetJetMC);
           fHistoMCGammaFromAllOmegaPt[fiCut]->Fill(gamma2->Pt(),fWeightJetJetMC);
-          fHistoMCPi0FromAllOmegaInvMassPt[fiCut]->Fill(TMath::Sqrt((pi0->E())*(pi0->E())-(pi0->P())*(pi0->P())),pi0->Pt(),fWeightJetJetMC);
+          fHistoMCPi0FromAllOmegaInvMassPt[fiCut]->Fill( ((pi0->GetCalcMass()) ? pi0->GetCalcMass() : pi0->M()),pi0->Pt(),fWeightJetJetMC);
           if(fDoMesonQA>0){
             fHistoMCPi0FromAllOmegaEtaPhi[fiCut]->Fill(pi0->Phi(),pi0->Eta(),fWeightJetJetMC);
             fHistoMCAllOmegaPtPi0Pt[fiCut]->Fill(particle->Pt(),pi0->Pt(),fWeightJetJetMC);
@@ -4391,7 +4397,7 @@ void AliAnalysisTaskOmegaToPiZeroGamma::CalculateBackground(){
             for(auto kCurrentClusterCandidates  : *fPi0Candidates){
               if(currentEventGoodV0Temp2 == ((AliAODConversionMother*) kCurrentClusterCandidates) ){ continue;}
 
-              std::unique_ptr<AliAODConversionMother> backgroundCandidate(new AliAODConversionMother(currentEventGoodPhotonRotation.get(), ((AliAODConversionPhoton*) kCurrentClusterCandidates)));
+              std::unique_ptr<AliAODConversionMother> backgroundCandidate(new AliAODConversionMother(((AliAODConversionMother*) kCurrentClusterCandidates), currentEventGoodPhotonRotation.get()));
 
               if(!(((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->CheckDistanceToBadChannelSwapping(cellIDRotatedPhoton, lvRotationPhoton.Phi(), fInputEvent)) && lvRotationPhoton.E() > ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetMinClusterEnergy())
               {

--- a/PWGGA/GammaConv/AliAnalysisTaskOmegaToPiZeroGamma.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskOmegaToPiZeroGamma.cxx
@@ -2945,10 +2945,6 @@ void AliAnalysisTaskOmegaToPiZeroGamma::CalculateOmegaCandidates()
               //change energy of pi0 candidate s.t. its mass is the pdg mass
               pi0cand->SetPxPyPzE(pi0cand->Px(),pi0cand->Py(),pi0cand->Pz(),TMath::Sqrt(0.1349766*0.1349766+pi0cand->P()*pi0cand->P()));
               fPi0Candidates->Add(pi0cand);
-              if( ((AliConversionMesonCuts*)fNeutralPionCutArray->At(fiCut))->UseGammaSelection() ) {
-                dropOutGammas_CALO.insert(firstGammaIndex);
-                dropOutGammas_CALO.insert(secondGammaIndex);
-              }
               if(fDoMesonQA>0){
                 fHistoPhotonPairYPt[fiCut]->Fill(pi0cand->Pt(),pi0cand->Rapidity()-((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift(),fWeightJetJetMC);
                 fHistoPhotonPairAlphaPt[fiCut]->Fill(pi0cand->Pt(),pi0cand->GetAlpha(),fWeightJetJetMC);

--- a/PWGGA/GammaConv/AliAnalysisTaskOmegaToPiZeroGamma.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskOmegaToPiZeroGamma.cxx
@@ -2889,6 +2889,8 @@ void AliAnalysisTaskOmegaToPiZeroGamma::CalculateOmegaCandidates()
                 dropOutGammas_CALO.insert(secondGammaIndex);
               }
             }
+            delete pi0cand;
+            pi0cand=0x0;
           }
         }
       }
@@ -2982,9 +2984,9 @@ void AliAnalysisTaskOmegaToPiZeroGamma::CalculateOmegaCandidates()
                 dropOutGammas_PCM.insert(firstGammaIndex);
                 dropOutGammas_PCM.insert(secondGammaIndex);
               }
-              delete pi0cand;
-              pi0cand=0x0;
             }
+            delete pi0cand;
+            pi0cand=0x0;
           }
         }
       }

--- a/PWGGA/GammaConv/AliAnalysisTaskOmegaToPiZeroGamma.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskOmegaToPiZeroGamma.cxx
@@ -2918,17 +2918,15 @@ void AliAnalysisTaskOmegaToPiZeroGamma::CalculateOmegaCandidates()
           for(Int_t secondGammaIndex=firstGammaIndex+1;secondGammaIndex<fClusterCandidates->GetEntries();secondGammaIndex++){
             AliAODConversionPhoton *gamma1=dynamic_cast<AliAODConversionPhoton*>(fClusterCandidates->At(secondGammaIndex));
             if (gamma1==NULL || !(gamma1->GetIsCaloPhoton())) continue;
-            AliAODConversionMother *pi0cand = new AliAODConversionMother(gamma0, gamma1);
+            AliAODConversionMother pi0cand = AliAODConversionMother(gamma0, gamma1);
             if(((AliConversionMesonCuts*)fNeutralPionCutArray->At(fiCut))
-                 ->MesonIsSelected(pi0cand,kTRUE,((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift())
-                && pi0cand->Pt() > fMinPi0Pt){
-              if( ((AliConversionMesonCuts*)fNeutralPionCutArray->At(fiCut))->MesonIsSelectedByMassCut(pi0cand, 0) ) {
+                 ->MesonIsSelected(&pi0cand,kTRUE,((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift())
+                && pi0cand.Pt() > fMinPi0Pt){
+              if( ((AliConversionMesonCuts*)fNeutralPionCutArray->At(fiCut))->MesonIsSelectedByMassCut(&pi0cand, 0) ) {
                 dropOutGammas_CALO.insert(firstGammaIndex);
                 dropOutGammas_CALO.insert(secondGammaIndex);
               }
             }
-            delete pi0cand;
-            pi0cand=0x0;
           }
         }
       }
@@ -3009,18 +3007,16 @@ void AliAnalysisTaskOmegaToPiZeroGamma::CalculateOmegaCandidates()
           for(Int_t secondGammaIndex=firstGammaIndex+1;secondGammaIndex<fGammaCandidates->GetEntries();secondGammaIndex++){
             AliAODConversionPhoton *gamma1=dynamic_cast<AliAODConversionPhoton*>(fGammaCandidates->At(secondGammaIndex));
             if (gamma1==NULL || (secondGammaIndex+1)>=(fGammaCandidates->GetEntries())) continue;
-            AliAODConversionMother *pi0cand = new AliAODConversionMother(gamma0, gamma1);
+            AliAODConversionMother pi0cand = AliAODConversionMother(gamma0, gamma1);
             if(((AliConversionMesonCuts*)fNeutralPionCutArray->At(fiCut))
-                 ->MesonIsSelected(pi0cand,kTRUE,((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift())
-                && pi0cand->Pt() > fMinPi0Pt){
-              fHistoPhotonPairInvMassPt[fiCut]->Fill(pi0cand->M(),pi0cand->Pt(),fWeightJetJetMC);
-              if( ((AliConversionMesonCuts*)fNeutralPionCutArray->At(fiCut))->MesonIsSelectedByMassCut(pi0cand, 0) ) {
+                 ->MesonIsSelected(&pi0cand,kTRUE,((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift())
+                && pi0cand.Pt() > fMinPi0Pt){
+              fHistoPhotonPairInvMassPt[fiCut]->Fill(pi0cand.M(),pi0cand.Pt(),fWeightJetJetMC);
+              if( ((AliConversionMesonCuts*)fNeutralPionCutArray->At(fiCut))->MesonIsSelectedByMassCut(&pi0cand, 0) ) {
                 dropOutGammas_PCM.insert(firstGammaIndex);
                 dropOutGammas_PCM.insert(secondGammaIndex);
               }
             }
-            delete pi0cand;
-            pi0cand=0x0;
           }
         }
       }

--- a/PWGGA/GammaConv/AliAnalysisTaskOmegaToPiZeroGamma.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskOmegaToPiZeroGamma.cxx
@@ -4397,11 +4397,7 @@ void AliAnalysisTaskOmegaToPiZeroGamma::CalculateBackground(){
             for(auto kCurrentClusterCandidates  : *fPi0Candidates){
               if(currentEventGoodV0Temp2 == ((AliAODConversionMother*) kCurrentClusterCandidates) ){ continue;}
 
-<<<<<<< HEAD
               std::unique_ptr<AliAODConversionMother> backgroundCandidate(new AliAODConversionMother(((AliAODConversionMother*) kCurrentClusterCandidates), currentEventGoodPhotonRotation.get()));
-=======
-              std::unique_ptr<AliAODConversionMother> backgroundCandidate(new AliAODConversionMother(currentEventGoodPhotonRotation.get(), ((AliAODConversionPhoton*) kCurrentClusterCandidates)));
->>>>>>> 642c935213909e9dc1dc3958687696b5d0da5b6b
 
               if(!(((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->CheckDistanceToBadChannelSwapping(cellIDRotatedPhoton, lvRotationPhoton.Phi(), fInputEvent)) && lvRotationPhoton.E() > ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetMinClusterEnergy())
               {

--- a/PWGGA/GammaConv/AliAnalysisTaskOmegaToPiZeroGamma.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskOmegaToPiZeroGamma.h
@@ -16,6 +16,7 @@
 #include "TH3.h"
 #include "TH3F.h"
 #include "THnSparse.h"
+#include "TGenPhaseSpace.h"
 #include <vector>
 #include <map>
 
@@ -64,6 +65,7 @@ class AliAnalysisTaskOmegaToPiZeroGamma : public AliAnalysisTaskSE {
                                           AliAODConversionPhoton *TrueGammaCandidate2);
 
     // switches for additional analysis streams or outputs
+    void SetLightOutput                 ( Bool_t flag )                                     { fDoLightOutput = flag                       ;}
     void SetDoMesonQA                   ( Int_t flag )                                      { fDoMesonQA = flag                           ;}
     void SetDoPhotonQA                  ( Int_t flag )                                      { fDoPhotonQA = flag                          ;}
     void SetPlotHistsExtQA              ( Bool_t flag )                                     { fSetPlotHistsExtQA = flag                   ;}
@@ -190,79 +192,80 @@ class AliAnalysisTaskOmegaToPiZeroGamma : public AliAnalysisTaskSE {
                       // 6: primary gamma
 
     //histograms for mesons reconstructed quantities
-    TH2F**                  fHistoPhotonPairInvMassPt;              //! array of histogram with signal + BG for same event photon pairs, inv Mass, pt
-    TH2F**                  fHistoPhotonPairMatchedInvMassPt;       //! array of histogram with signal + BG for same event photon pairs, inv Mass, pt
-    TH2F**                  fHistoPhotonPairYPt;                //! array of histograms with invariant mass cut of 0.05 && pi0cand->M() < 0.17, pt, Y
-    TH2F**                  fHistoPhotonPairAlphaPt;            //! array of histograms with invariant mass cut of 0.05 && pi0cand->M() < 0.17, pt, alpha
-    TH2F**                  fHistoPhotonPairOpenAnglePt;        //! array of histograms with invariant mass cut of 0.05 && pi0cand->M() < 0.17, pt, openAngle
-    TH2F**                  fHistoPhotonPairEtaPhi;             //! array of histograms with Eta, Phi of pi0 candidates
-    TH2F**                  fHistoMotherConvPhotonEtaPhi;       //! array of histograms with invariant mass cut of 0.05 && pi0cand->M() < 0.17 ,eta/phi of conversion photon
-    TH2F**                  fHistoMotherInvMassPt;              //! array of histograms for invariant mass of omega candidates
-    TH2F**                  fHistoMotherMatchedInvMassPt;           //! array of histograms with invariant mass and Pt of rejected omega candidates due to
-                                                                    //! matching between a pcm track and cluster which do not belong to the pair forming pi0
-    TH2F**                  fHistoMotherAngleCutRejectedInvMassPt;  //! array of histograms with invariant mass and Pt of omega candidates rejected by pi0-gamma angle cut
-    TH2F**                  fHistoMotherYPt;                    //! array of histograms for Y of omega candidates
-    TH2F**                  fHistoMotherAlphaPt;                //! array of histograms with pT, Alpha of omega candidates
-    TH2F**                  fHistoMotherEtaPhi;                 //! array of histograms with Eta and Phi of omega candidates
-    TH2F**                  fHistoMotherPi0AnglePt;             //! array of histograms with angle between omega candidates and pi0 candidates
-    TH2F**                  fHistoMotherGammaAnglePt;           //! array of histograms with angle between omega candidates and combined gammas
-    TH2F**                  fHistoPi0GammaAnglePt;              //! array of histograms with angle between pi0 candidates and combined gammas
-    TH2F**                  fHistoMotherRestGammaCosAnglePt;    //! array of histograms with cos angle between omega in lab frame candidates and gamma candidates in the omega rest frame
-    TH2F**                  fHistoMotherRestPi0CosAnglePt;      //! array of histograms with cos angle between omega in lab frame candidates and pi0 candidates in the omega rest frame
-    TH2F**                  fHistoMotherDalitzPlot;             //! array of histograms with mass squared of two pi0 gammas (gamma0 and gamma1) and mass squared of gamma1 and gamma2 (gamma2 directly from omega)
-    TH1F**                  fHistoGammaFromMotherPt;            //! array of histograms with pT of gammas from omega candidates
+    TH2F**                  fHistoPhotonPairInvMassPt;                          //! array of histogram with signal + BG for same event photon pairs, inv Mass, pt
+    TH2F**                  fHistoPhotonPairMatchedInvMassPt;                   //! array of histogram with signal + BG for same event photon pairs, inv Mass, pt
+    TH2F**                  fHistoPhotonPairYPt;                                //! array of histograms with invariant mass cut of 0.05 && pi0cand->M() < 0.17, pt, Y
+    TH2F**                  fHistoPhotonPairAlphaPt;                            //! array of histograms with invariant mass cut of 0.05 && pi0cand->M() < 0.17, pt, alpha
+    TH2F**                  fHistoPhotonPairOpenAnglePt;                        //! array of histograms with invariant mass cut of 0.05 && pi0cand->M() < 0.17, pt, openAngle
+    TH2F**                  fHistoPhotonPairEtaPhi;                             //! array of histograms with Eta, Phi of pi0 candidates
+    TH2F**                  fHistoMotherConvPhotonEtaPhi;                       //! array of histograms with invariant mass cut of 0.05 && pi0cand->M() < 0.17 ,eta/phi of conversion photon
+    TH2F**                  fHistoMotherInvMassPt;                              //! array of histograms for invariant mass of omega candidates
+    TH2F**                  fHistoMotherMatchedInvMassPt;                       //! array of histograms with invariant mass and Pt of rejected omega candidates due to
+                                                                                //! matching between a pcm track and cluster which do not belong to the pair forming pi0
+    TH2F**                  fHistoMotherAngleCutRejectedInvMassPt;              //! array of histograms with invariant mass and Pt of omega candidates rejected by pi0-gamma angle cut
+    TH2F**                  fHistoMotherYPt;                                    //! array of histograms for Y of omega candidates
+    TH2F**                  fHistoMotherAlphaPt;                                //! array of histograms with pT, Alpha of omega candidates
+    TH2F**                  fHistoMotherEtaPhi;                                 //! array of histograms with Eta and Phi of omega candidates
+    TH2F**                  fHistoMotherPi0AnglePt;                             //! array of histograms with angle between omega candidates and pi0 candidates
+    TH2F**                  fHistoMotherGammaAnglePt;                           //! array of histograms with angle between omega candidates and combined gammas
+    TH2F**                  fHistoPi0GammaAnglePt;                              //! array of histograms with angle between pi0 candidates and combined gammas
+    TH2F**                  fHistoMotherRestGammaCosAnglePt;                    //! array of histograms with cos angle between omega in lab frame candidates and gamma candidates in the omega rest frame
+    TH2F**                  fHistoMotherRestPi0CosAnglePt;                      //! array of histograms with cos angle between omega in lab frame candidates and pi0 candidates in the omega rest frame
+    TH2F**                  fHistoMotherDalitzPlot;                             //! array of histograms with mass squared of two pi0 gammas (gamma0 and gamma1) and mass squared of gamma1 and gamma2 (gamma2 directly from omega)
+    TH1F**                  fHistoGammaFromMotherPt;                            //! array of histograms with pT of gammas from omega candidates
 
     // BG histograms
-    TH2F**                  fHistoDiffPi0SameGammaBackInvMassPt;//! array of histograms with background generated by combining pi0's from the handler and photons from the current event
-    TH2F**                  fHistoSamePi0DiffGammaBackInvMassPt;//! array of histograms with background generated by combining pi0's from the current event and photons from the handler
-
+    TH2F**                  fHistoDiffPi0SameGammaBackInvMassPt;                //! array of histograms with background generated by combining pi0's from the handler and photons from the current event
+    TH2F**                  fHistoSamePi0DiffGammaBackInvMassPt;                //! array of histograms with background generated by combining pi0's from the current event and photons from the handler
+    TH2F**                  fHistoMotherSwappingBackInvMassPt;                  //! array of histograms with background generated by alterating one pi0 and one photon and match them with not altered photons or pi0's respectively, inv mass, pT
+    TH2F**		              fHistoMotherSwappingBackInvMassECalib;			        //! array of histograms with background generated by alterating one pi0 and one photon and match them with not altered photons or pi0's respectively, inv mass, energy of cluster
     // histograms for rec photon clusters
-    TH1F**                  fHistoClusGammaPt;                  //! array of histos with cluster, pt
-    TH1F**                  fHistoClusOverlapHeadersGammaPt;    //! array of histos with cluster, pt overlapping with other headers
+    TH1F**                  fHistoClusGammaPt;                                  //! array of histos with cluster, pt
+    TH1F**                  fHistoClusOverlapHeadersGammaPt;                    //! array of histos with cluster, pt overlapping with other headers
 
     //histograms for pure MC quantities
-    TH1F**                  fHistoMCAllGammaPt;                 //! array of histos with all gamma, pT
-    TH1F**                  fHistoMCAllGammaEMCALAccPt;         //! array of histos with all gamma in EMCAL acceptance, pT
-    TH1F**                  fHistoMCConvGammaPt;                //! array of histos with converted gamma, pT
-    TH1F**                  fHistoMCConvGammaR;                 //! array of histos with converted gamma, R
-    TH1F**                  fHistoMCConvGammaEta;               //! array of histos with converted gamma, Eta
-    TH1F**                  fHistoMCPi0Pt;                      //! array of histos with weighted pi0, pT
-    TH1F**                  fHistoMCPi0WOWeightPt;              //! array of histos with unweighted pi0, pT
-    TH1F**                  fHistoMCPi0WOEvtWeightPt;           //! array of histos without event weights pi0, pT
-    TH1F**                  fHistoMCPi0InAccPt;                 //! array of histos with weighted pi0 in acceptance, pT
-    TH1F**                  fHistoMCPi0WOWeightInAccPt;         //! array of histos without weight pi0 in acceptance, pT
-    TH2F**                  fHistoMCPi0PtY;                     //! array of histos with weighted pi0, pT, Y
-    TH2F**                  fHistoMCPi0PtAlpha;                 //! array of histos with weighted pi0, pT, alpha
-    TH2F**                  fHistoMCPi0PtJetPt;                 //! array of histos with weighted pi0, pT, hardest jet pt
-    TH1F**                  fHistoMCGammaFromAllOmegaPt;        //! array of histos with pT of photons which are decay products of omegas
-    TH1F**                  fHistoMCGammaFromOmegaInAccPt;      //! array of histos with pT of photons from omegas in acceptance
-    TH2F**                  fHistoMCPi0FromAllOmegaInvMassPt;   //! array of histos with pT & Inv Mass of pi0s which are daughters of omegas
-    TH2F**                  fHistoMCOmegaInAccInvMassPt;        //! array of histos with true omegas in acceptance, Inv Mass, pT
-    TH2F**                  fHistoMCOmegaInvMassPt;             //! array of histos with pT of true omegas within rapidity window, for acceptance correction
-    TH2F**                  fHistoMCAllOmegaYPt;                //! array of histos with pT, Y of all true omegas
-    TH2F**                  fHistoMCOmegaInAccYPt;              //! array of histos with pT, Y of true omegas in acceptance
-    TH2F**                  fHistoMCAllOmegaAlphaPt;            //! array of histos with pT, alpha of omegas which decayed into pi0+gamma
-    TH2F**                  fHistoMCOmegaInAccAlphaPt;          //! array of histos with pT, alpha of omegas in acceptance which decayed into pi0+gamma
-    TH2F**                  fHistoMCPi0FromAllOmegaAlphaPt;     //! array of histos with pT, alpha of pi0s which are daughters of omegas
-    TH2F**                  fHistoMCPi0FromOmegaInAccAlphaPt;   //! array of histos with pT, alpha of pi0s which are daughters of omegas in acceptance
-    TH2F**                  fHistoMCPi0FromAllOmegaYPt;         //! array of histos with pT, Y of pi0s from all true omegas
-    TH2F**                  fHistoMCPi0FromOmegaInAccYPt;       //! array of histos with pT, Y of pi0s from omegas in acceptance
-    TH2F**                  fHistoMCPi0FromOmegaInAccInvMassPt; //! array of histos with Inv Mass, pT of pi0s from omegas in acceptance
-    TH2F**                  fHistoMCPi0FromAllOmegaEtaPhi;      //! array of histos with eta and phi of pi0s from all true omegas
-    TH2F**                  fHistoMCPi0FromOmegaInAccEtaPhi;    //! array of histos with eta and phi of pi0s from omegas in acceptance
-    TH2F**                  fHistoMCAllOmegaEtaPhi;             //! array of histos with eta and phi of all true omegas
-    TH2F**                  fHistoMCOmegaInAccEtaPhi;           //! array of histos with eta and phi of all true omegas in acceptance
-    TH2F**                  fHistoMCAllOmegaPiZeroAnglePt;      //! array of histos with angle between true omega and pi0 daughter and pT of omega
-    TH2F**                  fHistoMCAllPiZeroGammaAnglePt;      //! array of histos with angle between pi0 and gamma daughters of true omega and pT of omega
-    TH2F**                  fHistoMCAllOmegaGammaAnglePt;       //! array of histos with angle between true omega and gamma daughter and pT of omega
-    TH2F**                  fHistoMCInAccOmegaPiZeroAnglePt;    //! array of histos with angle between true omega in acc. and pi0 daughter
-    TH2F**                  fHistoMCInAccPiZeroGammaAnglePt;    //! array of histos with angle between pi0 and gamma daughters of true omega in acc.
-    TH2F**                  fHistoMCInAccOmegaGammaAnglePt;     //! array of histos with angle between true omega in acc. and gamma daughter
-    TH2F**                  fHistoMCAllOmegaInvMassPt;          //! array of histos with all true omegas, invMass, pT
-    TH2F**                  fHistoMCAllOmegaPtPi0Pt;            //! array of histos with pT of all omegas and that of their pi0 daughters
-    TH2F**                  fHistoMCInAccOmegaPtPi0Pt;          //! array of histos with pT of omegas in acceptance and that of their pi0 daughters
-    TH2F**                  fHistoMCAllOmegaPtGammaPt;          //! array of histos with pT of all omegas and those of their gamma daughters
-    TH2F**                  fHistoMCInAccOmegaPtGammaPt;        //! array of histos with pT of omegas in acceptance and those of their gamma daughters
+    TH1F**                  fHistoMCAllGammaPt;                                 //! array of histos with all gamma, pT
+    TH1F**                  fHistoMCAllGammaEMCALAccPt;                         //! array of histos with all gamma in EMCAL acceptance, pT
+    TH1F**                  fHistoMCConvGammaPt;                                //! array of histos with converted gamma, pT
+    TH1F**                  fHistoMCConvGammaR;                                 //! array of histos with converted gamma, R
+    TH1F**                  fHistoMCConvGammaEta;                               //! array of histos with converted gamma, Eta
+    TH1F**                  fHistoMCPi0Pt;                                      //! array of histos with weighted pi0, pT
+    TH1F**                  fHistoMCPi0WOWeightPt;                              //! array of histos with unweighted pi0, pT
+    TH1F**                  fHistoMCPi0WOEvtWeightPt;                           //! array of histos without event weights pi0, pT
+    TH1F**                  fHistoMCPi0InAccPt;                                 //! array of histos with weighted pi0 in acceptance, pT
+    TH1F**                  fHistoMCPi0WOWeightInAccPt;                         //! array of histos without weight pi0 in acceptance, pT
+    TH2F**                  fHistoMCPi0PtY;                                     //! array of histos with weighted pi0, pT, Y
+    TH2F**                  fHistoMCPi0PtAlpha;                                 //! array of histos with weighted pi0, pT, alpha
+    TH2F**                  fHistoMCPi0PtJetPt;                                 //! array of histos with weighted pi0, pT, hardest jet pt
+    TH1F**                  fHistoMCGammaFromAllOmegaPt;                        //! array of histos with pT of photons which are decay products of omegas
+    TH1F**                  fHistoMCGammaFromOmegaInAccPt;                      //! array of histos with pT of photons from omegas in acceptance
+    TH2F**                  fHistoMCPi0FromAllOmegaInvMassPt;                   //! array of histos with pT & Inv Mass of pi0s which are daughters of omegas
+    TH2F**                  fHistoMCOmegaInAccInvMassPt;                        //! array of histos with true omegas in acceptance, Inv Mass, pT
+    TH2F**                  fHistoMCOmegaInvMassPt;                             //! array of histos with pT of true omegas within rapidity window, for acceptance correction
+    TH2F**                  fHistoMCAllOmegaYPt;                                //! array of histos with pT, Y of all true omegas
+    TH2F**                  fHistoMCOmegaInAccYPt;                              //! array of histos with pT, Y of true omegas in acceptance
+    TH2F**                  fHistoMCAllOmegaAlphaPt;                            //! array of histos with pT, alpha of omegas which decayed into pi0+gamma
+    TH2F**                  fHistoMCOmegaInAccAlphaPt;                          //! array of histos with pT, alpha of omegas in acceptance which decayed into pi0+gamma
+    TH2F**                  fHistoMCPi0FromAllOmegaAlphaPt;                     //! array of histos with pT, alpha of pi0s which are daughters of omegas
+    TH2F**                  fHistoMCPi0FromOmegaInAccAlphaPt;                   //! array of histos with pT, alpha of pi0s which are daughters of omegas in acceptance
+    TH2F**                  fHistoMCPi0FromAllOmegaYPt;                         //! array of histos with pT, Y of pi0s from all true omegas
+    TH2F**                  fHistoMCPi0FromOmegaInAccYPt;                       //! array of histos with pT, Y of pi0s from omegas in acceptance
+    TH2F**                  fHistoMCPi0FromOmegaInAccInvMassPt;                 //! array of histos with Inv Mass, pT of pi0s from omegas in acceptance
+    TH2F**                  fHistoMCPi0FromAllOmegaEtaPhi;                      //! array of histos with eta and phi of pi0s from all true omegas
+    TH2F**                  fHistoMCPi0FromOmegaInAccEtaPhi;                    //! array of histos with eta and phi of pi0s from omegas in acceptance
+    TH2F**                  fHistoMCAllOmegaEtaPhi;                             //! array of histos with eta and phi of all true omegas
+    TH2F**                  fHistoMCOmegaInAccEtaPhi;                           //! array of histos with eta and phi of all true omegas in acceptance
+    TH2F**                  fHistoMCAllOmegaPiZeroAnglePt;                      //! array of histos with angle between true omega and pi0 daughter and pT of omega
+    TH2F**                  fHistoMCAllPiZeroGammaAnglePt;                      //! array of histos with angle between pi0 and gamma daughters of true omega and pT of omega
+    TH2F**                  fHistoMCAllOmegaGammaAnglePt;                       //! array of histos with angle between true omega and gamma daughter and pT of omega
+    TH2F**                  fHistoMCInAccOmegaPiZeroAnglePt;                    //! array of histos with angle between true omega in acc. and pi0 daughter
+    TH2F**                  fHistoMCInAccPiZeroGammaAnglePt;                    //! array of histos with angle between pi0 and gamma daughters of true omega in acc.
+    TH2F**                  fHistoMCInAccOmegaGammaAnglePt;                     //! array of histos with angle between true omega in acc. and gamma daughter
+    TH2F**                  fHistoMCAllOmegaInvMassPt;                          //! array of histos with all true omegas, invMass, pT
+    TH2F**                  fHistoMCAllOmegaPtPi0Pt;                            //! array of histos with pT of all omegas and that of their pi0 daughters
+    TH2F**                  fHistoMCInAccOmegaPtPi0Pt;                          //! array of histos with pT of omegas in acceptance and that of their pi0 daughters
+    TH2F**                  fHistoMCAllOmegaPtGammaPt;                          //! array of histos with pT of all omegas and those of their gamma daughters
+    TH2F**                  fHistoMCInAccOmegaPtGammaPt;                        //! array of histos with pT of omegas in acceptance and those of their gamma daughters
 
     // MC validated reconstructed quantities mesons
     TH2F**                  fHistoTrueOmegaInvMassPt;                           //! array of histos with reconstructed true omegas, invMass, pT
@@ -319,6 +322,7 @@ class AliAnalysisTaskOmegaToPiZeroGamma : public AliAnalysisTaskSE {
     Int_t                   fiCut;                                              // current cut
     Bool_t                  fMoveParticleAccordingToVertex;                     // boolean for BG calculation
     Int_t                   fIsHeavyIon;                                        // switch for pp = 0, PbPb = 1, pPb = 2
+    Bool_t                  fDoLightOutput;                                     // switch for running light output, kFALSE -> normal mode, kTRUE -> light mode
     Int_t                   fDoMesonQA;                                         // flag for meson QA
     Int_t                   fDoPhotonQA;                                        // flag for photon QA
     Bool_t                  fIsFromMBHeader;                                    // flag for MC headers
@@ -336,6 +340,8 @@ class AliAnalysisTaskOmegaToPiZeroGamma : public AliAnalysisTaskSE {
 
     Bool_t                  fDoPiZeroGammaAngleCut;                             // flag for pi0-gamma angle cut
     Int_t                   fTrackMatcherRunningMode;                           // CaloTrackMatcher running mode
+    TRandom3                fRandom;                                            // random
+    TGenPhaseSpace          fGenPhaseSpace;                                     // For generation of decays into pi0n and photon
 
   private:
     AliAnalysisTaskOmegaToPiZeroGamma(const AliAnalysisTaskOmegaToPiZeroGamma&); // Prevent copy-construction

--- a/PWGGA/GammaConv/AliAnalysisTaskOmegaToPiZeroGamma.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskOmegaToPiZeroGamma.h
@@ -347,7 +347,7 @@ class AliAnalysisTaskOmegaToPiZeroGamma : public AliAnalysisTaskSE {
     AliAnalysisTaskOmegaToPiZeroGamma(const AliAnalysisTaskOmegaToPiZeroGamma&); // Prevent copy-construction
     AliAnalysisTaskOmegaToPiZeroGamma &operator=(const AliAnalysisTaskOmegaToPiZeroGamma&); // Prevent assignment
 
-    ClassDef(AliAnalysisTaskOmegaToPiZeroGamma, 14);
+    ClassDef(AliAnalysisTaskOmegaToPiZeroGamma, 15);
 };
 
 #endif

--- a/PWGGA/GammaConv/macros/AddTask_OmegaToPiZeroGamma_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_OmegaToPiZeroGamma_pp.C
@@ -66,6 +66,7 @@ void AddTask_OmegaToPiZeroGamma_pp(
                                 TString   photonCutNumberV0Reader       = "",                     // 00000008400000000100000000 nom. B, 00000088400000000100000000 low B
                                 Int_t     enableQAMesonTask             = 1,                      // enable QA in AliAnalysisTaskGammaConvV1
                                 Int_t     enableQAPhotonTask            = 1,                      // enable additional QA task
+                                Bool_t    enableLightOutput             = kFALSE,                 // switch to run light output (only essential histograms for afterburner)
                                 Int_t     DoPiZeroGammaAngleCut         = kFALSE,                 // flag for enabling cut on pi0-gamma angle
                                 Double_t  lowerFactor                   = 0.75,                   // scale factor for lower limit in pi0-gamma angle cut
                                 Double_t  upperFactor                   = 2.5,                    // scale factor for upper limit in pi0-gamma angle cut
@@ -712,6 +713,8 @@ void AddTask_OmegaToPiZeroGamma_pp(
     MesonCutList->Add(analysisMesonCuts[i]);
     analysisMesonCuts[i]->SetFillCutHistograms("MesonCuts");
     if(doSmear) analysisMesonCuts[i]->SetDefaultSmearing(bremSmear,smearPar,smearParConst);
+    if(analysisMesonCuts[i]->DoGammaSwappForBg()) analysisClusterCuts[i]->SetUseEtaPhiMapForBackCand(kTRUE);
+    analysisClusterCuts[i]->SetFillCutHistograms("");
   }
 
   task->SetEventCutList(numberOfCuts,EventCutList);

--- a/PWGGA/GammaConv/macros/AddTask_OmegaToPiZeroGamma_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_OmegaToPiZeroGamma_pp.C
@@ -407,25 +407,56 @@ void AddTask_OmegaToPiZeroGamma_pp(
     cuts.AddCut("00085113","00200009327000008250400000","411791106f032230000","01631031000000d0","01631030000000d0");
     cuts.AddCut("00083113","00200009327000008250400000","411791106f032230000","01631031000000d0","01631030000000d0");
   } else if( trainConfig == 261) {
-    //only MB 13TeV only EMCal
+    // MB 13TeV only EMCal
     cuts.AddCut("00010113","00200009327000008250400000","1111100067032230000","01631031000000d0","01631031000000d0");
   } else if( trainConfig == 262) {
-    //std NL 12
+    // MB std NL 12 EMCal + DCal
     cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","01631031000000d0","01631031000000d0");
   } else if( trainConfig == 263) {
-    //EG2 13TeV EMcal + Dcal
-    cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","01631031000000d0","01631031000000d0");
-    cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","01631036000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout
-  } else if( trainConfig == 264) {
-    //EG1 13TeV EMcal + Dcal
-    cuts.AddCut("0008d113","00200009327000008250400000","411791206f032230000","01631031000000d0","01631031000000d0");
-    cuts.AddCut("0008d113","00200009327000008250400000","411791206f032230000","01631036000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout
-  } else if( trainConfig == 265) {
-    //only MB 13TeV EMCal + DCal Pi0 selection plus Gamma dropout
-    cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","01631036000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout
+    // MB 13TeV EMCal + DCal, Pi0 selection plus Gamma dropout
     cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","0163103b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout
+    cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","01631036000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout
     cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","0163103c000000d0","01631031000000d0"); // 3 sigma Pi0 selection plus Gamma dropout
     cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","0163103d000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout
+  } else if( trainConfig == 264) {
+    // MB 13TeV EMCal + DCal Background Variation (Swapping Method by Joshua)
+    cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","0163103b000000d0","0r631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation
+    cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","0163103b000000d0","0v631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS without constraints
+    cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","0163103b000000d0","0x631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
+  } else if( trainConfig == 271) {
+    // EG2 13TeV EMcal
+    cuts.AddCut("0008e113","00200009327000008250400000","1111100067032230000","01631031000000d0","01631031000000d0");
+  } else if( trainConfig == 272) {
+    // EG2 std NL 12 EMCal + DCal
+    cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","01631031000000d0","01631031000000d0");
+  } else if( trainConfig == 273) {
+    // EG2 13TeV EMcal + Dcal, Pi0 selection plus Gamma dropout
+    cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","0163103b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout
+    cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","01631036000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout
+    cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","0163103c000000d0","01631031000000d0"); // 3 sigma Pi0 selection plus Gamma dropout
+    cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","0163103d000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout
+  } else if( trainConfig == 274) {
+    // EG2 13TeV EMcal + Dcal, Background Variation (Swapping Method by Joshua)
+    cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","0163103b000000d0","0r631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation
+    cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","0163103b000000d0","0v631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS without constraints
+    cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","0163103b000000d0","0x631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
+  } else if( trainConfig == 281) {
+    // EG1 13TeV EMcal
+    cuts.AddCut("0008d113","00200009327000008250400000","1111100067032230000","01631031000000d0","01631031000000d0");
+  } else if( trainConfig == 282) {
+    // EG1 13TeV EMcal + Dcal
+    cuts.AddCut("0008d113","00200009327000008250400000","411791206f032230000","01631031000000d0","01631031000000d0");
+  } else if( trainConfig == 283) {
+    // EG1 13TeV EMcal + Dcal, Pi0 selection plus Gamma dropout
+    cuts.AddCut("0008d113","00200009327000008250400000","411791206f032230000","0163103b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout
+    cuts.AddCut("0008d113","00200009327000008250400000","411791206f032230000","01631036000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout
+    cuts.AddCut("0008d113","00200009327000008250400000","411791206f032230000","0163103c000000d0","01631031000000d0"); // 3 sigma Pi0 selection plus Gamma dropout
+    cuts.AddCut("0008d113","00200009327000008250400000","411791206f032230000","0163103d000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout
+  } else if( trainConfig == 284) {
+    // EG1 13TeV EMcal + Dcal, Background Variation (Swapping Method by Joshua)
+    cuts.AddCut("0008d113","00200009327000008250400000","411791206f032230000","0163103b000000d0","0r631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation
+    cuts.AddCut("0008d113","00200009327000008250400000","411791206f032230000","0163103b000000d0","0v631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS without constraints
+    cuts.AddCut("0008d113","00200009327000008250400000","411791206f032230000","0163103b000000d0","0x631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
 
 
   // cuts for ReconMethod==3 Cal-Cal-PCM
@@ -468,31 +499,63 @@ void AddTask_OmegaToPiZeroGamma_pp(
 
     // 13 TeV
   } else if( trainConfig == 360) {
-    // MB
-    cuts.AddCut("00010113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
-    cuts.AddCut("00052113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
-    cuts.AddCut("00085113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
-    cuts.AddCut("00083113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
-  } else if( trainConfig == 361) {
-    //only MB
-    cuts.AddCut("00010113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010"); // only Pi0 selection
+    // MB 13TeV PCM Photon with EMcal + DCal Pi0
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791106f032230000","01631031000000d0","01631030000000d0");
+    cuts.AddCut("00052113","0dm00009f9730000dge0404000","411791106f032230000","01631031000000d0","01631030000000d0");
+    cuts.AddCut("00085113","0dm00009f9730000dge0404000","411791106f032230000","01631031000000d0","01631030000000d0");
+    cuts.AddCut("00083113","0dm00009f9730000dge0404000","411791106f032230000","01631031000000d0","01631030000000d0");
+  } else if( trainConfig == 261) {
+    // MB 13TeV PCM Photon with EMcal Pi0
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","1111100067032230000","01631031000000d0","01631031000000d0");
   } else if( trainConfig == 362) {
-    //std NL 12 EMCal + Dcal
-    cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","0163103100000010","01631031000000d0"); // only Pi0 selection
+    // MB std NL 12 PCM Photon with EMcal + DCal Pi0
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","01631031000000d0","01631031000000d0");
   } else if( trainConfig == 363) {
-    //EG2 trigger 13TeV EMcal + Dcal
-    cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","0163103100000010","01631031000000d0"); // only Pi0 selection
-    cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","0163103a00000010","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout
+    // MB 13TeV PCM Photon with EMcal + DCal Pi0, Pi0 selection plus Gamma dropout
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","0163103b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","01631036000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","0163103c000000d0","01631031000000d0"); // 3 sigma Pi0 selection plus Gamma dropout
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","0163103d000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout
   } else if( trainConfig == 364) {
-    //EG1 trigger 13TeV EMcal + Dcal
-    cuts.AddCut("0008d113","00200009327000008250400000","411791206f032230000","0163103100000010","01631031000000d0"); // only Pi0 selection
-    cuts.AddCut("0008d113","00200009327000008250400000","411791206f032230000","0163103a00000010","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout
-  } else if( trainConfig == 365) {
-    // EMCal + Dcal mass window cut
-    cuts.AddCut("00010113","00200009327000008250400000","1111111067032230000","0163103a00000010","01631030000000d0"); // 2 sigma Pi0 selection plus Gamma dropout
-    cuts.AddCut("00010113","00200009327000008250400000","1111111067032230000","0163103n00000010","01631030000000d0"); // 1 sigma Pi0 selection plus Gamma dropout
-    cuts.AddCut("00010113","00200009327000008250400000","1111111067032230000","0163103o00000010","01631030000000d0"); // 3 sigma Pi0 selection plus Gamma dropout
-    cuts.AddCut("00010113","00200009327000008250400000","1111111067032230000","0163103p00000010","01631030000000d0"); // 4 sigma Pi0 selection plus Gamma dropout
+    // MB 13TeV PCM Photon with EMcal + DCal Pi0, Background Variation (Swapping Method by Joshua)
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","0163103b000000d0","0r631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","0163103b000000d0","0v631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS without constraints
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","0163103b000000d0","0x631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
+  } else if( trainConfig == 371) {
+    // EG2 13TeV PCM Photon with EMcal Pi0
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","1111100067032230000","01631031000000d0","01631031000000d0");
+  } else if( trainConfig == 372) {
+    // EG2 std NL 12 PCM Photon with EMcal + DCal Pi0
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","01631031000000d0","01631031000000d0");
+  } else if( trainConfig == 373) {
+    // EG2 13TeV EMcal + Dcal, Pi0 selection plus Gamma dropout
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","0163103b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","01631036000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","0163103c000000d0","01631031000000d0"); // 3 sigma Pi0 selection plus Gamma dropout
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","0163103d000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout
+  } else if( trainConfig == 374) {
+    // EG2 13TeV EMcal + Dcal, Background Variation (Swapping Method by Joshua)
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","0163103b000000d0","0r631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","0163103b000000d0","0v631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS without constraints
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","0163103b000000d0","0x631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
+  } else if( trainConfig == 381) {
+    // EG1 13TeV EMcal
+    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","1111100067032230000","01631031000000d0","01631031000000d0");
+  } else if( trainConfig == 382) {
+    // EG1 13TeV EMcal + Dcal
+    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","411791206f032230000","01631031000000d0","01631031000000d0");
+  } else if( trainConfig == 383) {
+    // EG1 13TeV EMcal + Dcal, Pi0 selection plus Gamma dropout
+    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","411791206f032230000","0163103b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout
+    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","411791206f032230000","01631036000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout
+    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","411791206f032230000","0163103c000000d0","01631031000000d0"); // 3 sigma Pi0 selection plus Gamma dropout
+    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","411791206f032230000","0163103d000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout
+  } else if( trainConfig == 384) {
+    // EG1 13TeV EMcal + Dcal, Background Variation (Swapping Method by Joshua)
+    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","411791206f032230000","0163103b000000d0","0r631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation
+    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","411791206f032230000","0163103b000000d0","0v631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS without constraints
+    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","411791206f032230000","0163103b000000d0","0x631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
+
 
 
   // cuts for ReconMethod==4 PCM-PCM-Cal


### PR DESCRIPTION
+Added new background scheme (swapping method by Joshua)
+Added new train configs for 13 TeV
+Reordered and redone the 13 TeV train configs
+Fixed mass calculation for a rare case for neutral pions
+Added and reordered some deletes to be in the proper position
+Added lightweight option (still needs work, currently only used in the new background scheme)