### PR TITLE
Add fix for eventid in the Run2->Run3 converter for MC and add rejection of spd vertices

### DIFF
--- a/RUN3/AliAnalysisTaskAO2Dconverter.cxx
+++ b/RUN3/AliAnalysisTaskAO2Dconverter.cxx
@@ -480,6 +480,9 @@ void AliAnalysisTaskAO2Dconverter::UserExec(Option_t *)
   if (!pvtx) {
     ::Fatal("AliAnalysisTaskAO2Dconverter::UserExec", "Vertex not defined");
   }
+  TString title=pvtx->GetTitle();
+  if(pvtx->IsFromVertexer3D() || pvtx->IsFromVertexerZ()) return;
+  if(pvtx->GetNContributors()<2) return;
 
   //---------------------------------------------------------------------------
   // Collision data
@@ -490,7 +493,11 @@ void AliAnalysisTaskAO2Dconverter::UserExec(Option_t *)
 
   vtx.fNentries[kEvents] = 1;  // one entry per vertex
   vtx.fRunNumber = fESD->GetRunNumber();
-  vtx.fGlobalBC = GetEventIdAsLong(fESD->GetHeader());
+  ULong64_t evtid = GetEventIdAsLong(fESD->GetHeader());
+  if(!evtid){
+    evtid = (ULong64_t(fESD->GetTimeStamp())<<32) + ULong64_t((fESD->GetNumberOfTPCClusters()<<5)|(fESD->GetNumberOfTPCTracks()));
+  }
+  vtx.fGlobalBC = evtid;
   vtx.fX = pvtx->GetX();
   vtx.fY = pvtx->GetY();
   vtx.fZ = pvtx->GetZ();


### PR DESCRIPTION
Please do not merge this yet because it is still being tested. 
@pzhristov @jgrosseo. This PR should include the event id calculation for MC where the BC information are not stored and reject the events with only SPD vertex, which as we discuss should not be converted given that they will not be present in Run3. 
I will do a few checks and then remove the WIP. Please let me know if you have any suggestions. 
Thanks Cheers GM  