### PR TITLE
PWGHF: Several small fixes + improvements

### DIFF
--- a/PWGHF/treeHF/AliAnalysisTaskSEHFTreeCreator.cxx
+++ b/PWGHF/treeHF/AliAnalysisTaskSEHFTreeCreator.cxx
@@ -2285,35 +2285,17 @@ void AliAnalysisTaskSEHFTreeCreator::Process3Prong(TClonesArray *array3Prong, Al
       }
 
       if(fPreSelectLctopKpi){
-         Bool_t preSelectedLcMass=kTRUE;
-          
-          preSelectedLcMass = fCutsLctopKpi->PreSelectMass(arrTracks);
-
-         if (!preSelectedLcMass) continue;
-       }
+        Bool_t preSelectedLcMass=kTRUE;
+        preSelectedLcMass = fFiltCutsLctopKpi->PreSelectMass(arrTracks);
+        if (!preSelectedLcMass) continue;
+      }
 
       nFilteredLctopKpi++;
       fNentries->Fill(22);
       if((vHF->FillRecoCand(aod,lctopkpi))) {////Fill the data members of the candidate only if they are empty.
         
-        //To be added in AliRDHFCutsLctopKpi IsSelected. If the case, move down after isSelectedFilt as for other mesons
-        Bool_t unsetvtx=kFALSE;
-        if(!lctopkpi->GetOwnPrimaryVtx()){
-          lctopkpi->SetOwnPrimaryVtx(vtx1);
-          unsetvtx=kTRUE;
-          // NOTE: the own primary vertex should be unset, otherwise there is a memory leak
-          // Pay attention if you use continue inside this loop!!!
-        }
-        Bool_t recVtx=kFALSE;
-        AliAODVertex *origownvtx=0x0;
-        if(fFiltCutsLctopKpi->GetIsPrimaryWithoutDaughters()){
-          if(lctopkpi->GetOwnPrimaryVtx()) origownvtx=new AliAODVertex(*lctopkpi->GetOwnPrimaryVtx());
-          if(fFiltCutsLctopKpi->RecalcOwnPrimaryVtx(lctopkpi,aod))recVtx=kTRUE;
-          else fFiltCutsLctopKpi->CleanOwnPrimaryVtx(lctopkpi,aod,origownvtx);
-        }
-        
         Int_t isSelectedFilt    = fFiltCutsLctopKpi->IsSelected(lctopkpi,AliRDHFCuts::kAll,aod);
-        //Printf("isSelectedFilt = %i isSelectedAnalysis = %i",isSelectedFilt,isSelectedAnalysis);
+
         if(isSelectedFilt){
           fNentries->Fill(23);
           nSelectedLctopKpi++;
@@ -2345,6 +2327,21 @@ void AliAnalysisTaskSEHFTreeCreator::Process3Prong(TClonesArray *array3Prong, Al
           if(isSelectedFilt==1 || isSelectedFilt==3)                 ispKpi=kTRUE;
           if(isSelectedFilt>=2)                                      ispiKp=kTRUE;
           
+          Bool_t unsetvtx=kFALSE;
+          if(!lctopkpi->GetOwnPrimaryVtx()){
+            lctopkpi->SetOwnPrimaryVtx(vtx1);
+            unsetvtx=kTRUE;
+            // NOTE: the own primary vertex should be unset, otherwise there is a memory leak
+            // Pay attention if you use continue inside this loop!!!
+          }
+          Bool_t recVtx=kFALSE;
+          AliAODVertex *origownvtx=0x0;
+          if(fFiltCutsLctopKpi->GetIsPrimaryWithoutDaughters()){
+            if(lctopkpi->GetOwnPrimaryVtx()) origownvtx=new AliAODVertex(*lctopkpi->GetOwnPrimaryVtx());
+            if(fFiltCutsLctopKpi->RecalcOwnPrimaryVtx(lctopkpi,aod))recVtx=kTRUE;
+            else fFiltCutsLctopKpi->CleanOwnPrimaryVtx(lctopkpi,aod,origownvtx);
+          }
+
           bool isPrimary=kFALSE;
           bool isFeeddown=kFALSE;
           bool issignal=kFALSE;
@@ -2468,10 +2465,9 @@ void AliAnalysisTaskSEHFTreeCreator::Process3Prong(TClonesArray *array3Prong, Al
               fTreeHandlerLctopKpi->FillTree();
             }
           } // end fill piKpi
-          
+          if(recVtx)fFiltCutsLctopKpi->CleanOwnPrimaryVtx(lctopkpi,aod,origownvtx);
+          if(unsetvtx) lctopkpi->UnsetOwnPrimaryVtx();
         } //end topol and PID cuts
-        if(recVtx)fFiltCutsLctopKpi->CleanOwnPrimaryVtx(lctopkpi,aod,origownvtx);
-        if(unsetvtx) lctopkpi->UnsetOwnPrimaryVtx();
       }//end ok fill reco cand
       else{
         fNentries->Fill(24); //monitor how often this fails
@@ -2679,22 +2675,6 @@ void AliAnalysisTaskSEHFTreeCreator::ProcessCasc(TClonesArray *arrayCasc, AliAOD
         //Remember to run also CleanUpTask!
         if(d->GetIsFilled()==1 && fLc2V0bachelorCalcSecoVtx) vHF->RecoSecondaryVertexForCascades(aod, d);
         
-        //To be added in AliRDHFCutsLctoV0 IsSelected. If the case, move down after isSelectedFilt as for other mesons
-        Bool_t unsetvtx=kFALSE;
-        if(!d->GetOwnPrimaryVtx()){
-          d->SetOwnPrimaryVtx(vtx1);
-          unsetvtx=kTRUE;
-          // NOTE: the own primary vertex should be unset, otherwise there is a memory leak
-          // Pay attention if you use continue inside this loop!!!
-        }
-        Bool_t recVtx=kFALSE;
-        AliAODVertex *origownvtx=0x0;
-        if(fFiltCutsLc2V0bachelor->GetIsPrimaryWithoutDaughters()){
-          if(d->GetOwnPrimaryVtx()) origownvtx=new AliAODVertex(*d->GetOwnPrimaryVtx());
-          if(fFiltCutsLc2V0bachelor->RecalcOwnPrimaryVtx(d,aod))recVtx=kTRUE;
-          else fFiltCutsLc2V0bachelor->CleanOwnPrimaryVtx(d,aod,origownvtx);
-        }
-        
         Int_t isSelectedFilt = fFiltCutsLc2V0bachelor->IsSelected(d,AliRDHFCuts::kAll,aod); //selected
         if(isSelectedFilt > 0){
           fNentries->Fill(34);
@@ -2726,6 +2706,21 @@ void AliAnalysisTaskSEHFTreeCreator::ProcessCasc(TClonesArray *arrayCasc, AliAOD
           Int_t isSelectedTrackAnalysis = fCutsLc2V0bachelor->IsSelected(d,AliRDHFCuts::kTracks,aod);
           if(isSelectedTrackAnalysis > 0) isSelTracksAnCuts=kTRUE;
           
+          Bool_t unsetvtx=kFALSE;
+          if(!d->GetOwnPrimaryVtx()){
+            d->SetOwnPrimaryVtx(vtx1);
+            unsetvtx=kTRUE;
+            // NOTE: the own primary vertex should be unset, otherwise there is a memory leak
+            // Pay attention if you use continue inside this loop!!!
+          }
+          Bool_t recVtx=kFALSE;
+          AliAODVertex *origownvtx=0x0;
+          if(fFiltCutsLc2V0bachelor->GetIsPrimaryWithoutDaughters()){
+            if(d->GetOwnPrimaryVtx()) origownvtx=new AliAODVertex(*d->GetOwnPrimaryVtx());
+            if(fFiltCutsLc2V0bachelor->RecalcOwnPrimaryVtx(d,aod))recVtx=kTRUE;
+            else fFiltCutsLc2V0bachelor->CleanOwnPrimaryVtx(d,aod,origownvtx);
+          }
+
           Int_t labLc2V0bachelor = -1;
           Int_t pdgLc2V0bachelor = -99;
           Int_t origin= -1;
@@ -2771,9 +2766,9 @@ void AliAnalysisTaskSEHFTreeCreator::ProcessCasc(TClonesArray *arrayCasc, AliAOD
             if (fFillJets) fTreeHandlerLc2V0bachelor->SetJetVars(aod->GetTracks(),d,d->InvMassLctoK0sP(),arrMC,partLc2V0bachelor);
             fTreeHandlerLc2V0bachelor->FillTree();
           }
+          if(recVtx)fFiltCutsLc2V0bachelor->CleanOwnPrimaryVtx(d,aod,origownvtx);
+          if(unsetvtx) d->UnsetOwnPrimaryVtx();
         }//end is selected filt
-        if(recVtx)fFiltCutsLc2V0bachelor->CleanOwnPrimaryVtx(d,aod,origownvtx);
-        if(unsetvtx) d->UnsetOwnPrimaryVtx();
       }
       else {
         fNentries->Fill(35); //monitor how often this fails
@@ -3409,7 +3404,7 @@ void AliAnalysisTaskSEHFTreeCreator::ProcessLb(TClonesArray *array3Prong, AliAOD
 
     if(fPreSelectLctopKpi){
       Bool_t preSelectedLbMass=kTRUE;
-      preSelectedLbMass=fCutsLbtoLcpi->PreSelectMass(arrTracks);
+      preSelectedLbMass=fFiltCutsLbtoLcpi->PreSelectMass(arrTracks);
       if (!preSelectedLbMass) continue;
     }
 
@@ -3421,22 +3416,6 @@ void AliAnalysisTaskSEHFTreeCreator::ProcessLb(TClonesArray *array3Prong, AliAOD
         //To significantly speed up the task when only signal was requested
         if(fWriteOnlySignal && !fITSUpgradePreSelect){
           if(lctopkpi->MatchToMC(4122,arrMC,3,pdgLctopKpi) < 0) continue;
-        }
-
-        //To be added in AliRDHFCutsLctopKpi IsSelected. If the case, move down after isSelectedFilt as for other mesons
-        Bool_t unsetvtx=kFALSE;
-        if(!lctopkpi->GetOwnPrimaryVtx()){
-          lctopkpi->SetOwnPrimaryVtx(vtx1);
-          unsetvtx=kTRUE;
-          // NOTE: the own primary vertex should be unset, otherwise there is a memory leak
-          // Pay attention if you use continue inside this loop!!!
-        }
-        Bool_t recVtx=kFALSE;
-        AliAODVertex *origownvtx=0x0;
-        if(fFiltCutsLbtoLcpi->GetIsPrimaryWithoutDaughters()){
-          if(lctopkpi->GetOwnPrimaryVtx()) origownvtx=new AliAODVertex(*lctopkpi->GetOwnPrimaryVtx());
-          if(fFiltCutsLbtoLcpi->RecalcOwnPrimaryVtx(lctopkpi,aod))recVtx=kTRUE;
-          else fFiltCutsLbtoLcpi->CleanOwnPrimaryVtx(lctopkpi,aod,origownvtx);
         }
         
         //Only looking at Lc -> p K pi
@@ -3471,6 +3450,21 @@ void AliAnalysisTaskSEHFTreeCreator::ProcessLb(TClonesArray *array3Prong, AliAOD
           if(isSelectedTopoAnalysis > 0) isSelAnTopoCuts=kTRUE;
           if(isSelectedTrackAnalysis > 0) isSelTracksAnCuts=kTRUE;
           
+          Bool_t unsetvtx=kFALSE;
+          if(!lctopkpi->GetOwnPrimaryVtx()){
+            lctopkpi->SetOwnPrimaryVtx(vtx1);
+            unsetvtx=kTRUE;
+            // NOTE: the own primary vertex should be unset, otherwise there is a memory leak
+            // Pay attention if you use continue inside this loop!!!
+          }
+          Bool_t recVtx=kFALSE;
+          AliAODVertex *origownvtx=0x0;
+          if(fFiltCutsLbtoLcpi->GetIsPrimaryWithoutDaughters()){
+            if(lctopkpi->GetOwnPrimaryVtx()) origownvtx=new AliAODVertex(*lctopkpi->GetOwnPrimaryVtx());
+            if(fFiltCutsLbtoLcpi->RecalcOwnPrimaryVtx(lctopkpi,aod))recVtx=kTRUE;
+            else fFiltCutsLbtoLcpi->CleanOwnPrimaryVtx(lctopkpi,aod,origownvtx);
+          }
+
           //loop over all selected tracks for pion from Lb
           for (Int_t iTrack = 0; iTrack < nTracks; iTrack++) {
             if(!seleTrkFlags[iTrack]) continue;
@@ -3615,9 +3609,9 @@ void AliAnalysisTaskSEHFTreeCreator::ProcessLb(TClonesArray *array3Prong, AliAOD
               }//end check pion ID with Lc daughters
             }//end Lb pion filtering cuts
           }//end track-loop
+          if(recVtx)fFiltCutsLbtoLcpi->CleanOwnPrimaryVtx(lctopkpi,aod,origownvtx);
+          if(unsetvtx) lctopkpi->UnsetOwnPrimaryVtx();
         }//end Lc filtering cuts
-        if(recVtx)fFiltCutsLbtoLcpi->CleanOwnPrimaryVtx(lctopkpi,aod,origownvtx);
-        if(unsetvtx) lctopkpi->UnsetOwnPrimaryVtx();
       } else{
         fNentries->Fill(41); //monitor how often this fails
       }

--- a/PWGHF/vertexingHF/AliAnalysisTaskSED0Mass.cxx
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSED0Mass.cxx
@@ -2852,9 +2852,9 @@ void AliAnalysisTaskSED0Mass::Terminate(Option_t */*option*/)
     cstname="cstat1";
   }
 
-  TCanvas *cMass=new TCanvas(cvname,cvname);
-  cMass->cd();
-  ((TH1F*)fOutputMass->FindObject("histMass_3"))->Draw();
+  //TCanvas *cMass=new TCanvas(cvname,cvname);
+  //cMass->cd();
+  //((TH1F*)fOutputMass->FindObject("histMass_3"))->Draw();
 
   TCanvas* cStat=new TCanvas(cstname,Form("Stat%s",fArray ? "LS" : "D0"));
   cStat->cd();

--- a/PWGHF/vertexingHF/AliAnalysisTaskSEDStarSpectra.cxx
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSEDStarSpectra.cxx
@@ -609,6 +609,7 @@ void AliAnalysisTaskSEDStarSpectra::UserCreateOutputObjects() {
   PostData(1,fOutput);
   PostData(2,fOutputAll);
   PostData(3,fOutputPID);
+  PostData(5,fCounter);
 
   return;
 }

--- a/PWGHF/vertexingHF/AliAnalysisTaskSEDvsMultiplicity.cxx
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSEDvsMultiplicity.cxx
@@ -1149,10 +1149,10 @@ void AliAnalysisTaskSEDvsMultiplicity::UserExec(Option_t */*option*/)
     }
 
     Int_t passAllCuts=fRDCutsAnalysis->IsSelected(d,AliRDHFCuts::kAll,aod);
-    if (fPdgMeson == 4122 && fLctoV0) passAllCuts=(((fRDCutsAnalysis->IsSelected(d,AliRDHFCuts::kAll))&(AliRDHFCutsLctoV0::kLcToK0Spr))==(AliRDHFCutsLctoV0::kLcToK0Spr));
+    if (fPdgMeson == 4122 && fLctoV0) passAllCuts=(((fRDCutsAnalysis->IsSelected(d,AliRDHFCuts::kAll,aod))&(AliRDHFCutsLctoV0::kLcToK0Spr))==(AliRDHFCutsLctoV0::kLcToK0Spr));
     Int_t passTopolCuts=fRDCutsAnalysis->GetIsSelectedCuts();
     if (fPdgMeson == 4122){
-      if(fLctoV0) passTopolCuts=(((fRDCutsAnalysis->IsSelected(d,AliRDHFCuts::kCandidate))&(AliRDHFCutsLctoV0::kLcToK0Spr))==(AliRDHFCutsLctoV0::kLcToK0Spr));
+      if(fLctoV0) passTopolCuts=(((fRDCutsAnalysis->IsSelected(d,AliRDHFCuts::kCandidate,aod))&(AliRDHFCutsLctoV0::kLcToK0Spr))==(AliRDHFCutsLctoV0::kLcToK0Spr));
       else  passTopolCuts=fRDCutsAnalysis->IsSelected(d,AliRDHFCuts::kCandidate,aod);
     }
     if (fPdgMeson != 431 && passTopolCuts==0) continue;

--- a/PWGHF/vertexingHF/AliAnalysisTaskSELambdac.cxx
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSELambdac.cxx
@@ -136,8 +136,8 @@ AliAnalysisTaskSE(),
   fFillNtuple(kFALSE),
   fReadMC(kFALSE),
   fMCPid(kFALSE),
-  fRealPid(kFALSE),
-  fResPid(kTRUE),
+  fRealPid(kTRUE),
+  fResPid(kFALSE),
   fUseKF(kFALSE),
   fAnalysis(kFALSE),
   fVHF(0),
@@ -597,7 +597,7 @@ void AliAnalysisTaskSELambdac::UserCreateOutputObjects()
   fhRap3ProngProd	= new TH2F("hRap3ProngProd","hRap3ProngProd;3-Prong p_{T} GeV/c;3-Prong y",75,0.,15.,50,-2.0,2.0);
   fhRap3ProngAn	    = new TH2F("hRap3ProngAn","hRap3ProngAn;3-Prong p_{T} GeV/c;3-Prong y",75,0.,15.,50,-2.0,2.0);
     
-  fhSelectBit			= new TH1F("hSelectBit","hSelectBit",5,-0.5,5.5);
+  fhSelectBit			= new TH1F("hSelectBit","hSelectBit",6,-0.5,5.5);
   fhSelectBit->GetXaxis()->SetBinLabel(2,"All");
   fhSelectBit->GetXaxis()->SetBinLabel(3,"SelectionMap");
   fhSelectBit->GetXaxis()->SetBinLabel(4,"!LcCut");
@@ -692,7 +692,7 @@ void AliAnalysisTaskSELambdac::UserCreateOutputObjects()
 
   //  const char* nameoutput=GetOutputSlot(4)->GetContainer()->GetName();
 
-  fNentries=new TH1F("fNentries", "Integral(1,2) = number of AODs *** Integral(2,3) = number of candidates selected with cuts *** Integral(3,4) = number of Lc selected with cuts *** Integral(4,5) = events with good vertex ***  Integral(5,6) = pt out of bounds", 12,-0.5,14.5);
+  fNentries=new TH1F("fNentries", "Integral(1,2) = number of AODs *** Integral(2,3) = number of candidates selected with cuts *** Integral(3,4) = number of Lc selected with cuts *** Integral(4,5) = events with good vertex ***  Integral(5,6) = pt out of bounds", 17,-0.5,16.5);
 
   //ROS: qui il bin assignment e' modellato su D0 ma sicuramente iv arie
   fNentries->GetXaxis()->SetBinLabel(1,"nEventsAnal");
@@ -1476,12 +1476,6 @@ void AliAnalysisTaskSELambdac::UserExec(Option_t */*option*/)
       fNentries->Fill(15); //monitor how often this fails 
       continue;
     }
-     Bool_t unsetvtx=kFALSE;
-    if(!d->GetOwnPrimaryVtx()){
-      d->SetOwnPrimaryVtx(vtx1);
-      unsetvtx=kTRUE;
-    }
-
 
     Int_t isSelectedTracks = fRDCutsProduction->IsSelected(d,AliRDHFCuts::kTracks,aod);
     if(!isSelectedTracks) continue;
@@ -1513,7 +1507,6 @@ void AliAnalysisTaskSELambdac::UserExec(Option_t */*option*/)
     fHistOS->Fill(d->InvMassDplus());
     */
 
-    if(unsetvtx) d->UnsetOwnPrimaryVtx();
   }
   fCounter->StoreCandidates(aod,nSelectedloose[0],kTRUE);
   fCounter->StoreCandidates(aod,nSelectedtight[0],kFALSE);
@@ -2030,15 +2023,15 @@ void AliAnalysisTaskSELambdac::FillMassHists(AliAODEvent *aod,AliAODRecoDecayHF3
       fhEta3ProngAn->Fill(part->Pt(),part->Eta());
       fhRap3ProngAn->Fill(part->Pt(),part->Y(4122));
       if(invMasspiKp>0. && invMasspKpi>0.){
-        fhMassLcPt->Fill(part->Pt(),invMasspKpi,0.5);
-        fhMassLcPt->Fill(part->Pt(),invMasspiKp,0.5);
+        fhMassLcPt->Fill(part->Pt(),invMasspKpi);
+        fhMassLcPt->Fill(part->Pt(),invMasspiKp);
 		if(part->Charge()==1){
-		  fhMassLcplusPt->Fill(part->Pt(),invMasspKpi,0.5);
-          fhMassLcplusPt->Fill(part->Pt(),invMasspiKp,0.5);
+		  fhMassLcplusPt->Fill(part->Pt(),invMasspKpi);
+          fhMassLcplusPt->Fill(part->Pt(),invMasspiKp);
 		}
 		else if(part->Charge()==-1){
-		  fhMassLcminusPt->Fill(part->Pt(),invMasspKpi,0.5);
-          fhMassLcminusPt->Fill(part->Pt(),invMasspiKp,0.5);
+		  fhMassLcminusPt->Fill(part->Pt(),invMasspKpi);
+          fhMassLcminusPt->Fill(part->Pt(),invMasspiKp);
 		}
       }
       else if(invMasspiKp>0.){
@@ -2089,36 +2082,36 @@ void AliAnalysisTaskSELambdac::FillMassHists(AliAODEvent *aod,AliAODRecoDecayHF3
     
     if(part->Pt()>3.&& part->Pt()<=6.){
       if(invMasspiKp>0. && invMasspKpi>0.){
-	if(invMasspiKp>0.) fhMassPtGreater3->Fill(invMasspiKp,0.5);
-	if(invMasspKpi>0.) fhMassPtGreater3->Fill(invMasspKpi,0.5);
+	if(invMasspiKp>0.) fhMassPtGreater3->Fill(invMasspiKp);
+	if(invMasspKpi>0.) fhMassPtGreater3->Fill(invMasspKpi);
       }else{
 	if(invMasspiKp>0.) fhMassPtGreater3->Fill(invMasspiKp);
 	if(invMasspKpi>0.) fhMassPtGreater3->Fill(invMasspKpi);
       }
       if(invMasspiKpLpi>0. && invMasspKpiLpi>0.){
-	if(invMasspiKpLpi>0.) fhMassPtGreater3Lpi->Fill(invMasspiKpLpi,0.5);
-	if(invMasspKpiLpi>0.) fhMassPtGreater3Lpi->Fill(invMasspKpiLpi,0.5);
+	if(invMasspiKpLpi>0.) fhMassPtGreater3Lpi->Fill(invMasspiKpLpi);
+	if(invMasspKpiLpi>0.) fhMassPtGreater3Lpi->Fill(invMasspKpiLpi);
       }else{
 	if(invMasspiKpLpi>0.) fhMassPtGreater3Lpi->Fill(invMasspiKpLpi);
 	if(invMasspKpiLpi>0.) fhMassPtGreater3Lpi->Fill(invMasspKpiLpi);
       }
       if(invMasspiKpKp>0. && invMasspKpiKp>0.){
-	if(invMasspiKpKp>0.) fhMassPtGreater3Kp->Fill(invMasspiKpKp,0.5);
-	if(invMasspKpiKp>0.) fhMassPtGreater3Kp->Fill(invMasspKpiKp,0.5);
+	if(invMasspiKpKp>0.) fhMassPtGreater3Kp->Fill(invMasspiKpKp);
+	if(invMasspKpiKp>0.) fhMassPtGreater3Kp->Fill(invMasspKpiKp);
       }else{
 	if(invMasspiKpKp>0.) fhMassPtGreater3Kp->Fill(invMasspiKpKp);
 	if(invMasspKpiKp>0.) fhMassPtGreater3Kp->Fill(invMasspKpiKp);
       }
       if(invMasspiKpDk>0. && invMasspKpiDk>0.){
-       if(invMasspiKpDk>0.) fhMassPtGreater3Dk->Fill(invMasspiKpDk,0.5);
-       if(invMasspKpiDk>0.) fhMassPtGreater3Dk->Fill(invMasspKpiDk,0.5);
+       if(invMasspiKpDk>0.) fhMassPtGreater3Dk->Fill(invMasspiKpDk);
+       if(invMasspKpiDk>0.) fhMassPtGreater3Dk->Fill(invMasspKpiDk);
       }else{
        if(invMasspiKpDk>0.) fhMassPtGreater3Dk->Fill(invMasspiKpDk);
        if(invMasspKpiDk>0.) fhMassPtGreater3Dk->Fill(invMasspKpiDk);
       }
       if(invMasspiKp3Pr>0. && invMasspKpi3Pr>0.){
-        if(invMasspiKp3Pr>0.) fhMassPtGreater33Pr->Fill(invMasspiKp3Pr,0.5);
-        if(invMasspKpi3Pr>0.) fhMassPtGreater33Pr->Fill(invMasspKpi3Pr,0.5);
+        if(invMasspiKp3Pr>0.) fhMassPtGreater33Pr->Fill(invMasspiKp3Pr);
+        if(invMasspKpi3Pr>0.) fhMassPtGreater33Pr->Fill(invMasspKpi3Pr);
       }else{
         if(invMasspiKp3Pr>0.) fhMassPtGreater33Pr->Fill(invMasspiKp3Pr);
         if(invMasspKpi3Pr>0.) fhMassPtGreater33Pr->Fill(invMasspKpi3Pr);
@@ -2126,37 +2119,37 @@ void AliAnalysisTaskSELambdac::FillMassHists(AliAODEvent *aod,AliAODRecoDecayHF3
 
       if(passTightCuts>0){
 	if(invMasspiKp>0. && invMasspKpi>0.){
-	  if(invMasspiKp>0.) fhMassPtGreater3TC->Fill(invMasspiKp,0.5);
-	  if(invMasspKpi>0.) fhMassPtGreater3TC->Fill(invMasspKpi,0.5);
+	  if(invMasspiKp>0.) fhMassPtGreater3TC->Fill(invMasspiKp);
+	  if(invMasspKpi>0.) fhMassPtGreater3TC->Fill(invMasspKpi);
 	}else{
 	  if(invMasspiKp>0.) fhMassPtGreater3TC->Fill(invMasspiKp);
 	  if(invMasspKpi>0.) fhMassPtGreater3TC->Fill(invMasspKpi);
 	}
 	if(invMasspiKpLpi>0. && invMasspKpiLpi>0.){
-	  if(invMasspiKpLpi>0.) fhMassPtGreater3LpiTC->Fill(invMasspiKpLpi,0.5);
-	  if(invMasspKpiLpi>0.) fhMassPtGreater3LpiTC->Fill(invMasspKpiLpi,0.5);
+	  if(invMasspiKpLpi>0.) fhMassPtGreater3LpiTC->Fill(invMasspiKpLpi);
+	  if(invMasspKpiLpi>0.) fhMassPtGreater3LpiTC->Fill(invMasspKpiLpi);
 	}else{
 	  if(invMasspiKpLpi>0.) fhMassPtGreater3LpiTC->Fill(invMasspiKpLpi);
 	  if(invMasspKpiLpi>0.) fhMassPtGreater3LpiTC->Fill(invMasspKpiLpi);
 	}
 	if(invMasspiKpKp>0. && invMasspKpiKp>0.){
-	  if(invMasspiKpKp>0.) fhMassPtGreater3KpTC->Fill(invMasspiKpKp,0.5);
-	  if(invMasspKpiKp>0.) fhMassPtGreater3KpTC->Fill(invMasspKpiKp,0.5);
+	  if(invMasspiKpKp>0.) fhMassPtGreater3KpTC->Fill(invMasspiKpKp);
+	  if(invMasspKpiKp>0.) fhMassPtGreater3KpTC->Fill(invMasspKpiKp);
 	}else{
 	  if(invMasspiKpKp>0.) fhMassPtGreater3KpTC->Fill(invMasspiKpKp);
 	  if(invMasspKpiKp>0.) fhMassPtGreater3KpTC->Fill(invMasspKpiKp);
 	}
        
        if(invMasspiKpDk>0. && invMasspKpiDk>0.){
-        if(invMasspiKpDk>0.) fhMassPtGreater3DkTC->Fill(invMasspiKpDk,0.5);
-        if(invMasspKpiDk>0.) fhMassPtGreater3DkTC->Fill(invMasspKpiDk,0.5);
+        if(invMasspiKpDk>0.) fhMassPtGreater3DkTC->Fill(invMasspiKpDk);
+        if(invMasspKpiDk>0.) fhMassPtGreater3DkTC->Fill(invMasspKpiDk);
        }else{
         if(invMasspiKpDk>0.) fhMassPtGreater3DkTC->Fill(invMasspiKpDk);
         if(invMasspKpiDk>0.) fhMassPtGreater3DkTC->Fill(invMasspKpiDk);
        }
       if(invMasspiKp3Pr>0. && invMasspKpi3Pr>0.){
-       if(invMasspiKp3Pr>0.) fhMassPtGreater33PrTC->Fill(invMasspiKp3Pr,0.5);
-       if(invMasspKpi3Pr>0.) fhMassPtGreater33PrTC->Fill(invMasspKpi3Pr,0.5);
+       if(invMasspiKp3Pr>0.) fhMassPtGreater33PrTC->Fill(invMasspiKp3Pr);
+       if(invMasspKpi3Pr>0.) fhMassPtGreater33PrTC->Fill(invMasspKpi3Pr);
       }else{
        if(invMasspiKp3Pr>0.) fhMassPtGreater33PrTC->Fill(invMasspiKp3Pr);
        if(invMasspKpi3Pr>0.) fhMassPtGreater33PrTC->Fill(invMasspKpi3Pr);
@@ -2166,36 +2159,36 @@ void AliAnalysisTaskSELambdac::FillMassHists(AliAODEvent *aod,AliAODRecoDecayHF3
     }
     if(part->Pt()>2.&& part->Pt()<=6.){
       if(invMasspiKp>0. && invMasspKpi>0.){
-	if(invMasspiKp>0.) fhMassPtGreater2->Fill(invMasspiKp,0.5);
-	if(invMasspKpi>0.) fhMassPtGreater2->Fill(invMasspKpi,0.5);
+	if(invMasspiKp>0.) fhMassPtGreater2->Fill(invMasspiKp);
+	if(invMasspKpi>0.) fhMassPtGreater2->Fill(invMasspKpi);
       }else{
 	if(invMasspiKp>0.) fhMassPtGreater2->Fill(invMasspiKp);
 	if(invMasspKpi>0.) fhMassPtGreater2->Fill(invMasspKpi);
       }
       if(invMasspiKpLpi>0. && invMasspKpiLpi>0.){
-	if(invMasspiKpLpi>0.) fhMassPtGreater2Lpi->Fill(invMasspiKpLpi,0.5);
-	if(invMasspKpiLpi>0.) fhMassPtGreater2Lpi->Fill(invMasspKpiLpi,0.5);
+	if(invMasspiKpLpi>0.) fhMassPtGreater2Lpi->Fill(invMasspiKpLpi);
+	if(invMasspKpiLpi>0.) fhMassPtGreater2Lpi->Fill(invMasspKpiLpi);
       }else{
 	if(invMasspiKpLpi>0.) fhMassPtGreater2Lpi->Fill(invMasspiKpLpi);
 	if(invMasspKpiLpi>0.) fhMassPtGreater2Lpi->Fill(invMasspKpiLpi);
       }
       if(invMasspiKpKp>0. && invMasspKpiKp>0.){
-	if(invMasspiKpKp>0.) fhMassPtGreater2Kp->Fill(invMasspiKpKp,0.5);
-	if(invMasspKpiKp>0.) fhMassPtGreater2Kp->Fill(invMasspKpiKp,0.5);
+	if(invMasspiKpKp>0.) fhMassPtGreater2Kp->Fill(invMasspiKpKp);
+	if(invMasspKpiKp>0.) fhMassPtGreater2Kp->Fill(invMasspKpiKp);
       }else{
 	if(invMasspiKpKp>0.) fhMassPtGreater2Kp->Fill(invMasspiKpKp);
 	if(invMasspKpiKp>0.) fhMassPtGreater2Kp->Fill(invMasspKpiKp);
       }
       if(invMasspiKpDk>0. && invMasspKpiDk>0.){
-       if(invMasspiKpDk>0.) fhMassPtGreater2Dk->Fill(invMasspiKpDk,0.5);
-       if(invMasspKpiDk>0.) fhMassPtGreater2Dk->Fill(invMasspKpiDk,0.5);
+       if(invMasspiKpDk>0.) fhMassPtGreater2Dk->Fill(invMasspiKpDk);
+       if(invMasspKpiDk>0.) fhMassPtGreater2Dk->Fill(invMasspKpiDk);
       }else{
        if(invMasspiKpDk>0.) fhMassPtGreater2Dk->Fill(invMasspiKpDk);
        if(invMasspKpiDk>0.) fhMassPtGreater2Dk->Fill(invMasspKpiDk);
       }
      if(invMasspiKp3Pr>0. && invMasspKpi3Pr>0.){
-      if(invMasspiKp3Pr>0.) fhMassPtGreater23Pr->Fill(invMasspiKp3Pr,0.5);
-      if(invMasspKpi3Pr>0.) fhMassPtGreater23Pr->Fill(invMasspKpi3Pr,0.5);
+      if(invMasspiKp3Pr>0.) fhMassPtGreater23Pr->Fill(invMasspiKp3Pr);
+      if(invMasspKpi3Pr>0.) fhMassPtGreater23Pr->Fill(invMasspKpi3Pr);
      }else{
       if(invMasspiKp3Pr>0.) fhMassPtGreater23Pr->Fill(invMasspiKp3Pr);
       if(invMasspKpi3Pr>0.) fhMassPtGreater23Pr->Fill(invMasspKpi3Pr);
@@ -2203,36 +2196,36 @@ void AliAnalysisTaskSELambdac::FillMassHists(AliAODEvent *aod,AliAODRecoDecayHF3
 
       if(passTightCuts>0){
 	if(invMasspiKp>0. && invMasspKpi>0.){
-	  if(invMasspiKp>0.) fhMassPtGreater2TC->Fill(invMasspiKp,0.5);
-	  if(invMasspKpi>0.) fhMassPtGreater2TC->Fill(invMasspKpi,0.5);
+	  if(invMasspiKp>0.) fhMassPtGreater2TC->Fill(invMasspiKp);
+	  if(invMasspKpi>0.) fhMassPtGreater2TC->Fill(invMasspKpi);
 	}else{
 	  if(invMasspiKp>0.) fhMassPtGreater2TC->Fill(invMasspiKp);
 	  if(invMasspKpi>0.) fhMassPtGreater2TC->Fill(invMasspKpi);
 	}
 	if(invMasspiKpLpi>0. && invMasspKpiLpi>0.){
-	  if(invMasspiKpLpi>0.) fhMassPtGreater2LpiTC->Fill(invMasspiKpLpi,0.5);
-	  if(invMasspKpiLpi>0.) fhMassPtGreater2LpiTC->Fill(invMasspKpiLpi,0.5);
+	  if(invMasspiKpLpi>0.) fhMassPtGreater2LpiTC->Fill(invMasspiKpLpi);
+	  if(invMasspKpiLpi>0.) fhMassPtGreater2LpiTC->Fill(invMasspKpiLpi);
 	}else{
 	  if(invMasspiKpLpi>0.) fhMassPtGreater2LpiTC->Fill(invMasspiKpLpi);
 	  if(invMasspKpiLpi>0.) fhMassPtGreater2LpiTC->Fill(invMasspKpiLpi);
 	}
 	if(invMasspiKpKp>0. && invMasspKpiKp>0.){
-	  if(invMasspiKpKp>0.) fhMassPtGreater2KpTC->Fill(invMasspiKpKp,0.5);
-	  if(invMasspKpiKp>0.) fhMassPtGreater2KpTC->Fill(invMasspKpiKp,0.5);
+	  if(invMasspiKpKp>0.) fhMassPtGreater2KpTC->Fill(invMasspiKpKp);
+	  if(invMasspKpiKp>0.) fhMassPtGreater2KpTC->Fill(invMasspKpiKp);
 	}else{
 	  if(invMasspiKpKp>0.) fhMassPtGreater2KpTC->Fill(invMasspiKpKp);
 	  if(invMasspKpiKp>0.) fhMassPtGreater2KpTC->Fill(invMasspKpiKp);
 	}
        if(invMasspiKpDk>0. && invMasspKpiDk>0.){
-        if(invMasspiKpDk>0.) fhMassPtGreater2DkTC->Fill(invMasspiKpDk,0.5);
-        if(invMasspKpiDk>0.) fhMassPtGreater2DkTC->Fill(invMasspKpiDk,0.5);
+        if(invMasspiKpDk>0.) fhMassPtGreater2DkTC->Fill(invMasspiKpDk);
+        if(invMasspKpiDk>0.) fhMassPtGreater2DkTC->Fill(invMasspKpiDk);
        }else{
         if(invMasspiKpDk>0.) fhMassPtGreater2DkTC->Fill(invMasspiKpDk);
         if(invMasspKpiDk>0.) fhMassPtGreater2DkTC->Fill(invMasspKpiDk);
        }
        if(invMasspiKp3Pr>0. && invMasspKpi3Pr>0.){
-        if(invMasspiKp3Pr>0.) fhMassPtGreater23PrTC->Fill(invMasspiKp3Pr,0.5);
-        if(invMasspKpi3Pr>0.) fhMassPtGreater23PrTC->Fill(invMasspKpi3Pr,0.5);
+        if(invMasspiKp3Pr>0.) fhMassPtGreater23PrTC->Fill(invMasspiKp3Pr);
+        if(invMasspKpi3Pr>0.) fhMassPtGreater23PrTC->Fill(invMasspKpi3Pr);
       }else{
        if(invMasspiKp3Pr>0.) fhMassPtGreater23PrTC->Fill(invMasspiKp3Pr);
        if(invMasspKpi3Pr>0.) fhMassPtGreater23PrTC->Fill(invMasspKpi3Pr);
@@ -2244,36 +2237,36 @@ void AliAnalysisTaskSELambdac::FillMassHists(AliAODEvent *aod,AliAODRecoDecayHF3
     if(iPtBin>=0){
       index=GetHistoIndex(iPtBin);
       if(invMasspiKp>0. && invMasspKpi>0.){
-	if(invMasspiKp>0.) fMassHist[index]->Fill(invMasspiKp,0.5);
-	if(invMasspKpi>0.) fMassHist[index]->Fill(invMasspKpi,0.5);
+	if(invMasspiKp>0.) fMassHist[index]->Fill(invMasspiKp);
+	if(invMasspKpi>0.) fMassHist[index]->Fill(invMasspKpi);
       }else{
 	if(invMasspiKp>0.) fMassHist[index]->Fill(invMasspiKp);
 	if(invMasspKpi>0.) fMassHist[index]->Fill(invMasspKpi);
       }
       if(invMasspiKpLpi>0. && invMasspKpiLpi>0.){
-	if(invMasspiKpLpi>0.) fMassHistLpi[index]->Fill(invMasspiKpLpi,0.5);
-	if(invMasspKpiLpi>0.) fMassHistLpi[index]->Fill(invMasspKpiLpi,0.5);
+	if(invMasspiKpLpi>0.) fMassHistLpi[index]->Fill(invMasspiKpLpi);
+	if(invMasspKpiLpi>0.) fMassHistLpi[index]->Fill(invMasspKpiLpi);
       }else{
 	if(invMasspiKpLpi>0.) fMassHistLpi[index]->Fill(invMasspiKpLpi);
 	if(invMasspKpiLpi>0.) fMassHistLpi[index]->Fill(invMasspKpiLpi);
       }
       if(invMasspiKpKp>0. && invMasspKpiKp>0.){
-	if(invMasspiKpKp>0.) fMassHistKp[index]->Fill(invMasspiKpKp,0.5);
-	if(invMasspKpiKp>0.) fMassHistKp[index]->Fill(invMasspKpiKp,0.5);
+	if(invMasspiKpKp>0.) fMassHistKp[index]->Fill(invMasspiKpKp);
+	if(invMasspKpiKp>0.) fMassHistKp[index]->Fill(invMasspKpiKp);
       }else{
 	if(invMasspiKpKp>0.) fMassHistKp[index]->Fill(invMasspiKpKp);
 	if(invMasspKpiKp>0.) fMassHistKp[index]->Fill(invMasspKpiKp);
       }
       if(invMasspiKpDk>0. && invMasspKpiDk>0.){
-       if(invMasspiKpDk>0.) fMassHistDk[index]->Fill(invMasspiKpDk,0.5);
-       if(invMasspKpiDk>0.) fMassHistDk[index]->Fill(invMasspKpiDk,0.5);
+       if(invMasspiKpDk>0.) fMassHistDk[index]->Fill(invMasspiKpDk);
+       if(invMasspKpiDk>0.) fMassHistDk[index]->Fill(invMasspKpiDk);
       }else{
        if(invMasspiKpDk>0.) fMassHistDk[index]->Fill(invMasspiKpDk);
        if(invMasspKpiDk>0.) fMassHistDk[index]->Fill(invMasspKpiDk);
       }
       if(invMasspiKp3Pr>0. && invMasspKpi3Pr>0.){
-       if(invMasspiKp3Pr>0.) fMassHist3Pr[index]->Fill(invMasspiKp3Pr,0.5);
-       if(invMasspKpi3Pr>0.) fMassHist3Pr[index]->Fill(invMasspKpi3Pr,0.5);
+       if(invMasspiKp3Pr>0.) fMassHist3Pr[index]->Fill(invMasspiKp3Pr);
+       if(invMasspKpi3Pr>0.) fMassHist3Pr[index]->Fill(invMasspKpi3Pr);
       }else{
        if(invMasspiKp3Pr>0.) fMassHist3Pr[index]->Fill(invMasspiKp3Pr);
        if(invMasspKpi3Pr>0.) fMassHist3Pr[index]->Fill(invMasspKpi3Pr);
@@ -2281,36 +2274,36 @@ void AliAnalysisTaskSELambdac::FillMassHists(AliAODEvent *aod,AliAODRecoDecayHF3
 
       if(passTightCuts>0){
 	if(invMasspiKp>0. && invMasspKpi>0. && passTightCuts==3){
-	  if(invMasspiKp>0.) fMassHistTC[index]->Fill(invMasspiKp,0.5);
-	  if(invMasspKpi>0.) fMassHistTC[index]->Fill(invMasspKpi,0.5);
+	  if(invMasspiKp>0.) fMassHistTC[index]->Fill(invMasspiKp);
+	  if(invMasspKpi>0.) fMassHistTC[index]->Fill(invMasspKpi);
 	}else{
 	  if(invMasspiKp>0. && passTightCuts==2) fMassHistTC[index]->Fill(invMasspiKp);
 	  if(invMasspKpi>0. && passTightCuts==1) fMassHistTC[index]->Fill(invMasspKpi);
 	}
 	if(invMasspiKpLpi>0. && invMasspKpiLpi>0. && passTightCuts==3){
-	  if(invMasspiKpLpi>0.) fMassHistLpiTC[index]->Fill(invMasspiKpLpi,0.5);
-	  if(invMasspKpiLpi>0.) fMassHistLpiTC[index]->Fill(invMasspKpiLpi,0.5);
+	  if(invMasspiKpLpi>0.) fMassHistLpiTC[index]->Fill(invMasspiKpLpi);
+	  if(invMasspKpiLpi>0.) fMassHistLpiTC[index]->Fill(invMasspKpiLpi);
 	}else{
 	  if(invMasspiKpLpi>0. && passTightCuts==2) fMassHistLpiTC[index]->Fill(invMasspiKpLpi);
 	  if(invMasspKpiLpi>0.&& passTightCuts==1) fMassHistLpiTC[index]->Fill(invMasspKpiLpi);
 	}
 	if(invMasspiKpKp>0. && invMasspKpiKp>0. && passTightCuts==3){
-	  if(invMasspiKpKp>0.) fMassHistKpTC[index]->Fill(invMasspiKpKp,0.5);
-	  if(invMasspKpiKp>0.) fMassHistKpTC[index]->Fill(invMasspKpiKp,0.5);
+	  if(invMasspiKpKp>0.) fMassHistKpTC[index]->Fill(invMasspiKpKp);
+	  if(invMasspKpiKp>0.) fMassHistKpTC[index]->Fill(invMasspKpiKp);
 	}else{
 	  if(invMasspiKpKp>0. && passTightCuts==2) fMassHistKpTC[index]->Fill(invMasspiKpKp);
 	  if(invMasspKpiKp>0.&& passTightCuts==1) fMassHistKpTC[index]->Fill(invMasspKpiKp);
 	}
        if(invMasspiKpDk>0. && invMasspKpiDk>0. && passTightCuts==3){
-        if(invMasspiKpDk>0.) fMassHistDkTC[index]->Fill(invMasspiKpDk,0.5);
-        if(invMasspKpiDk>0.) fMassHistDkTC[index]->Fill(invMasspKpiDk,0.5);
+        if(invMasspiKpDk>0.) fMassHistDkTC[index]->Fill(invMasspiKpDk);
+        if(invMasspKpiDk>0.) fMassHistDkTC[index]->Fill(invMasspKpiDk);
        }else{
         if(invMasspiKpDk>0. && passTightCuts==2) fMassHistDkTC[index]->Fill(invMasspiKpDk);
         if(invMasspKpiDk>0.&& passTightCuts==1) fMassHistDkTC[index]->Fill(invMasspKpiDk);
        }
        if(invMasspiKp3Pr>0. && invMasspKpi3Pr>0. && passTightCuts==3){
-        if(invMasspiKp3Pr>0.) fMassHist3PrTC[index]->Fill(invMasspiKp3Pr,0.5);
-        if(invMasspKpi3Pr>0.) fMassHist3PrTC[index]->Fill(invMasspKpi3Pr,0.5);
+        if(invMasspiKp3Pr>0.) fMassHist3PrTC[index]->Fill(invMasspiKp3Pr);
+        if(invMasspKpi3Pr>0.) fMassHist3PrTC[index]->Fill(invMasspKpi3Pr);
        }else{
         if(invMasspiKp3Pr>0. && passTightCuts==2) fMassHist3PrTC[index]->Fill(invMasspiKp3Pr);
         if(invMasspKpi3Pr>0.&& passTightCuts==1) fMassHist3PrTC[index]->Fill(invMasspKpi3Pr);
@@ -2322,36 +2315,36 @@ void AliAnalysisTaskSELambdac::FillMassHists(AliAODEvent *aod,AliAODRecoDecayHF3
 	if(labDp>=0) {
 	  index=GetSignalHistoIndex(iPtBin);
 	  if(invMasspiKp>0. && invMasspKpi>0.){
-	    if(invMasspiKp>0.) fMassHist[index]->Fill(invMasspiKp,0.5);
-	    if(invMasspKpi>0.) fMassHist[index]->Fill(invMasspKpi,0.5);
+	    if(invMasspiKp>0.) fMassHist[index]->Fill(invMasspiKp);
+	    if(invMasspKpi>0.) fMassHist[index]->Fill(invMasspKpi);
 	  }else{
 	    if(invMasspiKp>0.) fMassHist[index]->Fill(invMasspiKp);
 	    if(invMasspKpi>0.) fMassHist[index]->Fill(invMasspKpi);
 	  }
 	  if(invMasspiKpLpi>0. && invMasspKpiLpi>0.){
-	    if(invMasspiKpLpi>0.) fMassHistLpi[index]->Fill(invMasspiKpLpi,0.5);
-	    if(invMasspKpiLpi>0.) fMassHistLpi[index]->Fill(invMasspKpiLpi,0.5);
+	    if(invMasspiKpLpi>0.) fMassHistLpi[index]->Fill(invMasspiKpLpi);
+	    if(invMasspKpiLpi>0.) fMassHistLpi[index]->Fill(invMasspKpiLpi);
 	  }else{
 	    if(invMasspiKpLpi>0.) fMassHistLpi[index]->Fill(invMasspiKpLpi);
 	    if(invMasspKpiLpi>0.) fMassHistLpi[index]->Fill(invMasspKpiLpi);
 	  }
 	  if(invMasspiKpKp>0. && invMasspKpiKp>0.){
-	    if(invMasspiKpKp>0.) fMassHistKp[index]->Fill(invMasspiKpKp,0.5);
-	    if(invMasspKpiKp>0.) fMassHistKp[index]->Fill(invMasspKpiKp,0.5);
+	    if(invMasspiKpKp>0.) fMassHistKp[index]->Fill(invMasspiKpKp);
+	    if(invMasspKpiKp>0.) fMassHistKp[index]->Fill(invMasspKpiKp);
 	  }else{
 	    if(invMasspiKpKp>0.) fMassHistKp[index]->Fill(invMasspiKpKp);
 	    if(invMasspKpiKp>0.) fMassHistKp[index]->Fill(invMasspKpiKp);
 	  }
 	  if(invMasspiKpDk>0. && invMasspKpiDk>0.){
-	    if(invMasspiKpDk>0.) fMassHistDk[index]->Fill(invMasspiKpDk,0.5);
-	    if(invMasspKpiDk>0.) fMassHistDk[index]->Fill(invMasspKpiDk,0.5);
+	    if(invMasspiKpDk>0.) fMassHistDk[index]->Fill(invMasspiKpDk);
+	    if(invMasspKpiDk>0.) fMassHistDk[index]->Fill(invMasspKpiDk);
 	  }else{
 	    if(invMasspiKpDk>0.) fMassHistDk[index]->Fill(invMasspiKpDk);
 	    if(invMasspKpiDk>0.) fMassHistDk[index]->Fill(invMasspKpiDk);
 	  }
 	  if(invMasspiKp3Pr>0. && invMasspKpi3Pr>0.){
-	    if(invMasspiKp3Pr>0.) fMassHist3Pr[index]->Fill(invMasspiKp3Pr,0.5);
-	    if(invMasspKpi3Pr>0.) fMassHist3Pr[index]->Fill(invMasspKpi3Pr,0.5);
+	    if(invMasspiKp3Pr>0.) fMassHist3Pr[index]->Fill(invMasspiKp3Pr);
+	    if(invMasspKpi3Pr>0.) fMassHist3Pr[index]->Fill(invMasspKpi3Pr);
 	  }else{
 	    if(invMasspiKp3Pr>0.) fMassHist3Pr[index]->Fill(invMasspiKp3Pr);
 	    if(invMasspKpi3Pr>0.) fMassHistDk[index]->Fill(invMasspKpi3Pr);
@@ -2359,36 +2352,36 @@ void AliAnalysisTaskSELambdac::FillMassHists(AliAODEvent *aod,AliAODRecoDecayHF3
 
 	  if(passTightCuts>0){
 	    if(invMasspiKp>0. && invMasspKpi>0. && passTightCuts==3){
-	      if(invMasspiKp>0.) fMassHistTC[index]->Fill(invMasspiKp,0.5);
-	      if(invMasspKpi>0.) fMassHistTC[index]->Fill(invMasspKpi,0.5);
+	      if(invMasspiKp>0.) fMassHistTC[index]->Fill(invMasspiKp);
+	      if(invMasspKpi>0.) fMassHistTC[index]->Fill(invMasspKpi);
 	    }else{
 	      if(invMasspiKp>0. && passTightCuts==2) fMassHistTC[index]->Fill(invMasspiKp);
 	      if(invMasspKpi>0.&& passTightCuts==1) fMassHistTC[index]->Fill(invMasspKpi);
 	    }
 	    if(invMasspiKpLpi>0. && invMasspKpiLpi>0. && passTightCuts==3){
-	      if(invMasspiKpLpi>0.) fMassHistLpiTC[index]->Fill(invMasspiKpLpi,0.5);
-	      if(invMasspKpiLpi>0.) fMassHistLpiTC[index]->Fill(invMasspKpiLpi,0.5);
+	      if(invMasspiKpLpi>0.) fMassHistLpiTC[index]->Fill(invMasspiKpLpi);
+	      if(invMasspKpiLpi>0.) fMassHistLpiTC[index]->Fill(invMasspKpiLpi);
 	    }else{
 	      if(invMasspiKpLpi>0. && passTightCuts==2) fMassHistLpiTC[index]->Fill(invMasspiKpLpi);
 	      if(invMasspKpiLpi>0.&& passTightCuts==1) fMassHistLpiTC[index]->Fill(invMasspKpiLpi);
 	    } 
 	    if(invMasspiKpKp>0. && invMasspKpiKp>0. && passTightCuts==3){
-	      if(invMasspiKpKp>0.) fMassHistKpTC[index]->Fill(invMasspiKpKp,0.5);
-	      if(invMasspKpiKp>0.) fMassHistKpTC[index]->Fill(invMasspKpiKp,0.5);
+	      if(invMasspiKpKp>0.) fMassHistKpTC[index]->Fill(invMasspiKpKp);
+	      if(invMasspKpiKp>0.) fMassHistKpTC[index]->Fill(invMasspKpiKp);
 	    }else{
 	      if(invMasspiKpKp>0. && passTightCuts==2) fMassHistKpTC[index]->Fill(invMasspiKpKp);
 	      if(invMasspKpiKp>0.&& passTightCuts==1) fMassHistKpTC[index]->Fill(invMasspKpiKp);
 	    }
 	    if(invMasspiKpDk>0. && invMasspKpiDk>0. && passTightCuts==3){
-	      if(invMasspiKpDk>0.) fMassHistDkTC[index]->Fill(invMasspiKpDk,0.5);
-	      if(invMasspKpiDk>0.) fMassHistDkTC[index]->Fill(invMasspKpiDk,0.5);
+	      if(invMasspiKpDk>0.) fMassHistDkTC[index]->Fill(invMasspiKpDk);
+	      if(invMasspKpiDk>0.) fMassHistDkTC[index]->Fill(invMasspKpiDk);
 	    }else{
 	      if(invMasspiKpDk>0. && passTightCuts==2) fMassHistDkTC[index]->Fill(invMasspiKpDk);
 	      if(invMasspKpiDk>0.&& passTightCuts==1) fMassHistDkTC[index]->Fill(invMasspKpiDk);
 	    }
 	    if(invMasspiKp3Pr>0. && invMasspKpi3Pr>0. && passTightCuts==3){
-	      if(invMasspiKp3Pr>0.) fMassHist3PrTC[index]->Fill(invMasspiKp3Pr,0.5);
-	      if(invMasspKpi3Pr>0.) fMassHist3PrTC[index]->Fill(invMasspKpi3Pr,0.5);
+	      if(invMasspiKp3Pr>0.) fMassHist3PrTC[index]->Fill(invMasspiKp3Pr);
+	      if(invMasspKpi3Pr>0.) fMassHist3PrTC[index]->Fill(invMasspKpi3Pr);
 	    }else{
 	      if(invMasspiKp3Pr>0. && passTightCuts==2) fMassHist3PrTC[index]->Fill(invMasspiKp3Pr);
 	      if(invMasspKpi3Pr>0.&& passTightCuts==1) fMassHist3PrTC[index]->Fill(invMasspKpi3Pr);
@@ -2398,16 +2391,16 @@ void AliAnalysisTaskSELambdac::FillMassHists(AliAODEvent *aod,AliAODRecoDecayHF3
          if(IsLc && IsLcfromLb){
           index=GetLbHistoIndex(iPtBin);
           if(invMasspiKp>0. && invMasspKpi>0.){
-	    	if(invMasspiKp>0.) fMassHist[index]->Fill(invMasspiKp,0.5);
-	        if(invMasspKpi>0.) fMassHist[index]->Fill(invMasspKpi,0.5);
+	    	if(invMasspiKp>0.) fMassHist[index]->Fill(invMasspiKp);
+	        if(invMasspKpi>0.) fMassHist[index]->Fill(invMasspKpi);
 	  }else{
 	        if(invMasspiKp>0.) fMassHist[index]->Fill(invMasspiKp);
 	        if(invMasspKpi>0.) fMassHist[index]->Fill(invMasspKpi);
 	  } 
           if(passTightCuts>0){ 	
                 if(invMasspiKp>0. && invMasspKpi>0. && passTightCuts==3){
-        		if(invMasspiKp>0.) fMassHistTC[index]->Fill(invMasspiKp,0.5);
-       			if(invMasspKpi>0.) fMassHistTC[index]->Fill(invMasspKpi,0.5);
+        		if(invMasspiKp>0.) fMassHistTC[index]->Fill(invMasspiKp);
+       			if(invMasspKpi>0.) fMassHistTC[index]->Fill(invMasspKpi);
 	    	}else{
 	       	       	if(invMasspiKp>0. && passTightCuts==2) fMassHistTC[index]->Fill(invMasspiKp); 
                         if(invMasspKpi>0.&& passTightCuts==1) fMassHistTC[index]->Fill(invMasspKpi);
@@ -2417,16 +2410,16 @@ void AliAnalysisTaskSELambdac::FillMassHists(AliAODEvent *aod,AliAODRecoDecayHF3
         if(IsLc && !IsLcfromLb && IsLcfromc)  {
            index=GetcOnlyHistoIndex(iPtBin);
            if(invMasspiKp>0. && invMasspKpi>0.){
-	         	if(invMasspiKp>0.) fMassHist[index]->Fill(invMasspiKp,0.5);
-	   	        if(invMasspKpi>0.) fMassHist[index]->Fill(invMasspKpi,0.5);
+	         	if(invMasspiKp>0.) fMassHist[index]->Fill(invMasspiKp);
+	   	        if(invMasspKpi>0.) fMassHist[index]->Fill(invMasspKpi);
 	   }else{
 	         	    if(invMasspiKp>0.) fMassHist[index]->Fill(invMasspiKp);
 			    if(invMasspKpi>0.) fMassHist[index]->Fill(invMasspKpi);
 	   } 
            if(passTightCuts>0){
 	       if(invMasspiKp>0. && invMasspKpi>0. && passTightCuts==3){
-	       if(invMasspiKp>0.) fMassHistTC[index]->Fill(invMasspiKp,0.5);
-	       if(invMasspKpi>0.) fMassHistTC[index]->Fill(invMasspKpi,0.5);
+	       if(invMasspiKp>0.) fMassHistTC[index]->Fill(invMasspiKp);
+	       if(invMasspKpi>0.) fMassHistTC[index]->Fill(invMasspKpi);
 	    }else{
 	       	if(invMasspiKp>0. && passTightCuts==2) fMassHistTC[index]->Fill(invMasspiKp);
 	    	if(invMasspKpi>0.&& passTightCuts==1) fMassHistTC[index]->Fill(invMasspKpi);
@@ -2438,16 +2431,16 @@ void AliAnalysisTaskSELambdac::FillMassHists(AliAODEvent *aod,AliAODRecoDecayHF3
          if(IsLc && !IsLcFromq)  {
            index=GetNoQuarkHistoIndex(iPtBin);
            if(invMasspiKp>0. && invMasspKpi>0.){
-	         	if(invMasspiKp>0.) fMassHist[index]->Fill(invMasspiKp,0.5);
-	   	        if(invMasspKpi>0.) fMassHist[index]->Fill(invMasspKpi,0.5);
+	         	if(invMasspiKp>0.) fMassHist[index]->Fill(invMasspiKp);
+	   	        if(invMasspKpi>0.) fMassHist[index]->Fill(invMasspKpi);
 	   }else{
 	         	    if(invMasspiKp>0.) fMassHist[index]->Fill(invMasspiKp);
 			    if(invMasspKpi>0.) fMassHist[index]->Fill(invMasspKpi);
 	   } 
            if(passTightCuts>0){
 	       if(invMasspiKp>0. && invMasspKpi>0. && passTightCuts==3){
-	       if(invMasspiKp>0.) fMassHistTC[index]->Fill(invMasspiKp,0.5);
-	       if(invMasspKpi>0.) fMassHistTC[index]->Fill(invMasspKpi,0.5);
+	       if(invMasspiKp>0.) fMassHistTC[index]->Fill(invMasspiKp);
+	       if(invMasspKpi>0.) fMassHistTC[index]->Fill(invMasspKpi);
 	    }else{
 	       	if(invMasspiKp>0. && passTightCuts==2) fMassHistTC[index]->Fill(invMasspiKp);
 	    	if(invMasspKpi>0.&& passTightCuts==1) fMassHistTC[index]->Fill(invMasspKpi);
@@ -2459,71 +2452,71 @@ void AliAnalysisTaskSELambdac::FillMassHists(AliAODEvent *aod,AliAODRecoDecayHF3
 	}else{
 	  index=GetBackgroundHistoIndex(iPtBin);
 	  if(invMasspiKp>0. && invMasspKpi>0.){
-	    fMassHist[index]->Fill(invMasspiKp,0.5);
-	    fMassHist[index]->Fill(invMasspKpi,0.5);
+	    fMassHist[index]->Fill(invMasspiKp);
+	    fMassHist[index]->Fill(invMasspKpi);
 	  }else{
 	    if(invMasspiKp>0.) fMassHist[index]->Fill(invMasspiKp);
 	    if(invMasspKpi>0.) fMassHist[index]->Fill(invMasspKpi);
 	  }
 	  if(invMasspiKpLpi>0. && invMasspKpiLpi>0.){
-	    if(invMasspiKpLpi>0.) fMassHistLpi[index]->Fill(invMasspiKpLpi,0.5);
-	    if(invMasspKpiLpi>0.) fMassHistLpi[index]->Fill(invMasspKpiLpi,0.5);
+	    if(invMasspiKpLpi>0.) fMassHistLpi[index]->Fill(invMasspiKpLpi);
+	    if(invMasspKpiLpi>0.) fMassHistLpi[index]->Fill(invMasspKpiLpi);
 	  }else{
 	    if(invMasspiKpLpi>0.) fMassHistLpi[index]->Fill(invMasspiKpLpi);
 	    if(invMasspKpiLpi>0.) fMassHistLpi[index]->Fill(invMasspKpiLpi);
 	  }
 	  if(invMasspiKpKp>0. && invMasspKpiKp>0.){
-	    if(invMasspiKpKp>0.) fMassHistKp[index]->Fill(invMasspiKpKp,0.5);
-	    if(invMasspKpiKp>0.) fMassHistKp[index]->Fill(invMasspKpiKp,0.5);
+	    if(invMasspiKpKp>0.) fMassHistKp[index]->Fill(invMasspiKpKp);
+	    if(invMasspKpiKp>0.) fMassHistKp[index]->Fill(invMasspKpiKp);
 	  }else{
 	    if(invMasspiKpKp>0.) fMassHistKp[index]->Fill(invMasspiKpKp);
 	    if(invMasspKpiKp>0.) fMassHistKp[index]->Fill(invMasspKpiKp);
 	  }
 	  if(invMasspiKpDk>0. && invMasspKpiDk>0.){
-	    if(invMasspiKpDk>0.) fMassHistDk[index]->Fill(invMasspiKpDk,0.5);
-	    if(invMasspKpiDk>0.) fMassHistDk[index]->Fill(invMasspKpiDk,0.5);
+	    if(invMasspiKpDk>0.) fMassHistDk[index]->Fill(invMasspiKpDk);
+	    if(invMasspKpiDk>0.) fMassHistDk[index]->Fill(invMasspKpiDk);
 	  }else{
 	    if(invMasspiKpDk>0.) fMassHistDk[index]->Fill(invMasspiKpDk);
 	    if(invMasspKpiDk>0.) fMassHistDk[index]->Fill(invMasspKpiDk);
 	  }
 	  if(invMasspiKp3Pr>0. && invMasspKpi3Pr>0.){
-	    if(invMasspiKp3Pr>0.) fMassHist3Pr[index]->Fill(invMasspiKp3Pr,0.5);
-	    if(invMasspKpi3Pr>0.) fMassHist3Pr[index]->Fill(invMasspKpi3Pr,0.5);
+	    if(invMasspiKp3Pr>0.) fMassHist3Pr[index]->Fill(invMasspiKp3Pr);
+	    if(invMasspKpi3Pr>0.) fMassHist3Pr[index]->Fill(invMasspKpi3Pr);
 	  }else{
 	    if(invMasspiKp3Pr>0.) fMassHist3Pr[index]->Fill(invMasspiKp3Pr);
 	    if(invMasspKpi3Pr>0.) fMassHistDk[index]->Fill(invMasspKpi3Pr);
 	  }
 	  if(invMasspiKp>0. && invMasspKpi>0. && passTightCuts==3){
-	    fMassHistTC[index]->Fill(invMasspiKp,0.5);
-	    fMassHistTC[index]->Fill(invMasspKpi,0.5);
+	    fMassHistTC[index]->Fill(invMasspiKp);
+	    fMassHistTC[index]->Fill(invMasspKpi);
 	  }else{
 	    if(invMasspiKp>0. && passTightCuts==2) fMassHistTC[index]->Fill(invMasspiKp);
 	    if(invMasspKpi>0. && passTightCuts==1) fMassHistTC[index]->Fill(invMasspKpi);
 	  }
 	  if(invMasspiKpLpi>0. && invMasspKpiLpi>0. && passTightCuts==3){
-	    if(invMasspiKpLpi>0.) fMassHistLpiTC[index]->Fill(invMasspiKpLpi,0.5);
-	    if(invMasspKpiLpi>0.) fMassHistLpiTC[index]->Fill(invMasspKpiLpi,0.5);
+	    if(invMasspiKpLpi>0.) fMassHistLpiTC[index]->Fill(invMasspiKpLpi);
+	    if(invMasspKpiLpi>0.) fMassHistLpiTC[index]->Fill(invMasspKpiLpi);
 	  }else{
 	    if(invMasspiKpLpi>0. && passTightCuts==2) fMassHistLpiTC[index]->Fill(invMasspiKpLpi);
 	    if(invMasspKpiLpi>0.&& passTightCuts==1) fMassHistLpiTC[index]->Fill(invMasspKpiLpi);
 	  } 
 	  if(invMasspiKpKp>0. && invMasspKpiKp>0. && passTightCuts==3){
-	    if(invMasspiKpKp>0.) fMassHistKpTC[index]->Fill(invMasspiKpKp,0.5);
-	    if(invMasspKpiKp>0.) fMassHistKpTC[index]->Fill(invMasspKpiKp,0.5);
+	    if(invMasspiKpKp>0.) fMassHistKpTC[index]->Fill(invMasspiKpKp);
+	    if(invMasspKpiKp>0.) fMassHistKpTC[index]->Fill(invMasspKpiKp);
 	  }else{
 	    if(invMasspiKpKp>0. && passTightCuts==2) fMassHistKpTC[index]->Fill(invMasspiKpKp);
 	    if(invMasspKpiKp>0.&& passTightCuts==1) fMassHistKpTC[index]->Fill(invMasspKpiKp);
 	  }
 	  if(invMasspiKpDk>0. && invMasspKpiDk>0. && passTightCuts==3){
-	    if(invMasspiKpDk>0.) fMassHistDkTC[index]->Fill(invMasspiKpDk,0.5);
-	    if(invMasspKpiDk>0.) fMassHistDkTC[index]->Fill(invMasspKpiDk,0.5);
+	    if(invMasspiKpDk>0.) fMassHistDkTC[index]->Fill(invMasspiKpDk);
+	    if(invMasspKpiDk>0.) fMassHistDkTC[index]->Fill(invMasspKpiDk);
 	  }else{
 	    if(invMasspiKpDk>0. && passTightCuts==2) fMassHistDkTC[index]->Fill(invMasspiKpDk);
 	    if(invMasspKpiDk>0.&& passTightCuts==1) fMassHistDkTC[index]->Fill(invMasspKpiDk);
 	   }
 	   if(invMasspiKp3Pr>0. && invMasspKpi3Pr>0. && passTightCuts==3){
-	    if(invMasspiKp3Pr>0.) fMassHist3PrTC[index]->Fill(invMasspiKp3Pr,0.5);
-	    if(invMasspKpi3Pr>0.) fMassHist3PrTC[index]->Fill(invMasspKpi3Pr,0.5);
+	    if(invMasspiKp3Pr>0.) fMassHist3PrTC[index]->Fill(invMasspiKp3Pr);
+	    if(invMasspKpi3Pr>0.) fMassHist3PrTC[index]->Fill(invMasspKpi3Pr);
 	   }else{
 	    if(invMasspiKp3Pr>0. && passTightCuts==2) fMassHist3PrTC[index]->Fill(invMasspiKp3Pr);
 	    if(invMasspKpi3Pr>0.&& passTightCuts==1) fMassHist3PrTC[index]->Fill(invMasspKpi3Pr);

--- a/PWGHF/vertexingHF/AliAnalysisTaskSELambdacTMVA.cxx
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSELambdacTMVA.cxx
@@ -1097,11 +1097,6 @@ void AliAnalysisTaskSELambdacTMVA::UserExec(Option_t */*option*/)
 		FillEffHists(kReco3Prong);
 		fNentries->Fill(6);
 
-		Bool_t unsetvtx=kFALSE;
-		if(!d->GetOwnPrimaryVtx()){
-			d->SetOwnPrimaryVtx(vtx1);
-			unsetvtx=kTRUE;
-		}
 
 
 
@@ -1166,7 +1161,6 @@ void AliAnalysisTaskSELambdacTMVA::UserExec(Option_t */*option*/)
 		if(fFillNtuple) FillNtuple(aod,d,arrayMC,selection);
 		FillEffHists(kIsSelectedNtuple);
 		if(fIsLc>=1 && fIsLc <= 2) fNentries->Fill(16);
-		if(unsetvtx) d->UnsetOwnPrimaryVtx();
 	}
 	fCounter->StoreCandidates(aod,nSelectedloose[0],kTRUE);
 	fCounter->StoreCandidates(aod,nSelectedtight[0],kFALSE);
@@ -1516,15 +1510,15 @@ void AliAnalysisTaskSELambdacTMVA::FillMassHists(AliAODEvent *aod, AliAODRecoDec
 				else if(fIsLc==2) fhPIDmassLcPtSigb->Fill(d->Pt(),invMassLcpiKp);
 			}
 			else if(selection==3){
-				fhPIDmassLcPtSig->Fill(d->Pt(),invMassLcpiKp,0.5);
-				fhPIDmassLcPtSig->Fill(d->Pt(),invMassLcpKpi,0.5);
+				fhPIDmassLcPtSig->Fill(d->Pt(),invMassLcpiKp);
+				fhPIDmassLcPtSig->Fill(d->Pt(),invMassLcpKpi);
 				if(fIsLc==1) {
-					fhPIDmassLcPtSigc->Fill(d->Pt(),invMassLcpiKp,0.5);
-					fhPIDmassLcPtSigc->Fill(d->Pt(),invMassLcpKpi,0.5);
+					fhPIDmassLcPtSigc->Fill(d->Pt(),invMassLcpiKp);
+					fhPIDmassLcPtSigc->Fill(d->Pt(),invMassLcpKpi);
 				}
 				else if(fIsLc==2) {
-					fhPIDmassLcPtSigb->Fill(d->Pt(),invMassLcpiKp,0.5);
-					fhPIDmassLcPtSigb->Fill(d->Pt(),invMassLcpKpi,0.5);
+					fhPIDmassLcPtSigb->Fill(d->Pt(),invMassLcpiKp);
+					fhPIDmassLcPtSigb->Fill(d->Pt(),invMassLcpKpi);
 				}
 			}
 			//max prob PID
@@ -1574,8 +1568,8 @@ void AliAnalysisTaskSELambdacTMVA::FillMassHists(AliAODEvent *aod, AliAODRecoDec
 			fhPIDmassLcPt->Fill(d->Pt(),invMassLcpiKp);
 		}
 		else if(selection==3){
-			fhPIDmassLcPt->Fill(d->Pt(),invMassLcpiKp,0.5);
-			fhPIDmassLcPt->Fill(d->Pt(),invMassLcpKpi,0.5);
+			fhPIDmassLcPt->Fill(d->Pt(),invMassLcpiKp);
+			fhPIDmassLcPt->Fill(d->Pt(),invMassLcpKpi);
 		}
 		//max prob PID
 		if(selectionProb==1) fhProbmassLcPt->Fill(d->Pt(),invMassLcpKpi);

--- a/PWGHF/vertexingHF/AliAnalysisTaskSELc2V0bachelor.cxx
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSELc2V0bachelor.cxx
@@ -595,12 +595,6 @@ void AliAnalysisTaskSELc2V0bachelor::MakeAnalysisForLc2prK0S(AliAODEvent *aodEve
       continue;
     }
 
-    Bool_t unsetvtx=kFALSE;
-    if (!lcK0Spr->GetOwnPrimaryVtx()) {
-      lcK0Spr->SetOwnPrimaryVtx(fVtx1);
-      unsetvtx=kTRUE;
-    }
-
     if(!vHF->FillRecoCasc(aodEvent,lcK0Spr,kFALSE)){//Fill the data members of the candidate only if they are empty.
        fCEvents->Fill(18);//monitor how often this fails
     continue;
@@ -696,9 +690,7 @@ void AliAnalysisTaskSELc2V0bachelor::MakeAnalysisForLc2prK0S(AliAODEvent *aodEve
 
     FillLc2pK0Sspectrum(lcK0Spr, isLc,
 			nSelectedAnal, cutsAnal,
-			mcArray, originLc);
-
-    if (unsetvtx) lcK0Spr->UnsetOwnPrimaryVtx();
+			mcArray, originLc, aodEvent);
 
   }
 
@@ -714,7 +706,8 @@ void AliAnalysisTaskSELc2V0bachelor::FillLc2pK0Sspectrum(AliAODRecoCascadeHF *pa
 							   Int_t &nSelectedAnal,
 							   AliRDHFCutsLctoV0 *cutsAnal,
 							   TClonesArray *mcArray,
-							   Int_t originLc)
+							   Int_t originLc,
+                 AliAODEvent *aod)
 {
   //
   /// Fill histos for Lc -> K0S+proton
@@ -730,36 +723,36 @@ void AliAnalysisTaskSELc2V0bachelor::FillLc2pK0Sspectrum(AliAODRecoCascadeHF *pa
 
   Bool_t areCutsUsingPID = cutsAnal->GetIsUsePID();
   cutsAnal->SetUsePID(kFALSE);
-  Bool_t isInCascadeWindow = (((cutsAnal->IsSelectedSingleCut(part,AliRDHFCuts::kCandidate,0))&(AliRDHFCutsLctoV0::kLcToK0Spr))==(AliRDHFCutsLctoV0::kLcToK0Spr)); // cut on Lc->p+K0S invMass
+  Bool_t isInCascadeWindow = (((cutsAnal->IsSelectedSingleCut(part,AliRDHFCuts::kCandidate,0,aod))&(AliRDHFCutsLctoV0::kLcToK0Spr))==(AliRDHFCutsLctoV0::kLcToK0Spr)); // cut on Lc->p+K0S invMass
   cutsAnal->SetUsePID(areCutsUsingPID);
 
   if ( onFlyV0 && !fUseOnTheFlyV0 ) return;
 
-  if (fAdditionalChecks) CheckCandidatesAtDifferentLevels(part,cutsAnal);
+  if (fAdditionalChecks) CheckCandidatesAtDifferentLevels(part,cutsAnal,aod);
 
   // track rotation
   if (fTrackRotation) {
     if (onFlyV0) {
-      TrackRotation(cutsAnal,part,"");
+      TrackRotation(cutsAnal,part,"",aod);
     }
     else {
-      TrackRotation(cutsAnal,part,"Offline");
+      TrackRotation(cutsAnal,part,"Offline",aod);
     }
     if (fUseMCInfo) {
       if (isLc==1) {
 	if (onFlyV0) {
-	  TrackRotation(cutsAnal,part,"Sgn");
+	  TrackRotation(cutsAnal,part,"Sgn",aod);
 	}
 	else {
-	  TrackRotation(cutsAnal,part,"OfflineSgn");
+	  TrackRotation(cutsAnal,part,"OfflineSgn",aod);
 	}
       }// sgn
       else { // bkg
 	if (onFlyV0) {
-	  TrackRotation(cutsAnal,part,"Bkg");
+	  TrackRotation(cutsAnal,part,"Bkg",aod);
 	}
 	else {
-	  TrackRotation(cutsAnal,part,"OfflineBkg");
+	  TrackRotation(cutsAnal,part,"OfflineBkg",aod);
 	}
       }
     } // if fUseMCInfo
@@ -770,9 +763,9 @@ void AliAnalysisTaskSELc2V0bachelor::FillLc2pK0Sspectrum(AliAODRecoCascadeHF *pa
 
   if ( !(cutsAnal->IsInFiducialAcceptance(part->Pt(),part->Y(4122))) ) return;
 
-  if ( !( ( (cutsAnal->IsSelected(part,AliRDHFCuts::kTracks))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) ) return;
+  if ( !( ( (cutsAnal->IsSelected(part,AliRDHFCuts::kTracks,aod))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) ) return;
 
-  if ( ( ( (cutsAnal->IsSelected(part,AliRDHFCuts::kAll))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) ) nSelectedAnal++;
+  if ( ( ( (cutsAnal->IsSelected(part,AliRDHFCuts::kAll,aod))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) ) nSelectedAnal++;
 
   // Fill candidate variable Tree (track selection, V0 invMass selection)
   if ( fWriteVariableTree ) {
@@ -789,12 +782,12 @@ void AliAnalysisTaskSELc2V0bachelor::FillLc2pK0Sspectrum(AliAODRecoCascadeHF *pa
   }
 
   cutsAnal->SetUsePID(kFALSE);
-  Bool_t isCandidateSelectedCuts = (((cutsAnal->IsSelected(part,AliRDHFCuts::kCandidate))&(AliRDHFCutsLctoV0::kLcToK0Spr))==(AliRDHFCutsLctoV0::kLcToK0Spr)); // kinematic/topological cuts
+  Bool_t isCandidateSelectedCuts = (((cutsAnal->IsSelected(part,AliRDHFCuts::kCandidate,aod))&(AliRDHFCutsLctoV0::kLcToK0Spr))==(AliRDHFCutsLctoV0::kLcToK0Spr)); // kinematic/topological cuts
   cutsAnal->SetUsePID(areCutsUsingPID);
-  Bool_t isBachelorID = (((cutsAnal->IsSelected(part,AliRDHFCuts::kPID))&(AliRDHFCutsLctoV0::kLcToK0Spr))==(AliRDHFCutsLctoV0::kLcToK0Spr)); // ID x bachelor
+  Bool_t isBachelorID = (((cutsAnal->IsSelected(part,AliRDHFCuts::kPID,aod))&(AliRDHFCutsLctoV0::kLcToK0Spr))==(AliRDHFCutsLctoV0::kLcToK0Spr)); // ID x bachelor
 
-  //if (((cutsAnal->IsSelected(part,AliRDHFCuts::kCandidate))&(AliRDHFCutsLctoV0::kLcToK0Spr))==(AliRDHFCutsLctoV0::kLcToK0Spr)) {
-  if (((cutsAnal->IsSelected(part,AliRDHFCuts::kAll))&(AliRDHFCutsLctoV0::kLcToK0Spr))==(AliRDHFCutsLctoV0::kLcToK0Spr)) {
+  //if (((cutsAnal->IsSelected(part,AliRDHFCuts::kCandidate,aod))&(AliRDHFCutsLctoV0::kLcToK0Spr))==(AliRDHFCutsLctoV0::kLcToK0Spr)) {
+  if (((cutsAnal->IsSelected(part,AliRDHFCuts::kAll,aod))&(AliRDHFCutsLctoV0::kLcToK0Spr))==(AliRDHFCutsLctoV0::kLcToK0Spr)) {
     if (fUseMCInfo && isLc && !fWriteVariableTree) {
       Int_t pdgCand1 = 4122;
       Int_t pdgDgLctoV0bachelor1[2]={2212,310};
@@ -828,7 +821,7 @@ void AliAnalysisTaskSELc2V0bachelor::FillLc2pK0Sspectrum(AliAODRecoCascadeHF *pa
     FillArmPodDistribution(part,fillthis,isCandidateSelectedCuts,isBachelorID);
 
     //if (isCandidateSelectedCuts) {
-    FillAnalysisHistograms(part,cutsAnal,"");
+    FillAnalysisHistograms(part,cutsAnal,"",aod);
     //}
   }
   else {
@@ -839,13 +832,13 @@ void AliAnalysisTaskSELc2V0bachelor::FillLc2pK0Sspectrum(AliAODRecoCascadeHF *pa
     fillthis="histArmPodLcOffline";
     FillArmPodDistribution(part,fillthis,isCandidateSelectedCuts,isBachelorID);
 
-    FillAnalysisHistograms(part,cutsAnal,"Offline");
+    FillAnalysisHistograms(part,cutsAnal,"Offline",aod);
     if (isCandidateSelectedCuts) {
       fillthis="histoprotonBachSigmaVspTOF";
       ((TH2F*)(fOutput->FindObject(fillthis)))->Fill(momBach,nSigmaTOFpr);
       fillthis="histoprotonBachSigmaVspTPC";
       ((TH2F*)(fOutput->FindObject(fillthis)))->Fill(momBach,nSigmaTPCpr);
-      //FillAnalysisHistograms(part,cutsAnal,"Offline");
+      //FillAnalysisHistograms(part,cutsAnal,"Offline",aod);
     }
   }
   if (fUseMCInfo) {
@@ -859,18 +852,18 @@ void AliAnalysisTaskSELc2V0bachelor::FillLc2pK0Sspectrum(AliAODRecoCascadeHF *pa
 	FillArmPodDistribution(part,fillthis,isCandidateSelectedCuts,isBachelorID);
 
 	//if (isCandidateSelectedCuts) {
-	FillAnalysisHistograms(part,cutsAnal,"Sgn");
+	FillAnalysisHistograms(part,cutsAnal,"Sgn",aod);
 	//}
 	if (fCheckOrigin) {
 	  switch (originLc) {
 	  case 1:
-	    FillAnalysisHistograms(part,cutsAnal,"SgnC");
+	    FillAnalysisHistograms(part,cutsAnal,"SgnC",aod);
 	    break;
 	  case 2:
-	    FillAnalysisHistograms(part,cutsAnal,"SgnB");
+	    FillAnalysisHistograms(part,cutsAnal,"SgnB",aod);
 	    break;
 	  case 3:
-	    FillAnalysisHistograms(part,cutsAnal,"SgnNoQ");
+	    FillAnalysisHistograms(part,cutsAnal,"SgnNoQ",aod);
 	    break;
 	  }
 	}
@@ -888,23 +881,23 @@ void AliAnalysisTaskSELc2V0bachelor::FillLc2pK0Sspectrum(AliAODRecoCascadeHF *pa
 	  ((TH2F*)(fOutput->FindObject(fillthis)))->Fill(momBach,nSigmaTOFpr);
 	  fillthis="histoprotonBachSigmaVspTPCsgn";
 	  ((TH2F*)(fOutput->FindObject(fillthis)))->Fill(momBach,nSigmaTPCpr);
-	  //FillAnalysisHistograms(part,cutsAnal,"OfflineSgn");
+	  //FillAnalysisHistograms(part,cutsAnal,"OfflineSgn",aod);
 	}
 
 	if (fCheckOrigin) {
 	  switch (originLc) {
 	  case 1:
-	    FillAnalysisHistograms(part,cutsAnal,"OfflineSgnC");
+	    FillAnalysisHistograms(part,cutsAnal,"OfflineSgnC",aod);
 	    break;
 	  case 2:
-	    FillAnalysisHistograms(part,cutsAnal,"OfflineSgnB");
+	    FillAnalysisHistograms(part,cutsAnal,"OfflineSgnB",aod);
 	    break;
 	  case 3:
-	    FillAnalysisHistograms(part,cutsAnal,"OfflineSgnNoQ");
+	    FillAnalysisHistograms(part,cutsAnal,"OfflineSgnNoQ",aod);
 	    break;
 	  }
 	}
-	FillAnalysisHistograms(part,cutsAnal,"OfflineSgn");
+	FillAnalysisHistograms(part,cutsAnal,"OfflineSgn",aod);
 
       }
     }// sgn
@@ -918,7 +911,7 @@ void AliAnalysisTaskSELc2V0bachelor::FillLc2pK0Sspectrum(AliAODRecoCascadeHF *pa
 	FillArmPodDistribution(part,fillthis,isCandidateSelectedCuts,isBachelorID);
 
 	//if (isCandidateSelectedCuts) {
-	FillAnalysisHistograms(part,cutsAnal,"Bkg");
+	FillAnalysisHistograms(part,cutsAnal,"Bkg",aod);
 	//}
       }
       else {
@@ -929,13 +922,13 @@ void AliAnalysisTaskSELc2V0bachelor::FillLc2pK0Sspectrum(AliAODRecoCascadeHF *pa
 	fillthis="histArmPodLcOfflineBkg";
 	FillArmPodDistribution(part,fillthis,isCandidateSelectedCuts,isBachelorID);
 
-	FillAnalysisHistograms(part,cutsAnal,"OfflineBkg");
+	FillAnalysisHistograms(part,cutsAnal,"OfflineBkg",aod);
 	if (isCandidateSelectedCuts) {
 	  fillthis="histoprotonBachSigmaVspTOFbkg";
 	  ((TH2F*)(fOutput->FindObject(fillthis)))->Fill(momBach,nSigmaTOFpr);
 	  fillthis="histoprotonBachSigmaVspTPCbkg";
 	  ((TH2F*)(fOutput->FindObject(fillthis)))->Fill(momBach,nSigmaTPCpr);
-	  //FillAnalysisHistograms(part,cutsAnal,"OfflineBkg");
+	  //FillAnalysisHistograms(part,cutsAnal,"OfflineBkg",aod);
 	}
       }
     }
@@ -3491,7 +3484,7 @@ void AliAnalysisTaskSELc2V0bachelor::FillArmPodDistribution(AliAODRecoDecay *vZe
 }
 
 //-------------------------------------------------------------------------------
-void AliAnalysisTaskSELc2V0bachelor::CheckCandidatesAtDifferentLevels(AliAODRecoCascadeHF *part, AliRDHFCutsLctoV0* cutsAnal) {
+void AliAnalysisTaskSELc2V0bachelor::CheckCandidatesAtDifferentLevels(AliAODRecoCascadeHF *part, AliRDHFCutsLctoV0* cutsAnal, AliAODEvent *aod) {
   //
   /// This is to check candidates at different levels
   //
@@ -3508,24 +3501,24 @@ void AliAnalysisTaskSELc2V0bachelor::CheckCandidatesAtDifferentLevels(AliAODReco
 
   if ( cutsAnal->IsInFiducialAcceptance(part->Pt(),part->Y(4122)) )
     ((TH1F*)(fOutput->FindObject("hCandidateSelection")))->Fill(4);
-  if ( (((cutsAnal->IsSelected(part,AliRDHFCuts::kTracks))&(AliRDHFCutsLctoV0::kLcToK0Spr))==(AliRDHFCutsLctoV0::kLcToK0Spr)) )
+  if ( (((cutsAnal->IsSelected(part,AliRDHFCuts::kTracks,aod))&(AliRDHFCutsLctoV0::kLcToK0Spr))==(AliRDHFCutsLctoV0::kLcToK0Spr)) )
     ((TH1F*)(fOutput->FindObject("hCandidateSelection")))->Fill(5);
   cutsAnal->SetUsePID(kFALSE);
-  if ( (((cutsAnal->IsSelected(part,AliRDHFCuts::kCandidate))&(AliRDHFCutsLctoV0::kLcToK0Spr))==(AliRDHFCutsLctoV0::kLcToK0Spr)) )
+  if ( (((cutsAnal->IsSelected(part,AliRDHFCuts::kCandidate,aod))&(AliRDHFCutsLctoV0::kLcToK0Spr))==(AliRDHFCutsLctoV0::kLcToK0Spr)) )
     ((TH1F*)(fOutput->FindObject("hCandidateSelection")))->Fill(6);
   cutsAnal->SetUsePID(areCutsUsingPID);
-  if ( (((cutsAnal->IsSelected(part,AliRDHFCuts::kPID))&(AliRDHFCutsLctoV0::kLcToK0Spr))==(AliRDHFCutsLctoV0::kLcToK0Spr)) )
+  if ( (((cutsAnal->IsSelected(part,AliRDHFCuts::kPID,aod))&(AliRDHFCutsLctoV0::kLcToK0Spr))==(AliRDHFCutsLctoV0::kLcToK0Spr)) )
     ((TH1F*)(fOutput->FindObject("hCandidateSelection")))->Fill(7);
-  if ( (((cutsAnal->IsSelected(part,AliRDHFCuts::kCandidate))&(AliRDHFCutsLctoV0::kLcToK0Spr))==(AliRDHFCutsLctoV0::kLcToK0Spr)) )
+  if ( (((cutsAnal->IsSelected(part,AliRDHFCuts::kCandidate,aod))&(AliRDHFCutsLctoV0::kLcToK0Spr))==(AliRDHFCutsLctoV0::kLcToK0Spr)) )
     ((TH1F*)(fOutput->FindObject("hCandidateSelection")))->Fill(8);
-  if ( (((cutsAnal->IsSelected(part,AliRDHFCuts::kAll))&(AliRDHFCutsLctoV0::kLcToK0Spr))==(AliRDHFCutsLctoV0::kLcToK0Spr)) )
+  if ( (((cutsAnal->IsSelected(part,AliRDHFCuts::kAll,aod))&(AliRDHFCutsLctoV0::kLcToK0Spr))==(AliRDHFCutsLctoV0::kLcToK0Spr)) )
     ((TH1F*)(fOutput->FindObject("hCandidateSelection")))->Fill(9);
 
   if ( cutsAnal->IsInFiducialAcceptance(part->Pt(),part->Y(4122)) ) {
 
-    if ( ( (cutsAnal->IsSelected(part,AliRDHFCuts::kTracks))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
+    if ( ( (cutsAnal->IsSelected(part,AliRDHFCuts::kTracks,aod))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
 
-      Int_t aaa = cutsAnal->IsSelected(part,AliRDHFCuts::kTracks);
+      Int_t aaa = cutsAnal->IsSelected(part,AliRDHFCuts::kTracks,aod);
       if ( (aaa&AliRDHFCutsLctoV0::kLcToK0Spr)==AliRDHFCutsLctoV0::kLcToK0Spr ) {
 	if ( ( (aaa&AliRDHFCutsLctoV0::kLcToLpi)==AliRDHFCutsLctoV0::kLcToLpi && bachelor->Charge()<0)  ||
 	     ( (aaa&AliRDHFCutsLctoV0::kLcToLBarpi)==AliRDHFCutsLctoV0::kLcToLBarpi && bachelor->Charge()>0) )
@@ -3535,7 +3528,7 @@ void AliAnalysisTaskSELc2V0bachelor::CheckCandidatesAtDifferentLevels(AliAODReco
       }
 
       cutsAnal->SetUsePID(kFALSE);
-      aaa = cutsAnal->IsSelected(part,AliRDHFCuts::kCandidate);
+      aaa = cutsAnal->IsSelected(part,AliRDHFCuts::kCandidate,aod);
       if ((aaa&AliRDHFCutsLctoV0::kLcToK0Spr)==AliRDHFCutsLctoV0::kLcToK0Spr) {
 	if ( ( (aaa&AliRDHFCutsLctoV0::kLcToLpi)==AliRDHFCutsLctoV0::kLcToLpi && bachelor->Charge()<0) ||
 	     ( (aaa&AliRDHFCutsLctoV0::kLcToLBarpi)==AliRDHFCutsLctoV0::kLcToLBarpi && bachelor->Charge()>0) )
@@ -3545,7 +3538,7 @@ void AliAnalysisTaskSELc2V0bachelor::CheckCandidatesAtDifferentLevels(AliAODReco
       }
       cutsAnal->SetUsePID(areCutsUsingPID);
 
-      aaa = cutsAnal->IsSelected(part,AliRDHFCuts::kPID);
+      aaa = cutsAnal->IsSelected(part,AliRDHFCuts::kPID,aod);
       if ((aaa&AliRDHFCutsLctoV0::kLcToK0Spr)==AliRDHFCutsLctoV0::kLcToK0Spr) {
 	if ( ( (aaa&AliRDHFCutsLctoV0::kLcToLpi)==AliRDHFCutsLctoV0::kLcToLpi && bachelor->Charge()<0) ||
 	     ( (aaa&AliRDHFCutsLctoV0::kLcToLBarpi)==AliRDHFCutsLctoV0::kLcToLBarpi && bachelor->Charge()>0) )
@@ -3554,7 +3547,7 @@ void AliAnalysisTaskSELc2V0bachelor::CheckCandidatesAtDifferentLevels(AliAODReco
 	  ((TH1F*)(fOutput->FindObject("hSwitchOnCandidates3")))->Fill( aaa );
       }
 
-      aaa = cutsAnal->IsSelected(part,AliRDHFCuts::kAll);
+      aaa = cutsAnal->IsSelected(part,AliRDHFCuts::kAll,aod);
       if ((aaa&AliRDHFCutsLctoV0::kLcToK0Spr)==AliRDHFCutsLctoV0::kLcToK0Spr) {
 	if ( ( (aaa&AliRDHFCutsLctoV0::kLcToLpi)==AliRDHFCutsLctoV0::kLcToLpi && bachelor->Charge()<0) ||
 	     ( (aaa&AliRDHFCutsLctoV0::kLcToLBarpi)==AliRDHFCutsLctoV0::kLcToLBarpi && bachelor->Charge()>0) )
@@ -4360,14 +4353,14 @@ void  AliAnalysisTaskSELc2V0bachelor::DefineGeneralHistograms() {
 }
 
 //________________________________________________________________________
-void  AliAnalysisTaskSELc2V0bachelor::FillAnalysisHistograms(AliAODRecoCascadeHF *part, AliRDHFCutsLctoV0 *cutsAnal, TString appendthis) {
+void  AliAnalysisTaskSELc2V0bachelor::FillAnalysisHistograms(AliAODRecoCascadeHF *part, AliRDHFCutsLctoV0 *cutsAnal, TString appendthis, AliAODEvent *aod) {
   //
   // This is to fill analysis histograms
   //
 
   TString fillthis="";
 
-  Bool_t isBachelorID = (((cutsAnal->IsSelected(part,AliRDHFCuts::kPID))&(AliRDHFCutsLctoV0::kLcToK0Spr))==(AliRDHFCutsLctoV0::kLcToK0Spr)); // ID x bachelor
+  Bool_t isBachelorID = (((cutsAnal->IsSelected(part,AliRDHFCuts::kPID, aod))&(AliRDHFCutsLctoV0::kLcToK0Spr))==(AliRDHFCutsLctoV0::kLcToK0Spr)); // ID x bachelor
 
   Bool_t areCutsUsingPID = cutsAnal->GetIsUsePID();
   cutsAnal->SetUsePID(kFALSE);
@@ -4393,7 +4386,7 @@ void  AliAnalysisTaskSELc2V0bachelor::FillAnalysisHistograms(AliAODRecoCascadeHF
   if (!appendthis.Contains("SgnC") && !appendthis.Contains("SgnB") && !appendthis.Contains("SgnNoQ")) {
     fillthis="histpK0Svsp"+appendthis;
     //cout << fillthis << endl;
-    if ( ((cutsAnal->IsSelected(part,AliRDHFCuts::kCandidate))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
+    if ( ((cutsAnal->IsSelected(part,AliRDHFCuts::kCandidate,aod))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
       ((TH2F*)(fOutputAll->FindObject(fillthis)))->Fill(momBach,momK0S);
       if (isBachelorID)  ((TH2F*)(fOutputPIDBach->FindObject(fillthis)))->Fill(momBach,momK0S);
     }
@@ -4401,14 +4394,14 @@ void  AliAnalysisTaskSELc2V0bachelor::FillAnalysisHistograms(AliAODRecoCascadeHF
 
   fillthis="histLcMassByK0S"+appendthis;
   //cout << fillthis << endl;
-  if ( ((cutsAnal->IsSelected(part,AliRDHFCuts::kCandidate))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
+  if ( ((cutsAnal->IsSelected(part,AliRDHFCuts::kCandidate,aod))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
     ((TH2F*)(fOutputAll->FindObject(fillthis)))->Fill(invmassLc,lambdacpt);
     if (isBachelorID)((TH2F*)(fOutputPIDBach->FindObject(fillthis)))->Fill(invmassLc,lambdacpt);
   }
 
   if(fFillSubSampleHist && appendthis=="Offline"){
     fillthis="histLcMassByK0SSubSample"+appendthis;
-    if ( ((cutsAnal->IsSelected(part,AliRDHFCuts::kCandidate))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
+    if ( ((cutsAnal->IsSelected(part,AliRDHFCuts::kCandidate,aod))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
       Double_t contsp[3];contsp[0]=invmassLc;contsp[1]=lambdacpt;contsp[2]=(Double_t)(fEventCounter%24);
       if (isBachelorID)((THnSparse*)(fOutputPIDBach->FindObject(fillthis)))->Fill(contsp);
     }
@@ -4418,7 +4411,7 @@ void  AliAnalysisTaskSELc2V0bachelor::FillAnalysisHistograms(AliAODRecoCascadeHF
     fillthis="histK0SMass"+appendthis;
     //    cout << fillthis << endl;
     cutsAnal->SetExcludedCut(2);
-    if ( ((cutsAnal->IsSelected(part,AliRDHFCuts::kCandidate))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
+    if ( ((cutsAnal->IsSelected(part,AliRDHFCuts::kCandidate,aod))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
       ((TH2F*)(fOutputAll->FindObject(fillthis)))->Fill(lambdacpt,invmassK0S);
       if (isBachelorID)  ((TH2F*)(fOutputPIDBach->FindObject(fillthis)))->Fill(lambdacpt,invmassK0S);
     }
@@ -4428,7 +4421,7 @@ void  AliAnalysisTaskSELc2V0bachelor::FillAnalysisHistograms(AliAODRecoCascadeHF
   fillthis="histptK0S"+appendthis;
   //cout << fillthis << endl;
   cutsAnal->SetExcludedCut(15);
-  if ( ((cutsAnal->IsSelected(part,AliRDHFCuts::kCandidate))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
+  if ( ((cutsAnal->IsSelected(part,AliRDHFCuts::kCandidate,aod))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
     ((TH2F*)(fOutputAll->FindObject(fillthis)))->Fill(lambdacpt,ptK0S);
     if (isBachelorID)((TH2F*)(fOutputPIDBach->FindObject(fillthis)))->Fill(lambdacpt,ptK0S);
   }
@@ -4436,7 +4429,7 @@ void  AliAnalysisTaskSELc2V0bachelor::FillAnalysisHistograms(AliAODRecoCascadeHF
   fillthis="histptP"+appendthis;
   //cout << fillthis << endl;
   cutsAnal->SetExcludedCut(4);
-  if ( ((cutsAnal->IsSelected(part,AliRDHFCuts::kCandidate))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
+  if ( ((cutsAnal->IsSelected(part,AliRDHFCuts::kCandidate,aod))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
     ((TH2F*)(fOutputAll->FindObject(fillthis)))->Fill(lambdacpt,ptBach);
     if (isBachelorID)((TH2F*)(fOutputPIDBach->FindObject(fillthis)))->Fill(lambdacpt,ptBach);
   }
@@ -4444,7 +4437,7 @@ void  AliAnalysisTaskSELc2V0bachelor::FillAnalysisHistograms(AliAODRecoCascadeHF
   fillthis="histptPip"+appendthis;
   //cout << fillthis << endl;
   cutsAnal->SetExcludedCut(5);
-  if ( ((cutsAnal->IsSelected(part,AliRDHFCuts::kCandidate))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
+  if ( ((cutsAnal->IsSelected(part,AliRDHFCuts::kCandidate,aod))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
     ((TH2F*)(fOutputAll->FindObject(fillthis)))->Fill(lambdacpt,ptV0pos);
     if (isBachelorID)((TH2F*)(fOutputPIDBach->FindObject(fillthis)))->Fill(lambdacpt,ptV0pos);
   }
@@ -4452,7 +4445,7 @@ void  AliAnalysisTaskSELc2V0bachelor::FillAnalysisHistograms(AliAODRecoCascadeHF
   fillthis="histptPim"+appendthis;
   //cout << fillthis << endl;
   cutsAnal->SetExcludedCut(6);
-  if ( ((cutsAnal->IsSelected(part,AliRDHFCuts::kCandidate))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
+  if ( ((cutsAnal->IsSelected(part,AliRDHFCuts::kCandidate,aod))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
     ((TH2F*)(fOutputAll->FindObject(fillthis)))->Fill(lambdacpt,ptV0neg);
     if (isBachelorID)((TH2F*)(fOutputPIDBach->FindObject(fillthis)))->Fill(lambdacpt,ptV0neg);
   }
@@ -4461,7 +4454,7 @@ void  AliAnalysisTaskSELc2V0bachelor::FillAnalysisHistograms(AliAODRecoCascadeHF
     fillthis="histLambdaMass"+appendthis;
     //    cout << fillthis << endl;
     cutsAnal->SetExcludedCut(13);
-    if ( ((cutsAnal->IsSelected(part,AliRDHFCuts::kCandidate))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
+    if ( ((cutsAnal->IsSelected(part,AliRDHFCuts::kCandidate,aod))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
       ((TH2F*)(fOutputAll->FindObject(fillthis)))->Fill(lambdacpt,v0part->MassLambda());
       if (isBachelorID)((TH2F*)(fOutputPIDBach->FindObject(fillthis)))->Fill(lambdacpt,v0part->MassLambda());
     }
@@ -4469,7 +4462,7 @@ void  AliAnalysisTaskSELc2V0bachelor::FillAnalysisHistograms(AliAODRecoCascadeHF
     fillthis="histLambdaBarMass"+appendthis;
     //    cout << fillthis << endl;
     cutsAnal->SetExcludedCut(13);
-    if ( ((cutsAnal->IsSelected(part,AliRDHFCuts::kCandidate))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
+    if ( ((cutsAnal->IsSelected(part,AliRDHFCuts::kCandidate,aod))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
       ((TH2F*)(fOutputAll->FindObject(fillthis)))->Fill(lambdacpt,v0part->MassAntiLambda());
       if (isBachelorID)((TH2F*)(fOutputPIDBach->FindObject(fillthis)))->Fill(lambdacpt,v0part->MassAntiLambda());
     }
@@ -4477,7 +4470,7 @@ void  AliAnalysisTaskSELc2V0bachelor::FillAnalysisHistograms(AliAODRecoCascadeHF
     fillthis="histGammaMass"+appendthis;
     //    cout << fillthis << endl;
     cutsAnal->SetExcludedCut(14);
-    if ( ((cutsAnal->IsSelected(part,AliRDHFCuts::kCandidate))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
+    if ( ((cutsAnal->IsSelected(part,AliRDHFCuts::kCandidate,aod))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
       ((TH2F*)(fOutputAll->FindObject(fillthis)))->Fill(lambdacpt,v0part->InvMass2Prongs(0,1,11,11));
       if (isBachelorID)((TH2F*)(fOutputPIDBach->FindObject(fillthis)))->Fill(lambdacpt,v0part->InvMass2Prongs(0,1,11,11));
     }
@@ -4486,7 +4479,7 @@ void  AliAnalysisTaskSELc2V0bachelor::FillAnalysisHistograms(AliAODRecoCascadeHF
   fillthis="histD0K0S"+appendthis;
   //cout << fillthis << endl;
   cutsAnal->SetExcludedCut(11);
-  if ( ((cutsAnal->IsSelected(part,AliRDHFCuts::kCandidate))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
+  if ( ((cutsAnal->IsSelected(part,AliRDHFCuts::kCandidate,aod))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
     ((TH2F*)(fOutputAll->FindObject(fillthis)))->Fill(lambdacpt,part->Getd0Prong(1));
     if (isBachelorID)((TH2F*)(fOutputPIDBach->FindObject(fillthis)))->Fill(lambdacpt,part->Getd0Prong(1));
   }
@@ -4494,7 +4487,7 @@ void  AliAnalysisTaskSELc2V0bachelor::FillAnalysisHistograms(AliAODRecoCascadeHF
   fillthis="histD0P"+appendthis;
   //cout << fillthis << endl;
   cutsAnal->SetExcludedCut(10);
-  if ( ((cutsAnal->IsSelected(part,AliRDHFCuts::kCandidate))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
+  if ( ((cutsAnal->IsSelected(part,AliRDHFCuts::kCandidate,aod))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
     ((TH2F*)(fOutputAll->FindObject(fillthis)))->Fill(lambdacpt,part->Getd0Prong(0));
     if (isBachelorID)((TH2F*)(fOutputPIDBach->FindObject(fillthis)))->Fill(lambdacpt,part->Getd0Prong(0));
   }
@@ -4502,7 +4495,7 @@ void  AliAnalysisTaskSELc2V0bachelor::FillAnalysisHistograms(AliAODRecoCascadeHF
   fillthis="histCosPAK0S"+appendthis;
   //cout << fillthis << endl;
   cutsAnal->SetExcludedCut(9);
-  if ( ((cutsAnal->IsSelected(part,AliRDHFCuts::kCandidate))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
+  if ( ((cutsAnal->IsSelected(part,AliRDHFCuts::kCandidate,aod))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
     ((TH2F*)(fOutputAll->FindObject(fillthis)))->Fill(lambdacpt,part->CosV0PointingAngle());
     if (isBachelorID)((TH2F*)(fOutputPIDBach->FindObject(fillthis)))->Fill(lambdacpt,part->CosV0PointingAngle());
   }
@@ -4510,7 +4503,7 @@ void  AliAnalysisTaskSELc2V0bachelor::FillAnalysisHistograms(AliAODRecoCascadeHF
   fillthis="histCosThetaProtonCMS"+appendthis;
   //cout << fillthis << endl;
   cutsAnal->SetExcludedCut(16);
-  if ( ((cutsAnal->IsSelected(part,AliRDHFCuts::kCandidate))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
+  if ( ((cutsAnal->IsSelected(part,AliRDHFCuts::kCandidate,aod))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
     ((TH2F*)(fOutputAll->FindObject(fillthis)))->Fill(lambdacpt,cutsAnal->GetProtonEmissionAngleCMS(part));
     if (isBachelorID)((TH2F*)(fOutputPIDBach->FindObject(fillthis)))->Fill(lambdacpt,cutsAnal->GetProtonEmissionAngleCMS(part));
   }
@@ -4518,7 +4511,7 @@ void  AliAnalysisTaskSELc2V0bachelor::FillAnalysisHistograms(AliAODRecoCascadeHF
   fillthis="histResignedD0"+appendthis;
   //cout << fillthis << endl;
   cutsAnal->SetExcludedCut(18);
-  if ( ((cutsAnal->IsSelected(part,AliRDHFCuts::kCandidate))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
+  if ( ((cutsAnal->IsSelected(part,AliRDHFCuts::kCandidate,aod))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
     ((TH2F*)(fOutputAll->FindObject(fillthis)))->Fill(lambdacpt,cutsAnal->GetReSignedd0(part));
     if (isBachelorID)((TH2F*)(fOutputPIDBach->FindObject(fillthis)))->Fill(lambdacpt,cutsAnal->GetReSignedd0(part));
   }
@@ -4835,7 +4828,7 @@ Int_t AliAnalysisTaskSELc2V0bachelor::SearchForCommonMother(TClonesArray *mcArra
 
 }
 
-void AliAnalysisTaskSELc2V0bachelor::TrackRotation(AliRDHFCutsLctoV0 * cuts, AliAODRecoCascadeHF *part, TString appendthis)
+void AliAnalysisTaskSELc2V0bachelor::TrackRotation(AliRDHFCutsLctoV0 * cuts, AliAODRecoCascadeHF *part, TString appendthis, AliAODEvent *aod)
 {
 
   AliAODRecoCascadeHF *partCopy = new AliAODRecoCascadeHF(*part);
@@ -4853,7 +4846,7 @@ void AliAnalysisTaskSELc2V0bachelor::TrackRotation(AliRDHFCutsLctoV0 * cuts, Ali
 
   TString fillthis;
 
-  if ( ( ( (cuts->IsSelected(part,AliRDHFCuts::kAll))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) ) {
+  if ( ( ( (cuts->IsSelected(part,AliRDHFCuts::kAll,aod))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) ) {
     fillthis="hMassVsPtVsY"+appendthis;
     //cout << fillthis << endl;
     ((TH3F*)(fOutputPIDBachTR->FindObject(fillthis)))->Fill(mass,pt,rapid);
@@ -4882,7 +4875,7 @@ void AliAnalysisTaskSELc2V0bachelor::TrackRotation(AliRDHFCutsLctoV0 * cuts, Ali
     rapid = partCopy->Y(pdgD);
     //if(minv2>fMinMass*fMinMass && minv2<fMaxMass*fMaxMass){
     if ( cuts->IsInFiducialAcceptance(pt,partCopy->Y(4122)) ) {
-      if ( ((cuts->IsSelected(partCopy,AliRDHFCuts::kAll))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
+      if ( ((cuts->IsSelected(partCopy,AliRDHFCuts::kAll,aod))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
 
 	fillthis="histLcMassByK0S"+appendthis;
 	//cout << fillthis << endl;
@@ -4913,70 +4906,70 @@ void AliAnalysisTaskSELc2V0bachelor::TrackRotation(AliRDHFCutsLctoV0 * cuts, Ali
       fillthis="histptK0S"+appendthis;
       //cout << fillthis << endl;
       cuts->SetExcludedCut(15);
-      if ( ((cuts->IsSelected(partCopy,AliRDHFCuts::kAll))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
+      if ( ((cuts->IsSelected(partCopy,AliRDHFCuts::kAll,aod))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
 	((TH2F*)(fOutputPIDBachTR->FindObject(fillthis)))->Fill(pt,TMath::Sqrt(px[1]*px[1]+py[1]*py[1]));
       }
 
       fillthis="histptP"+appendthis;
       //cout << fillthis << endl;
       cuts->SetExcludedCut(4);
-      if ( ((cuts->IsSelected(partCopy,AliRDHFCuts::kAll))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
+      if ( ((cuts->IsSelected(partCopy,AliRDHFCuts::kAll,aod))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
 	((TH2F*)(fOutputPIDBachTR->FindObject(fillthis)))->Fill(pt,TMath::Sqrt(px[0]*px[0]+py[0]*py[0]));
       }
 
       fillthis="histptPip"+appendthis;
       //cout << fillthis << endl;
       cuts->SetExcludedCut(5);
-      if ( ((cuts->IsSelected(partCopy,AliRDHFCuts::kAll))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
+      if ( ((cuts->IsSelected(partCopy,AliRDHFCuts::kAll,aod))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
 	((TH2F*)(fOutputPIDBachTR->FindObject(fillthis)))->Fill(pt,(partCopy->Getv0PositiveTrack())->Pt());
       }
 
       fillthis="histptPim"+appendthis;
       //cout << fillthis << endl;
       cuts->SetExcludedCut(6);
-      if ( ((cuts->IsSelected(partCopy,AliRDHFCuts::kAll))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
+      if ( ((cuts->IsSelected(partCopy,AliRDHFCuts::kAll,aod))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
 	((TH2F*)(fOutputPIDBachTR->FindObject(fillthis)))->Fill(pt,(partCopy->Getv0NegativeTrack())->Pt());
       }
 
       fillthis="histLambdaMass"+appendthis;
       //cout << fillthis << endl;
       cuts->SetExcludedCut(13);
-      if ( ((cuts->IsSelected(partCopy,AliRDHFCuts::kAll))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
+      if ( ((cuts->IsSelected(partCopy,AliRDHFCuts::kAll,aod))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
 	((TH2F*)(fOutputPIDBachTR->FindObject(fillthis)))->Fill(pt,(partCopy->Getv0())->MassLambda());
       }
 
       fillthis="histLambdaBarMass"+appendthis;
       //cout << fillthis << endl;
       cuts->SetExcludedCut(13);
-      if ( ((cuts->IsSelected(partCopy,AliRDHFCuts::kAll))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
+      if ( ((cuts->IsSelected(partCopy,AliRDHFCuts::kAll,aod))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
 	((TH2F*)(fOutputPIDBachTR->FindObject(fillthis)))->Fill(pt,(partCopy->Getv0())->MassAntiLambda());
       }
 
       fillthis="histGammaMass"+appendthis;
       //cout << fillthis << endl;
       cuts->SetExcludedCut(14);
-      if ( ((cuts->IsSelected(partCopy,AliRDHFCuts::kAll))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
+      if ( ((cuts->IsSelected(partCopy,AliRDHFCuts::kAll,aod))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
 	((TH2F*)(fOutputPIDBachTR->FindObject(fillthis)))->Fill(pt,(partCopy->Getv0())->InvMass2Prongs(0,1,11,11));
       }
 
       fillthis="histCosPAK0S"+appendthis;
       //cout << fillthis << endl;
       cuts->SetExcludedCut(9);
-      if ( ((cuts->IsSelected(partCopy,AliRDHFCuts::kAll))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
+      if ( ((cuts->IsSelected(partCopy,AliRDHFCuts::kAll,aod))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
 	((TH2F*)(fOutputPIDBachTR->FindObject(fillthis)))->Fill(pt,partCopy->CosV0PointingAngle());
       }
 
       fillthis="histCosThetaProtonCMS"+appendthis;
       //cout << fillthis << endl;
       cuts->SetExcludedCut(16);
-      if ( ((cuts->IsSelected(partCopy,AliRDHFCuts::kAll))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
+      if ( ((cuts->IsSelected(partCopy,AliRDHFCuts::kAll,aod))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
         ((TH2F*)(fOutputPIDBachTR->FindObject(fillthis)))->Fill(pt,cuts->GetProtonEmissionAngleCMS(partCopy));
       }
 
       fillthis="histResignedD0"+appendthis;
       //cout << fillthis << endl;
       cuts->SetExcludedCut(18);
-      if ( ((cuts->IsSelected(partCopy,AliRDHFCuts::kAll))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
+      if ( ((cuts->IsSelected(partCopy,AliRDHFCuts::kAll,aod))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
         ((TH2F*)(fOutputPIDBach->FindObject(fillthis)))->Fill(pt,cuts->GetReSignedd0(partCopy));
       }
       cuts->SetExcludedCut(-1);

--- a/PWGHF/vertexingHF/AliAnalysisTaskSELc2V0bachelor.h
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSELc2V0bachelor.h
@@ -55,7 +55,7 @@ class AliAnalysisTaskSELc2V0bachelor : public AliAnalysisTaskSE
   /// histos
   void FillLc2pK0Sspectrum(AliAODRecoCascadeHF *part, Int_t isLc,
 			   Int_t &nSelectedAnal, AliRDHFCutsLctoV0 *cutsAnal,
-			   TClonesArray *mcArray, Int_t originLc);
+			   TClonesArray *mcArray, Int_t originLc, AliAODEvent *aod);
 
   void MakeAnalysisForLc2prK0S(AliAODEvent* aodEvent,TClonesArray *arrayLctopK0S,
 			       TClonesArray *mcArray,
@@ -125,7 +125,7 @@ class AliAnalysisTaskSELc2V0bachelor : public AliAnalysisTaskSE
   
   void CheckEventSelection(AliAODEvent *aodEvent);
   void CheckEventSelectionWithCandidates(AliAODEvent *aodEvent);
-  void CheckCandidatesAtDifferentLevels(AliAODRecoCascadeHF *part,AliRDHFCutsLctoV0* cutsAnal);
+  void CheckCandidatesAtDifferentLevels(AliAODRecoCascadeHF *part,AliRDHFCutsLctoV0* cutsAnal, AliAODEvent *aod);
   void FillTheTree(AliAODRecoCascadeHF *part, AliRDHFCutsLctoV0 *cutsAnal, TClonesArray *mcArray, Int_t isLc, Int_t originLc);
   void DefineTreeVariables();
 
@@ -138,8 +138,8 @@ class AliAnalysisTaskSELc2V0bachelor : public AliAnalysisTaskSE
   void DefineGeneralHistograms();
   void DefineK0SHistos();
   void DefineSignalHistosSeparatedPerOrigin();
-  void FillAnalysisHistograms(AliAODRecoCascadeHF *part, AliRDHFCutsLctoV0 *cutsAnal, TString appendthis);
-  void TrackRotation(AliRDHFCutsLctoV0 *cutsAnal, AliAODRecoCascadeHF *part, TString appendthis);
+  void FillAnalysisHistograms(AliAODRecoCascadeHF *part, AliRDHFCutsLctoV0 *cutsAnal, TString appendthis, AliAODEvent *aod);
+  void TrackRotation(AliRDHFCutsLctoV0 *cutsAnal, AliAODRecoCascadeHF *part, TString appendthis, AliAODEvent *aod);
 
   AliAnalysisTaskSELc2V0bachelor(const AliAnalysisTaskSELc2V0bachelor &source);
   AliAnalysisTaskSELc2V0bachelor& operator=(const AliAnalysisTaskSELc2V0bachelor& source); 

--- a/PWGHF/vertexingHF/AliAnalysisTaskSELc2V0bachelorTMVA.cxx
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSELc2V0bachelorTMVA.cxx
@@ -1165,7 +1165,7 @@ void AliAnalysisTaskSELc2V0bachelorTMVA::UserExec(Option_t *)
 
   Int_t nSelectedAnal = 0;
   if (fIsK0sAnalysis) {
-    MakeAnalysisForLc2prK0S(arrayLctopKos, mcArray,
+    MakeAnalysisForLc2prK0S(aodEvent, arrayLctopKos, mcArray,
 			    nSelectedAnal, fAnalCuts,
 			    array3Prong, mcHeader);
   }
@@ -1320,7 +1320,8 @@ void AliAnalysisTaskSELc2V0bachelorTMVA::FillMCHisto(TClonesArray *mcArray){
 }
 
 //-------------------------------------------------------------------------------
-void AliAnalysisTaskSELc2V0bachelorTMVA::MakeAnalysisForLc2prK0S(TClonesArray *arrayLctopKos,
+void AliAnalysisTaskSELc2V0bachelorTMVA::MakeAnalysisForLc2prK0S(AliAODEvent *aodEvent,
+                 TClonesArray *arrayLctopKos,
 								 TClonesArray *mcArray,
 								 Int_t &nSelectedAnal,
 								 AliRDHFCutsLctoV0 *cutsAnal, TClonesArray *array3Prong,
@@ -1531,8 +1532,8 @@ void AliAnalysisTaskSELc2V0bachelorTMVA::MakeAnalysisForLc2prK0S(TClonesArray *a
       }
     }
 
-    //FillLc2pK0Sspectrum(lcK0spr, isLc, nSelectedAnal, cutsAnal, mcArray, iLctopK0s);
-    FillLc2pK0Sspectrum(lcK0spr, isLc, nSelectedAnal, cutsAnal, mcArray, mcLabel);
+    //FillLc2pK0Sspectrum(lcK0spr, isLc, nSelectedAnal, cutsAnal, mcArray, iLctopK0s, aodEvent);
+    FillLc2pK0Sspectrum(lcK0spr, isLc, nSelectedAnal, cutsAnal, mcArray, mcLabel, aodEvent);
 
 
   }
@@ -1545,7 +1546,7 @@ void AliAnalysisTaskSELc2V0bachelorTMVA::FillLc2pK0Sspectrum(AliAODRecoCascadeHF
 							     Int_t isLc,
 							     Int_t &nSelectedAnal,
 							     AliRDHFCutsLctoV0 *cutsAnal,
-							     TClonesArray *mcArray, Int_t iLctopK0s){
+							     TClonesArray *mcArray, Int_t iLctopK0s, AliAODEvent *aod){
   //
   /// Fill histos for Lc -> K0S+proton
   //
@@ -1600,7 +1601,7 @@ void AliAnalysisTaskSELc2V0bachelorTMVA::FillLc2pK0Sspectrum(AliAODRecoCascadeHF
     }
   }
 
-  Int_t isInV0window = (((cutsAnal->IsSelectedSingleCut(part, AliRDHFCuts::kCandidate, 2)) & (AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr)); // cut on V0 invMass
+  Int_t isInV0window = (((cutsAnal->IsSelectedSingleCut(part, AliRDHFCuts::kCandidate, 2, aod)) & (AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr)); // cut on V0 invMass
 
   if (isInV0window == 0) {
     AliDebug(2, "No: The candidate has NOT passed the V0 window cuts!");
@@ -1609,7 +1610,7 @@ void AliAnalysisTaskSELc2V0bachelorTMVA::FillLc2pK0Sspectrum(AliAODRecoCascadeHF
   }
   else AliDebug(2, "Yes: The candidate has passed the mass cuts!");
 
-  Bool_t isInCascadeWindow = (((cutsAnal->IsSelectedSingleCut(part, AliRDHFCuts::kCandidate, 0)) & (AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr)); // cut on Lc->p+K0S invMass
+  Bool_t isInCascadeWindow = (((cutsAnal->IsSelectedSingleCut(part, AliRDHFCuts::kCandidate, 0, aod)) & (AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr)); // cut on Lc->p+K0S invMass
 
   if (!isInCascadeWindow) {
     AliDebug(2, "No: The candidate has NOT passed the cascade window cuts!");
@@ -1618,8 +1619,8 @@ void AliAnalysisTaskSELc2V0bachelorTMVA::FillLc2pK0Sspectrum(AliAODRecoCascadeHF
   }
   else AliDebug(2, "Yes: The candidate has passed the cascade window cuts!");
 
-  Bool_t isCandidateSelectedCuts = (((cutsAnal->IsSelected(part, AliRDHFCuts::kCandidate)) & (AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr)); // kinematic/topological cuts
-  AliDebug(2, Form("recoAnalysisCuts = %d", cutsAnal->IsSelected(part, AliRDHFCuts::kCandidate) & (AliRDHFCutsLctoV0::kLcToK0Spr)));
+  Bool_t isCandidateSelectedCuts = (((cutsAnal->IsSelected(part, AliRDHFCuts::kCandidate, aod)) & (AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr)); // kinematic/topological cuts
+  AliDebug(2, Form("recoAnalysisCuts = %d", cutsAnal->IsSelected(part, AliRDHFCuts::kCandidate, aod) & (AliRDHFCutsLctoV0::kLcToK0Spr)));
   if (!isCandidateSelectedCuts){
     AliDebug(2, "No: Analysis cuts kCandidate level NOT passed");
     if (isLc) Printf("SIGNAL candidate rejected");
@@ -1635,7 +1636,7 @@ void AliAnalysisTaskSELc2V0bachelorTMVA::FillLc2pK0Sspectrum(AliAODRecoCascadeHF
     return;
   }
 
-  //Bool_t isBachelorID = (((cutsAnal->IsSelected(part,AliRDHFCuts::kPID))&(AliRDHFCutsLctoV0::kLcToK0Spr))==(AliRDHFCutsLctoV0::kLcToK0Spr)); // ID x bachelor
+  //Bool_t isBachelorID = (((cutsAnal->IsSelected(part,AliRDHFCuts::kPID, aod))&(AliRDHFCutsLctoV0::kLcToK0Spr))==(AliRDHFCutsLctoV0::kLcToK0Spr)); // ID x bachelor
   Double_t probTPCTOF[AliPID::kSPECIES]={-1.};
 
   UInt_t detUsed = fPIDCombined->ComputeProbabilities(bachelor, fPIDResponse, probTPCTOF);
@@ -1684,13 +1685,13 @@ void AliAnalysisTaskSELc2V0bachelorTMVA::FillLc2pK0Sspectrum(AliAODRecoCascadeHF
     return;
   }
 
-  if ( (((cutsAnal->IsSelected(part,AliRDHFCuts::kAll))&(AliRDHFCutsLctoV0::kLcToK0Spr))==(AliRDHFCutsLctoV0::kLcToK0Spr)) ) {
+  if ( (((cutsAnal->IsSelected(part,AliRDHFCuts::kAll, aod))&(AliRDHFCutsLctoV0::kLcToK0Spr))==(AliRDHFCutsLctoV0::kLcToK0Spr)) ) {
     nSelectedAnal++;
   }
 
   if ( !(cutsAnal->IsInFiducialAcceptance(part->Pt(),part->Y(4122))) ) return;
 
-  if ( !( ( (cutsAnal->IsSelected(part, AliRDHFCuts::kTracks)) & (AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) ) { // esd track cuts
+  if ( !( ( (cutsAnal->IsSelected(part, AliRDHFCuts::kTracks, aod)) & (AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) ) { // esd track cuts
     if (isLc) Printf("SIGNAL candidate rejected");
     AliDebug(2, "No: Analysis cuts kTracks level NOT passed");
     return;

--- a/PWGHF/vertexingHF/AliAnalysisTaskSELc2V0bachelorTMVA.h
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSELc2V0bachelorTMVA.h
@@ -86,9 +86,10 @@ class AliAnalysisTaskSELc2V0bachelorTMVA : public AliAnalysisTaskSE
   /// histos
   void FillLc2pK0Sspectrum(AliAODRecoCascadeHF *part, Int_t isLc,
 			   Int_t &nSelectedAnal, AliRDHFCutsLctoV0 *cutsAnal,
-			   TClonesArray *mcArray, Int_t iLctopK0s);
+			   TClonesArray *mcArray, Int_t iLctopK0s, AliAODEvent *aod);
 
-  void MakeAnalysisForLc2prK0S(TClonesArray *arrayLctopK0s,
+  void MakeAnalysisForLc2prK0S(AliAODEvent *aodEvent,
+             TClonesArray *arrayLctopK0s,
 			       TClonesArray *mcArray,
 			       Int_t &nSelectedAnal, AliRDHFCutsLctoV0 *cutsAnal, 
 			       TClonesArray *array3Prong, AliAODMCHeader *aodheader);

--- a/PWGHF/vertexingHF/AliAnalysisTaskSELc2V0bachelorTMVAApp.cxx
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSELc2V0bachelorTMVAApp.cxx
@@ -1695,8 +1695,8 @@ void AliAnalysisTaskSELc2V0bachelorTMVAApp::MakeAnalysisForLc2prK0S(AliAODEvent 
       }
     }
 
-    //FillLc2pK0Sspectrum(lcK0spr, isLc, nSelectedAnal, cutsAnal, mcArray, iLctopK0s);
-    FillLc2pK0Sspectrum(lcK0spr, isLc, nSelectedAnal, cutsAnal, mcArray, mcLabel);    
+    //FillLc2pK0Sspectrum(lcK0spr, isLc, nSelectedAnal, cutsAnal, mcArray, iLctopK0s, aodEvent);
+    FillLc2pK0Sspectrum(lcK0spr, isLc, nSelectedAnal, cutsAnal, mcArray, mcLabel, aodEvent);
   }
   
   delete vHF;
@@ -1709,7 +1709,7 @@ void AliAnalysisTaskSELc2V0bachelorTMVAApp::FillLc2pK0Sspectrum(AliAODRecoCascad
 							     Int_t isLc,
 							     Int_t &nSelectedAnal,
 							     AliRDHFCutsLctoV0 *cutsAnal,
-							     TClonesArray *mcArray, Int_t iLctopK0s){
+							     TClonesArray *mcArray, Int_t iLctopK0s, AliAODEvent *aod){
   //
   /// Fill histos for Lc -> K0S+proton
   //
@@ -1763,7 +1763,7 @@ void AliAnalysisTaskSELc2V0bachelorTMVAApp::FillLc2pK0Sspectrum(AliAODRecoCascad
     }
   }
 
-  Int_t isInV0window = (((cutsAnal->IsSelectedSingleCut(part, AliRDHFCuts::kCandidate, 2)) & (AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr)); // cut on V0 invMass
+  Int_t isInV0window = (((cutsAnal->IsSelectedSingleCut(part, AliRDHFCuts::kCandidate, 2, aod)) & (AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr)); // cut on V0 invMass
 
   if (isInV0window == 0) {
     AliDebug(2, "No: The candidate has NOT passed the V0 window cuts!");
@@ -1772,7 +1772,7 @@ void AliAnalysisTaskSELc2V0bachelorTMVAApp::FillLc2pK0Sspectrum(AliAODRecoCascad
   }
   else AliDebug(2, "Yes: The candidate has passed the mass cuts!");  
 
-  Bool_t isInCascadeWindow = (((cutsAnal->IsSelectedSingleCut(part, AliRDHFCuts::kCandidate, 0)) & (AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr)); // cut on Lc->p+K0S invMass
+  Bool_t isInCascadeWindow = (((cutsAnal->IsSelectedSingleCut(part, AliRDHFCuts::kCandidate, 0, aod)) & (AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr)); // cut on Lc->p+K0S invMass
 
   if (!isInCascadeWindow) {
     AliDebug(2, "No: The candidate has NOT passed the cascade window cuts!");
@@ -1781,8 +1781,8 @@ void AliAnalysisTaskSELc2V0bachelorTMVAApp::FillLc2pK0Sspectrum(AliAODRecoCascad
   }
   else AliDebug(2, "Yes: The candidate has passed the cascade window cuts!");
 
-  Bool_t isCandidateSelectedCuts = (((cutsAnal->IsSelected(part, AliRDHFCuts::kCandidate)) & (AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr)); // kinematic/topological cuts
-  AliDebug(2, Form("recoAnalysisCuts = %d", cutsAnal->IsSelected(part, AliRDHFCuts::kCandidate) & (AliRDHFCutsLctoV0::kLcToK0Spr)));
+  Bool_t isCandidateSelectedCuts = (((cutsAnal->IsSelected(part, AliRDHFCuts::kCandidate, aod)) & (AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr)); // kinematic/topological cuts
+  AliDebug(2, Form("recoAnalysisCuts = %d", cutsAnal->IsSelected(part, AliRDHFCuts::kCandidate, aod) & (AliRDHFCutsLctoV0::kLcToK0Spr)));
   if (!isCandidateSelectedCuts){
     AliDebug(2, "No: Analysis cuts kCandidate level NOT passed");
     if (isLc) AliDebug(2, "SIGNAL candidate rejected");
@@ -1798,7 +1798,7 @@ void AliAnalysisTaskSELc2V0bachelorTMVAApp::FillLc2pK0Sspectrum(AliAODRecoCascad
     return;
   }
 
-  //Bool_t isBachelorID = (((cutsAnal->IsSelected(part,AliRDHFCuts::kPID))&(AliRDHFCutsLctoV0::kLcToK0Spr))==(AliRDHFCutsLctoV0::kLcToK0Spr)); // ID x bachelor
+  //Bool_t isBachelorID = (((cutsAnal->IsSelected(part,AliRDHFCuts::kPID, aod))&(AliRDHFCutsLctoV0::kLcToK0Spr))==(AliRDHFCutsLctoV0::kLcToK0Spr)); // ID x bachelor
   Double_t probTPCTOF[AliPID::kSPECIES] = {-1.};
 
   UInt_t detUsed = fPIDCombined->ComputeProbabilities(bachelor, fPIDResponse, probTPCTOF);
@@ -1847,13 +1847,13 @@ void AliAnalysisTaskSELc2V0bachelorTMVAApp::FillLc2pK0Sspectrum(AliAODRecoCascad
     return;
   }
 
-  if ( (((cutsAnal->IsSelected(part,AliRDHFCuts::kAll)) & (AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr)) ) {
+  if ( (((cutsAnal->IsSelected(part,AliRDHFCuts::kAll, aod)) & (AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr)) ) {
     nSelectedAnal++;
   }
 
   if ( !(cutsAnal->IsInFiducialAcceptance(part->Pt(), part->Y(4122))) ) return;
 
-  if ( !( ( (cutsAnal->IsSelected(part, AliRDHFCuts::kTracks)) & (AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) ) { // esd track cuts
+  if ( !( ( (cutsAnal->IsSelected(part, AliRDHFCuts::kTracks, aod)) & (AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) ) { // esd track cuts
     if (isLc) AliDebug(2, "SIGNAL candidate rejected");
     AliDebug(2, "No: Analysis cuts kTracks level NOT passed");
     return;

--- a/PWGHF/vertexingHF/AliAnalysisTaskSELc2V0bachelorTMVAApp.h
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSELc2V0bachelorTMVAApp.h
@@ -89,7 +89,7 @@ class AliAnalysisTaskSELc2V0bachelorTMVAApp : public AliAnalysisTaskSE
   /// histos
   void FillLc2pK0Sspectrum(AliAODRecoCascadeHF *part, Int_t isLc,
 			   Int_t &nSelectedAnal, AliRDHFCutsLctoV0 *cutsAnal,
-			   TClonesArray *mcArray, Int_t iLctopK0s);
+			   TClonesArray *mcArray, Int_t iLctopK0s, AliAODEvent *aod);
 
   void MakeAnalysisForLc2prK0S(AliAODEvent *aodEvent,
 			       TClonesArray *arrayLctopK0s,

--- a/PWGHF/vertexingHF/AliRDHFCutsLctoV0.cxx
+++ b/PWGHF/vertexingHF/AliRDHFCutsLctoV0.cxx
@@ -271,7 +271,7 @@ AliRDHFCutsLctoV0::~AliRDHFCutsLctoV0() {
 }
 
 //---------------------------------------------------------------------------
-void AliRDHFCutsLctoV0::GetCutVarsForOpt(AliAODRecoDecayHF *d,Float_t *vars,Int_t nvars,Int_t *pdgdaughters) {
+void AliRDHFCutsLctoV0::GetCutVarsForOpt(AliAODRecoDecayHF *d,Float_t *vars,Int_t nvars,Int_t *pdgdaughters, AliAODEvent *aod) {
   //
   // Fills in vars the values of the variables
   //
@@ -288,6 +288,18 @@ void AliRDHFCutsLctoV0::GetCutVarsForOpt(AliAODRecoDecayHF *d,Float_t *vars,Int_
   Double_t mLPDG   = TDatabasePDG::Instance()->GetParticle(3122)->Mass();
 
   AliAODRecoCascadeHF *dd = (AliAODRecoCascadeHF*)d;
+
+  //recalculate vertex w/o daughters
+  Bool_t cleanvtx=kFALSE;
+  AliAODVertex *origownvtx=0x0;
+  if(fRemoveDaughtersFromPrimary && aod) {
+    if(dd->GetOwnPrimaryVtx()) origownvtx=new AliAODVertex(*dd->GetOwnPrimaryVtx());
+    cleanvtx=kTRUE;
+    if(!RecalcOwnPrimaryVtx(dd,aod)) {
+      CleanOwnPrimaryVtx(dd,aod,origownvtx);
+      cleanvtx=kFALSE;
+    }
+  }
 
   // Get the v0 and all daughter tracks
   AliAODTrack *bachelorTrack = (AliAODTrack*)dd->GetBachelor();
@@ -430,7 +442,7 @@ void AliRDHFCutsLctoV0::GetCutVarsForOpt(AliAODRecoDecayHF *d,Float_t *vars,Int_
     vars[iter]= v0->PtArmV0()/TMath::Abs(v0->AlphaV0());
   }
 
-
+  if(cleanvtx) CleanOwnPrimaryVtx(dd,aod,origownvtx);
   return;
 }
 //---------------------------------------------------------------------------
@@ -526,6 +538,19 @@ Int_t AliRDHFCutsLctoV0::IsSelected(TObject* obj,Int_t selectionLevel, AliAODEve
   if (selectionLevel==AliRDHFCuts::kAll ||
       selectionLevel==AliRDHFCuts::kCandidate) {
 
+    //recalculate vertex w/o daughters
+    Bool_t cleanvtx=kFALSE;
+    AliAODVertex *origownvtx=0x0;
+    if(fRemoveDaughtersFromPrimary && aod) {
+      if(d->GetOwnPrimaryVtx()) origownvtx=new AliAODVertex(*d->GetOwnPrimaryVtx());
+      cleanvtx=kTRUE;
+      if(!RecalcOwnPrimaryVtx(d,aod)) {
+        CleanOwnPrimaryVtx(d,aod,origownvtx);
+        cleanvtx=kFALSE;
+        return 0;
+      }
+    }
+
     Double_t pt = d->Pt();
     Int_t ptbin = PtBin(pt);
 
@@ -580,19 +605,22 @@ Int_t AliRDHFCutsLctoV0::IsSelected(TObject* obj,Int_t selectionLevel, AliAODEve
     // cut on K0S invariant mass veto
     if (TMath::Abs(v0->MassK0Short()-mk0sPDG) < fCutsRD[GetGlobalIndex(12,ptbin)] && fExcludedCut!=12) { // K0S invariant mass veto
       AliDebug(4,Form(" veto on K0S invariant mass doesn't pass the cut"));
-      //return 0;
       isNotK0S=kFALSE;
+      //if(cleanvtx) CleanOwnPrimaryVtx(d,aod,origownvtx);
+      //return 0;
     }
 
     // cut on Lambda/LambdaBar invariant mass veto
     if (TMath::Abs(v0->MassLambda()-mLPDG) < fCutsRD[GetGlobalIndex(13,ptbin)] && fExcludedCut!=13) { // Lambda invariant mass veto
       AliDebug(4,Form(" veto on Lambda invariant mass doesn't pass the cut"));
       isNotLambda=kFALSE;
+      //if(cleanvtx) CleanOwnPrimaryVtx(d,aod,origownvtx);
       //return 0;
     }
     if (TMath::Abs(v0->MassAntiLambda()-mLPDG) < fCutsRD[GetGlobalIndex(13,ptbin)] && fExcludedCut!=13) { // LambdaBar invariant mass veto
       AliDebug(4,Form(" veto on LambdaBar invariant mass doesn't pass the cut"));
       isNotLambdaBar=kFALSE;
+      //if(cleanvtx) CleanOwnPrimaryVtx(d,aod,origownvtx);
       //return 0;
     }
 
@@ -600,6 +628,7 @@ Int_t AliRDHFCutsLctoV0::IsSelected(TObject* obj,Int_t selectionLevel, AliAODEve
     if (v0->InvMass2Prongs(0,1,11,11) < fCutsRD[GetGlobalIndex(14,ptbin)] && fExcludedCut!=14) { // K0S invariant mass veto
       AliDebug(4,Form(" veto on gamma invariant mass doesn't pass the cut"));
       isNotGamma=kFALSE;
+      //if(cleanvtx) CleanOwnPrimaryVtx(d,aod,origownvtx);
       //return 0;
     }
 
@@ -607,55 +636,67 @@ Int_t AliRDHFCutsLctoV0::IsSelected(TObject* obj,Int_t selectionLevel, AliAODEve
     okLcLpi    = okLcLpi    && okLppi    && isNotK0S    && isNotLambdaBar && isNotGamma;
     okLcLBarpi = okLcLBarpi && okLBarpip && isNotK0S    && isNotLambda    && isNotGamma;
 
-    if (!okLck0sp && !okLcLpi && !okLcLBarpi) return 0;
+    if (!okLck0sp && !okLcLpi && !okLcLBarpi){
+      if(cleanvtx) CleanOwnPrimaryVtx(d,aod,origownvtx);
+      return 0;
+    }
 
     // cuts on the minimum pt of the tracks
     if (TMath::Abs(bachelorTrack->Pt()) < fCutsRD[GetGlobalIndex(4,ptbin)] && fExcludedCut!=4) {
       AliDebug(4,Form(" bachelor track Pt=%2.2e > %2.2e",bachelorTrack->Pt(),fCutsRD[GetGlobalIndex(4,ptbin)]));
+      if(cleanvtx) CleanOwnPrimaryVtx(d,aod,origownvtx);
       return 0;
     }
     if (TMath::Abs(v0positiveTrack->Pt()) < fCutsRD[GetGlobalIndex(5,ptbin)] && fExcludedCut!=5) {
       AliDebug(4,Form(" V0-positive track Pt=%2.2e > %2.2e",v0positiveTrack->Pt(),fCutsRD[GetGlobalIndex(5,ptbin)]));
+      if(cleanvtx) CleanOwnPrimaryVtx(d,aod,origownvtx);
       return 0;
     }
     if (TMath::Abs(v0negativeTrack->Pt()) < fCutsRD[GetGlobalIndex(6,ptbin)] && fExcludedCut!=6) {
       AliDebug(4,Form(" V0-negative track Pt=%2.2e > %2.2e",v0negativeTrack->Pt(),fCutsRD[GetGlobalIndex(6,ptbin)]));
+      if(cleanvtx) CleanOwnPrimaryVtx(d,aod,origownvtx);
       return 0;
     }
 
     // cut on cascade dca (prong-to-prong)
     if ( TMath::Abs(d->GetDCA()) > fCutsRD[GetGlobalIndex(7,ptbin)] && fExcludedCut!=7) { // prong-to-prong cascade DCA
       AliDebug(4,Form(" cascade tracks DCA don't pass the cut"));
+      if(cleanvtx) CleanOwnPrimaryVtx(d,aod,origownvtx);
       return 0;
     }
 
     // cut on V0 dca (prong-to-prong)
     if ( TMath::Abs(v0->GetDCA()) > fCutsRD[GetGlobalIndex(8,ptbin)] && fExcludedCut!=8) { // prong-to-prong V0 DCA
       AliDebug(4,Form(" V0 DCA don't pass the cut"));
+      if(cleanvtx) CleanOwnPrimaryVtx(d,aod,origownvtx);
       return 0;
     }
 
     // cut on V0 cosine of pointing angle wrt PV
     if (d->CosV0PointingAngle() < fCutsRD[GetGlobalIndex(9,ptbin)] && fExcludedCut!=9) { // cosine of V0 pointing angle wrt primary vertex
       AliDebug(4,Form(" V0 cosine of pointing angle doesn't pass the cut"));
+      if(cleanvtx) CleanOwnPrimaryVtx(d,aod,origownvtx);
       return 0;
     }
 
     // cut on bachelor transverse impact parameter wrt PV
     if (TMath::Abs(d->Getd0Prong(0)) > fCutsRD[GetGlobalIndex(10,ptbin)] && fExcludedCut!=10) { // bachelor transverse impact parameter wrt PV
       AliDebug(4,Form(" bachelor transverse impact parameter doesn't pass the cut"));
+      if(cleanvtx) CleanOwnPrimaryVtx(d,aod,origownvtx);
       return 0;
     }
 
     // cut on V0 transverse impact parameter wrt PV
     if (TMath::Abs(d->Getd0Prong(1)) > fCutsRD[GetGlobalIndex(11,ptbin)] && fExcludedCut!=11) { // V0 transverse impact parameter wrt PV
       AliDebug(4,Form(" V0 transverse impact parameter doesn't pass the cut"));
+      if(cleanvtx) CleanOwnPrimaryVtx(d,aod,origownvtx);
       return 0;
     }
 
     // cut on V0 pT min
     if (v0->Pt() < fCutsRD[GetGlobalIndex(15,ptbin)] && fExcludedCut!=15) { // V0 pT min
       AliDebug(4,Form(" V0 track Pt=%2.2e > %2.2e",v0->Pt(),fCutsRD[GetGlobalIndex(15,ptbin)]));
+      if(cleanvtx) CleanOwnPrimaryVtx(d,aod,origownvtx);
       return 0;
     }
 
@@ -664,10 +705,12 @@ Int_t AliRDHFCutsLctoV0::IsSelected(TObject* obj,Int_t selectionLevel, AliAODEve
       Double_t cutvar = GetProtonEmissionAngleCMS(d);
       if (cutvar > fCutsRD[GetGlobalIndex(16,ptbin)] && fExcludedCut!=16 && fExcludedCut!=17) { // Proton emission angle
         AliDebug(4,Form(" Cos proton emission=%2.2e < %2.2e",cutvar,fCutsRD[GetGlobalIndex(16,ptbin)]));
+        if(cleanvtx) CleanOwnPrimaryVtx(d,aod,origownvtx);
         return 0;
       }
       if (cutvar < fCutsRD[GetGlobalIndex(17,ptbin)] && fExcludedCut!=16 && fExcludedCut!=17) { // Proton emission angle
         AliDebug(4,Form(" Cos proton emission=%2.2e > %2.2e",cutvar,fCutsRD[GetGlobalIndex(17,ptbin)]));
+        if(cleanvtx) CleanOwnPrimaryVtx(d,aod,origownvtx);
         return 0;
       }
     }
@@ -677,6 +720,7 @@ Int_t AliRDHFCutsLctoV0::IsSelected(TObject* obj,Int_t selectionLevel, AliAODEve
       Double_t cutvar = GetReSignedd0(d) ;
       if (cutvar< fCutsRD[GetGlobalIndex(18,ptbin)] && fExcludedCut!=18) { // proton d0
         AliDebug(4,Form(" Proton d0 (re-signed)=%2.2e > %2.2e",cutvar,fCutsRD[GetGlobalIndex(18,ptbin)]));
+        if(cleanvtx) CleanOwnPrimaryVtx(d,aod,origownvtx);
         return 0;
       }
     }
@@ -686,10 +730,12 @@ Int_t AliRDHFCutsLctoV0::IsSelected(TObject* obj,Int_t selectionLevel, AliAODEve
       Double_t cutvar = v0->PtArmV0()/TMath::Abs(v0->AlphaV0());
       if (cutvar < fCutsRD[GetGlobalIndex(19,ptbin)] && fExcludedCut!=19) { // v0 armenteros variable
         AliDebug(4,Form(" qT/|alpha|=%2.2e > %2.2e",cutvar,fCutsRD[GetGlobalIndex(19,ptbin)]));
+        if(cleanvtx) CleanOwnPrimaryVtx(d,aod,origownvtx);
         return 0;
       }
     }
 
+    if(cleanvtx) CleanOwnPrimaryVtx(d,aod,origownvtx);
   }
 
   Int_t returnvalue = okLck0sp+2*okLcLBarpi+4*okLcLpi;
@@ -1343,6 +1389,19 @@ Int_t AliRDHFCutsLctoV0::IsSelectedSingleCut(TObject* obj, Int_t selectionLevel,
   if (selectionLevel==AliRDHFCuts::kAll ||
       selectionLevel==AliRDHFCuts::kCandidate) {
 
+    //recalculate vertex w/o daughters
+    Bool_t cleanvtx=kFALSE;
+    AliAODVertex *origownvtx=0x0;
+    if(fRemoveDaughtersFromPrimary && aod) {
+      if(d->GetOwnPrimaryVtx()) origownvtx=new AliAODVertex(*d->GetOwnPrimaryVtx());
+      cleanvtx=kTRUE;
+      if(!RecalcOwnPrimaryVtx(d,aod)) {
+        CleanOwnPrimaryVtx(d,aod,origownvtx);
+        cleanvtx=kFALSE;
+        return 0;
+      }
+    }
+
     Double_t pt = d->Pt();
     Int_t ptbin = PtBin(pt);
 
@@ -1477,6 +1536,7 @@ Int_t AliRDHFCutsLctoV0::IsSelectedSingleCut(TObject* obj, Int_t selectionLevel,
       okLcLBarpi = okLck0sp;
       break;
     }
+    if(cleanvtx) CleanOwnPrimaryVtx(d,aod,origownvtx);
   }
 
   Int_t returnvalue = okLck0sp+2*okLcLBarpi+4*okLcLpi;

--- a/PWGHF/vertexingHF/AliRDHFCutsLctoV0.h
+++ b/PWGHF/vertexingHF/AliRDHFCutsLctoV0.h
@@ -43,7 +43,10 @@ class AliRDHFCutsLctoV0 : public AliRDHFCuts
   AliRDHFCutsLctoV0& operator=(const AliRDHFCutsLctoV0& source);
 
   using AliRDHFCuts::GetCutVarsForOpt;
-  virtual void GetCutVarsForOpt(AliAODRecoDecayHF *d,Float_t *vars,Int_t nvars,Int_t *pdgdaughters);
+  virtual void GetCutVarsForOpt(AliAODRecoDecayHF *d,Float_t *vars,Int_t nvars,Int_t *pdgdaughters){
+    return GetCutVarsForOpt(d,vars,nvars,pdgdaughters,0x0);
+  }
+  virtual void GetCutVarsForOpt(AliAODRecoDecayHF *d,Float_t *vars,Int_t nvars,Int_t *pdgdaughters,AliAODEvent *aod);
 
   using AliRDHFCuts::IsSelected;
   virtual Int_t IsSelected(TObject* obj,Int_t selectionLevel)

--- a/PWGHF/vertexingHF/AliRDHFCutsLctopKpi.cxx
+++ b/PWGHF/vertexingHF/AliRDHFCutsLctopKpi.cxx
@@ -176,6 +176,18 @@ void AliRDHFCutsLctopKpi::GetCutVarsForOpt(AliAODRecoDecayHF *d,Float_t *vars,In
 
   AliAODRecoDecayHF3Prong *dd = (AliAODRecoDecayHF3Prong*)d;
 
+  //recalculate vertex w/o daughters
+  Bool_t cleanvtx=kFALSE;
+  AliAODVertex *origownvtx=0x0;
+  if(fRemoveDaughtersFromPrimary && aod) {
+    if(dd->GetOwnPrimaryVtx()) origownvtx=new AliAODVertex(*dd->GetOwnPrimaryVtx());
+    cleanvtx=kTRUE;
+    if(!RecalcOwnPrimaryVtx(dd,aod)) {
+      CleanOwnPrimaryVtx(dd,aod,origownvtx);
+      cleanvtx=kFALSE;
+    }
+  }
+
   Int_t iter=-1;
   if(fVarsForOpt[0]){
     iter++;
@@ -254,6 +266,7 @@ void AliRDHFCutsLctopKpi::GetCutVarsForOpt(AliAODRecoDecayHF *d,Float_t *vars,In
     }
   }
 
+  if(cleanvtx) CleanOwnPrimaryVtx(dd,aod,origownvtx);
   return;
 }
 //---------------------------------------------------------------------------
@@ -338,6 +351,19 @@ Int_t AliRDHFCutsLctopKpi::IsSelected(TObject* obj,Int_t selectionLevel,AliAODEv
   if(selectionLevel==AliRDHFCuts::kAll || 
      selectionLevel==AliRDHFCuts::kCandidate) {
 
+    //recalculate vertex w/o daughters
+    Bool_t cleanvtx=kFALSE;
+    AliAODVertex *origownvtx=0x0;
+    if(fRemoveDaughtersFromPrimary && aod) {
+      if(d->GetOwnPrimaryVtx()) origownvtx=new AliAODVertex(*d->GetOwnPrimaryVtx());
+      cleanvtx=kTRUE;
+      if(!RecalcOwnPrimaryVtx(d,aod)) {
+        CleanOwnPrimaryVtx(d,aod,origownvtx);
+        cleanvtx=kFALSE;
+        return 0;
+      }
+    }
+
     Double_t pt=d->Pt();
     
     Int_t ptbin=PtBin(pt);
@@ -349,35 +375,35 @@ Int_t AliRDHFCutsLctopKpi::IsSelected(TObject* obj,Int_t selectionLevel,AliAODEv
   switch (fCutsStrategy) {
 
     case kStandard:
-    if(d->GetSigmaVert(aod)>fCutsRD[GetGlobalIndex(6,ptbin)]) return 0;
+    if(d->GetSigmaVert(aod)>fCutsRD[GetGlobalIndex(6,ptbin)]){ if(cleanvtx){ CleanOwnPrimaryVtx(d,aod,origownvtx); } return 0; }
     //DCA
-    for(Int_t i=0;i<3;i++) if(d->GetDCA(i)>fCutsRD[GetGlobalIndex(11,ptbin)]) return 0;
-    if(TMath::Abs(d->PtProng(1)) < fCutsRD[GetGlobalIndex(1,ptbin)] || TMath::Abs(d->Getd0Prong(1))<fCutsRD[GetGlobalIndex(3,ptbin)]) return 0;//Kaon
-    if(d->Pt()>=3. && d->PProng(1)<0.55) return 0;
+    for(Int_t i=0;i<3;i++){ if(d->GetDCA(i)>fCutsRD[GetGlobalIndex(11,ptbin)]){ if(cleanvtx){ CleanOwnPrimaryVtx(d,aod,origownvtx); } return 0; } }
+    if(TMath::Abs(d->PtProng(1)) < fCutsRD[GetGlobalIndex(1,ptbin)] || TMath::Abs(d->Getd0Prong(1))<fCutsRD[GetGlobalIndex(3,ptbin)]){ if(cleanvtx){ CleanOwnPrimaryVtx(d,aod,origownvtx); } return 0; }//Kaon
+    if(d->Pt()>=3. && d->PProng(1)<0.55){ if(cleanvtx){ CleanOwnPrimaryVtx(d,aod,origownvtx); } return 0; }
     if(fUseSpecialCut) {
       if(TMath::Abs(d->PtProng(0)) < TMath::Abs(d->PtProng(2)) )okLcpKpi=0;
       if(TMath::Abs(d->PtProng(2)) < TMath::Abs(d->PtProng(0)) )okLcpiKp=0;
     }
     if((TMath::Abs(d->PtProng(0)) < fCutsRD[GetGlobalIndex(2,ptbin)]) || (TMath::Abs(d->PtProng(2)) < fCutsRD[GetGlobalIndex(12,ptbin)])) okLcpKpi=0;
     if((TMath::Abs(d->PtProng(2)) < fCutsRD[GetGlobalIndex(2,ptbin)]) || (TMath::Abs(d->PtProng(0)) < fCutsRD[GetGlobalIndex(12,ptbin)]))okLcpiKp=0;
-    if(!okLcpKpi && !okLcpiKp) return 0;
+    if(!okLcpKpi && !okLcpiKp){ if(cleanvtx){ CleanOwnPrimaryVtx(d,aod,origownvtx); } return 0; }
     //2track cuts
-    if(d->GetDist12toPrim()<fCutsRD[GetGlobalIndex(5,ptbin)]|| d->GetDist23toPrim()<fCutsRD[GetGlobalIndex(5,ptbin)]) return 0;
-    if(d->GetDist12toPrim()>fMaxDistanceSecPrimVertex) return 0;
-    if(d->GetDist23toPrim()>fMaxDistanceSecPrimVertex) return 0;
+    if(d->GetDist12toPrim()<fCutsRD[GetGlobalIndex(5,ptbin)]|| d->GetDist23toPrim()<fCutsRD[GetGlobalIndex(5,ptbin)]){ if(cleanvtx){ CleanOwnPrimaryVtx(d,aod,origownvtx); } return 0; }
+    if(d->GetDist12toPrim()>fMaxDistanceSecPrimVertex){ if(cleanvtx){ CleanOwnPrimaryVtx(d,aod,origownvtx); } return 0; }
+    if(d->GetDist23toPrim()>fMaxDistanceSecPrimVertex){ if(cleanvtx){ CleanOwnPrimaryVtx(d,aod,origownvtx); } return 0; }
     if(fUseImpParProdCorrCut){
-      if(d->Getd0Prong(0)*d->Getd0Prong(1)<0. && d->Getd0Prong(2)*d->Getd0Prong(1)<0.) return 0;
+      if(d->Getd0Prong(0)*d->Getd0Prong(1)<0. && d->Getd0Prong(2)*d->Getd0Prong(1)<0.){ if(cleanvtx){ CleanOwnPrimaryVtx(d,aod,origownvtx); } return 0; }
     }
     //sec vert
-    if(d->DecayLength()<fCutsRD[GetGlobalIndex(7,ptbin)]) return 0;
-    if(d->DecayLength()>fMaxDistanceSecPrimVertex) return 0;
+    if(d->DecayLength()<fCutsRD[GetGlobalIndex(7,ptbin)]){ if(cleanvtx){ CleanOwnPrimaryVtx(d,aod,origownvtx); } return 0; }
+    if(d->DecayLength()>fMaxDistanceSecPrimVertex){ if(cleanvtx){ CleanOwnPrimaryVtx(d,aod,origownvtx); } return 0; }
 
   //  Double_t sumd0s=d->Getd0Prong(0)*d->Getd0Prong(0)+d->Getd0Prong(1)*d->Getd0Prong(1)+d->Getd0Prong(2)*d->Getd0Prong(2);
-  //  if(sumd0s<fCutsRD[GetGlobalIndex(10,ptbin)]) return 0;
-    if((d->Getd0Prong(0)*d->Getd0Prong(0)+d->Getd0Prong(1)*d->Getd0Prong(1)+d->Getd0Prong(2)*d->Getd0Prong(2))<fCutsRD[GetGlobalIndex(10,ptbin)]) return 0;
+  //  if(sumd0s<fCutsRD[GetGlobalIndex(10,ptbin)]){ if(cleanvtx){ CleanOwnPrimaryVtx(d,aod,origownvtx); } return 0; }
+    if((d->Getd0Prong(0)*d->Getd0Prong(0)+d->Getd0Prong(1)*d->Getd0Prong(1)+d->Getd0Prong(2)*d->Getd0Prong(2))<fCutsRD[GetGlobalIndex(10,ptbin)]){ if(cleanvtx){ CleanOwnPrimaryVtx(d,aod,origownvtx); } return 0; }
     
-    if(TMath::Abs(d->PtProng(0))<fCutsRD[GetGlobalIndex(8,ptbin)] && TMath::Abs(d->PtProng(1))<fCutsRD[GetGlobalIndex(8,ptbin)] && TMath::Abs(d->PtProng(2))<fCutsRD[GetGlobalIndex(8,ptbin)]) return 0;
-    if(d->CosPointingAngle()< fCutsRD[GetGlobalIndex(9,ptbin)]) return 0;
+    if(TMath::Abs(d->PtProng(0))<fCutsRD[GetGlobalIndex(8,ptbin)] && TMath::Abs(d->PtProng(1))<fCutsRD[GetGlobalIndex(8,ptbin)] && TMath::Abs(d->PtProng(2))<fCutsRD[GetGlobalIndex(8,ptbin)]){ if(cleanvtx){ CleanOwnPrimaryVtx(d,aod,origownvtx); } return 0; }
+    if(d->CosPointingAngle()< fCutsRD[GetGlobalIndex(9,ptbin)]){ if(cleanvtx){ CleanOwnPrimaryVtx(d,aod,origownvtx); } return 0; }
     
 
     break;
@@ -400,7 +426,7 @@ Int_t AliRDHFCutsLctopKpi::IsSelected(TObject* obj,Int_t selectionLevel,AliAODEv
 
       pdgs[0]=211;pdgs[2]=2212;
       AliKFParticle *lc2=ReconstructKF(d,pdgs,field,constraint);
-      if(!lc2){ 
+      if(!lc2){
 	okLcpiKp=0;
       }else{
 	if(lc2->GetChi2()/lc2->GetNDF()>fCutsRD[GetGlobalIndex(2,ptbin)])okLcpiKp=0; 
@@ -417,12 +443,13 @@ Int_t AliRDHFCutsLctopKpi::IsSelected(TObject* obj,Int_t selectionLevel,AliAODEv
 
     if(TMath::Abs(mLcpKpi-mLcPDG)>fCutsRD[GetGlobalIndex(0,ptbin)]) okLcpKpi = 0;
     if(TMath::Abs(mLcpiKp-mLcPDG)>fCutsRD[GetGlobalIndex(0,ptbin)]) okLcpiKp = 0;
-    if(!okLcpKpi && !okLcpiKp) return 0;
+    if(!okLcpKpi && !okLcpiKp){ if(cleanvtx){ CleanOwnPrimaryVtx(d,aod,origownvtx); } return 0; }
 
     if(okLcpKpi) returnvalue=1; //cuts passed as Lc->pKpi
     if(okLcpiKp) returnvalue=2; //cuts passed as Lc->piKp
     if(okLcpKpi && okLcpiKp) returnvalue=3; //cuts passed as both pKpi and piKp
    
+    if(cleanvtx) CleanOwnPrimaryVtx(d,aod,origownvtx);
   }
 
 
@@ -1491,7 +1518,7 @@ Bool_t AliRDHFCutsLctopKpi::PreSelectMass(TObjArray aodTracks){
     
     
   Bool_t recoLc=true;
-  Bool_t v, vv=false;
+  Bool_t v=false;
   Int_t chargeLc=0;
   //compute pt and charge
   Double_t px=0, py=0;

--- a/PWGHF/vertexingHF/macros/AddTaskDStarSpectra.C
+++ b/PWGHF/vertexingHF/macros/AddTaskDStarSpectra.C
@@ -18,7 +18,7 @@ AliAnalysisTaskSEDStarSpectra *AddTaskDStarSpectra(Int_t system=0/*0=pp,1=PbPb*/
 
 						   TString cutsfile="", TString usercomment = "username",
 
-						   Bool_t theMCon=kFALSE, Bool_t doDStarVsY=kFALSE)
+						   Bool_t theMCon=kFALSE, Bool_t doDStarVsY=kFALSE, TString cutsname = "DStartoKpipiCuts")
 
 {
 
@@ -79,7 +79,7 @@ AliAnalysisTaskSEDStarSpectra *AddTaskDStarSpectra(Int_t system=0/*0=pp,1=PbPb*/
   }
 
  else {
-    RDHFDStartoKpipi = (AliRDHFCutsDStartoKpipi*)filecuts->Get("DStartoKpipiCuts");
+    RDHFDStartoKpipi = (AliRDHFCutsDStartoKpipi*)filecuts->Get(cutsname.Data());
     if(minC!=0 && maxC!=0) { //if centrality 0 and 0 leave the values in the cut object
       RDHFDStartoKpipi->SetMinCentrality(minC);
       RDHFDStartoKpipi->SetMaxCentrality(maxC);

--- a/PWGHF/vertexingHF/macros/AddTaskLambdac.C
+++ b/PWGHF/vertexingHF/macros/AddTaskLambdac.C
@@ -121,13 +121,16 @@
 								     AliAnalysisManager::kOutputContainer,outputfile.Data());
   mgr->ConnectOutput(lambdacTask,4,coutputLambdacNev);
 
-  AliAnalysisDataContainer *coutputAPriori = mgr->CreateContainer(aPrioriname,TList::Class(),
+  if(priorsHists){
+    AliAnalysisDataContainer *coutputAPriori = mgr->CreateContainer(aPrioriname,TList::Class(),
 								  AliAnalysisManager::kOutputContainer,outputfile.Data());
-  mgr->ConnectOutput(lambdacTask,5,coutputAPriori);
-  AliAnalysisDataContainer *coutputMultiplicity = mgr->CreateContainer(multiplicityname,TList::Class(),
+    mgr->ConnectOutput(lambdacTask,5,coutputAPriori);
+  }
+  if(multiplicityHists){
+    AliAnalysisDataContainer *coutputMultiplicity = mgr->CreateContainer(multiplicityname,TList::Class(),
 								       AliAnalysisManager::kOutputContainer,outputfile.Data());
-  mgr->ConnectOutput(lambdacTask,6,coutputMultiplicity);
-
+    mgr->ConnectOutput(lambdacTask,6,coutputMultiplicity);
+  }
   AliAnalysisDataContainer *coutputLambdacNorm = mgr->CreateContainer(normname,AliNormalizationCounter::Class(),AliAnalysisManager::kOutputContainer,outputfile.Data());
 
  mgr->ConnectOutput(lambdacTask,7,coutputLambdacNorm);

--- a/PWGHF/vertexingHF/vHFML/AliAnalysisTaskSEDplus.cxx
+++ b/PWGHF/vertexingHF/vHFML/AliAnalysisTaskSEDplus.cxx
@@ -752,6 +752,7 @@ void AliAnalysisTaskSEDplus::UserCreateOutputObjects()
   }
 
   PostData(1, fOutput);
+  PostData(3, fCounter);
 
   //Create ML tree
   if (fCreateMLtree)


### PR DESCRIPTION
Small fixes to several HF tasks after a direct comparison of the output between the dedicated task, the DvsMultiplicity task, and HFTTreeCreator task. 

Should have no, or a negligible, impact on the ongoing/published analyses. Only when certain flags are enabled in cutobject (fRemoveDaughtersFromPrimary, fUseCutGeoNcrNcl) for Lc tasks, but these are disabled by default.