### PR TITLE
  PWGDQ EtaReconstruction Implemented looser primary track cuts before PreFilter

### DIFF
--- a/PWGDQ/dielectron/core/AliAnalysisTaskEtaReconstruction.cxx
+++ b/PWGDQ/dielectron/core/AliAnalysisTaskEtaReconstruction.cxx
@@ -95,7 +95,7 @@ AliAnalysisTaskEtaReconstruction::AliAnalysisTaskEtaReconstruction(): AliAnalysi
                                                                               , fLowerMassCutPrimaries(), fUpperMassCutPrimaries(), fMassCutSecondaries(), fUpperPreFilterMass(), fLowerPreFilterMass()
                                                                               , fSinglePrimaryLegMCSignal(), fSingleSecondaryLegMCSignal(), fPrimaryPairMCSignal(), fSecondaryPairMCSignal(), fFourPairMCSignal(), fPrimaryDielectronPairNotFromSameMother(), fSecondaryDielectronPairNotFromSameMother()
                                                                               , fGeneratorName(""), fGeneratorMCSignalName(""), fGeneratorULSSignalName(""), fGeneratorHashs(), fGeneratorMCSignalHashs(), fGeneratorULSSignalHashs(), fPIDResponse(0x0), fEvent(0x0), fMC(0x0), fTrack(0x0), isAOD(false), fSelectPhysics(false), fTriggerMask(0)
-                                                                              , fTrackCuts_primary(), fPairCuts_primary(), fPairCuts_secondary_loose(), fPairCuts_secondary_standard(), fUsedVars(0x0)
+                                                                              , fTrackCuts_primary_PreFilter(), fTrackCuts_primary_standard(), fPairCuts_primary(), fPairCuts_secondary_PreFilter(), fPairCuts_secondary_standard(), fUsedVars(0x0)
                                                                               , fSupportMCSignal(0), fSupportCutsetting(0)
                                                                               , fHistEvents(0x0), fHistEventStat(0x0), fHistCentrality(0x0), fHistVertex(0x0), fHistVertexContibutors(0x0), fHistNTracks(0x0)
                                                                               , fMinCentrality(0.), fMaxCentrality(100), fCentralityFile(0x0), fCentralityFilename(""), fHistCentralityCorrection(0x0)
@@ -130,7 +130,7 @@ AliAnalysisTaskEtaReconstruction::AliAnalysisTaskEtaReconstruction(const char * 
                                                                               , fLowerMassCutPrimaries(), fUpperMassCutPrimaries(), fMassCutSecondaries(), fUpperPreFilterMass(), fLowerPreFilterMass()
                                                                               , fSinglePrimaryLegMCSignal(), fSingleSecondaryLegMCSignal(), fPrimaryPairMCSignal(), fSecondaryPairMCSignal(), fFourPairMCSignal(), fPrimaryDielectronPairNotFromSameMother(), fSecondaryDielectronPairNotFromSameMother()
                                                                               , fGeneratorName(""), fGeneratorMCSignalName(""), fGeneratorULSSignalName(""), fGeneratorHashs(), fGeneratorMCSignalHashs(), fGeneratorULSSignalHashs(), fPIDResponse(0x0), fEvent(0x0), fMC(0x0), fTrack(0x0), isAOD(false), fSelectPhysics(false), fTriggerMask(0)
-                                                                              , fTrackCuts_primary(), fPairCuts_primary(), fPairCuts_secondary_loose(), fPairCuts_secondary_standard(), fUsedVars(0x0)
+                                                                              , fTrackCuts_primary_PreFilter(), fTrackCuts_primary_standard(), fPairCuts_primary(), fPairCuts_secondary_PreFilter(), fPairCuts_secondary_standard(), fUsedVars(0x0)
                                                                               , fSupportMCSignal(0), fSupportCutsetting(0)
                                                                               , fHistEvents(0x0), fHistEventStat(0x0), fHistCentrality(0x0), fHistVertex(0x0), fHistVertexContibutors(0x0), fHistNTracks(0x0)
                                                                               , fMinCentrality(0.), fMaxCentrality(100), fCentralityFile(0x0), fCentralityFilename(""), fHistCentralityCorrection(0x0)
@@ -1155,59 +1155,59 @@ void AliAnalysisTaskEtaReconstruction::UserExec(Option_t* option){
     //
     // }
 
-    // ##########################################################
-    // Filling primary reconstructed particle histograms according to MCSignals
-    for (unsigned int i = 0; i < part.isMCSignal_primary.size(); ++i){
-      for (unsigned int j = 0; j < part.isReconstructed_primary.size(); ++j){
-        if (part.isMCSignal_primary[i] == kTRUE) {
-          if (part.isReconstructed_primary[j] == kTRUE){
-            if      (part.fCharge < 0) {
-              dynamic_cast<TH3D*>(fHistRecPrimaryNegPart.at(j * part.isMCSignal_primary.size() + i))->Fill(part.fPt, part.fEta, part.fPhi, centralityWeight);
-            }
-            else if (part.fCharge > 0) {
-              dynamic_cast<TH3D*>(fHistRecPrimaryPosPart.at(j * part.isMCSignal_primary.size() + i))->Fill(part.fPt, part.fEta, part.fPhi, centralityWeight);
-            }
-          }// is selected by cutsetting
-        } // is selected by MC signal
-      } // end of loop over all cutsettings
-    } // end of loop over all MCsignals
-    // Filling secondary reconstructed particle histograms according to MCSignals
-    for (unsigned int i = 0; i < part.isMCSignal_secondary.size(); ++i){
-      for (unsigned int j = 0; j < part.isReconstructed_secondary.size(); ++j){
-        if (part.isMCSignal_secondary[i] == kTRUE) {
-          if (part.isReconstructed_secondary[j] == kTRUE){
-            if      (part.fCharge < 0) {
-              dynamic_cast<TH3D*>(fHistRecSecondaryNegPart.at(j * part.isMCSignal_secondary.size() + i))->Fill(part.fPt, part.fEta, part.fPhi, centralityWeight);
-            }
-            else if (part.fCharge > 0) {
-              dynamic_cast<TH3D*>(fHistRecSecondaryPosPart.at(j * part.isMCSignal_secondary.size() + i))->Fill(part.fPt, part.fEta, part.fPhi, centralityWeight);
-            }
-          }// is selected by cutsetting
-        } // is selected by MC signal
-      } // end of loop over all cutsettings
-    } // end of loop over all MCsignals
-    // ##########################################################
-    // Fill support histograms with first cutsetting and first mcsignal
-    // if(part.isMCSignal_primary[fSupportMCSignal] == true && part.isReconstructed_primary[fSupportCutsetting] == kTRUE){
-    AliVParticle* mcPart1 = fMC->GetTrack(abslabel);
-    for (unsigned int i = 0; i < part.isReconstructed_primary.size(); i++) {
-      if(part.isReconstructed_primary[i] == kTRUE){    // check if part is reconstructed in each primary cut setting
-        for (unsigned int j = 0; j < part.isMCSignal_primary.size(); j++) {
-          if (part.isMCSignal_primary[j] == kTRUE) {
-            FillTrackHistograms_Primary(track, mcPart1, i, j); // Fill primary support histograms
-          }
-        }
-      }
-    }
-    // for (unsigned int i = 0; i < part.isReconstructed_secondary.size(); i++) {
-    //   if(part.isReconstructed_secondary[i] == kTRUE){
-    //     for (unsigned int j = 0; j < part.isMCSignal_secondary.size(); j++) {
-    //       if (part.isMCSignal_secondary[j] == kTRUE) {
-    //         FillTrackHistograms_Secondary(track, mcPart1, i, j); // Fill secondary support histograms
+    // // ##########################################################
+    // // Filling primary reconstructed particle histograms according to MCSignals
+    // for (unsigned int i = 0; i < part.isMCSignal_primary.size(); ++i){
+    //   for (unsigned int j = 0; j < part.isReconstructed_primary.size(); ++j){
+    //     if (part.isMCSignal_primary[i] == kTRUE) {
+    //       if (part.isReconstructed_primary[j] == kTRUE){
+    //         if      (part.fCharge < 0) {
+    //           dynamic_cast<TH3D*>(fHistRecPrimaryNegPart.at(j * part.isMCSignal_primary.size() + i))->Fill(part.fPt, part.fEta, part.fPhi, centralityWeight);
+    //         }
+    //         else if (part.fCharge > 0) {
+    //           dynamic_cast<TH3D*>(fHistRecPrimaryPosPart.at(j * part.isMCSignal_primary.size() + i))->Fill(part.fPt, part.fEta, part.fPhi, centralityWeight);
+    //         }
+    //       }// is selected by cutsetting
+    //     } // is selected by MC signal
+    //   } // end of loop over all cutsettings
+    // } // end of loop over all MCsignals
+    // // Filling secondary reconstructed particle histograms according to MCSignals
+    // for (unsigned int i = 0; i < part.isMCSignal_secondary.size(); ++i){
+    //   for (unsigned int j = 0; j < part.isReconstructed_secondary.size(); ++j){
+    //     if (part.isMCSignal_secondary[i] == kTRUE) {
+    //       if (part.isReconstructed_secondary[j] == kTRUE){
+    //         if      (part.fCharge < 0) {
+    //           dynamic_cast<TH3D*>(fHistRecSecondaryNegPart.at(j * part.isMCSignal_secondary.size() + i))->Fill(part.fPt, part.fEta, part.fPhi, centralityWeight);
+    //         }
+    //         else if (part.fCharge > 0) {
+    //           dynamic_cast<TH3D*>(fHistRecSecondaryPosPart.at(j * part.isMCSignal_secondary.size() + i))->Fill(part.fPt, part.fEta, part.fPhi, centralityWeight);
+    //         }
+    //       }// is selected by cutsetting
+    //     } // is selected by MC signal
+    //   } // end of loop over all cutsettings
+    // } // end of loop over all MCsignals
+    // // ##########################################################
+    // // Fill support histograms with first cutsetting and first mcsignal
+    // // if(part.isMCSignal_primary[fSupportMCSignal] == true && part.isReconstructed_primary[fSupportCutsetting] == kTRUE){
+    // AliVParticle* mcPart1 = fMC->GetTrack(abslabel);
+    // for (unsigned int i = 0; i < part.isReconstructed_primary.size(); i++) {
+    //   if(part.isReconstructed_primary[i] == kTRUE){    // check if part is reconstructed in each primary cut setting
+    //     for (unsigned int j = 0; j < part.isMCSignal_primary.size(); j++) {
+    //       if (part.isMCSignal_primary[j] == kTRUE) {
+    //         FillTrackHistograms_Primary(track, mcPart1, i, j); // Fill primary support histograms
     //       }
     //     }
     //   }
     // }
+    // // for (unsigned int i = 0; i < part.isReconstructed_secondary.size(); i++) {
+    // //   if(part.isReconstructed_secondary[i] == kTRUE){
+    // //     for (unsigned int j = 0; j < part.isMCSignal_secondary.size(); j++) {
+    // //       if (part.isMCSignal_secondary[j] == kTRUE) {
+    // //         FillTrackHistograms_Secondary(track, mcPart1, i, j); // Fill secondary support histograms
+    // //       }
+    // //     }
+    // //   }
+    // // }
 
     if (part.isMCSignal_primary[fSupportMCSignal] == true && part.isReconstructed_primary[fSupportCutsetting] == kTRUE) {
       // ##########################################################
@@ -1380,6 +1380,7 @@ void AliAnalysisTaskEtaReconstruction::UserExec(Option_t* option){
     if(fdebug) std::cout << "Doing four pairing..." << std::endl;
     Bool_t SmearedPair  = kTRUE;
     Bool_t ReconstructedPair = kTRUE;
+    Bool_t PairPrimary = kTRUE;
                                                                                 // if(fdebug) std::cout << __LINE__ << " DEBUG_AnalysisTask: Line cout " << std::endl;
                                                                                 if (fdebug) std::cout << "Do generated four pairing" << std::endl;
                                                                                 DoFourPairing(fGenPairVec_primary, fGenPairVec_secondary, !ReconstructedPair, !SmearedPair, centralityWeight);
@@ -1390,7 +1391,8 @@ void AliAnalysisTaskEtaReconstruction::UserExec(Option_t* option){
                                                                                 if(fdebug) std::cout << __LINE__ << " Start Four PreFilter " << std::endl;
                                                                                 if(fUsePreFilter)DoFourPreFilter(&fRecPairVec_primary, &fRecV0Pair);
                                                                                 if(fdebug) std::cout << __LINE__ << " Apply Sec_StandardCuts for Pairing " << std::endl;
-                                                                                ApplySecondaryCutsAndFillHists(&fRecV0Pair, fPairCuts_secondary_standard, centralityWeight);
+                                                                                ApplyStandardCutsAndFillHists(&fRecPairVec_primary, fTrackCuts_primary_standard ,  TrackCuts,  PairPrimary, centralityWeight);
+                                                                                ApplyStandardCutsAndFillHists(&fRecV0Pair         , fPairCuts_secondary_standard, !TrackCuts, !PairPrimary, centralityWeight);
 
                                                                                 if(fdebug) std::cout << __LINE__ << " Start Four Reconstructed Pairing " << std::endl;
                                                                                 DoFourPairing(fRecPairVec_primary, fRecV0Pair, ReconstructedPair, !SmearedPair, centralityWeight);
@@ -2100,97 +2102,257 @@ void AliAnalysisTaskEtaReconstruction::SetWidthCorrFunction(Detector det, TObjec
 }
 
 
-void AliAnalysisTaskEtaReconstruction::ApplySecondaryCutsAndFillHists (std::vector<TwoPair>* fSecPairVec, std::vector<AliAnalysisFilter*> fTrackCuts_secondary, double centralityWeight) {
-  // Get V0 from Event, selected trough V0ID stored in TwoPair and set in reconstructed secondarie two pairing
-  for (unsigned int iV0 = 0; iV0 < fSecPairVec->size(); iV0++){
-    Int_t fV0ID = fSecPairVec->at(iV0).GetV0ID();
-    AliAODv0* fV0 = ((AliAODEvent*)fEvent)->GetV0(fV0ID);
-    AliAODTrack *posAODTrack = (AliAODTrack *) (fV0->GetSecondaryVtx()->GetDaughter(0));
-    AliAODTrack *negAODTrack = (AliAODTrack *) (fV0->GetSecondaryVtx()->GetDaughter(1));
-
-    AliDielectronPair *pair = new AliDielectronPair;
-    pair->SetKFUsage(false);
-    pair->SetTracks(static_cast<AliAODTrack*>(negAODTrack), 11, static_cast<AliAODTrack*>(posAODTrack), -11);
-
-
-    //  ---------- RECONSTRUCTED for PAIR  ---------- //
-    // Check if particle is passing secondary selection cuts
-    std::vector<bool> selected_secondary(fTrackCuts_secondary.size(), kFALSE); // vector which stores if track is accepted by [i]-th selection cut
-    for (UInt_t iCut=0; iCut<fTrackCuts_secondary.size(); ++iCut){ // loop over all specified cutInstances
-      UInt_t selectedMask_secondary=( 1 << fTrackCuts_secondary.at(iCut)->GetCuts()->GetEntries())-1;
-      // cutting logic taken from AliDielectron::FillTrackArrays()          FillPairArrays()
-      // apply track cuts
-      UInt_t cutMask_secondary = fTrackCuts_secondary.at(iCut)->IsSelected(pair);
-      if (cutMask_secondary == selectedMask_secondary) {selected_secondary[iCut] = kTRUE; /*std::cout << "sec_reconstructed TRUE" << std::endl;*/}
+void AliAnalysisTaskEtaReconstruction::ApplyStandardCutsAndFillHists (std::vector<TwoPair>* fPairVec, std::vector<AliAnalysisFilter*> fCutsetting, Bool_t TrackCuts, Bool_t PairPrimary, double centralityWeight) {
+  // If TrackCuts   = true :   Aplly standard TrackCuts to primary particles (there are no track cuts on secondaries yet)
+  // If TrackCuts   = false:   Aplly standard PairCuts to either primary pairs or secondary pairs
+  // If PairPrimary = true :   fPairVec is the reconstructed primary pair vector
+  // If PairPrimary = false:   fPairVec is the reconstructed secondary pair vector
+  for (unsigned int iPair = 0; iPair < fPairVec->size(); iPair++){
+    if(PairPrimary == kTRUE){
+      AliVParticle* posTrack = fEvent->GetTrack(fPairVec->GetFirstDaughter());
+      AliVParticle* negTrack = fEvent->GetTrack(fPairVec->GetSecondDaughter());
+      int poslabel = posTrack->GetLabel();
+      int neglabel = negTrack->GetLabel();
+      int absposlabel = TMath::Abs(poslabel);
+      int absneglabel = TMath::Abs(neglabel);
     }
-    // ##########################################################
-    // check if at least one is selected by cuts otherwise skip this particle
-    if (CheckIfOneIsTrue(selected_secondary) == kFALSE) {
-      fSecPairVec->erase(fSecPairVec->begin()+iV0);
-      iV0--;
-      continue;
+    else if(PairPrimary == kFALSE){
+      // Get V0 from Event, selected trough V0ID stored in TwoPair and is set in reconstructed secondarie two pairing
+      Int_t fV0ID = fPairVec->at(iPair).GetV0ID();
+      AliAODv0* fV0 = ((AliAODEvent*)fEvent)->GetV0(fV0ID);
+      AliAODTrack *posTrack = (AliAODTrack *) (fV0->GetSecondaryVtx()->GetDaughter(0));
+      AliAODTrack *negTrack = (AliAODTrack *) (fV0->GetSecondaryVtx()->GetDaughter(1));
     }
 
-    fSecPairVec->at(iV0).isReconstructed_secondary = selected_secondary;
+    if(TrackCuts == kFALSE){
+      AliDielectronPair *pair = new AliDielectronPair;
+      pair->SetKFUsage(false);
+      if     (PairPrimary == kTRUE)  pair->SetTracks(static_cast<AliVTrack*>(negTrack), 11, static_cast<AliVTrack*>(posTrack), -11);
+      else if(PairPrimary == kFALSE) pair->SetTracks(static_cast<AliAODTrack*>(negTrack), 11, static_cast<AliAODTrack*>(posTrack), -11);
+
+      //  ---------- RECONSTRUCTED Pairs with PAIR  ---------- //
+      // Check if pair is passing cut selections
+      std::vector<bool> selected(fCutsetting.size(), kFALSE); // vector which stores if pair is accepted by [i]-th selection cut
+      for (UInt_t iCut=0; iCut<fCutsetting.size(); ++iCut){ // loop over all specified cutInstances
+        UInt_t selectedMask=( 1 << fCutsetting.at(iCut)->GetCuts()->GetEntries())-1;
+        // cutting logic taken from AliDielectron::FillTrackArrays()          FillPairArrays()
+        // apply pair cuts
+        UInt_t cutMask = fCutsetting.at(iCut)->IsSelected(pair);
+        if (cutMask == selectedMask) {selected[iCut] = kTRUE; /*std::cout << "reconstructed TRUE" << std::endl;*/}
+      }
+      // ##########################################################
+      // check if at least one is selected by cuts otherwise remove this pair from vector
+      if (CheckIfOneIsTrue(selected) == kFALSE) {
+        fPairVec->erase(fPairVec->begin()+iPair);
+        iPair--;
+        continue;
+      }
+    }
+
+    else if (TrackCuts == kTRUE) {
+      //  ---------- RECONSTRUCTED Tracks  ---------- //
+      // Check if pos and neg Track are passing cut selections
+      std::vector<bool> selected_posTrack(fCutsetting.size(), kFALSE); // vector which stores if track is accepted by [i]-th selection cut
+      for (UInt_t iCut=0; iCut<fCutsetting.size(); ++iCut){ // loop over all specified cutInstances
+        UInt_t selectedMask_posTrack=( 1 << fCutsetting.at(iCut)->GetCuts()->GetEntries())-1;
+        // cutting logic taken from AliDielectron::FillTrackArrays()          FillPairArrays()
+        // apply track cuts
+        UInt_t cutMask_posTrack = fCutsetting.at(iCut)->IsSelected(posTrack);
+        if (cutMask_posTrack == selectedMask_posTrack) {selected_posTrack[iCut] = kTRUE; /*std::cout << "reconstructed TRUE" << std::endl;*/}
+      }
+      std::vector<bool> selected_negTrack(fCutsetting.size(), kFALSE); // vector which stores if track is accepted by [i]-th selection cut
+      for (UInt_t iCut=0; iCut<fCutsetting.size(); ++iCut){ // loop over all specified cutInstances
+        UInt_t selectedMask_negTrack=( 1 << fCutsetting.at(iCut)->GetCuts()->GetEntries())-1;
+        // cutting logic taken from AliDielectron::FillTrackArrays()          FillPairArrays()
+        // apply track cuts
+        UInt_t cutMask_negTrack = fCutsetting.at(iCut)->IsSelected(posTrack);
+        if (cutMask_negTrack == selectedMask_negTrack) {selected_negTrack[iCut] = kTRUE; /*std::cout << "reconstructed TRUE" << std::endl;*/}
+      }
+      // ##########################################################
+      // check if at least one is selected by cuts otherwise remove this pair from vector
+      if ((CheckIfOneIsTrue(selected_posTrack) == kFALSE) || (CheckIfOneIsTrue(selected_negTrack) == kFALSE)) {
+        fPairVec->erase(fPairVec->begin()+iPair);
+        iPair--;
+        continue;
+      }
+    }
+
+    if     (PairPrimary == kTRUE)  fPairVec->at(iPair).isReconstructed_primary = selected;
+    else if(PairPrimary == kFALSE) fPairVec->at(iPair).isReconstructed_secondary = selected;
 
 
-    // //  ---------- RECONSTRUCTED for TRACKS  ---------- //
-    // for (UInt_t iCut=0; iCut<fTrackCuts_secondary.size(); ++iCut){ // loop over all specified cutInstances
-    //   UInt_t selectedMask_secondary_firstPar=( 1 << fTrackCuts_secondary.at(iCut)->GetCuts()->GetEntries())-1;
-    //   UInt_t selectedMask_secondary_secPar=( 1 << fTrackCuts_secondary.at(iCut)->GetCuts()->GetEntries())-1;
+    // //  ---------- RECONSTRUCTED Pairs with TRACKS  ---------- //
+    // for (UInt_t iCut=0; iCut<fCutsetting.size(); ++iCut){ // loop over all specified cutInstances
+    //   UInt_t selectedMask_firstPar=( 1 << fCutsetting.at(iCut)->GetCuts()->GetEntries())-1;
+    //   UInt_t selectedMask_secPar=( 1 << fCutsetting.at(iCut)->GetCuts()->GetEntries())-1;
     //   // cutting logic taken from AliDielectron::FillTrackArrays()          FillPairArrays()
     //   // apply track cuts
-    //   UInt_t cutMask_secondary_firstPar = fTrackCuts_secondary.at(iCut)->IsSelected(posAODTrack);
-    //   UInt_t cutMask_secondary_secPar = fTrackCuts_secondary.at(iCut)->IsSelected(negAODTrack);
-    //   if (cutMask_secondary_firstPar == selectedMask_secondary_firstPar) {selected_secondary_firstPar[iCut] = kTRUE; /*std::cout << "sec_reconstructed TRUE" << std::endl;*/}
-    //   if (cutMask_secondary_secPar == selectedMask_secondary_secPar) {selected_secondary_secPar[iCut] = kTRUE; /*std::cout << "sec_reconstructed TRUE" << std::endl;*/}
+    //   UInt_t cutMask_firstPar = fCutsetting.at(iCut)->IsSelected(posTrack);
+    //   UInt_t cutMask_secPar = fCutsetting.at(iCut)->IsSelected(negTrack);
+    //   if (cutMask_firstPar == selectedMask_firstPar) {selected_firstPar[iCut] = kTRUE; /*std::cout << "reconstructed TRUE" << std::endl;*/}
+    //   if (cutMask_secPar == selectedMask_secPar) {selected_secPar[iCut] = kTRUE; /*std::cout << "reconstructed TRUE" << std::endl;*/}
     // }
     // // ##########################################################
-    // // check if at least one is selected by cuts otherwise skip this particle
-    // if (CheckIfOneIsTrue(selected_secondary_firstPar) == kFALSE && CheckIfOneIsTrue(selected_secondary_secPar) == kFALSE)  {
-    //   fSecPairVec->erase(fSecPairVec->begin()+iV0);
-    //   iV0--;
+    // // check if at least one is selected by cuts otherwise remove this pair from vector
+    // if (CheckIfOneIsTrue(selected_firstPar) == kFALSE && CheckIfOneIsTrue(selected_secPar) == kFALSE)  {
+    //   fPairVec->erase(fPairVec->begin()+iPair);
+    //   iPair--;
     //   continue;
     // }
 
+    // Fill reconstructed TRACK Histograms
+    if (TrackCuts == kTRUE) {
+      if(PairPrimary == kTRUE)  {
+        std::vector<Bool_t> mcSignal_acc_posPart(fSinglePrimaryLegMCSignal.size(), kFALSE); // vector which stores if track is accepted by [i]-th mcsignal
+        std::vector<Bool_t> mcSignal_acc_negPart(fSinglePrimaryLegMCSignal.size(), kFALSE); // vector which stores if track is accepted by [i]-th mcsignal
+        CheckSinglePrimaryLegMCsignals(mcSignal_acc_posPart, absposlabel);
+        CheckSinglePrimaryLegMCsignals(mcSignal_acc_negPart, absneglabel);
+      }
+      // else if(PairPrimary == kFALSE) {
+      //   std::vector<Bool_t> mcSignal_acc_posPart(fSingleSecondaryLegMCSignal.size(), kFALSE); // vector which stores if track is accepted by [i]-th mcsignal
+      //   std::vector<Bool_t> mcSignal_acc_negPart(fSingleSecondaryLegMCSignal.size(), kFALSE); // vector which stores if track is accepted by [i]-th mcsignal
+      //   CheckSingleSecondaryLegMCsignals(mcSignal_acc_posPart, absposlabel);
+      //   CheckSingleSecondaryLegMCsignals(mcSignal_acc_negPart, absneglabel);
+      // }
 
-    // Apply MC signals
-    std::vector<Bool_t> mcTwoSignal_acc(fSecondaryPairMCSignal.size(), kFALSE); // vector which stores if track is accepted by [i]-th mcsignal
+      // ##########################################################
+      // Create summary particle from track info
+      Particle posPart  = CreateParticle(posTrack);
+      Particle negPart  = CreateParticle(negTrack);
+      if(PairPrimary == kTRUE)  {
+        posPart.isMCSignal_primary   = mcSignal_acc_posPart;
+        negPart.isMCSignal_primary   = mcSignal_acc_negPart;
+        posPart.isReconstructed_primary = selected_posTrack;
+        negPart.isReconstructed_primary = selected_negTrack;
 
-    for (unsigned int i = 0; i < fSecondaryPairMCSignal.size(); ++i){
-      mcTwoSignal_acc[i] = AliDielectronMC::Instance()->IsMCTruth(pair, &(fSecondaryPairMCSignal[i]));
+      }
+      // if(PairPrimary == kFALSE) {
+      //   posPart.isMCSignal_secondary = mcSignal_acc_posPart;
+      //   negPart.isMCSignal_secondary = mcSignal_acc_negPart;
+      //   posPart.isReconstructed_secondary = selected_posTrack;
+      //   negPart.isReconstructed_secondary = selected_negTrack;
+      // }
+
+
+      // ##########################################################
+      // Filling primary reconstructed particle histograms according to MCSignals
+      if(PairPrimary == kTRUE){
+        // check if MCSignal and isReconstructed for positive primary track
+        for (unsigned int i = 0; i < posPart.isMCSignal_primary.size(); ++i){
+          for (unsigned int j = 0; j < posPart.isReconstructed_primary.size(); ++j){
+            if (posPart.isMCSignal_primary[i] == kTRUE) {
+              if (posPart.isReconstructed_primary[j] == kTRUE){
+                if (posPart.fCharge > 0) {
+                  dynamic_cast<TH3D*>(fHistRecPrimaryPosPart.at(j * posPart.isMCSignal_primary.size() + i))->Fill(posPart.fPt, posPart.fEta, posPart.fPhi, centralityWeight);
+                }
+              }// is selected by cutsetting
+            } // is selected by MC signal
+          } // end of loop over all cutsettings
+        } // end of loop over all MCsignals
+
+        // check if MCSignal and isReconstructed for negative primaryTrack
+        for (unsigned int i = 0; i < negPart.isMCSignal_primary.size(); ++i){
+          for (unsigned int j = 0; j < negPart.isReconstructed_primary.size(); ++j){
+            if (negPart.isMCSignal_primary[i] == kTRUE) {
+              if (negPart.isReconstructed_primary[j] == kTRUE){
+                if (negPart.fCharge < 0) {
+                  dynamic_cast<TH3D*>(fHistRecPrimaryNegPart.at(j * negPart.isMCSignal_primary.size() + i))->Fill(negPart.fPt, negPart.fEta, negPart.fPhi, centralityWeight);
+                }
+              }// is selected by cutsetting
+            } // is selected by MC signal
+          } // end of loop over all cutsettings
+        } // end of loop over all MCsignals
+      } // end if PairPrimary
+
+      // ##########################################################
+      // Fill support histograms with first cutsetting and first mcsignal
+      // if(part.isMCSignal_primary[fSupportMCSignal] == true && part.isReconstructed_primary[fSupportCutsetting] == kTRUE){
+      AliVParticle* mcPosPart = fMC->GetTrack(absposlabel);
+      AliVParticle* mcNegPart = fMC->GetTrack(absneglabel);
+      for (unsigned int i = 0; i < posPart.isReconstructed_primary.size(); i++) {
+        if(posPart.isReconstructed_primary[i] == kTRUE){    // check if part is reconstructed in each primary cut setting
+          for (unsigned int j = 0; j < posPart.isMCSignal_primary.size(); j++) {
+            if (posPart.isMCSignal_primary[j] == kTRUE) {
+              FillTrackHistograms_Primary(posTrack, mcPosPart, i, j); // Fill primary support histograms with positive partilces
+            }
+          }
+        }
+      }
+      for (unsigned int i = 0; i < negPart.isReconstructed_primary.size(); i++) {
+        if(negPart.isReconstructed_primary[i] == kTRUE){    // check if part is reconstructed in each primary cut setting
+          for (unsigned int j = 0; j < negPart.isMCSignal_primary.size(); j++) {
+            if (negPart.isMCSignal_primary[j] == kTRUE) {
+              FillTrackHistograms_Primary(negTrack, mcNegPart, i, j); // Fill primary support histograms with negative particles
+            }
+          }
+        }
+      }
     }
-    // check if at least one mc signal is true
-    if (CheckIfOneIsTrue(mcTwoSignal_acc) == kFALSE) continue;
 
-    double weight  = 1.;
-    double mass    = fSecPairVec->at(iV0).fMass;
-    double pairpt  = fSecPairVec->at(iV0).fPt;
+    // Fill reconstructed PAIR histograms
+    else if(TrackCuts == kFALSE)
+      // Apply MC signals
+      if(PairPrimary == kTRUE)  {
+        std::vector<Bool_t> mcTwoSignal_acc(fPrimaryPairMCSignal.size(), kFALSE); // vector which stores if pair is accepted by [i]-th mcsignal
+        for (unsigned int i = 0; i < fPrimaryPairMCSignal.size(); ++i){
+          mcTwoSignal_acc[i] = AliDielectronMC::Instance()->IsMCTruth(pair, &(fPrimaryPairMCSignal[i]));
+        }
+      }
+      else if(PairPrimary == kFALSE) {
+        std::vector<Bool_t> mcTwoSignal_acc(fSecondaryPairMCSignal.size(), kFALSE); // vector which stores if pair is accepted by [i]-th mcsignal
+        for (unsigned int i = 0; i < fSecondaryPairMCSignal.size(); ++i){
+          mcTwoSignal_acc[i] = AliDielectronMC::Instance()->IsMCTruth(pair, &(fSecondaryPairMCSignal[i]));
+        }
+      }
+
+      // check if at least one mc signal is true
+      if (CheckIfOneIsTrue(mcTwoSignal_acc) == kFALSE) continue;
+
+      double weight  = 1.;
+      double mass    = fPairVec->at(iPair).fMass;
+      double pairpt  = fPairVec->at(iPair).fPt;
 
 
-    // track label, points back to MC track
-    Int_t posTrackLabel = TMath::Abs(posAODTrack->GetLabel());
-    Int_t negTrackLabel = TMath::Abs(negAODTrack->GetLabel());
+      // track label, points back to MC track
+      Int_t posTrackLabel = TMath::Abs(posTrack->GetLabel());
+      Int_t negTrackLabel = TMath::Abs(negTrack->GetLabel());
 
-    // Fill secondary support histos
-    AliVParticle* mcPosPart = fMC->GetTrack(posTrackLabel);
-    AliVParticle* mcNegPart = fMC->GetTrack(negTrackLabel);
+      // Fill secondary support histos
+      AliVParticle* mcPosPart = fMC->GetTrack(posTrackLabel);
+      AliVParticle* mcNegPart = fMC->GetTrack(negTrackLabel);
 
-    // Filling reconstructed secondary particle histograms according to MCSignals
-      for (unsigned int i = 0; i < fSecPairVec->at(iV0).isReconstructed_secondary.size(); ++i){
-        if (fSecPairVec->at(iV0).isReconstructed_secondary[i] == kTRUE){
-          for (unsigned int j = 0; j < mcTwoSignal_acc.size(); ++j){
-            if (mcTwoSignal_acc[j] == kTRUE){
-            fHistRecSecondaryPair.at(  i *   mcTwoSignal_acc.size() + j)->Fill(mass, pairpt, weight * centralityWeight);
-            FillTrackHistograms_Secondary(posAODTrack, mcPosPart, i, j); // Fill secondary support histograms
-            FillTrackHistograms_Secondary(negAODTrack, mcNegPart, i, j); // Fill secondary ssupport histograms
-            FillPairHistograms_Secondary(pair, i, j);                    // Fill pair secondary histograms
-          }// is selected by cutsetting
-        } // end of loop over all cutsettings
-      } // is selected by MCSignal
-    } // end of loop over all MCsignals
-  delete pair;
-  } // End of iV0 loop
+      // Filling reconstructed secondary particle histograms according to MCSignals
+      if (PairPrimary == kTRUE) {
+        for (unsigned int i = 0; i < fPairVec->at(iPair).isReconstructed_primary.size(); ++i){
+          if (fPairVec->at(iPair).isReconstructed_primary[i] == kTRUE){
+            for (unsigned int j = 0; j < mcTwoSignal_acc.size(); ++j){
+              if (mcTwoSignal_acc[j] == kTRUE){
+                fHistRecPrimaryPair.at(  i *   mcTwoSignal_acc.size() + j)->Fill(mass, pairpt, weight * centralityWeight);
+                // FillPairHistograms_Primary(pair, i, j);                 // Fill pair primary histograms
+              }// is selected by cutsetting
+            } // end of loop over all cutsettings
+          } // is selected by MCSignal
+        } // end of loop over all MCsignals
+      } // end of if PairPrimary
+
+      // Filling reconstructed secondary particle histograms according to MCSignals
+      else if (PairPrimary == kFALSE) {
+        for (unsigned int i = 0; i < fPairVec->at(iPair).isReconstructed_secondary.size(); ++i){
+          if (fPairVec->at(iPair).isReconstructed_secondary[i] == kTRUE){
+            for (unsigned int j = 0; j < mcTwoSignal_acc.size(); ++j){
+              if (mcTwoSignal_acc[j] == kTRUE){
+                fHistRecSecondaryPair.at(  i *   mcTwoSignal_acc.size() + j)->Fill(mass, pairpt, weight * centralityWeight);
+                FillTrackHistograms_Secondary(posTrack, mcPosPart, i, j); // Fill secondary support histograms
+                FillTrackHistograms_Secondary(negTrack, mcNegPart, i, j); // Fill secondary support histograms
+                FillPairHistograms_Secondary(pair, i, j);                    // Fill pair secondary histograms
+              }// is selected by cutsetting
+            } // end of loop over all cutsettings
+          } // is selected by MCSignal
+        } // end of loop over all MCsignals
+      } // end of if PairSecondary
+      delete pair;
+    }
+  } // End of iPair loop
 }
 
 

--- a/PWGDQ/dielectron/core/AliAnalysisTaskEtaReconstruction.cxx
+++ b/PWGDQ/dielectron/core/AliAnalysisTaskEtaReconstruction.cxx
@@ -399,9 +399,9 @@ void AliAnalysisTaskEtaReconstruction::UserCreateOutputObjects(){
       fSingleElectronList->Add(fGeneratedSmearedSecondaryList);
 
       // Generated reconstructed lists for every cutsetting one list and every MCsignal 2 histograms with pos and neg charge
-      for (unsigned int list_i = 0; list_i < fTrackCuts_primary.size(); ++list_i){
+      for (unsigned int list_i = 0; list_i < fTrackCuts_primary_standard.size(); ++list_i){
         fRecPrimaryList = new TList();
-        fRecPrimaryList->SetName(Form("%s_Primary",fTrackCuts_primary.at(list_i)->GetName()));
+        fRecPrimaryList->SetName(Form("%s_Primary",fTrackCuts_primary_standard.at(list_i)->GetName()));
         fRecPrimaryList->SetOwner();
 
         for (unsigned int i = 0; i < fSinglePrimaryLegMCSignal.size(); ++i){
@@ -526,9 +526,9 @@ void AliAnalysisTaskEtaReconstruction::UserCreateOutputObjects(){
         fPairList->Add(fGeneratedSmearedSecondaryPairsList);
 
         // Generated reconstructed lists for every cutsetting one list and every MCsignal 1 histogram
-        for (unsigned int list_i = 0; list_i < fTrackCuts_primary.size(); ++list_i){
+        for (unsigned int list_i = 0; list_i < fTrackCuts_primary_standard.size(); ++list_i){
           TList* list = new TList();
-          list->SetName(Form("%s_Primary",fTrackCuts_primary.at(list_i)->GetName()));
+          list->SetName(Form("%s_Primary",fTrackCuts_primary_standard.at(list_i)->GetName()));
           list->SetOwner();
 
           for (unsigned int i = 0; i < fPrimaryPairMCSignal.size(); ++i){
@@ -719,9 +719,9 @@ void AliAnalysisTaskEtaReconstruction::UserCreateOutputObjects(){
         fFourPairList->Add(fGeneratedSmearedFourPairsList);
 
         // Generated reconstructed lists for every cutsetting one list and every MCsignal 1 histogram
-        for (unsigned int list_i = 0; list_i < fTrackCuts_primary.size(); ++list_i){
+        for (unsigned int list_i = 0; list_i < fTrackCuts_primary_standard.size(); ++list_i){
           TList* list = new TList();
-          list->SetName(fTrackCuts_primary.at(list_i)->GetName());
+          list->SetName(fTrackCuts_primary_standard.at(list_i)->GetName());
           list->SetOwner();
 
           for (unsigned int i = 0; i < fFourPairMCSignal.size(); i+=2){
@@ -1080,16 +1080,16 @@ void AliAnalysisTaskEtaReconstruction::UserExec(Option_t* option){
 
     // ##########################################################
                                                                                 // // changed in order to disable reconstructed cuts
-                                                                                // std::vector<bool> selected_primary(fTrackCuts_primary.size(), kTRUE); // vector which stores if track is accepted by [i]-th selection cut
+                                                                                // std::vector<bool> selected_primary(fTrackCuts_primary_PreFilter.size(), kTRUE); // vector which stores if track is accepted by [i]-th selection cut
                                                                                 // std::vector<bool> selected_secondary(fPairCuts_secondary_standard.size(), kTRUE); // vector which stores if track is accepted by [i]-th selection cut
     // Check if particle is passing primary selection cuts
-    std::vector<bool> selected_primary(fTrackCuts_primary.size(), kFALSE); // vector which stores if track is accepted by [i]-th selection cut
-    for (UInt_t iCut=0; iCut<fTrackCuts_primary.size(); ++iCut){ // loop over all specified cutInstances
-      UInt_t selectedMask_primary=( 1 << fTrackCuts_primary.at(iCut)->GetCuts()->GetEntries())-1;
+    std::vector<bool> selected_primary(fTrackCuts_primary_PreFilter.size(), kFALSE); // vector which stores if track is accepted by [i]-th selection cut
+    for (UInt_t iCut=0; iCut<fTrackCuts_primary_PreFilter.size(); ++iCut){ // loop over all specified cutInstances
+      UInt_t selectedMask_primary=( 1 << fTrackCuts_primary_PreFilter.at(iCut)->GetCuts()->GetEntries())-1;
       // cutting logic taken from AliDielectron::FillTrackArrays()
       // apply track cuts
                                                                                 // if(fdebug) std::cout << __LINE__ << " DEBUG_AnalysisTask: Cout line" << std::endl;
-      UInt_t cutMask_primary = fTrackCuts_primary.at(iCut)->IsSelected(track);
+      UInt_t cutMask_primary = fTrackCuts_primary_PreFilter.at(iCut)->IsSelected(track);
       if (cutMask_primary == selectedMask_primary) {selected_primary[iCut] = kTRUE; /*std::cout << "prim_reconstructed TRUE" << std::endl;*/}
     }
 
@@ -1213,6 +1213,7 @@ void AliAnalysisTaskEtaReconstruction::UserExec(Option_t* option){
       // ##########################################################
       // Fill resolution histograms
       // ##########################################################
+      AliVParticle* mcPart1 = fMC->GetTrack(abslabel);
       double mcP     = mcPart1->P();
       double mcPt    = mcPart1->Pt();
       double mcEta   = mcPart1->Eta();
@@ -1260,11 +1261,11 @@ void AliAnalysisTaskEtaReconstruction::UserExec(Option_t* option){
     }
   }
 
-                                                                                // if(fdebug) std::cout << __LINE__ << " DEBUG_AnalysisTask: fTrackCuts_primary.size: " << fTrackCuts_primary.size() << std::endl;
+                                                                                // if(fdebug) std::cout << __LINE__ << " DEBUG_AnalysisTask: fTrackCuts_primary_PreFilter.size: " << fTrackCuts_primary_PreFilter.size() << std::endl;
                                                                                 // if(fdebug){
-                                                                                //   for (size_t i = 0; i < fTrackCuts_primary.size(); i++) {
-                                                                                //   std::cout << __LINE__ << " DEBUG_AnalysisTask: " << i+1 << "-th CutSetting: " << fTrackCuts_primary.at(i)->GetName() << std::endl;
-                                                                                //   const AliDielectronCutGroup* cgPIDCutsAna = dynamic_cast< const AliDielectronCutGroup*> (fTrackCuts_primary.at(i)->GetCuts()->At(0));
+                                                                                //   for (size_t i = 0; i < fTrackCuts_primary_PreFilter.size(); i++) {
+                                                                                //   std::cout << __LINE__ << " DEBUG_AnalysisTask: " << i+1 << "-th CutSetting: " << fTrackCuts_primary_PreFilter.at(i)->GetName() << std::endl;
+                                                                                //   const AliDielectronCutGroup* cgPIDCutsAna = dynamic_cast< const AliDielectronCutGroup*> (fTrackCuts_primary_PreFilter.at(i)->GetCuts()->At(0));
                                                                                 //   const AliDielectronCutGroup* cgTrackCutsAnaSPDfirst = dynamic_cast< const AliDielectronCutGroup*> (cgPIDCutsAna->GetCut(3));
                                                                                 //   const AliDielectronVarCuts*  trackCutsAOD = dynamic_cast< const AliDielectronVarCuts*> (cgTrackCutsAnaSPDfirst->GetCut(1));
                                                                                 //
@@ -1381,6 +1382,8 @@ void AliAnalysisTaskEtaReconstruction::UserExec(Option_t* option){
     Bool_t SmearedPair  = kTRUE;
     Bool_t ReconstructedPair = kTRUE;
     Bool_t PairPrimary = kTRUE;
+    Bool_t TrackCuts = kTRUE;
+
                                                                                 // if(fdebug) std::cout << __LINE__ << " DEBUG_AnalysisTask: Line cout " << std::endl;
                                                                                 if (fdebug) std::cout << "Do generated four pairing" << std::endl;
                                                                                 DoFourPairing(fGenPairVec_primary, fGenPairVec_secondary, !ReconstructedPair, !SmearedPair, centralityWeight);
@@ -1600,9 +1603,10 @@ void AliAnalysisTaskEtaReconstruction::CreateSupportHistos()
   fOutputListSupportHistos->SetName("Support");
   fOutputListSupportHistos->SetOwner();
 
-  for (unsigned int list_i = 0; list_i < fTrackCuts_primary.size(); ++list_i){
+
+  for (unsigned int list_i = 0; list_i < fTrackCuts_primary_standard.size(); ++list_i){
     TList* list1 = new TList();
-    list1->SetName(Form("PrimaryTrackCuts: %s",fTrackCuts_primary.at(list_i)->GetName()));
+    list1->SetName(Form("PrimaryTrackCuts: %s",fTrackCuts_primary_standard.at(list_i)->GetName()));
     list1->SetOwner();
     for (unsigned int i = 0; i < fSinglePrimaryLegMCSignal.size(); ++i){
       TList* list_temp = new TList();
@@ -2107,236 +2111,235 @@ void AliAnalysisTaskEtaReconstruction::ApplyStandardCutsAndFillHists (std::vecto
   // If TrackCuts   = false:   Aplly standard PairCuts to either primary pairs or secondary pairs
   // If PairPrimary = true :   fPairVec is the reconstructed primary pair vector
   // If PairPrimary = false:   fPairVec is the reconstructed secondary pair vector
+
+  // ###############################
+  // primary part
+  // ###############################
   for (unsigned int iPair = 0; iPair < fPairVec->size(); iPair++){
-    if(PairPrimary == kTRUE){
-      AliVParticle* posTrack = fEvent->GetTrack(fPairVec->GetFirstDaughter());
-      AliVParticle* negTrack = fEvent->GetTrack(fPairVec->GetSecondDaughter());
+    if (PairPrimary == kTRUE) {
+      AliVParticle* negTrack = fEvent->GetTrack(fPairVec->at(iPair).GetFirstDaughter());
+      AliVParticle* posTrack = fEvent->GetTrack(fPairVec->at(iPair).GetSecondDaughter());
+
       int poslabel = posTrack->GetLabel();
       int neglabel = negTrack->GetLabel();
       int absposlabel = TMath::Abs(poslabel);
       int absneglabel = TMath::Abs(neglabel);
-    }
-    else if(PairPrimary == kFALSE){
-      // Get V0 from Event, selected trough V0ID stored in TwoPair and is set in reconstructed secondarie two pairing
-      Int_t fV0ID = fPairVec->at(iPair).GetV0ID();
-      AliAODv0* fV0 = ((AliAODEvent*)fEvent)->GetV0(fV0ID);
-      AliAODTrack *posTrack = (AliAODTrack *) (fV0->GetSecondaryVtx()->GetDaughter(0));
-      AliAODTrack *negTrack = (AliAODTrack *) (fV0->GetSecondaryVtx()->GetDaughter(1));
-    }
-
-    if(TrackCuts == kFALSE){
-      AliDielectronPair *pair = new AliDielectronPair;
-      pair->SetKFUsage(false);
-      if     (PairPrimary == kTRUE)  pair->SetTracks(static_cast<AliVTrack*>(negTrack), 11, static_cast<AliVTrack*>(posTrack), -11);
-      else if(PairPrimary == kFALSE) pair->SetTracks(static_cast<AliAODTrack*>(negTrack), 11, static_cast<AliAODTrack*>(posTrack), -11);
-
-      //  ---------- RECONSTRUCTED Pairs with PAIR  ---------- //
-      // Check if pair is passing cut selections
-      std::vector<bool> selected(fCutsetting.size(), kFALSE); // vector which stores if pair is accepted by [i]-th selection cut
-      for (UInt_t iCut=0; iCut<fCutsetting.size(); ++iCut){ // loop over all specified cutInstances
-        UInt_t selectedMask=( 1 << fCutsetting.at(iCut)->GetCuts()->GetEntries())-1;
-        // cutting logic taken from AliDielectron::FillTrackArrays()          FillPairArrays()
-        // apply pair cuts
-        UInt_t cutMask = fCutsetting.at(iCut)->IsSelected(pair);
-        if (cutMask == selectedMask) {selected[iCut] = kTRUE; /*std::cout << "reconstructed TRUE" << std::endl;*/}
-      }
-      // ##########################################################
-      // check if at least one is selected by cuts otherwise remove this pair from vector
-      if (CheckIfOneIsTrue(selected) == kFALSE) {
-        fPairVec->erase(fPairVec->begin()+iPair);
-        iPair--;
-        continue;
-      }
-    }
-
-    else if (TrackCuts == kTRUE) {
-      //  ---------- RECONSTRUCTED Tracks  ---------- //
-      // Check if pos and neg Track are passing cut selections
-      std::vector<bool> selected_posTrack(fCutsetting.size(), kFALSE); // vector which stores if track is accepted by [i]-th selection cut
-      for (UInt_t iCut=0; iCut<fCutsetting.size(); ++iCut){ // loop over all specified cutInstances
-        UInt_t selectedMask_posTrack=( 1 << fCutsetting.at(iCut)->GetCuts()->GetEntries())-1;
-        // cutting logic taken from AliDielectron::FillTrackArrays()          FillPairArrays()
-        // apply track cuts
-        UInt_t cutMask_posTrack = fCutsetting.at(iCut)->IsSelected(posTrack);
-        if (cutMask_posTrack == selectedMask_posTrack) {selected_posTrack[iCut] = kTRUE; /*std::cout << "reconstructed TRUE" << std::endl;*/}
-      }
-      std::vector<bool> selected_negTrack(fCutsetting.size(), kFALSE); // vector which stores if track is accepted by [i]-th selection cut
-      for (UInt_t iCut=0; iCut<fCutsetting.size(); ++iCut){ // loop over all specified cutInstances
-        UInt_t selectedMask_negTrack=( 1 << fCutsetting.at(iCut)->GetCuts()->GetEntries())-1;
-        // cutting logic taken from AliDielectron::FillTrackArrays()          FillPairArrays()
-        // apply track cuts
-        UInt_t cutMask_negTrack = fCutsetting.at(iCut)->IsSelected(posTrack);
-        if (cutMask_negTrack == selectedMask_negTrack) {selected_negTrack[iCut] = kTRUE; /*std::cout << "reconstructed TRUE" << std::endl;*/}
-      }
-      // ##########################################################
-      // check if at least one is selected by cuts otherwise remove this pair from vector
-      if ((CheckIfOneIsTrue(selected_posTrack) == kFALSE) || (CheckIfOneIsTrue(selected_negTrack) == kFALSE)) {
-        fPairVec->erase(fPairVec->begin()+iPair);
-        iPair--;
-        continue;
-      }
-    }
-
-    if     (PairPrimary == kTRUE)  fPairVec->at(iPair).isReconstructed_primary = selected;
-    else if(PairPrimary == kFALSE) fPairVec->at(iPair).isReconstructed_secondary = selected;
 
 
-    // //  ---------- RECONSTRUCTED Pairs with TRACKS  ---------- //
-    // for (UInt_t iCut=0; iCut<fCutsetting.size(); ++iCut){ // loop over all specified cutInstances
-    //   UInt_t selectedMask_firstPar=( 1 << fCutsetting.at(iCut)->GetCuts()->GetEntries())-1;
-    //   UInt_t selectedMask_secPar=( 1 << fCutsetting.at(iCut)->GetCuts()->GetEntries())-1;
-    //   // cutting logic taken from AliDielectron::FillTrackArrays()          FillPairArrays()
-    //   // apply track cuts
-    //   UInt_t cutMask_firstPar = fCutsetting.at(iCut)->IsSelected(posTrack);
-    //   UInt_t cutMask_secPar = fCutsetting.at(iCut)->IsSelected(negTrack);
-    //   if (cutMask_firstPar == selectedMask_firstPar) {selected_firstPar[iCut] = kTRUE; /*std::cout << "reconstructed TRUE" << std::endl;*/}
-    //   if (cutMask_secPar == selectedMask_secPar) {selected_secPar[iCut] = kTRUE; /*std::cout << "reconstructed TRUE" << std::endl;*/}
-    // }
-    // // ##########################################################
-    // // check if at least one is selected by cuts otherwise remove this pair from vector
-    // if (CheckIfOneIsTrue(selected_firstPar) == kFALSE && CheckIfOneIsTrue(selected_secPar) == kFALSE)  {
-    //   fPairVec->erase(fPairVec->begin()+iPair);
-    //   iPair--;
-    //   continue;
-    // }
+      // ###############################
+      // Track cuts on primary pair
+      // ###############################
+      if(TrackCuts == kTRUE){
 
-    // Fill reconstructed TRACK Histograms
-    if (TrackCuts == kTRUE) {
-      if(PairPrimary == kTRUE)  {
+        //  ---------- RECONSTRUCTED Tracks  ---------- //
+        // Check if pos and neg Track are passing cut selections
+        std::vector<bool> selected_posTrack(fCutsetting.size(), kFALSE); // vector which stores if track is accepted by [i]-th selection cut
+        for (UInt_t iCut=0; iCut<fCutsetting.size(); ++iCut){ // loop over all specified cutInstances
+          UInt_t selectedMask_posTrack=( 1 << fCutsetting.at(iCut)->GetCuts()->GetEntries())-1;
+          // cutting logic taken from AliDielectron::FillTrackArrays()          FillPairArrays()
+          // apply track cuts
+          UInt_t cutMask_posTrack = fCutsetting.at(iCut)->IsSelected(posTrack);
+          if (cutMask_posTrack == selectedMask_posTrack) {selected_posTrack[iCut] = kTRUE; /*std::cout << "reconstructed TRUE" << std::endl;*/}
+        }
+        std::vector<bool> selected_negTrack(fCutsetting.size(), kFALSE); // vector which stores if track is accepted by [i]-th selection cut
+        for (UInt_t iCut=0; iCut<fCutsetting.size(); ++iCut){ // loop over all specified cutInstances
+          UInt_t selectedMask_negTrack=( 1 << fCutsetting.at(iCut)->GetCuts()->GetEntries())-1;
+          // cutting logic taken from AliDielectron::FillTrackArrays()          FillPairArrays()
+          // apply track cuts
+          UInt_t cutMask_negTrack = fCutsetting.at(iCut)->IsSelected(negTrack);
+          if (cutMask_negTrack == selectedMask_negTrack) {selected_negTrack[iCut] = kTRUE; /*std::cout << "reconstructed TRUE" << std::endl;*/}
+        }
+        // ##########################################################
+        // check if at least one is selected by cuts otherwise remove this pair from vector
+        if ((CheckIfOneIsTrue(selected_posTrack) == kFALSE) || (CheckIfOneIsTrue(selected_negTrack) == kFALSE)) {
+          fPairVec->erase(fPairVec->begin()+iPair);
+          iPair--;
+          continue;
+        }
+
         std::vector<Bool_t> mcSignal_acc_posPart(fSinglePrimaryLegMCSignal.size(), kFALSE); // vector which stores if track is accepted by [i]-th mcsignal
         std::vector<Bool_t> mcSignal_acc_negPart(fSinglePrimaryLegMCSignal.size(), kFALSE); // vector which stores if track is accepted by [i]-th mcsignal
         CheckSinglePrimaryLegMCsignals(mcSignal_acc_posPart, absposlabel);
         CheckSinglePrimaryLegMCsignals(mcSignal_acc_negPart, absneglabel);
-      }
-      // else if(PairPrimary == kFALSE) {
-      //   std::vector<Bool_t> mcSignal_acc_posPart(fSingleSecondaryLegMCSignal.size(), kFALSE); // vector which stores if track is accepted by [i]-th mcsignal
-      //   std::vector<Bool_t> mcSignal_acc_negPart(fSingleSecondaryLegMCSignal.size(), kFALSE); // vector which stores if track is accepted by [i]-th mcsignal
-      //   CheckSingleSecondaryLegMCsignals(mcSignal_acc_posPart, absposlabel);
-      //   CheckSingleSecondaryLegMCsignals(mcSignal_acc_negPart, absneglabel);
-      // }
 
-      // ##########################################################
-      // Create summary particle from track info
-      Particle posPart  = CreateParticle(posTrack);
-      Particle negPart  = CreateParticle(negTrack);
-      if(PairPrimary == kTRUE)  {
+        Particle posPart  = CreateParticle(posTrack);
+        Particle negPart  = CreateParticle(negTrack);
         posPart.isMCSignal_primary   = mcSignal_acc_posPart;
         negPart.isMCSignal_primary   = mcSignal_acc_negPart;
         posPart.isReconstructed_primary = selected_posTrack;
         negPart.isReconstructed_primary = selected_negTrack;
 
-      }
-      // if(PairPrimary == kFALSE) {
-      //   posPart.isMCSignal_secondary = mcSignal_acc_posPart;
-      //   negPart.isMCSignal_secondary = mcSignal_acc_negPart;
-      //   posPart.isReconstructed_secondary = selected_posTrack;
-      //   negPart.isReconstructed_secondary = selected_negTrack;
-      // }
-
-
-      // ##########################################################
-      // Filling primary reconstructed particle histograms according to MCSignals
-      if(PairPrimary == kTRUE){
         // check if MCSignal and isReconstructed for positive primary track
-        for (unsigned int i = 0; i < posPart.isMCSignal_primary.size(); ++i){
-          for (unsigned int j = 0; j < posPart.isReconstructed_primary.size(); ++j){
-            if (posPart.isMCSignal_primary[i] == kTRUE) {
-              if (posPart.isReconstructed_primary[j] == kTRUE){
-                if (posPart.fCharge > 0) {
-                  dynamic_cast<TH3D*>(fHistRecPrimaryPosPart.at(j * posPart.isMCSignal_primary.size() + i))->Fill(posPart.fPt, posPart.fEta, posPart.fPhi, centralityWeight);
-                }
-              }// is selected by cutsetting
-            } // is selected by MC signal
-          } // end of loop over all cutsettings
-        } // end of loop over all MCsignals
+        if (posPart.fCharge > 0) {
+          for (unsigned int i = 0; i < posPart.isMCSignal_primary.size(); ++i){
+            for (unsigned int j = 0; j < posPart.isReconstructed_primary.size(); ++j){
+              if (posPart.isMCSignal_primary[i] == kTRUE) {
+                if (posPart.isReconstructed_primary[j] == kTRUE){
+                                  dynamic_cast<TH3D*>(fHistRecPrimaryPosPart.at(j * posPart.isMCSignal_primary.size() + i))->Fill(posPart.fPt, posPart.fEta, posPart.fPhi, centralityWeight);
+                }// is selected by cutsetting
+              } // is selected by MC signal
+            } // end of loop over all cutsettings
+          } // end of loop over all MCsignals
+        } // end if particle positive
 
         // check if MCSignal and isReconstructed for negative primaryTrack
-        for (unsigned int i = 0; i < negPart.isMCSignal_primary.size(); ++i){
-          for (unsigned int j = 0; j < negPart.isReconstructed_primary.size(); ++j){
-            if (negPart.isMCSignal_primary[i] == kTRUE) {
-              if (negPart.isReconstructed_primary[j] == kTRUE){
-                if (negPart.fCharge < 0) {
+        if (negPart.fCharge < 0) {
+          for (unsigned int i = 0; i < negPart.isMCSignal_primary.size(); ++i){
+            for (unsigned int j = 0; j < negPart.isReconstructed_primary.size(); ++j){
+              if (negPart.isMCSignal_primary[i] == kTRUE) {
+                if (negPart.isReconstructed_primary[j] == kTRUE){
                   dynamic_cast<TH3D*>(fHistRecPrimaryNegPart.at(j * negPart.isMCSignal_primary.size() + i))->Fill(negPart.fPt, negPart.fEta, negPart.fPhi, centralityWeight);
-                }
-              }// is selected by cutsetting
-            } // is selected by MC signal
-          } // end of loop over all cutsettings
-        } // end of loop over all MCsignals
-      } // end if PairPrimary
+                }// is selected by cutsetting
+              } // is selected by MC signal
+            } // end of loop over all cutsettings
+          } // end of loop over all MCsignals
+        } // end if particle negative
+      } // end if TrackCuts true
 
-      // ##########################################################
-      // Fill support histograms with first cutsetting and first mcsignal
-      // if(part.isMCSignal_primary[fSupportMCSignal] == true && part.isReconstructed_primary[fSupportCutsetting] == kTRUE){
-      AliVParticle* mcPosPart = fMC->GetTrack(absposlabel);
-      AliVParticle* mcNegPart = fMC->GetTrack(absneglabel);
-      for (unsigned int i = 0; i < posPart.isReconstructed_primary.size(); i++) {
-        if(posPart.isReconstructed_primary[i] == kTRUE){    // check if part is reconstructed in each primary cut setting
-          for (unsigned int j = 0; j < posPart.isMCSignal_primary.size(); j++) {
-            if (posPart.isMCSignal_primary[j] == kTRUE) {
-              FillTrackHistograms_Primary(posTrack, mcPosPart, i, j); // Fill primary support histograms with positive partilces
-            }
-          }
-        }
-      }
-      for (unsigned int i = 0; i < negPart.isReconstructed_primary.size(); i++) {
-        if(negPart.isReconstructed_primary[i] == kTRUE){    // check if part is reconstructed in each primary cut setting
-          for (unsigned int j = 0; j < negPart.isMCSignal_primary.size(); j++) {
-            if (negPart.isMCSignal_primary[j] == kTRUE) {
-              FillTrackHistograms_Primary(negTrack, mcNegPart, i, j); // Fill primary support histograms with negative particles
-            }
-          }
-        }
-      }
-    }
 
-    // Fill reconstructed PAIR histograms
-    else if(TrackCuts == kFALSE)
-      // Apply MC signals
-      if(PairPrimary == kTRUE)  {
+
+
+      // ###############################
+      // Pair cuts on primary pair
+      // ###############################
+      else if (TrackCuts == kFALSE) {
+
+        AliDielectronPair *pair = new AliDielectronPair;
+        pair->SetKFUsage(false);
+        pair->SetTracks(static_cast<AliVTrack*>(negTrack), 11, static_cast<AliVTrack*>(posTrack), -11);
+
+        //  ---------- RECONSTRUCTED Pairs with PAIR  ---------- //
+        // Check if pair is passing cut selections
+        std::vector<bool> selected(fCutsetting.size(), kFALSE); // vector which stores if pair is accepted by [i]-th selection cut
+        for (UInt_t iCut=0; iCut<fCutsetting.size(); ++iCut){ // loop over all specified cutInstances
+          UInt_t selectedMask=( 1 << fCutsetting.at(iCut)->GetCuts()->GetEntries())-1;
+          // cutting logic taken from AliDielectron::FillTrackArrays()          FillPairArrays()
+          // apply pair cuts
+          UInt_t cutMask = fCutsetting.at(iCut)->IsSelected(pair);
+          if (cutMask == selectedMask) {selected[iCut] = kTRUE; /*std::cout << "reconstructed TRUE" << std::endl;*/}
+        }
+        // ##########################################################
+        // check if at least one is selected by cuts otherwise remove this pair from vector
+        if (CheckIfOneIsTrue(selected) == kFALSE) {
+          fPairVec->erase(fPairVec->begin()+iPair);
+          iPair--;
+          continue;
+        }
+
+        fPairVec->at(iPair).isReconstructed_primary = selected;
+
+
         std::vector<Bool_t> mcTwoSignal_acc(fPrimaryPairMCSignal.size(), kFALSE); // vector which stores if pair is accepted by [i]-th mcsignal
         for (unsigned int i = 0; i < fPrimaryPairMCSignal.size(); ++i){
           mcTwoSignal_acc[i] = AliDielectronMC::Instance()->IsMCTruth(pair, &(fPrimaryPairMCSignal[i]));
         }
-      }
-      else if(PairPrimary == kFALSE) {
+
+
+        // check if at least one mc signal is true
+        if (CheckIfOneIsTrue(mcTwoSignal_acc) == kFALSE) continue;
+
+        double weight  = 1.;
+        double mass    = fPairVec->at(iPair).fMass;
+        double pairpt  = fPairVec->at(iPair).fPt;
+
+
+        // track label, points back to MC track
+        Int_t posTrackLabel = TMath::Abs(posTrack->GetLabel());
+        Int_t negTrackLabel = TMath::Abs(negTrack->GetLabel());
+
+        // Fill secondary support histos
+        AliVParticle* mcPosPart = fMC->GetTrack(posTrackLabel);
+        AliVParticle* mcNegPart = fMC->GetTrack(negTrackLabel);
+
+        // Filling reconstructed primary particle histograms according to MCSignals
+        if (PairPrimary == kTRUE) {
+          for (unsigned int i = 0; i < fPairVec->at(iPair).isReconstructed_primary.size(); ++i){
+            if (fPairVec->at(iPair).isReconstructed_primary[i] == kTRUE){
+              for (unsigned int j = 0; j < mcTwoSignal_acc.size(); ++j){
+                if (mcTwoSignal_acc[j] == kTRUE){
+                  fHistRecPrimaryPair.at(  i *   mcTwoSignal_acc.size() + j)->Fill(mass, pairpt, weight * centralityWeight);
+                  // FillPairHistograms_Primary(pair, i, j);                 // Fill pair primary histograms
+                }// is selected by cutsetting
+              } // end of loop over all cutsettings
+            } // is selected by MCSignal
+          } // end of loop over all MCsignals
+        } // end of if PairPrimary
+        delete pair;
+      } // end if TrackCuts false
+    } // end if Pair primary
+
+
+
+
+    // ###############################
+    // secondary part
+    // ###############################
+    if (PairPrimary == kFALSE) {
+      // Get V0 from Event, selected trough V0ID stored in TwoPair and is set in reconstructed secondary two pairing
+      Int_t fV0ID = fPairVec->at(iPair).GetV0ID();
+      AliAODv0* fV0 = ((AliAODEvent*)fEvent)->GetV0(fV0ID);
+      AliAODTrack *posTrack = (AliAODTrack *) (fV0->GetSecondaryVtx()->GetDaughter(0));
+      AliAODTrack *negTrack = (AliAODTrack *) (fV0->GetSecondaryVtx()->GetDaughter(1));
+
+
+      if (TrackCuts == kTRUE) {
+        // ###############################
+        // Track cuts on secondary pair   *** not implemented yet ***
+        // ###############################
+      } // end if TrackCuts true
+
+
+      // ###############################
+      // Pair cuts on secondary pair
+      // ###############################
+      else if(TrackCuts == kFALSE) {
+
+        AliDielectronPair *pair = new AliDielectronPair;
+        pair->SetKFUsage(false);
+        pair->SetTracks(static_cast<AliAODTrack*>(negTrack), 11, static_cast<AliAODTrack*>(posTrack), -11);
+
+        //  ---------- RECONSTRUCTED Pairs with PAIR  ---------- //
+        // Check if pair is passing cut selections
+        std::vector<bool> selected(fCutsetting.size(), kFALSE); // vector which stores if pair is accepted by [i]-th selection cut
+        for (UInt_t iCut=0; iCut<fCutsetting.size(); ++iCut){ // loop over all specified cutInstances
+          UInt_t selectedMask=( 1 << fCutsetting.at(iCut)->GetCuts()->GetEntries())-1;
+          // cutting logic taken from AliDielectron::FillTrackArrays()          FillPairArrays()
+          // apply pair cuts
+          UInt_t cutMask = fCutsetting.at(iCut)->IsSelected(pair);
+          if (cutMask == selectedMask) {selected[iCut] = kTRUE; /*std::cout << "reconstructed TRUE" << std::endl;*/}
+        }
+        // ##########################################################
+        // check if at least one is selected by cuts otherwise remove this pair from vector
+        if (CheckIfOneIsTrue(selected) == kFALSE) {
+          fPairVec->erase(fPairVec->begin()+iPair);
+          iPair--;
+          continue;
+        }
+
+        fPairVec->at(iPair).isReconstructed_secondary = selected;
+
         std::vector<Bool_t> mcTwoSignal_acc(fSecondaryPairMCSignal.size(), kFALSE); // vector which stores if pair is accepted by [i]-th mcsignal
         for (unsigned int i = 0; i < fSecondaryPairMCSignal.size(); ++i){
           mcTwoSignal_acc[i] = AliDielectronMC::Instance()->IsMCTruth(pair, &(fSecondaryPairMCSignal[i]));
         }
-      }
 
-      // check if at least one mc signal is true
-      if (CheckIfOneIsTrue(mcTwoSignal_acc) == kFALSE) continue;
+        // check if at least one mc signal is true
+        if (CheckIfOneIsTrue(mcTwoSignal_acc) == kFALSE) continue;
 
-      double weight  = 1.;
-      double mass    = fPairVec->at(iPair).fMass;
-      double pairpt  = fPairVec->at(iPair).fPt;
+        double weight  = 1.;
+        double mass    = fPairVec->at(iPair).fMass;
+        double pairpt  = fPairVec->at(iPair).fPt;
 
 
-      // track label, points back to MC track
-      Int_t posTrackLabel = TMath::Abs(posTrack->GetLabel());
-      Int_t negTrackLabel = TMath::Abs(negTrack->GetLabel());
+        // track label, points back to MC track
+        Int_t posTrackLabel = TMath::Abs(posTrack->GetLabel());
+        Int_t negTrackLabel = TMath::Abs(negTrack->GetLabel());
 
-      // Fill secondary support histos
-      AliVParticle* mcPosPart = fMC->GetTrack(posTrackLabel);
-      AliVParticle* mcNegPart = fMC->GetTrack(negTrackLabel);
+        // Fill secondary support histos
+        AliVParticle* mcPosPart = fMC->GetTrack(posTrackLabel);
+        AliVParticle* mcNegPart = fMC->GetTrack(negTrackLabel);
 
-      // Filling reconstructed secondary particle histograms according to MCSignals
-      if (PairPrimary == kTRUE) {
-        for (unsigned int i = 0; i < fPairVec->at(iPair).isReconstructed_primary.size(); ++i){
-          if (fPairVec->at(iPair).isReconstructed_primary[i] == kTRUE){
-            for (unsigned int j = 0; j < mcTwoSignal_acc.size(); ++j){
-              if (mcTwoSignal_acc[j] == kTRUE){
-                fHistRecPrimaryPair.at(  i *   mcTwoSignal_acc.size() + j)->Fill(mass, pairpt, weight * centralityWeight);
-                // FillPairHistograms_Primary(pair, i, j);                 // Fill pair primary histograms
-              }// is selected by cutsetting
-            } // end of loop over all cutsettings
-          } // is selected by MCSignal
-        } // end of loop over all MCsignals
-      } // end of if PairPrimary
 
-      // Filling reconstructed secondary particle histograms according to MCSignals
-      else if (PairPrimary == kFALSE) {
         for (unsigned int i = 0; i < fPairVec->at(iPair).isReconstructed_secondary.size(); ++i){
           if (fPairVec->at(iPair).isReconstructed_secondary[i] == kTRUE){
             for (unsigned int j = 0; j < mcTwoSignal_acc.size(); ++j){
@@ -2349,9 +2352,9 @@ void AliAnalysisTaskEtaReconstruction::ApplyStandardCutsAndFillHists (std::vecto
             } // end of loop over all cutsettings
           } // is selected by MCSignal
         } // end of loop over all MCsignals
-      } // end of if PairSecondary
-      delete pair;
-    }
+        delete pair;
+      } // end if TrackCuts false
+    } // end if Pair secondary
   } // End of iPair loop
 }
 
@@ -2795,25 +2798,26 @@ void AliAnalysisTaskEtaReconstruction::DoRecTwoPairingV0(std::vector<AliDielectr
 
       //  ---------- RECONSTRUCTED for PAIR  ---------- //
       // Check if particle is passing secondary selection cuts
-      std::vector<bool> selected_secondary(fPairCuts_secondary_loose.size(), kFALSE); // vector which stores if track is accepted by [i]-th selection cut
-      for (UInt_t iCut=0; iCut<fPairCuts_secondary_loose.size(); ++iCut){ // loop over all specified cutInstances
-        UInt_t selectedMask_secondary=( 1 << fPairCuts_secondary_loose.at(iCut)->GetCuts()->GetEntries())-1;
+
+      std::vector<bool> selected_secondary(fPairCuts_secondary_PreFilter.size(), kFALSE); // vector which stores if track is accepted by [i]-th selection cut
+      for (UInt_t iCut=0; iCut<fPairCuts_secondary_PreFilter.size(); ++iCut){ // loop over all specified cutInstances
+        UInt_t selectedMask_secondary=( 1 << fPairCuts_secondary_PreFilter.at(iCut)->GetCuts()->GetEntries())-1;
         // cutting logic taken from AliDielectron::FillTrackArrays()          FillPairArrays()
         // apply track cuts
-        UInt_t cutMask_secondary = fPairCuts_secondary_loose.at(iCut)->IsSelected(pair);
+        UInt_t cutMask_secondary = fPairCuts_secondary_PreFilter.at(iCut)->IsSelected(pair);
         if (cutMask_secondary == selectedMask_secondary) {selected_secondary[iCut] = kTRUE; /*std::cout << "sec_reconstructed TRUE" << std::endl;*/}
       }
 
 
 
       // //  ---------- RECONSTRUCTED for TRACKS  ---------- //
-      // for (UInt_t iCut=0; iCut<fPairCuts_secondary_loose.size(); ++iCut){ // loop over all specified cutInstances
-        //   UInt_t selectedMask_secondary_firstPar=( 1 << fPairCuts_secondary_loose.at(iCut)->GetCuts()->GetEntries())-1;
-        //   UInt_t selectedMask_secondary_secPar=( 1 << fPairCuts_secondary_loose.at(iCut)->GetCuts()->GetEntries())-1;
+      // for (UInt_t iCut=0; iCut<fPairCuts_secondary_PreFilter.size(); ++iCut){ // loop over all specified cutInstances
+        //   UInt_t selectedMask_secondary_firstPar=( 1 << fPairCuts_secondary_PreFilter.at(iCut)->GetCuts()->GetEntries())-1;
+        //   UInt_t selectedMask_secondary_secPar=( 1 << fPairCuts_secondary_PreFilter.at(iCut)->GetCuts()->GetEntries())-1;
         //   // cutting logic taken from AliDielectron::FillTrackArrays()          FillPairArrays()
         //   // apply track cuts
-        //   UInt_t cutMask_secondary_firstPar = fPairCuts_secondary_loose.at(iCut)->IsSelected(posAODTrack);
-        //   UInt_t cutMask_secondary_secPar = fPairCuts_secondary_loose.at(iCut)->IsSelected(negAODTrack);
+        //   UInt_t cutMask_secondary_firstPar = fPairCuts_secondary_PreFilter.at(iCut)->IsSelected(posAODTrack);
+        //   UInt_t cutMask_secondary_secPar = fPairCuts_secondary_PreFilter.at(iCut)->IsSelected(negAODTrack);
         //   if (cutMask_secondary_firstPar == selectedMask_secondary_firstPar) {selected_secondary_firstPar[iCut] = kTRUE; /*std::cout << "sec_reconstructed TRUE" << std::endl;*/}
         //   if (cutMask_secondary_secPar == selectedMask_secondary_secPar) {selected_secondary_secPar[iCut] = kTRUE; /*std::cout << "sec_reconstructed TRUE" << std::endl;*/}
         // }

--- a/PWGDQ/dielectron/core/AliAnalysisTaskEtaReconstruction.h
+++ b/PWGDQ/dielectron/core/AliAnalysisTaskEtaReconstruction.h
@@ -269,7 +269,8 @@ private:
   void   DoRecTwoPairingV0(std::vector<AliDielectronSignalMC> fPairMCSignal);
   void   DoFourPairing(std::vector<TwoPair> fPairVec_primary, std::vector<TwoPair> fPairVec_secondary, Bool_t ReconstructedPair, Bool_t SmearedPair, double centralityWeight);
   void   DoFourPreFilter(std::vector<TwoPair>* fPairVec_primary, std::vector<TwoPair>* fPairVec_secondary);
-  void   ApplyStandardCutsAndFillHists(std::vector<TwoPair>* fPairVec, std::vector<AliAnalysisFilter*> fTrackCuts, Bool_t TrackCuts, Bool_t PairPrimary, double centralityWeight) {
+  void   ApplyStandardCutsAndFillHists(std::vector<TwoPair>* fPairVec, std::vector<AliAnalysisFilter*> fTrackCuts, Bool_t TrackCuts, Bool_t PairPrimary, double centralityWeight);
+
 
   void    FillTrackHistograms_Primary(AliVParticle* track, AliVParticle* mcTrack, int iMCSignal, int iCutList);
   void    FillTrackHistograms_Secondary(AliVParticle* track, AliVParticle* mcTrack, int iMCSignal, int iCutList);
@@ -465,6 +466,7 @@ private:
   Bool_t fUsePreFilter;
   Bool_t fDoMassCut;
   Bool_t fPhotonMass;
+  Bool_t fDoULSandLS;
 
   std::vector<Particle> fGenNegPart_primary;
   std::vector<Particle> fGenPosPart_primary;

--- a/PWGDQ/dielectron/core/AliAnalysisTaskEtaReconstruction.h
+++ b/PWGDQ/dielectron/core/AliAnalysisTaskEtaReconstruction.h
@@ -161,12 +161,13 @@ public:
 
 
    // Track cuts setter
-   void   AddTrackCuts_primary_single  (AliAnalysisFilter* filter) {fTrackCuts_primary.push_back(filter);}
+   void   AddTrackCuts_primary_standard  (AliAnalysisFilter* filter)  {fTrackCuts_primary_standard.push_back(filter);}
+   void   AddTrackCuts_primary_PreFilter  (AliAnalysisFilter* filter) {fTrackCuts_primary_PreFilter.push_back(filter);}
 
    // Pair cuts setter
-   void   AddTrackCuts_primary_pair  (AliAnalysisFilter* filter) {fPairCuts_primary.push_back(filter);}
-   void   AddTrackCuts_secondary_loose(AliAnalysisFilter* filter) {fPairCuts_secondary_loose.push_back(filter);}
-   void   AddTrackCuts_secondary_standard(AliAnalysisFilter* filter) {fPairCuts_secondary_standard.push_back(filter);}
+   void   AddPairCuts_primary  (AliAnalysisFilter* filter) {fPairCuts_primary.push_back(filter);}
+   void   AddPairCuts_secondary_PreFilter(AliAnalysisFilter* filter) {fPairCuts_secondary_PreFilter.push_back(filter);}
+   void   AddPairCuts_secondary_standard(AliAnalysisFilter* filter)  {fPairCuts_secondary_standard.push_back(filter);}
 
 
 
@@ -268,7 +269,7 @@ private:
   void   DoRecTwoPairingV0(std::vector<AliDielectronSignalMC> fPairMCSignal);
   void   DoFourPairing(std::vector<TwoPair> fPairVec_primary, std::vector<TwoPair> fPairVec_secondary, Bool_t ReconstructedPair, Bool_t SmearedPair, double centralityWeight);
   void   DoFourPreFilter(std::vector<TwoPair>* fPairVec_primary, std::vector<TwoPair>* fPairVec_secondary);
-  void   ApplySecondaryCutsAndFillHists(std::vector<TwoPair>*  fSecPairVec, std::vector<AliAnalysisFilter*> fTrackCuts_secondary, double centralityWeight);
+  void   ApplyStandardCutsAndFillHists(std::vector<TwoPair>* fPairVec, std::vector<AliAnalysisFilter*> fTrackCuts, Bool_t TrackCuts, Bool_t PairPrimary, double centralityWeight) {
 
   void    FillTrackHistograms_Primary(AliVParticle* track, AliVParticle* mcTrack, int iMCSignal, int iCutList);
   void    FillTrackHistograms_Secondary(AliVParticle* track, AliVParticle* mcTrack, int iMCSignal, int iCutList);
@@ -382,9 +383,10 @@ private:
 
   Bool_t fSelectPhysics;
   Int_t  fTriggerMask;
-  std::vector<AliAnalysisFilter*> fTrackCuts_primary;
+  std::vector<AliAnalysisFilter*> fTrackCuts_primary_standard;
+  std::vector<AliAnalysisFilter*> fTrackCuts_primary_PreFilter;
   std::vector<AliAnalysisFilter*> fPairCuts_primary;
-  std::vector<AliAnalysisFilter*> fPairCuts_secondary_loose;
+  std::vector<AliAnalysisFilter*> fPairCuts_secondary_PreFilter;
   std::vector<AliAnalysisFilter*> fPairCuts_secondary_standard;
   TBits*  fUsedVars;                // used variables by AliDielectronVarManager
 

--- a/PWGDQ/dielectron/macrosLMEE/AddTask_feisenhut_EtaReconstruction.C
+++ b/PWGDQ/dielectron/macrosLMEE/AddTask_feisenhut_EtaReconstruction.C
@@ -184,48 +184,64 @@ AliAnalysisTaskEtaReconstruction* AddTask_feisenhut_EtaReconstruction(TString na
 
 
   // #########################################################
+  // #                set track cutsettings                  #
   // #########################################################
-  // Adding primary electron cutsettings
-  TObjArray*  arrNames_prim=names_Prim_Single_Cuts.Tokenize(";");
+  // Adding standard primary electron track cutsettings
+  TObjArray*  arrNames_prim=names_Prim_Track_standard_Cuts.Tokenize(";");
   const Int_t nDie=arrNames_prim->GetEntriesFast();
 
   for (int iCut = 0; iCut < nDie; ++iCut){
     TString cutDefinition(arrNames_prim->At(iCut)->GetName());
     AliAnalysisFilter* filter = SetupTrackCutsAndSettings(cutDefinition, isAOD);
-    task->AddTrackCuts_primary_single(filter);
+    task->AddTrackCuts_primary_standard(filter);
     DoAdditionalWork(task);
   }
 
-  // Adding primary electron cutsettings
+  // Adding PreFilter primary electron track cutsettings
+  TObjArray*  arrNames_prim=names_Prim_Track_PreFilter_Cuts.Tokenize(";");
+  const Int_t nDie=arrNames_prim->GetEntriesFast();
+
+  for (int iCut = 0; iCut < nDie; ++iCut){
+    TString cutDefinition(arrNames_prim->At(iCut)->GetName());
+    AliAnalysisFilter* filter = SetupTrackCutsAndSettings(cutDefinition, isAOD);
+    task->AddTrackCuts_primary_PreFilter(filter);
+    DoAdditionalWork(task);
+  }
+
+
+  // #########################################################
+  // #                 set pair cutsettings                  #
+  // #########################################################
+  // Adding primary pair cutsettings
   TObjArray*  arrNames_prim=names_Prim_Pair_Cuts.Tokenize(";");
   const Int_t nDie=arrNames_prim->GetEntriesFast();
 
   for (int iCut = 0; iCut < nDie; ++iCut){
     TString cutDefinition(arrNames_prim->At(iCut)->GetName());
     AliAnalysisFilter* filter = SetupTrackCutsAndSettings(cutDefinition, isAOD);
-    task->AddTrackCuts_primary_pair(filter);
+    task->AddPairCuts_primary(filter);
     DoAdditionalWork(task);
   }
 
-  // Adding standard secondary electron cutsettings
-  TObjArray*  arrNames_sec=names_Sec_Cuts.Tokenize(";");
+  // Adding standard secondary pair cutsettings
+  TObjArray*  arrNames_sec=names_Sec_Pair_standard_Cuts.Tokenize(";");
   const Int_t nDie=arrNames_sec->GetEntriesFast();
 
   for (int iCut = 0; iCut < nDie; ++iCut){
     TString cutDefinition(arrNames_sec->At(iCut)->GetName());
     AliAnalysisFilter* filter = SetupTrackCutsAndSettings(cutDefinition, isAOD);
-    task->AddTrackCuts_secondary_standard(filter);
+    task->AddPairCuts_secondary_standard(filter);
     DoAdditionalWork(task);
   }
 
-  // Adding loose secondary electron cutsettings
-  TObjArray*  arrNames_sec_loose=names_Sec_loose_Cuts.Tokenize(";");
-  const Int_t nDie=arrNames_sec_loose->GetEntriesFast();
+  // Adding PreFilter secondary pair cutsettings
+  TObjArray*  arrNames_sec_PreFilter=names_Sec_Pair_PreFilter_Cuts.Tokenize(";");
+  const Int_t nDie=arrNames_sec_PreFilter->GetEntriesFast();
 
   for (int iCut = 0; iCut < nDie; ++iCut){
-    TString cutDefinition(arrNames_sec_loose->At(iCut)->GetName());
+    TString cutDefinition(arrNames_sec_PreFilter->At(iCut)->GetName());
     AliAnalysisFilter* filter = SetupTrackCutsAndSettings(cutDefinition, isAOD);
-    task->AddTrackCuts_secondary_loose(filter);
+    task->AddPairCuts_secondary_PreFilter(filter);
     DoAdditionalWork(task);
   }
 

--- a/PWGDQ/dielectron/macrosLMEE/AddTask_feisenhut_EtaReconstruction.C
+++ b/PWGDQ/dielectron/macrosLMEE/AddTask_feisenhut_EtaReconstruction.C
@@ -8,7 +8,6 @@ AliAnalysisTaskEtaReconstruction* AddTask_feisenhut_EtaReconstruction(TString na
                                                                 Int_t centrality = 4) {
 
 
-
   std::cout << "########################################\nADDTASK of ANALYSIS started\n########################################" << std::endl;
 
   // #########################################################
@@ -161,6 +160,7 @@ AliAnalysisTaskEtaReconstruction* AddTask_feisenhut_EtaReconstruction(TString na
   // Pairing related config
   task->SetDoPairing(DoPairing);
   task->SetDoFourPairing(DoFourPairing);
+  // task->SetULSandLS(DoULSLS);
   task->SetUsePreFilter(UsePreFilter);
 
   // #########################################################
@@ -188,8 +188,8 @@ AliAnalysisTaskEtaReconstruction* AddTask_feisenhut_EtaReconstruction(TString na
   // #########################################################
   // Adding standard primary electron track cutsettings
   TObjArray*  arrNames_prim=names_Prim_Track_standard_Cuts.Tokenize(";");
-  const Int_t nDie=arrNames_prim->GetEntriesFast();
 
+  const Int_t nDie=arrNames_prim->GetEntriesFast();
   for (int iCut = 0; iCut < nDie; ++iCut){
     TString cutDefinition(arrNames_prim->At(iCut)->GetName());
     AliAnalysisFilter* filter = SetupTrackCutsAndSettings(cutDefinition, isAOD);
@@ -207,7 +207,6 @@ AliAnalysisTaskEtaReconstruction* AddTask_feisenhut_EtaReconstruction(TString na
     task->AddTrackCuts_primary_PreFilter(filter);
     DoAdditionalWork(task);
   }
-
 
   // #########################################################
   // #                 set pair cutsettings                  #

--- a/PWGDQ/dielectron/macrosLMEE/Config_feisenhut_EtaReconstruction.C
+++ b/PWGDQ/dielectron/macrosLMEE/Config_feisenhut_EtaReconstruction.C
@@ -4,29 +4,30 @@
 // TString names_Prim_Cuts=("JPID_sum_pt75");
 // TString names_Prim_Cuts=("JPID_sum_pt75;JPID_sum2_pt75_sec_OnlyCosOpenAngle;JPID_sum7_pt75_sec_OnlyM;JPID_sum8_pt75_sec_OnlyArmPt;JPID_sum9_pt75_sec_OnlyArmAlpha;JPID_sum1_pt75_sec_kV0");
 // TString names_Prim_Cuts=("JPID_sum_pt75;JPID_sum6_pt75_sec_wCosChi2LegDistRPsiPairM;JPID_sum7_pt75_sec_wCosChi2LegDistRPsiPairMArmPt;JPID_sum8_pt75_sec_wCosChi2LegDistRPsiPairMArmPtAlpha");
-TString names_Prim_Single_Cuts=("JPID_sum_pt75;JPID_sum1_pt75_sec_kV0");
+TString names_Prim_Track_standard_Cuts=("JPID_sum_pt75;JPID_sum1_pt75_sec_kV0");
+TString names_Prim_Track_PreFilter_Cuts=("JPID_sum_pt75;JPID_sum1_pt75_sec_kV0");
 
 // +++++++++++++++++ Cuts for primary pairs  +++++++++++++++++
 TString names_Prim_Pair_Cuts=("pairJPID_sum_pt75;pairJPID_sum1_pt75_sec_kV0");
 
 // +++++++++++++++++ Cuts for secondary electrons +++++++++++++++++
-// TString names_Sec_Cuts=("noPID");      // still has kin cuts (pt 75 MeV/c)
-// TString names_Sec_Cuts=("JPID_sum_pt75_secondary");
-// TString names_Sec_Cuts=("kV0");
-// TString names_Sec_Cuts=("noPID;kV0OnlyCosOpenAngle;kV0OnlyM;kV0OnlyArmPt;kV0OnlyArmAlpha;kV0");
-// TString names_Sec_Cuts=("noPID;kV0wPairM;kV0wPairMArmPt;kV0wPairMArmPtAlpha");
-TString names_Sec_Cuts=("noPID;kV0");
-// TString names_Sec_Cuts=("noPID;kV0_loose");
+// TString names_Sec_Pair_standard_Cuts=("noPID");      // still has kin cuts (pt 75 MeV/c)
+// TString names_Sec_Pair_standard_Cuts=("JPID_sum_pt75_secondary");
+// TString names_Sec_Pair_standard_Cuts=("kV0");
+// TString names_Sec_Pair_standard_Cuts=("noPID;kV0OnlyCosOpenAngle;kV0OnlyM;kV0OnlyArmPt;kV0OnlyArmAlpha;kV0");
+// TString names_Sec_Pair_standard_Cuts=("noPID;kV0wPairM;kV0wPairMArmPt;kV0wPairMArmPtAlpha");
+TString names_Sec_Pair_standard_Cuts=("noPID;kV0");
+// TString names_Sec_Pair_standard_Cuts=("noPID;kV0_PreFilter");
 
 
-                                                                                // TString names_Sec_Cuts=("onlyPIDcut1_noTrackCuts");
-                                                                                // TString names_Sec_Cuts=("cut1_pt75_secondary");
-                                                                                // TString names_Sec_Cuts=("cut1_pt75");
-                                                                                // TString names_Sec_Cuts=("noPID;cut1_pt75_secondary");
+                                                                                // TString names_Sec_Pair_standard_Cuts=("onlyPIDcut1_noTrackCuts");
+                                                                                // TString names_Sec_Pair_standard_Cuts=("cut1_pt75_secondary");
+                                                                                // TString names_Sec_Pair_standard_Cuts=("cut1_pt75");
+                                                                                // TString names_Sec_Pair_standard_Cuts=("noPID;cut1_pt75_secondary");
 
 
-// TString names_Sec_loose_Cuts=("noPID;kV0");
-TString names_Sec_loose_Cuts=("noPID;kV0_loose");
+// TString names_Sec_Pair_PreFilter_Cuts=("noPID;kV0");
+TString names_Sec_Pair_PreFilter_Cuts=("noPID;kV0_PreFilter");
 
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!
 // 400 MEV CUT !!!!!!!!!!!!!!!
@@ -416,7 +417,7 @@ AliAnalysisFilter* SetupTrackCutsAndSettings(TString cutDefinition, Bool_t isAOD
     AnaCut.SetStandardCut();
   }
 
-  else if (cutDefinition == "kV0_loose"){
+  else if (cutDefinition == "kV0_PreFilter"){
     // AnaCut.SetPIDAna(LMEECutLib::kPIDcut_TEST);
     AnaCut.SetPIDAna(LMEECutLib::kNoPID_Pt20);
     // AnaCut.SetPIDAna(LMEECutLib::kNoPID_noKinCuts);
@@ -425,7 +426,7 @@ AliAnalysisFilter* SetupTrackCutsAndSettings(TString cutDefinition, Bool_t isAOD
     // AnaCut.SetTrackSelectionAna(LMEECutLib::kTRACKcut_1_secondary);
     AnaCut.SetTrackSelectionAna(LMEECutLib::kDefaultNoTrackCuts);
 
-    AnaCut.SetPairCutsAna(LMEECutLib::kV0_loose);
+    AnaCut.SetPairCutsAna(LMEECutLib::kV0_PreFilter);
 
     AnaCut.SetCentrality(centrality);
     AnaCut.SetStandardCut();

--- a/PWGDQ/dielectron/macrosLMEE/Config_feisenhut_EtaReconstruction.C
+++ b/PWGDQ/dielectron/macrosLMEE/Config_feisenhut_EtaReconstruction.C
@@ -1,16 +1,24 @@
 
 // +++++++++++++++++ Cuts for primary single electrons +++++++++++++++++
+TString names_Prim_Track_PreFilter_Cuts=("JPID_sum_pt75_PreFilter;JPID_sum1_pt75_sec_kV0_PreFilter");
+// TString names_Prim_Track_PreFilter_Cuts=("JPID_sum_pt75;JPID_sum1_pt75_sec_kV0");
+
+
 // TString names_Prim_Cuts=("noPID");     // still has kin cuts (pt 75 MeV/c)
 // TString names_Prim_Cuts=("JPID_sum_pt75");
 // TString names_Prim_Cuts=("JPID_sum_pt75;JPID_sum2_pt75_sec_OnlyCosOpenAngle;JPID_sum7_pt75_sec_OnlyM;JPID_sum8_pt75_sec_OnlyArmPt;JPID_sum9_pt75_sec_OnlyArmAlpha;JPID_sum1_pt75_sec_kV0");
 // TString names_Prim_Cuts=("JPID_sum_pt75;JPID_sum6_pt75_sec_wCosChi2LegDistRPsiPairM;JPID_sum7_pt75_sec_wCosChi2LegDistRPsiPairMArmPt;JPID_sum8_pt75_sec_wCosChi2LegDistRPsiPairMArmPtAlpha");
 TString names_Prim_Track_standard_Cuts=("JPID_sum_pt75;JPID_sum1_pt75_sec_kV0");
-TString names_Prim_Track_PreFilter_Cuts=("JPID_sum_pt75;JPID_sum1_pt75_sec_kV0");
+// TString names_Prim_Track_standard_Cuts=("JPID_sum_pt75_PreFilter;JPID_sum1_pt75_sec_kV0_PreFilter");
 
 // +++++++++++++++++ Cuts for primary pairs  +++++++++++++++++
 TString names_Prim_Pair_Cuts=("pairJPID_sum_pt75;pairJPID_sum1_pt75_sec_kV0");
 
 // +++++++++++++++++ Cuts for secondary electrons +++++++++++++++++
+// TString names_Sec_Pair_PreFilter_Cuts=("noPID;kV0");
+TString names_Sec_Pair_PreFilter_Cuts=("noPID;kV0_PreFilter");
+
+
 // TString names_Sec_Pair_standard_Cuts=("noPID");      // still has kin cuts (pt 75 MeV/c)
 // TString names_Sec_Pair_standard_Cuts=("JPID_sum_pt75_secondary");
 // TString names_Sec_Pair_standard_Cuts=("kV0");
@@ -25,9 +33,6 @@ TString names_Sec_Pair_standard_Cuts=("noPID;kV0");
                                                                                 // TString names_Sec_Pair_standard_Cuts=("cut1_pt75");
                                                                                 // TString names_Sec_Pair_standard_Cuts=("noPID;cut1_pt75_secondary");
 
-
-// TString names_Sec_Pair_PreFilter_Cuts=("noPID;kV0");
-TString names_Sec_Pair_PreFilter_Cuts=("noPID;kV0_PreFilter");
 
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!
 // 400 MEV CUT !!!!!!!!!!!!!!!
@@ -56,6 +61,7 @@ bool DoPairing      = true;
 bool DoFourPairing  = true;
 bool UsePreFilter   = false;
 bool DoMassCut      = false;
+// bool DoULSLS   = true;
 
 bool UseMCDataSig   = false;
 
@@ -325,10 +331,19 @@ AliAnalysisFilter* SetupTrackCutsAndSettings(TString cutDefinition, Bool_t isAOD
   /////////////////////////////////////////////////////////
   //             primary single cut settings             //
   /////////////////////////////////////////////////////////
-  else if (cutDefinition == "JPID_sum_pt75"){
+  else if (cutDefinition == "JPID_sum_pt75" || cutDefinition == "JPID_sum_pt75_PreFilter"){
     AnaCut.SetPIDAna(LMEECutLib::kPID_Jeromian_01);
     // AnaCut.SetTrackSelectionAna(LMEECutLib::kTRACKcut_1);
     AnaCut.SetTrackSelectionAna(LMEECutLib::kTRACKcut_2);
+    AnaCut.SetPairCutsAna(LMEECutLib::kNoPairCutsAna);
+    AnaCut.SetCentrality(centrality);
+    AnaCut.SetStandardCut();
+  }
+
+  else if (cutDefinition == "JPID_sum_pt75_PreFilter" || cutDefinition == "JPID_sum1_pt75_sec_kV0_PreFilter"){
+    AnaCut.SetPIDAna(LMEECutLib::kPID_Jeromian_01_PreFilter);
+    // AnaCut.SetTrackSelectionAna(LMEECutLib::kTRACKcut_1);
+    AnaCut.SetTrackSelectionAna(LMEECutLib::kTRACKcut_2_PreFilter);
     AnaCut.SetPairCutsAna(LMEECutLib::kNoPairCutsAna);
     AnaCut.SetCentrality(centrality);
     AnaCut.SetStandardCut();
@@ -351,7 +366,7 @@ AliAnalysisFilter* SetupTrackCutsAndSettings(TString cutDefinition, Bool_t isAOD
            cutDefinition == "JPID_sum6_pt75_sec_OnlyPsiPair"           || cutDefinition == "JPID_sum6_pt75_sec_wCosChi2LegDistRPsiPairM"           ||
            cutDefinition == "JPID_sum7_pt75_sec_OnlyM"                 || cutDefinition == "JPID_sum7_pt75_sec_wCosChi2LegDistRPsiPairMArmPt"      ||
            cutDefinition == "JPID_sum8_pt75_sec_OnlyArmPt"             || cutDefinition == "JPID_sum8_pt75_sec_wCosChi2LegDistRPsiPairMArmPtAlpha" ||
-           cutDefinition == "JPID_sum9_pt75_sec_OnlyArmAlpha"
+           cutDefinition == "JPID_sum9_pt75_sec_OnlyArmAlpha"          || cutDefinition == "JPID_sum1_pt75_sec_kV0_PreFilter"
           ){
     AnaCut.SetPIDAna(LMEECutLib::kPID_Jeromian_01);
     // AnaCut.SetTrackSelectionAna(LMEECutLib::kTRACKcut_1);

--- a/PWGDQ/dielectron/macrosLMEE/LMEECutLib_feisenhut.C
+++ b/PWGDQ/dielectron/macrosLMEE/LMEECutLib_feisenhut.C
@@ -65,6 +65,7 @@ public:
     kNoPID_Pt75,
     kNoPID_Pt200,
     kPID_Jeromian_01,
+    kPID_Jeromian_01_PreFilter,
     kPID_Jeromian_01_pt200,
     kPIDcut_1_pt75,
     kPIDcut_TEST,
@@ -78,6 +79,7 @@ public:
     kNoTrackCuts,
     kTRACKcut_1,
     kTRACKcut_2,
+    kTRACKcut_2_PreFilter,
     kTRACKcut_1_secondary,
     kDefaultNoTrackCuts,
     kV0
@@ -182,14 +184,14 @@ public:
     AliDielectronCutGroup* cgPIDCutsAna = new AliDielectronCutGroup("cgPIDCutsAna","cgPIDCutsAna",AliDielectronCutGroup::kCompAND);
     cgPIDCutsAna->AddCut(etaRange);
     cgPIDCutsAna->AddCut(ptRange);
-                                                                                Printf("%d DEBUG CutLib before PID " , __LINE__);
+                                                                                // Printf("%d DEBUG CutLib before PID " , __LINE__);
     cgPIDCutsAna->AddCut(PID);
-                                                                                Printf("%d DEBUG CutLib after PID " , __LINE__);
+                                                                                // Printf("%d DEBUG CutLib after PID " , __LINE__);
 
     cgPIDCutsAna->AddCut(GetTrackSelectionAna(AnaCut));
-                                                                                Printf("%d DEBUG CutLib after GetTrackSelectionAna " , __LINE__);
+                                                                                // Printf("%d DEBUG CutLib after GetTrackSelectionAna " , __LINE__);
     cgPIDCutsAna->AddCut(GetPairCutsAna(AnaCut));
-                                                                                Printf("%d DEBUG CutLib after GetPairCutsAna " , __LINE__);
+                                                                                // Printf("%d DEBUG CutLib after GetPairCutsAna " , __LINE__);
     return cgPIDCutsAna;
   }
 
@@ -780,6 +782,8 @@ AliAnalysisCuts* LMEECutLib::GetPIDCutsAna(AnalysisCut AnaCut) {
   // eta range:
   AliDielectronVarCuts *etaRange080 = new AliDielectronVarCuts("etaRange080","etaRange080");
   etaRange080->AddCut(AliDielectronVarManager::kEta, -0.80, 0.80);
+  AliDielectronVarCuts *etaRange110 = new AliDielectronVarCuts("etaRange110","etaRange110");
+  etaRange110->AddCut(AliDielectronVarManager::kEta, -1.10, 1.10);
   AliDielectronVarCuts *etaRange120 = new AliDielectronVarCuts("etaRange120","etaRange120");
   etaRange120->AddCut(AliDielectronVarManager::kEta, -1.20, 1.20);
   AliDielectronVarCuts *etaRange150 = new AliDielectronVarCuts("etaRange150","etaRange150");
@@ -795,6 +799,8 @@ AliAnalysisCuts* LMEECutLib::GetPIDCutsAna(AnalysisCut AnaCut) {
   ptRange100toINF->AddCut(AliDielectronVarManager::kPt, 0.1, 100.0);
   AliDielectronVarCuts *ptRange75to8000 = new AliDielectronVarCuts("ptRange75to8000","ptRange75to8000");
   ptRange75to8000->AddCut(AliDielectronVarManager::kPt, 0.075, 8.0);
+  AliDielectronVarCuts *ptRange50to8000 = new AliDielectronVarCuts("ptRange50to8000","ptRange50to8000");
+  ptRange50to8000->AddCut(AliDielectronVarManager::kPt, 0.050, 8.0);
   AliDielectronVarCuts *ptRange20to8000 = new AliDielectronVarCuts("ptRange20to8000","ptRange20to8000");
   ptRange20to8000->AddCut(AliDielectronVarManager::kPt, 0.02, 8.0);
   AliDielectronVarCuts *ptRange200to8000 = new AliDielectronVarCuts("ptRange200to8000","ptRange200to8000");
@@ -887,6 +893,12 @@ AliAnalysisCuts* LMEECutLib::GetPIDCutsAna(AnalysisCut AnaCut) {
   Jeromian_01_sum->AddCut(Jeromian_01_hadron_cut);
   Jeromian_01_sum->AddCut(Jeromian_01_ele_incl);
 
+
+  AliDielectronPID *Jeromian_01_PreFilter_hadron_cut = new AliDielectronPID("Jeromian_01_hadron_cut","Jeromian_01_hadron_cut");
+  Jeromian_01_hadron_cut->AddCut(AliDielectronPID::kTPC,AliPID::kElectron,  -3. , 3. ,0.0, 100., kFALSE,AliDielectronPID::kIfAvailable    ,AliDielectronVarManager::kP);
+
+  AliDielectronCutGroup* Jeromian_01_sum_PreFilter = new AliDielectronCutGroup("Jeromian_01_sum","Jeromian_01_sum",AliDielectronCutGroup::kCompOR);
+  Jeromian_01_sum_PreFilter->AddCut(Jeromian_01_PreFilter_hadron_cut);
 
 
   AliDielectronPID *PIDcut_1 = new AliDielectronPID("PIDcut_1","PIDcut_1");
@@ -1310,9 +1322,12 @@ AliAnalysisCuts* LMEECutLib::GetPIDCutsAna(AnalysisCut AnaCut) {
     case kPID_Jeromian_01:
       pidCuts = LMEECutLib::SetKinematics(etaRange080, ptRange75to8000, Jeromian_01_sum, AnaCut);;
       break;
-      case kPID_Jeromian_01_pt200:
-        pidCuts = LMEECutLib::SetKinematics(etaRange080, ptRange200to8000, Jeromian_01_sum, AnaCut);;
-        break;
+    case kPID_Jeromian_01_PreFilter:
+      pidCuts = LMEECutLib::SetKinematics(etaRange110, ptRange50to8000, Jeromian_01_sum_PreFilter, AnaCut);;
+      break;
+    case kPID_Jeromian_01_pt200:
+      pidCuts = LMEECutLib::SetKinematics(etaRange080, ptRange200to8000, Jeromian_01_sum, AnaCut);;
+      break;
     case kPIDcut_1_pt75:
       pidCuts = LMEECutLib::SetKinematics(etaRange080, ptRange75to8000, PIDcut_1, AnaCut);;
       break;
@@ -1431,6 +1446,49 @@ AliAnalysisCuts* LMEECutLib::GetTrackSelectionAna(AnalysisCut AnaCut) {
          cgTrackCutsAnaSPDfirst->AddCut(SharedClusterCut);
          trackCuts = cgTrackCutsAnaSPDfirst;
          break;
+
+         case kTRACKcut_2_PreFilter:
+           AliDielectronVarCuts* trackCutsAOD =new AliDielectronVarCuts("trackCutsAOD","trackCutsAOD");
+           trackCutsAOD->AddCut(AliDielectronVarManager::kImpactParXY, -1.0,   1.0);
+           trackCutsAOD->AddCut(AliDielectronVarManager::kImpactParZ,  -3.0,   3.0);
+           trackCutsAOD->AddCut(AliDielectronVarManager::kKinkIndex0,          0. );
+           trackCutsAOD->AddCut(AliDielectronVarManager::kNclsITS,      3.0, 100.0);
+           // trackCutsAOD->AddCut(AliDielectronVarManager::kNclsTPC,      80.0, 160.0);
+           trackCutsAOD->AddCut(AliDielectronVarManager::kITSchi2Cl,    0.0,   5.0);
+           // trackCutsAOD->AddCut(AliDielectronVarManager::kTPCchi2Cl,    0.0,   4.0);
+           // trackCutsAOD->AddCut(AliDielectronVarManager::kNFclsTPCr,    80.0, 161.0);
+           // trackCutsAOD->AddCut(AliDielectronVarManager::kNFclsTPCfCross,     0.95, 1.05);
+           // AliDielectronCutGroup* SharedClusterCut = new AliDielectronCutGroup("SharedClusterCut","SharedClusterCut",AliDielectronCutGroup::kCompOR);
+           // double delta = 0.00001;
+           // AliDielectronVarCuts* trackCutsSharedCluster0 = new AliDielectronVarCuts("trackCutsSharedCluster0", "trackCutsSharedCluster0");
+           // trackCutsSharedCluster0->AddCut(AliDielectronVarManager::kNclsSMapITS, 0-delta, 0+delta);
+           // AliDielectronVarCuts* trackCutsSharedCluster2 = new AliDielectronVarCuts("trackCutsSharedCluster2", "trackCutsSharedCluster2");
+           // trackCutsSharedCluster2->AddCut(AliDielectronVarManager::kNclsSMapITS, 2-delta, 2+delta);
+           // AliDielectronVarCuts* trackCutsSharedCluster4 = new AliDielectronVarCuts("trackCutsSharedCluster4", "trackCutsSharedCluster4");
+           // trackCutsSharedCluster4->AddCut(AliDielectronVarManager::kNclsSMapITS, 4-delta, 4+delta);
+           // AliDielectronVarCuts* trackCutsSharedCluster8 = new AliDielectronVarCuts("trackCutsSharedCluster8", "trackCutsSharedCluster8");
+           // trackCutsSharedCluster8->AddCut(AliDielectronVarManager::kNclsSMapITS, 8-delta, 8+delta);
+           // AliDielectronVarCuts* trackCutsSharedCluster16 = new AliDielectronVarCuts("trackCutsSharedCluster16", "trackCutsSharedCluster16");
+           // trackCutsSharedCluster16->AddCut(AliDielectronVarManager::kNclsSMapITS, 16-delta, 16+delta);
+           // AliDielectronVarCuts* trackCutsSharedCluster32 = new AliDielectronVarCuts("trackCutsSharedCluster32", "trackCutsSharedCluster32");
+           // trackCutsSharedCluster32->AddCut(AliDielectronVarManager::kNclsSMapITS, 32-delta, 32+delta);
+           // SharedClusterCut->AddCut(trackCutsSharedCluster0);
+           // SharedClusterCut->AddCut(trackCutsSharedCluster2);
+           // SharedClusterCut->AddCut(trackCutsSharedCluster4);
+           // SharedClusterCut->AddCut(trackCutsSharedCluster8);
+           // SharedClusterCut->AddCut(trackCutsSharedCluster16);
+           // SharedClusterCut->AddCut(trackCutsSharedCluster32);
+           AliDielectronTrackCuts *trackCutsDiel = new AliDielectronTrackCuts("trackCutsDiel","trackCutsDiel");
+           // trackCutsDiel->SetAODFilterBit(1<<4);
+           trackCutsDiel->SetAODFilterBit(1<<0);
+           // trackCutsDiel->SetClusterRequirementITS(AliESDtrackCuts::kSPD, AliESDtrackCuts::kFirst);
+           trackCutsDiel->SetClusterRequirementITS(AliESDtrackCuts::kSPD, AliESDtrackCuts::kAny);
+           cgTrackCutsAnaSPDfirst = new AliDielectronCutGroup("cgTrackCutsAnaSPDfirst","cgTrackCutsAnaSPDfirst",AliDielectronCutGroup::kCompAND);
+           cgTrackCutsAnaSPDfirst->AddCut(trackCutsDiel);
+           cgTrackCutsAnaSPDfirst->AddCut(trackCutsAOD);
+           // cgTrackCutsAnaSPDfirst->AddCut(SharedClusterCut);
+           trackCuts = cgTrackCutsAnaSPDfirst;
+           break;
 
       case kTRACKcut_1_secondary:
         std::cout << "kTRACKcut_1_secondary" << std::endl;

--- a/PWGDQ/dielectron/macrosLMEE/LMEECutLib_feisenhut.C
+++ b/PWGDQ/dielectron/macrosLMEE/LMEECutLib_feisenhut.C
@@ -95,7 +95,7 @@ public:
     kPairCutsAna, // Cut off (theta < 0.05) && (Minv < 0.02)
     kNoPairCutsAna, // No Cuts applied, since 18.02.2014
     kV0,
-    kV0_loose,
+    kV0_PreFilter,
     kV0_onlyCos,
     kV0_onlyChi2NDF,
     kV0_onlyLegDist,
@@ -520,9 +520,9 @@ AliAnalysisCuts* LMEECutLib::GetPairCutsAna(AnalysisCut AnaCut, Int_t togglePC) 
       pairCuts = cgTrackCutsV0select;
       break;
 
-      case kV0_loose:
+      case kV0_PreFilter:
         // primarily meant for inclusion, for quite pure sample...
-        std::cout << "Using kV0_loose Cutsetting" << std::endl;
+        std::cout << "Using kV0_PreFilter Cutsetting" << std::endl;
         // AliDielectronV0Cuts *gammaV0Cuts = new AliDielectronV0Cuts("gammaV0Cuts","gammaV0Cuts");
         AliDielectronVarCuts* gammaV0Cuts =new AliDielectronVarCuts("gammaV0Cuts","gammaV0Cuts");
         gammaV0Cuts->AddCut(AliDielectronVarManager::kCosPointingAngle,              0.8,  1.0,  kFALSE);


### PR DESCRIPTION
I added a new cutsetting that can be used before the PreFilter in order to select more particles that can be paired in the PreFilter and reject false identified particles afterwards with an other cutsetting.