### PR TITLE
PWGDQ/reducedTree: updates for EMCal triggered analysis

### DIFF
--- a/PWGDQ/reducedTree/AliReducedAnalysisJpsi2ee.h
+++ b/PWGDQ/reducedTree/AliReducedAnalysisJpsi2ee.h
@@ -71,10 +71,13 @@ public:
   virtual AliReducedCaloClusterTrackMatcher* GetClusterTrackMatcher() const {return fClusterTrackMatcher;}
   Int_t GetNClusterCuts() const {return fClusterCuts.GetEntries();}
   const Char_t* GetClusterCutName(Int_t i) const {return (i<fClusterCuts.GetEntries() ? fClusterCuts.At(i)->GetName() : "");}
+  AliReducedInfoCut* GetCaloClusterCut(Int_t i) const {return (i<fClusterCuts.GetEntries() ? (AliReducedInfoCut*)fClusterCuts.At(i) : NULL);}
   Int_t GetNTrackCuts() const {return fTrackCuts.GetEntries();}
   const Char_t* GetTrackCutName(Int_t i) const {return (i<fTrackCuts.GetEntries() ? fTrackCuts.At(i)->GetName() : "");}
+  AliReducedInfoCut* GetTrackCut(Int_t i) const {return (i<fTrackCuts.GetEntries() ? (AliReducedInfoCut*)fTrackCuts.At(i) : NULL);}
   Int_t GetNPairCuts() const {return fPairCuts.GetEntries();}
   const Char_t* GetPairCutName(Int_t i) const {return (i<fPairCuts.GetEntries() ? fPairCuts.At(i)->GetName() : "");}
+  AliReducedInfoCut* GetPairCut(Int_t i) const {return (i<fPairCuts.GetEntries() ? (AliReducedInfoCut*)fPairCuts.At(i) : NULL);}
   Bool_t GetRunOverMC() const {return fOptionRunOverMC;};
   Bool_t GetRunLikeSignPairing() const {return fOptionRunLikeSignPairing;}
   Bool_t GetRunEventMixing() const {return fOptionRunMixing;}
@@ -169,7 +172,7 @@ protected:
   Bool_t fSkipMCEvent;          // decision to skip MC event
   TH1F*  fMCJpsiPtWeights;            // weights vs pt to reject events depending on the jpsi true pt (needed to re-weights jpsi Pt distribution)
   
-  ClassDef(AliReducedAnalysisJpsi2ee,12);
+  ClassDef(AliReducedAnalysisJpsi2ee,13);
 };
 
 #endif

--- a/PWGDQ/reducedTree/AliReducedCompositeCut.cxx
+++ b/PWGDQ/reducedTree/AliReducedCompositeCut.cxx
@@ -61,6 +61,21 @@ Bool_t AliReducedCompositeCut::IsSelected(TObject* obj, Float_t* values) {
   else return kFALSE;
 }
 
+//____________________________________________________________________________
+Bool_t AliReducedCompositeCut::IsSelected(Float_t* values) {
+  //
+  // apply cuts
+  //
+  for(Int_t iCut=0; iCut<fCuts.GetEntries(); ++iCut) {
+     AliReducedInfoCut* cut = (AliReducedInfoCut*)fCuts.At(iCut);
+
+     if(fOptionUseAND && !cut->IsSelected(values)) return kFALSE;
+     if(!fOptionUseAND && cut->IsSelected(values)) return kTRUE;
+  }
+
+  if(fOptionUseAND) return kTRUE;
+  else return kFALSE;
+}
 
 //____________________________________________________________________________
 Bool_t AliReducedCompositeCut::IsSelected(TObject* obj) {

--- a/PWGDQ/reducedTree/AliReducedCompositeCut.h
+++ b/PWGDQ/reducedTree/AliReducedCompositeCut.h
@@ -22,6 +22,7 @@ public:
    Int_t    GetNCuts() const {return fCuts.GetEntries();}
    
    virtual Bool_t IsSelected(TObject* obj);
+   virtual Bool_t IsSelected(Float_t* values);
    virtual Bool_t IsSelected(TObject* obj, Float_t* values);
   
 protected:
@@ -31,7 +32,7 @@ protected:
    AliReducedCompositeCut(const AliReducedCompositeCut &c);
    AliReducedCompositeCut& operator= (const AliReducedCompositeCut &c);
   
-   ClassDef(AliReducedCompositeCut,1);
+   ClassDef(AliReducedCompositeCut,2);
 };
 
 #endif

--- a/PWGDQ/reducedTree/AliReducedTrackInfo.cxx
+++ b/PWGDQ/reducedTree/AliReducedTrackInfo.cxx
@@ -66,6 +66,7 @@ AliReducedTrackInfo::AliReducedTrackInfo() :
   fTRDGTUpt(0.),
   fTRDGTUsagitta(2.0),
   fTRDGTUPID(0.),
+  fMatchedEMCalClusterEnergy(-999),
   fEMCALnSigEle(-999),
   fCaloClusterId(-999),
   fTrackParam(),
@@ -136,6 +137,7 @@ AliReducedTrackInfo::AliReducedTrackInfo(const AliReducedTrackInfo &c) :
   fTRDGTUpt(c.fTRDGTUpt),
   fTRDGTUsagitta(c.fTRDGTUsagitta),
   fTRDGTUPID(c.fTRDGTUPID),
+  fMatchedEMCalClusterEnergy(c.fMatchedEMCalClusterEnergy),
   fEMCALnSigEle(c.fEMCALnSigEle),
   fCaloClusterId(c.fCaloClusterId),
   fMCGeneratorIndex(c.fMCGeneratorIndex)

--- a/PWGDQ/reducedTree/AliReducedTrackInfo.h
+++ b/PWGDQ/reducedTree/AliReducedTrackInfo.h
@@ -91,6 +91,7 @@ class AliReducedTrackInfo : public AliReducedBaseTrack {
   Float_t   TRDGTUsagitta()        const {return fTRDGTUsagitta;}
   UChar_t   TRDGTUPID()            const {return fTRDGTUPID;}
 
+  Float_t   MatchedEMCalClusterEnergy() const {return fMatchedEMCalClusterEnergy;}
   Float_t   EMCALnSigEle()  const {return fEMCALnSigEle;}
   Int_t     CaloClusterId() const {return fCaloClusterId;}
   
@@ -111,8 +112,9 @@ class AliReducedTrackInfo : public AliReducedBaseTrack {
   Int_t HFProc() const {return fHFProc;}
   Short_t MCGeneratorIndex() {return fMCGeneratorIndex;}
   
+  // setters
+  void SetMatchedEMCalClusterEnergy(Float_t energy) {fMatchedEMCalClusterEnergy=energy;}
 
-     
  protected:
   ULong_t fStatus;              // tracking status
   Float_t fTPCPhi;              // inner param phi
@@ -175,6 +177,7 @@ class AliReducedTrackInfo : public AliReducedBaseTrack {
   UChar_t  fTRDGTUPID;          // TRD online track pid
 
   // EMCAL/PHOS
+  Float_t fMatchedEMCalClusterEnergy; // EMCal cluster energy for matched cluster
   Float_t fEMCALnSigEle;        // EMCal n-sigma deviation from expected electron signal
   Int_t   fCaloClusterId;       // ID for the calorimeter cluster (if any)
   
@@ -193,7 +196,7 @@ class AliReducedTrackInfo : public AliReducedBaseTrack {
 
   AliReducedTrackInfo& operator= (const AliReducedTrackInfo &c);
   
-  ClassDef(AliReducedTrackInfo, 10);
+  ClassDef(AliReducedTrackInfo, 11);
 };
 
 //_______________________________________________________________________________

--- a/PWGDQ/reducedTree/AliReducedVarManager.cxx
+++ b/PWGDQ/reducedTree/AliReducedVarManager.cxx
@@ -1927,6 +1927,7 @@ void AliReducedVarManager::FillClusterMatchedTrackInfo(AliReducedBaseTrack* p, F
       else                  mom = pinfo->P();
       values[kEMCALmatchedEOverP] = (TMath::Abs(mom)>1.e-8 && cluster ? values[kEMCALmatchedEnergy]/mom : -9999.);
     }
+    pinfo->SetMatchedEMCalClusterEnergy(values[kEMCALmatchedEnergy]);
   }
 }
 
@@ -2149,7 +2150,15 @@ void AliReducedVarManager::FillPairInfo(BASETRACK* t1, BASETRACK* t2, Int_t type
         values[kPseudoProperDecayTime] = pairKF.GetPseudoProperDecayTime(primVtx, fgkPairMass[type], &errPseudoProperTime2);
      if(fgUsedVars[kPairLxy]) values[kPairLxy] =  ( (pairKF.X() - primVtx.X())*p.Px() + (pairKF.Y() - primVtx.Y())*p.Py() )/p.Pt(); // = values[kPseudoProperDecayTime]*(p.Pt()/PAIR::fgkPairMass[type]);
   }
-  
+
+  if ((fgUsedVars[kPairLegEMCALmatchedEnergy] || fgUsedVars[kPairLegEMCALmatchedEnergy+1]) &&
+      (t1->IsA()==TRACK::Class()) && (t2->IsA()==TRACK::Class())) {
+    TRACK* ti1=(TRACK*)t1;
+    TRACK* ti2=(TRACK*)t2;
+    values[kPairLegEMCALmatchedEnergy]    = ti1->MatchedEMCalClusterEnergy();
+    values[kPairLegEMCALmatchedEnergy+1]  = ti2->MatchedEMCalClusterEnergy();
+  }
+
   // fill MC information
   if(p.PairType()==1) {
      TRACK* pinfo1 = 0x0;
@@ -2408,6 +2417,14 @@ void AliReducedVarManager::FillPairInfoME(BASETRACK* t1, BASETRACK* t2, Int_t ty
   if(fgUsedVars[kPhi])    values[kPhi]    = p.Phi();
   if(fgUsedVars[kTheta])  values[kTheta]  = p.Theta();
   
+  if ((fgUsedVars[kPairLegEMCALmatchedEnergy] || fgUsedVars[kPairLegEMCALmatchedEnergy+1]) &&
+      (t1->IsA()==TRACK::Class()) && (t2->IsA()==TRACK::Class())) {
+    TRACK* ti1=(TRACK*)t1;
+    TRACK* ti2=(TRACK*)t2;
+    values[kPairLegEMCALmatchedEnergy]    = ti1->MatchedEMCalClusterEnergy();
+    values[kPairLegEMCALmatchedEnergy+1]  = ti2->MatchedEMCalClusterEnergy();
+  }
+
   if((fgUsedVars[kPairEff] || fgUsedVars[kOneOverPairEff] || fgUsedVars[kOneOverPairEffSq]) && fgPairEffMap) {
     Int_t binX = 0;
     if (fgEffMapVarDependencyX!=kNothing) {
@@ -3317,6 +3334,8 @@ void AliReducedVarManager::SetDefaultVarNames() {
      fgVariableNames[kPairLegPt+i] = Form("Leg%d p_{T}", i+1);
      fgVariableNames[kPairLegPtMC+i] = Form("Leg%d p^{MC}_{T}", i+1);
      fgVariableUnits[kPairLegPt+i] = "GeV/c"; fgVariableUnits[kPairLegPtMC+i] = "GeV/c";
+     fgVariableNames[kPairLegEMCALmatchedEnergy+i] = Form("Leg%d E_{calo cluster}", i+1);
+     fgVariableUnits[kPairLegEMCALmatchedEnergy+i] = "GeV";
   }
   fgVariableNames[kPairLegPtSum] = "Pair leg p_{T,1} + p_{T,2}"; fgVariableUnits[kPairLegPtSum] = "GeV/c";
   fgVariableNames[kPairLegPtMCSum] = "Pair leg p^{MC}_{T,1} + p^{MC}_{T,2}"; fgVariableUnits[kPairLegPtMCSum] = "GeV/c";

--- a/PWGDQ/reducedTree/AliReducedVarManager.h
+++ b/PWGDQ/reducedTree/AliReducedVarManager.h
@@ -555,9 +555,10 @@ class AliReducedVarManager : public TObject {
     kPairLegPtSum=kPairLegPt+2,                   // sum of the pt of the two legs
     kPairLegPtMC,                                // MC truth pair leg pt
     kPairLegPtMCSum=kPairLegPtMC+2,               // sum of the MC truth leg pt's
+    kPairLegEMCALmatchedEnergy,                   // pair leg EMCal cluster energy
 
     // Track-only variables -------------------------------------
-    kPtTPC,     
+    kPtTPC=kPairLegEMCALmatchedEnergy+2,
     kPhiTPC,    
     kEtaTPC,    
     kDcaXYTPC,    
@@ -848,7 +849,7 @@ class AliReducedVarManager : public TObject {
   AliReducedVarManager(AliReducedVarManager const&);
   AliReducedVarManager& operator=(AliReducedVarManager const&);  
   
-  ClassDef(AliReducedVarManager, 16);
+  ClassDef(AliReducedVarManager, 17);
 };
 
 #endif


### PR DESCRIPTION
- AliReducedCompositeCut: new method using values (like other cut classes)
- AliReducedAnalysisJpsi2ee: methods to return cuts (e.g. useful when setting up mixing handler)
- AliReducedTrackInfo: new data member to hold EMCal cluster energy and corresponding setters/getters
- AliReducedVarManager: assigning EMCal cluster energy to track after cluster-track matching, new variable to store EMCal cluster energy per leg for pair