### PR TITLE
OmegaToPiZeroGamma added PHOS configs

### DIFF
--- a/PWGCF/EBYE/BalanceFunctions/HFtest/AliAnalysisTaskLcToD0MC.cxx
+++ b/PWGCF/EBYE/BalanceFunctions/HFtest/AliAnalysisTaskLcToD0MC.cxx
@@ -35,12 +35,15 @@ AliAnalysisTaskLcToD0MC::AliAnalysisTaskLcToD0MC(const char *name)
   fHistVz(0),
   fHistMultiplicity(0),
   fHistPtVsNch(0),
-  fHistDZeroALICE(0),
-  fHistLambdacALICE(0),
-  fHistDZeroCMS(0),
-  fHistLambdacCMS(0),
-  fHistDZeroLHCb(0),
-  fHistLambdacLHCb(0),
+  fHistProtonALICE(0), fHistPionALICE(0),
+  fHistLambdaALICE(0), fHistK0sALICE(0),
+  fHistLambdacALICE(0), fHistDZeroALICE(0),
+  fHistProtonCMS(0), fHistPionCMS(0),
+  fHistLambdaCMS(0), fHistK0sCMS(0),
+  fHistLambdacCMS(0), fHistDZeroCMS(0),
+  fHistProtonLHCb(0), fHistPionLHCb(0),
+  fHistLambdaLHCb(0), fHistK0sLHCb(0),
+  fHistLambdacLHCb(0), fHistDZeroLHCb(0),
   fVxMax(0.3),
   fVyMax(0.3),
   fVzMax(10.),
@@ -51,9 +54,8 @@ AliAnalysisTaskLcToD0MC::AliAnalysisTaskLcToD0MC(const char *name)
   fEtaMinCMS(-2.4),
   fEtaMaxCMS(2.4),
   fEtaMinLHCb(2.),
-  fEtaMaxLHCb(4.5)
-{
-// Constructor
+  fEtaMaxLHCb(4.5) {
+  // Constructor
 
   // Define input and output slots here
   // Input slot #0 works with a TChain
@@ -104,17 +106,45 @@ void AliAnalysisTaskLcToD0MC::UserCreateOutputObjects() {
   fHistPtVsNch = new TH2F("fHistPtVsNch","pT spectrum;N_{ch.};p_{T} (GeV/c);Entries",500,-0.5,499.5,1000,0.,20.);
   fList->Add(fHistPtVsNch);
 
+  fHistProtonALICE = new TH2F("fHistProtonALICE",";p_{T};Multiplicity;Counts",100,0,50,200,-0.5,199.5);
+  fHistPionALICE = new TH2F("fHistPionALICE",";p_{T};Multiplicity;Counts",100,0,50,200,-0.5,199.5);
+  fHistK0sALICE = new TH2F("fHistK0sALICE",";p_{T};Multiplicity;Counts",100,0,50,200,-0.5,199.5);
+  fHistLambdaALICE = new TH2F("fHistLambdaALICE",";p_{T};Multiplicity;Counts",100,0,50,200,-0.5,199.5);
   fHistDZeroALICE = new TH2F("fHistDZeroALICE",";p_{T};Multiplicity;Counts",100,0,50,200,-0.5,199.5);
   fHistLambdacALICE = new TH2F("fHistLambdacALICE",";p_{T};Multiplicity;Counts",100,0,50,200,-0.5,199.5);
+
+  fHistProtonCMS = new TH2F("fHistProtonCMS",";p_{T};Multiplicity;Counts",100,0,50,200,-0.5,199.5);
+  fHistPionCMS = new TH2F("fHistPionCMS",";p_{T};Multiplicity;Counts",100,0,50,200,-0.5,199.5);
+  fHistK0sCMS = new TH2F("fHistK0sCMS",";p_{T};Multiplicity;Counts",100,0,50,200,-0.5,199.5);
+  fHistLambdaCMS = new TH2F("fHistLambdaCMS",";p_{T};Multiplicity;Counts",100,0,50,200,-0.5,199.5);
   fHistDZeroCMS = new TH2F("fHistDZeroCMS",";p_{T};Multiplicity;Counts",100,0,50,200,-0.5,199.5);
   fHistLambdacCMS = new TH2F("fHistLambdacCMS",";p_{T};Multiplicity;Counts",100,0,50,200,-0.5,199.5);
+
+  fHistProtonLHCb = new TH2F("fHistProtonLHCb",";p_{T};Multiplicity;Counts",100,0,50,200,-0.5,199.5);
+  fHistPionLHCb = new TH2F("fHistPionLHCb",";p_{T};Multiplicity;Counts",100,0,50,200,-0.5,199.5);
+  fHistK0sLHCb = new TH2F("fHistK0sLHCb",";p_{T};Multiplicity;Counts",100,0,50,200,-0.5,199.5);
+  fHistLambdaLHCb = new TH2F("fHistLambdaLHCb",";p_{T};Multiplicity;Counts",100,0,50,200,-0.5,199.5);
   fHistDZeroLHCb = new TH2F("fHistDZeroLHCb",";p_{T};Multiplicity;Counts",100,0,50,200,-0.5,199.5);
   fHistLambdacLHCb = new TH2F("fHistLambdacLHCb",";p_{T};Multiplicity;Counts",100,0,50,200,-0.5,199.5);
 
+  fList->Add(fHistPionALICE);
+  fList->Add(fHistProtonALICE);
+  fList->Add(fHistK0sALICE);
+  fList->Add(fHistLambdaALICE);
   fList->Add(fHistDZeroALICE);
   fList->Add(fHistLambdacALICE);
+
+  fList->Add(fHistPionCMS);
+  fList->Add(fHistProtonCMS);
+  fList->Add(fHistK0sCMS);
+  fList->Add(fHistLambdaCMS);
   fList->Add(fHistDZeroCMS);
   fList->Add(fHistLambdacCMS);
+
+  fList->Add(fHistPionLHCb);
+  fList->Add(fHistProtonLHCb);
+  fList->Add(fHistK0sLHCb);
+  fList->Add(fHistLambdaLHCb);
   fList->Add(fHistDZeroLHCb);
   fList->Add(fHistLambdacLHCb);
 
@@ -198,6 +228,53 @@ void AliAnalysisTaskLcToD0MC::UserExec(Option_t *) {
 	    //getting epg code from each particle
 	    Int_t epg = gParticle -> PdgCode();
 
+	    //==============LIGHT====================//
+	    //checking for PION particle
+	    if(TMath::Abs(epg) == 211){
+	      //getting multiplicity for events with Dzero particle
+	      if(eta > fEtaMin && eta < fEtaMax){
+		fHistPionALICE -> Fill(pT,nAcceptedParticlesControl);}
+	      if(eta > fEtaMinCMS && eta < fEtaMaxCMS){
+		fHistPionCMS -> Fill(pT,nAcceptedParticlesControl);}
+	      if(eta > fEtaMinLHCb && eta < fEtaMaxLHCb){
+		fHistPionLHCb -> Fill(pT,nAcceptedParticlesControl);}
+	    }
+
+	    //checking for proton particle
+	    else if(epg == 2212){
+	      //getting multiplicity for events with Lambdac particle      
+	      if(eta > fEtaMin && eta < fEtaMax){
+		fHistProtonALICE -> Fill(pT,nAcceptedParticlesControl);}
+	      if(eta > fEtaMinCMS && eta < fEtaMaxCMS){
+		fHistProtonCMS -> Fill(pT,nAcceptedParticlesControl);}
+	      if(eta > fEtaMinLHCb && eta < fEtaMaxLHCb){
+		fHistProtonLHCb -> Fill(pT,nAcceptedParticlesControl);}
+	    }
+
+	    //==============STRANGE====================//
+	    //checking for K0s particle
+	    if(TMath::Abs(epg) == 310){
+	      //getting multiplicity for events with Dzero particle
+	      if(eta > fEtaMin && eta < fEtaMax){
+		fHistK0sALICE -> Fill(pT,nAcceptedParticlesControl);}
+	      if(eta > fEtaMinCMS && eta < fEtaMaxCMS){
+		fHistK0sCMS -> Fill(pT,nAcceptedParticlesControl);}
+	      if(eta > fEtaMinLHCb && eta < fEtaMaxLHCb){
+		fHistK0sLHCb -> Fill(pT,nAcceptedParticlesControl);}
+	    }
+
+	    //checking for Lambda particle
+	    else if(epg == 3122){
+	      //getting multiplicity for events with Lambdac particle      
+	      if(eta > fEtaMin && eta < fEtaMax){
+		fHistLambdaALICE -> Fill(pT,nAcceptedParticlesControl);}
+	      if(eta > fEtaMinCMS && eta < fEtaMaxCMS){
+		fHistLambdaCMS -> Fill(pT,nAcceptedParticlesControl);}
+	      if(eta > fEtaMinLHCb && eta < fEtaMaxLHCb){
+		fHistLambdaLHCb -> Fill(pT,nAcceptedParticlesControl);}
+	    }
+
+	    //==============CHARM====================//
 	    //checking for Dzero particle
 	    if(TMath::Abs(epg) == 421){
 	      //getting multiplicity for events with Dzero particle
@@ -219,15 +296,12 @@ void AliAnalysisTaskLcToD0MC::UserExec(Option_t *) {
 	      if(eta > fEtaMinLHCb && eta < fEtaMaxLHCb){
 		fHistLambdacLHCb -> Fill(pT,nAcceptedParticlesControl);}
 	    }
-	  }
-	  
-	  
-	  
+	    
+	  }//particle loop
 	}//Vz cut
       }//Vy cut
     }//Vx cut
   }//vertex object valid
-
 }      
 
 //________________________________________________________________________

--- a/PWGCF/EBYE/BalanceFunctions/HFtest/AliAnalysisTaskLcToD0MC.h
+++ b/PWGCF/EBYE/BalanceFunctions/HFtest/AliAnalysisTaskLcToD0MC.h
@@ -50,12 +50,24 @@ class AliAnalysisTaskLcToD0MC : public AliAnalysisTaskSE {
   
   TH2F *fHistPtVsNch; //pt spectrum vs multiplicity
 
+  TH2F *fHistProtonALICE;
+  TH2F *fHistPionALICE;
+  TH2F *fHistLambdaALICE;
+  TH2F *fHistK0sALICE;
   TH2F *fHistLambdacALICE;
   TH2F *fHistDZeroALICE;
 
+  TH2F *fHistProtonCMS;
+  TH2F *fHistPionCMS;
+  TH2F *fHistLambdaCMS;
+  TH2F *fHistK0sCMS;
   TH2F *fHistLambdacCMS;
   TH2F *fHistDZeroCMS;
 
+  TH2F *fHistProtonLHCb;
+  TH2F *fHistPionLHCb;
+  TH2F *fHistLambdaLHCb;
+  TH2F *fHistK0sLHCb;
   TH2F *fHistLambdacLHCb;
   TH2F *fHistDZeroLHCb;
 

--- a/PWGDQ/dielectron/core/AliAnalysisTaskEtaReconstruction.cxx
+++ b/PWGDQ/dielectron/core/AliAnalysisTaskEtaReconstruction.cxx
@@ -101,7 +101,8 @@ AliAnalysisTaskEtaReconstruction::AliAnalysisTaskEtaReconstruction(): AliAnalysi
                                                                               , fMinCentrality(0.), fMaxCentrality(100), fCentralityFile(0x0), fCentralityFilename(""), fHistCentralityCorrection(0x0)
                                                                               , fOutputListSupportHistos(0x0), fTrackCutListVecPrim(), fTrackCutListVecSec(), fPairCutListVecSec(), fFourPairCutListVec()
                                                                               , fHistGenPrimaryPosPart(), fHistGenPrimaryNegPart(), fHistGenSecondaryPosPart(), fHistGenSecondaryNegPart(), fHistGenSmearedPrimaryPosPart(), fHistGenSmearedPrimaryNegPart(), fHistGenSmearedSecondaryPosPart(), fHistGenSmearedSecondaryNegPart(), fHistRecPrimaryPosPart(), fHistRecPrimaryNegPart(), fHistRecSecondaryPosPart(), fHistRecSecondaryNegPart()
-                                                                              , fHistGenPrimaryPair(), fHistGenSecondaryPair(), fHistGenSmearedPrimaryPair(), fHistGenSmearedSecondaryPair(), fHistRecPrimaryPair(), fHistRecSecondaryPair(), fHistGenFourPair(), fHistGenSmearedFourPair(), fHistRecFourPair(), fHistGenPair_ULSandLS(), fHistGenFourPair_ULSandLS(), fHistGenSmearedPair_ULSandLS(), fHistGenSmearedFourPair_ULSandLS(), fHistRecPair_ULSandLS(), fHistRecFourPair_ULSandLS(), fWriteLegsFromPair(false), fPtMinLegsFromPair(-99.), fPtMaxLegsFromPair(-99.), fEtaMinLegsFromPair(-99.), fEtaMaxLegsFromPair(-99.), fPhiMinLegsFromPair(-99.), fPhiMaxLegsFromPair(-99.), fOpAngleMinLegsFromPair(-99.), fOpAngleMaxLegsFromPair(-99.), fPtNBinsLegsFromPair(-99), fEtaNBinsLegsFromPair(-99), fPhiNBinsLegsFromPair(-99), fOpAngleNBinsLegsFromPair(-99), fTHnSparseGenSmearedLegsFromPrimaryPair(), fTHnSparseGenSmearedLegsFromSecondaryPair(), fTHnSparseRecLegsFromPrimaryPair(), fTHnSparseRecLegsFromSecondaryPair()
+                                                                              , fHistGenPrimaryPair(), fHistGenSecondaryPair(), fHistGenSmearedPrimaryPair(), fHistGenSmearedSecondaryPair(), fHistRecPrimaryPair(), fHistRecSecondaryPair(), fHistGenFourPair(), fHistGenSmearedFourPair(), fHistRecFourPair()
+                                                                              , fWriteLegsFromPair(false), fPtMinLegsFromPair(-99.), fPtMaxLegsFromPair(-99.), fEtaMinLegsFromPair(-99.), fEtaMaxLegsFromPair(-99.), fPhiMinLegsFromPair(-99.), fPhiMaxLegsFromPair(-99.), fOpAngleMinLegsFromPair(-99.), fOpAngleMaxLegsFromPair(-99.), fPtNBinsLegsFromPair(-99), fEtaNBinsLegsFromPair(-99), fPhiNBinsLegsFromPair(-99), fOpAngleNBinsLegsFromPair(-99), fTHnSparseGenSmearedLegsFromPrimaryPair(), fTHnSparseGenSmearedLegsFromSecondaryPair(), fTHnSparseRecLegsFromPrimaryPair(), fTHnSparseRecLegsFromSecondaryPair()
                                                                               , fDoPairing(false), fDoFourPairing(false), fUsePreFilter(false), fDoMassCut(), fPhotonMass()
                                                                               , fGenNegPart_primary(), fGenPosPart_primary(), fGenNegPart_secondary(), fGenPosPart_secondary(), fGenSmearedNegPart_primary(), fGenSmearedPosPart_primary(), fGenSmearedNegPart_secondary(), fGenSmearedPosPart_secondary(), fRecNegPart_primary(), fRecPosPart_primary(), fRecNegPart_secondary(), fRecPosPart_secondary(), fGenPairVec_primary(), fGenPairVec_secondary(), fGenSmearedPairVec_primary(), fGenSmearedPairVec_secondary(), fRecPairVec_primary(), fRecPairVec_secondary(), fRecV0Pair()
                                                                               , fDoCocktailWeighting(false), fCocktailFilename(""), fCocktailFilenameFromAlien(""), fCocktailFile(0x0)
@@ -136,7 +137,8 @@ AliAnalysisTaskEtaReconstruction::AliAnalysisTaskEtaReconstruction(const char * 
                                                                               , fMinCentrality(0.), fMaxCentrality(100), fCentralityFile(0x0), fCentralityFilename(""), fHistCentralityCorrection(0x0)
                                                                               , fOutputListSupportHistos(0x0), fTrackCutListVecPrim(), fTrackCutListVecSec(), fPairCutListVecSec(), fFourPairCutListVec()
                                                                               , fHistGenPrimaryPosPart(), fHistGenPrimaryNegPart(), fHistGenSecondaryPosPart(), fHistGenSecondaryNegPart(), fHistGenSmearedPrimaryPosPart(), fHistGenSmearedPrimaryNegPart(), fHistGenSmearedSecondaryPosPart(), fHistGenSmearedSecondaryNegPart(), fHistRecPrimaryPosPart(), fHistRecPrimaryNegPart(), fHistRecSecondaryPosPart(), fHistRecSecondaryNegPart()
-                                                                              , fHistGenPrimaryPair(), fHistGenSecondaryPair(), fHistGenSmearedPrimaryPair(), fHistGenSmearedSecondaryPair(), fHistRecPrimaryPair(), fHistRecSecondaryPair(), fHistGenFourPair(), fHistGenSmearedFourPair(), fHistRecFourPair(), fHistGenPair_ULSandLS(), fHistGenFourPair_ULSandLS(), fHistGenSmearedPair_ULSandLS(), fHistGenSmearedFourPair_ULSandLS(), fHistRecPair_ULSandLS(), fHistRecFourPair_ULSandLS(), fWriteLegsFromPair(false), fPtMinLegsFromPair(-99.), fPtMaxLegsFromPair(-99.), fEtaMinLegsFromPair(-99.), fEtaMaxLegsFromPair(-99.), fPhiMinLegsFromPair(-99.), fPhiMaxLegsFromPair(-99.), fOpAngleMinLegsFromPair(-99.), fOpAngleMaxLegsFromPair(-99.), fPtNBinsLegsFromPair(-99), fEtaNBinsLegsFromPair(-99), fPhiNBinsLegsFromPair(-99), fOpAngleNBinsLegsFromPair(-99), fTHnSparseGenSmearedLegsFromPrimaryPair(), fTHnSparseGenSmearedLegsFromSecondaryPair(), fTHnSparseRecLegsFromPrimaryPair(), fTHnSparseRecLegsFromSecondaryPair()
+                                                                              , fHistGenPrimaryPair(), fHistGenSecondaryPair(), fHistGenSmearedPrimaryPair(), fHistGenSmearedSecondaryPair(), fHistRecPrimaryPair(), fHistRecSecondaryPair(), fHistGenFourPair(), fHistGenSmearedFourPair(), fHistRecFourPair()
+                                                                              , fWriteLegsFromPair(false), fPtMinLegsFromPair(-99.), fPtMaxLegsFromPair(-99.), fEtaMinLegsFromPair(-99.), fEtaMaxLegsFromPair(-99.), fPhiMinLegsFromPair(-99.), fPhiMaxLegsFromPair(-99.), fOpAngleMinLegsFromPair(-99.), fOpAngleMaxLegsFromPair(-99.), fPtNBinsLegsFromPair(-99), fEtaNBinsLegsFromPair(-99), fPhiNBinsLegsFromPair(-99), fOpAngleNBinsLegsFromPair(-99), fTHnSparseGenSmearedLegsFromPrimaryPair(), fTHnSparseGenSmearedLegsFromSecondaryPair(), fTHnSparseRecLegsFromPrimaryPair(), fTHnSparseRecLegsFromSecondaryPair()
                                                                               , fDoPairing(false), fDoFourPairing(false), fUsePreFilter(false), fDoMassCut(), fPhotonMass()
                                                                               , fGenNegPart_primary(), fGenPosPart_primary(), fGenNegPart_secondary(), fGenPosPart_secondary(), fGenSmearedNegPart_primary(), fGenSmearedPosPart_primary(), fGenSmearedNegPart_secondary(), fGenSmearedPosPart_secondary(), fRecNegPart_primary(), fRecPosPart_primary(), fRecNegPart_secondary(), fRecPosPart_secondary(), fGenPairVec_primary(), fGenPairVec_secondary(), fGenSmearedPairVec_primary(), fGenSmearedPairVec_secondary(), fRecPairVec_primary(), fRecPairVec_secondary(), fRecV0Pair()
                                                                               , fDoCocktailWeighting(false), fCocktailFilename(""), fCocktailFilenameFromAlien(""), fCocktailFile(0x0)
@@ -1395,6 +1397,8 @@ void AliAnalysisTaskEtaReconstruction::UserExec(Option_t* option){
                                                                                 if(fUsePreFilter)DoFourPreFilter(&fRecPairVec_primary, &fRecV0Pair);
                                                                                 if(fdebug) std::cout << __LINE__ << " Apply Sec_StandardCuts for Pairing " << std::endl;
                                                                                 ApplyStandardCutsAndFillHists(&fRecPairVec_primary, fTrackCuts_primary_standard ,  TrackCuts,  PairPrimary, centralityWeight);
+                                                                                ApplyStandardCutsAndFillHists(&fRecPairVec_primary, fPairCuts_primary           , !TrackCuts,  PairPrimary, centralityWeight);
+                                                                                // ApplyStandardCutsAndFillHists(&fRecV0Pair         , fPairCuts_secondary_standard,  TrackCuts, !PairPrimary, centralityWeight); // track cuts on secondaries not implemented yet
                                                                                 ApplyStandardCutsAndFillHists(&fRecV0Pair         , fPairCuts_secondary_standard, !TrackCuts, !PairPrimary, centralityWeight);
 
                                                                                 if(fdebug) std::cout << __LINE__ << " Start Four Reconstructed Pairing " << std::endl;
@@ -2175,7 +2179,7 @@ void AliAnalysisTaskEtaReconstruction::ApplyStandardCutsAndFillHists (std::vecto
             for (unsigned int j = 0; j < posPart.isReconstructed_primary.size(); ++j){
               if (posPart.isMCSignal_primary[i] == kTRUE) {
                 if (posPart.isReconstructed_primary[j] == kTRUE){
-                                  dynamic_cast<TH3D*>(fHistRecPrimaryPosPart.at(j * posPart.isMCSignal_primary.size() + i))->Fill(posPart.fPt, posPart.fEta, posPart.fPhi, centralityWeight);
+                  dynamic_cast<TH3D*>(fHistRecPrimaryPosPart.at(j * posPart.isMCSignal_primary.size() + i))->Fill(posPart.fPt, posPart.fEta, posPart.fPhi, centralityWeight);
                 }// is selected by cutsetting
               } // is selected by MC signal
             } // end of loop over all cutsettings
@@ -2208,7 +2212,7 @@ void AliAnalysisTaskEtaReconstruction::ApplyStandardCutsAndFillHists (std::vecto
         pair->SetKFUsage(false);
         pair->SetTracks(static_cast<AliVTrack*>(negTrack), 11, static_cast<AliVTrack*>(posTrack), -11);
 
-        //  ---------- RECONSTRUCTED Pairs with PAIR  ---------- //
+        //  ---------- RECONSTRUCTED Pairs: Apply pair cuts on PAIR  ---------- //
         // Check if pair is passing cut selections
         std::vector<bool> selected(fCutsetting.size(), kFALSE); // vector which stores if pair is accepted by [i]-th selection cut
         for (UInt_t iCut=0; iCut<fCutsetting.size(); ++iCut){ // loop over all specified cutInstances
@@ -2233,10 +2237,13 @@ void AliAnalysisTaskEtaReconstruction::ApplyStandardCutsAndFillHists (std::vecto
         for (unsigned int i = 0; i < fPrimaryPairMCSignal.size(); ++i){
           mcTwoSignal_acc[i] = AliDielectronMC::Instance()->IsMCTruth(pair, &(fPrimaryPairMCSignal[i]));
         }
-
-
+        
         // check if at least one mc signal is true
-        if (CheckIfOneIsTrue(mcTwoSignal_acc) == kFALSE) continue;
+        if (CheckIfOneIsTrue(mcTwoSignal_acc) == kFALSE) {
+          fPairVec->erase(fPairVec->begin()+iPair);
+          iPair--;
+          continue;
+        }
 
         double weight  = 1.;
         double mass    = fPairVec->at(iPair).fMass;
@@ -2699,60 +2706,60 @@ void AliAnalysisTaskEtaReconstruction::DoRecTwoPairing(std::vector<Particle> fRe
                                                                                 // ", Mass = " << MotherParticle.fMass <<
                                                                                 // ", charge = " << MotherParticle.fCharge << std::endl;}
 
-      // ##########################################################
-      float ptPos       = -999;
-      float etaPos      = -999;
-      float phiPos      = -999;
-      float ptNeg       = -999;
-      float etaNeg      = -999;
-      float phiNeg      = -999;
-      float op_angle    = -999;
-      for (unsigned int i = 0; i < mcTwoSignal_acc.size(); ++i){
-
-        // Filling reconstructed primary particle histograms according to MCSignals
-        if (mcTwoSignal_acc[i] == kTRUE && PartPrimary == kTRUE){
-          for (unsigned int j = 0; j < fRecNegPart[neg_i].isReconstructed_primary.size(); ++j){
-            if (fRecNegPart[neg_i].isReconstructed_primary[j] == kTRUE && fRecPosPart[pos_i].isReconstructed_primary[j] == kTRUE){
-              fHistRecPrimaryPair.at(j * mcTwoSignal_acc.size() + i)->Fill(mass, pairpt, weight * centralityWeight);
-
-              if (fWriteLegsFromPair){
-                ptNeg  = fRecNegPart[neg_i].fPt;
-                etaNeg = fRecNegPart[neg_i].fEta;
-                phiNeg = fRecNegPart[neg_i].fPhi;
-                ptPos  = fRecPosPart[pos_i].fPt;
-                etaPos = fRecPosPart[pos_i].fEta;
-                phiPos = fRecPosPart[pos_i].fPhi;
-                op_angle = Lvec2.Angle(Lvec1.Vect());
-
-                const double tuple[7] = {ptPos,etaPos,phiPos,ptNeg,etaNeg,phiNeg,op_angle};
-                fTHnSparseRecLegsFromPrimaryPair.at(j * mcTwoSignal_acc.size() + i)->Fill(tuple);
-              }
-            }// is selected by cutsetting
-          } // end of loop over all cutsettings
-        } // is selected by MCSignal
-
-        // Filling reconstructed secondary particle histograms according to MCSignals
-        if (mcTwoSignal_acc[i] == kTRUE && PartPrimary == kFALSE){
-          for (unsigned int j = 0; j < fRecNegPart[neg_i].isReconstructed_secondary.size(); ++j){
-            if (fRecNegPart[neg_i].isReconstructed_secondary[j] == kTRUE && fRecPosPart[pos_i].isReconstructed_secondary[j] == kTRUE){
-              fHistRecSecondaryPair.at(j * mcTwoSignal_acc.size() + i)->Fill(mass, pairpt, weight * centralityWeight);
-
-              if (fWriteLegsFromPair){
-                ptNeg  = fRecNegPart[neg_i].fPt;
-                etaNeg = fRecNegPart[neg_i].fEta;
-                phiNeg = fRecNegPart[neg_i].fPhi;
-                ptPos  = fRecPosPart[pos_i].fPt;
-                etaPos = fRecPosPart[pos_i].fEta;
-                phiPos = fRecPosPart[pos_i].fPhi;
-                op_angle = Lvec2.Angle(Lvec1.Vect());
-
-                const double tuple[7] = {ptPos,etaPos,phiPos,ptNeg,etaNeg,phiNeg,op_angle};
-                fTHnSparseRecLegsFromSecondaryPair.at(j * mcTwoSignal_acc.size() + i)->Fill(tuple);
-              }
-            }// is selected by cutsetting
-          } // end of loop over all cutsettings
-        } // is selected by MCSignal
-      } // end of loop over all MCsignals
+      // // ##########################################################
+      // float ptPos       = -999;
+      // float etaPos      = -999;
+      // float phiPos      = -999;
+      // float ptNeg       = -999;
+      // float etaNeg      = -999;
+      // float phiNeg      = -999;
+      // float op_angle    = -999;
+      // for (unsigned int i = 0; i < mcTwoSignal_acc.size(); ++i){
+      //
+      //   // Filling reconstructed primary particle histograms according to MCSignals
+      //   if (mcTwoSignal_acc[i] == kTRUE && PartPrimary == kTRUE){
+      //     for (unsigned int j = 0; j < fRecNegPart[neg_i].isReconstructed_primary.size(); ++j){
+      //       if (fRecNegPart[neg_i].isReconstructed_primary[j] == kTRUE && fRecPosPart[pos_i].isReconstructed_primary[j] == kTRUE){
+      //         fHistRecPrimaryPair.at(j * mcTwoSignal_acc.size() + i)->Fill(mass, pairpt, weight * centralityWeight);
+      //
+      //         if (fWriteLegsFromPair){
+      //           ptNeg  = fRecNegPart[neg_i].fPt;
+      //           etaNeg = fRecNegPart[neg_i].fEta;
+      //           phiNeg = fRecNegPart[neg_i].fPhi;
+      //           ptPos  = fRecPosPart[pos_i].fPt;
+      //           etaPos = fRecPosPart[pos_i].fEta;
+      //           phiPos = fRecPosPart[pos_i].fPhi;
+      //           op_angle = Lvec2.Angle(Lvec1.Vect());
+      //
+      //           const double tuple[7] = {ptPos,etaPos,phiPos,ptNeg,etaNeg,phiNeg,op_angle};
+      //           fTHnSparseRecLegsFromPrimaryPair.at(j * mcTwoSignal_acc.size() + i)->Fill(tuple);
+      //         }
+      //       }// is selected by cutsetting
+      //     } // end of loop over all cutsettings
+      //   } // is selected by MCSignal
+      //
+      //   // Filling reconstructed secondary particle histograms according to MCSignals
+      //   if (mcTwoSignal_acc[i] == kTRUE && PartPrimary == kFALSE){
+      //     for (unsigned int j = 0; j < fRecNegPart[neg_i].isReconstructed_secondary.size(); ++j){
+      //       if (fRecNegPart[neg_i].isReconstructed_secondary[j] == kTRUE && fRecPosPart[pos_i].isReconstructed_secondary[j] == kTRUE){
+      //         fHistRecSecondaryPair.at(j * mcTwoSignal_acc.size() + i)->Fill(mass, pairpt, weight * centralityWeight);
+      //
+      //         if (fWriteLegsFromPair){
+      //           ptNeg  = fRecNegPart[neg_i].fPt;
+      //           etaNeg = fRecNegPart[neg_i].fEta;
+      //           phiNeg = fRecNegPart[neg_i].fPhi;
+      //           ptPos  = fRecPosPart[pos_i].fPt;
+      //           etaPos = fRecPosPart[pos_i].fEta;
+      //           phiPos = fRecPosPart[pos_i].fPhi;
+      //           op_angle = Lvec2.Angle(Lvec1.Vect());
+      //
+      //           const double tuple[7] = {ptPos,etaPos,phiPos,ptNeg,etaNeg,phiNeg,op_angle};
+      //           fTHnSparseRecLegsFromSecondaryPair.at(j * mcTwoSignal_acc.size() + i)->Fill(tuple);
+      //         }
+      //       }// is selected by cutsetting
+      //     } // end of loop over all cutsettings
+      //   } // is selected by MCSignal
+      // } // end of loop over all MCsignals
       delete pair;
     }// end of positive particle loop
   } // end of negative particle loop

--- a/PWGDQ/dielectron/core/AliAnalysisTaskEtaReconstruction.h
+++ b/PWGDQ/dielectron/core/AliAnalysisTaskEtaReconstruction.h
@@ -384,8 +384,8 @@ private:
 
   Bool_t fSelectPhysics;
   Int_t  fTriggerMask;
-  std::vector<AliAnalysisFilter*> fTrackCuts_primary_standard;
   std::vector<AliAnalysisFilter*> fTrackCuts_primary_PreFilter;
+  std::vector<AliAnalysisFilter*> fTrackCuts_primary_standard;
   std::vector<AliAnalysisFilter*> fPairCuts_primary;
   std::vector<AliAnalysisFilter*> fPairCuts_secondary_PreFilter;
   std::vector<AliAnalysisFilter*> fPairCuts_secondary_standard;
@@ -435,12 +435,7 @@ private:
   std::vector<TH2D*> fHistGenFourPair;
   std::vector<TH2D*> fHistGenSmearedFourPair;
   std::vector<TH2D*> fHistRecFourPair;
-  std::vector<TH2D*> fHistGenPair_ULSandLS;
-  std::vector<TH2D*> fHistGenFourPair_ULSandLS;
-  std::vector<TH2D*> fHistGenSmearedPair_ULSandLS;
-  std::vector<TH2D*> fHistGenSmearedFourPair_ULSandLS;
-  std::vector<TH2D*> fHistRecPair_ULSandLS;
-  std::vector<TH2D*> fHistRecFourPair_ULSandLS;
+
 
   bool fWriteLegsFromPair;
   double fPtMinLegsFromPair;

--- a/PWGDQ/dielectron/macrosLMEE/Config_feisenhut_EtaReconstruction.C
+++ b/PWGDQ/dielectron/macrosLMEE/Config_feisenhut_EtaReconstruction.C
@@ -12,7 +12,7 @@ TString names_Prim_Track_standard_Cuts=("JPID_sum_pt75;JPID_sum1_pt75_sec_kV0");
 // TString names_Prim_Track_standard_Cuts=("JPID_sum_pt75_PreFilter;JPID_sum1_pt75_sec_kV0_PreFilter");
 
 // +++++++++++++++++ Cuts for primary pairs  +++++++++++++++++
-TString names_Prim_Pair_Cuts=("pairJPID_sum_pt75;pairJPID_sum1_pt75_sec_kV0");
+TString names_Prim_Pair_Cuts=("pairJPID_sum_pt20;pairJPID_sum1_pt20_sec_kV0");
 
 // +++++++++++++++++ Cuts for secondary electrons +++++++++++++++++
 // TString names_Sec_Pair_PreFilter_Cuts=("noPID;kV0");
@@ -55,12 +55,12 @@ Bool_t SetITSCorrection = kFALSE;
 Bool_t SetTOFCorrection = kFALSE;
 
 
-bool debug = false;
+bool debug = true;
 
 bool DoPairing      = true;
 bool DoFourPairing  = true;
 bool UsePreFilter   = false;
-bool DoMassCut      = false;
+bool DoMassCut      = true;
 // bool DoULSLS   = true;
 
 bool UseMCDataSig   = false;
@@ -109,8 +109,11 @@ const double minEtaCut = -0.8;
 const double maxEtaCut = 0.8;
 
 
-const double upperMassCutPrimaries = 0.547862;
-const double lowerMassCutPrimaries = 0.1349766;
+// const double upperMassCutPrimaries = 0.547862;
+// const double lowerMassCutPrimaries = 0.1349766;
+// const double upperMassCutPrimaries = 1.;
+const double upperMassCutPrimaries = 0.1349766;
+const double lowerMassCutPrimaries = 0;
 const double upperPreFilterMass = 0.25;
 const double lowerPreFilterMass = 0.03;
 const double massCutSecondaries = 0.01;
@@ -331,7 +334,7 @@ AliAnalysisFilter* SetupTrackCutsAndSettings(TString cutDefinition, Bool_t isAOD
   /////////////////////////////////////////////////////////
   //             primary single cut settings             //
   /////////////////////////////////////////////////////////
-  else if (cutDefinition == "JPID_sum_pt75" || cutDefinition == "JPID_sum_pt75_PreFilter"){
+  else if (cutDefinition == "JPID_sum_pt75"){
     AnaCut.SetPIDAna(LMEECutLib::kPID_Jeromian_01);
     // AnaCut.SetTrackSelectionAna(LMEECutLib::kTRACKcut_1);
     AnaCut.SetTrackSelectionAna(LMEECutLib::kTRACKcut_2);
@@ -379,7 +382,7 @@ AliAnalysisFilter* SetupTrackCutsAndSettings(TString cutDefinition, Bool_t isAOD
   /////////////////////////////////////////////////////////
   //              primary pair cut settings              //
   /////////////////////////////////////////////////////////
-  else if (cutDefinition == "pairJPID_sum_pt75"){
+  else if (cutDefinition == "pairJPID_sum_pt20"){
     AnaCut.SetPIDAna(LMEECutLib::kNoPID_Pt20);
     AnaCut.SetTrackSelectionAna(LMEECutLib::kDefaultNoTrackCuts);
     AnaCut.SetPairCutsAna(LMEECutLib::kNoPairCutsAna);
@@ -387,7 +390,7 @@ AliAnalysisFilter* SetupTrackCutsAndSettings(TString cutDefinition, Bool_t isAOD
     AnaCut.SetStandardCut();
   }
 
-  else if (cutDefinition == "pairJPID_sum1_pt75_sec_kV0"){
+  else if (cutDefinition == "pairJPID_sum1_pt20_sec_kV0"){
     AnaCut.SetPIDAna(LMEECutLib::kNoPID_Pt20);
     AnaCut.SetTrackSelectionAna(LMEECutLib::kDefaultNoTrackCuts);
     AnaCut.SetPairCutsAna(LMEECutLib::kNoPairCutsAna);

--- a/PWGDQ/dielectron/macrosLMEE/LMEECutLib_feisenhut.C
+++ b/PWGDQ/dielectron/macrosLMEE/LMEECutLib_feisenhut.C
@@ -894,10 +894,10 @@ AliAnalysisCuts* LMEECutLib::GetPIDCutsAna(AnalysisCut AnaCut) {
   Jeromian_01_sum->AddCut(Jeromian_01_ele_incl);
 
 
-  AliDielectronPID *Jeromian_01_PreFilter_hadron_cut = new AliDielectronPID("Jeromian_01_hadron_cut","Jeromian_01_hadron_cut");
-  Jeromian_01_hadron_cut->AddCut(AliDielectronPID::kTPC,AliPID::kElectron,  -3. , 3. ,0.0, 100., kFALSE,AliDielectronPID::kIfAvailable    ,AliDielectronVarManager::kP);
+  AliDielectronPID *Jeromian_01_PreFilter_hadron_cut = new AliDielectronPID("Jeromian_01_PreFilter_hadron_cut","Jeromian_01_PreFilter_hadron_cut");
+  Jeromian_01_PreFilter_hadron_cut->AddCut(AliDielectronPID::kTPC,AliPID::kElectron,  -3. , 3. ,0.0, 100., kFALSE,AliDielectronPID::kIfAvailable    ,AliDielectronVarManager::kP);
 
-  AliDielectronCutGroup* Jeromian_01_sum_PreFilter = new AliDielectronCutGroup("Jeromian_01_sum","Jeromian_01_sum",AliDielectronCutGroup::kCompOR);
+  AliDielectronCutGroup* Jeromian_01_sum_PreFilter = new AliDielectronCutGroup("Jeromian_01_sum_PreFilter","Jeromian_01_sum_PreFilter",AliDielectronCutGroup::kCompOR);
   Jeromian_01_sum_PreFilter->AddCut(Jeromian_01_PreFilter_hadron_cut);
 
 

--- a/PWGGA/GammaConv/AliAnalysisTaskOmegaToPiZeroGamma.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskOmegaToPiZeroGamma.cxx
@@ -60,7 +60,6 @@
 #include <vector>
 #include <map>
 #include <iostream>
-#include <set>
 
 ClassImp(AliAnalysisTaskOmegaToPiZeroGamma)
 

--- a/PWGGA/GammaConv/AliAnalysisTaskOmegaToPiZeroGamma.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskOmegaToPiZeroGamma.cxx
@@ -781,12 +781,12 @@ void AliAnalysisTaskOmegaToPiZeroGamma::UserCreateOutputObjects(){
       }
     }
 
-    fHistoPhotonPairInvMassPt[iCut]             = new TH2F("ESD_PhotonPair_InvMass_Pt","ESD_PhotonPair_InvMass_Pt",800,0,0.8,nBinsPt, arrPtBinning);
+    fHistoPhotonPairInvMassPt[iCut]             = new TH2F("ESD_PhotonPair_InvMass_Pt","ESD_PhotonPair_InvMass_Pt",800,0,0.8,200,0.,20.);
     fHistoPhotonPairInvMassPt[iCut]->SetXTitle("M_{inv, #pi^{0} cand}(GeV/c^{2})");
     fHistoPhotonPairInvMassPt[iCut]->SetYTitle("p_{T, #pi^{0} cand}(GeV/c)");
     fESDList[iCut]->Add(fHistoPhotonPairInvMassPt[iCut]);
 
-    fHistoMotherInvMassPt[iCut]                 = new TH2F("ESD_Mother_InvMass_Pt","ESD_Mother_InvMass_Pt",400,0.4,1.2,nBinsPt, arrPtBinning);
+    fHistoMotherInvMassPt[iCut]                 = new TH2F("ESD_Mother_InvMass_Pt","ESD_Mother_InvMass_Pt",100,0.4,1.2,nBinsPt, arrPtBinning);
     fHistoMotherInvMassPt[iCut]->SetXTitle("M_{inv, #omega cand}(GeV/c^{2})");
     fHistoMotherInvMassPt[iCut]->SetYTitle("p_{T, #omega cand}(GeV/c)");
     fESDList[iCut]->Add(fHistoMotherInvMassPt[iCut]);
@@ -796,45 +796,45 @@ void AliAnalysisTaskOmegaToPiZeroGamma::UserCreateOutputObjects(){
     fESDList[iCut]->Add(fHistoGammaFromMotherPt[iCut]);
 
     if(fReconMethod!=2 && fReconMethod!=5){
-      fHistoMotherMatchedInvMassPt[iCut]        = new TH2F("ESD_Mother_Matched_InvMass_Pt","ESD_Mother_Matched_InvMass_Pt",400,0.4,1.2,nBinsPt, arrPtBinning);
+      fHistoMotherMatchedInvMassPt[iCut]        = new TH2F("ESD_Mother_Matched_InvMass_Pt","ESD_Mother_Matched_InvMass_Pt",100,0.4,1.2,nBinsPt, arrPtBinning);
       fHistoMotherMatchedInvMassPt[iCut]->SetXTitle("M_{inv, #omega matched}(GeV/c^{2})");
       fHistoMotherMatchedInvMassPt[iCut]->SetYTitle("p_{T, #omega matched}(GeV/c)");
       fESDList[iCut]->Add(fHistoMotherMatchedInvMassPt[iCut]);
     }
 
     if(fDoPiZeroGammaAngleCut){
-      fHistoMotherAngleCutRejectedInvMassPt[iCut]        = new TH2F("ESD_Mother_AngleCutRejected_InvMass_Pt","ESD_Mother_AngleCutRejected_InvMass_Pt",400,0.4,1.2,nBinsPt, arrPtBinning);
+      fHistoMotherAngleCutRejectedInvMassPt[iCut]        = new TH2F("ESD_Mother_AngleCutRejected_InvMass_Pt","ESD_Mother_AngleCutRejected_InvMass_Pt",100,0.4,1.2,nBinsPt, arrPtBinning);
       fHistoMotherAngleCutRejectedInvMassPt[iCut]->SetXTitle("M_{inv, #omega rejected}(GeV/c^{2})");
       fHistoMotherAngleCutRejectedInvMassPt[iCut]->SetYTitle("p_{T, #omega rejected}(GeV/c)");
       fESDList[iCut]->Add(fHistoMotherAngleCutRejectedInvMassPt[iCut]);
     }
 
     if(fReconMethod<2){
-      fHistoPhotonPairMatchedInvMassPt[iCut]      = new TH2F("ESD_PhotonPair_Matched_InvMass_Pt","ESD_PhotonPair_Matched_InvMass_Pt",800,0,0.8,nBinsPt, arrPtBinning);
+      fHistoPhotonPairMatchedInvMassPt[iCut]      = new TH2F("ESD_PhotonPair_Matched_InvMass_Pt","ESD_PhotonPair_Matched_InvMass_Pt",800,0,0.8,200,0.,20.);
       fHistoPhotonPairMatchedInvMassPt[iCut]->SetXTitle("M_{inv}(GeV/c^{2}) matched conv e^{+/-}to cluster");
       fHistoPhotonPairMatchedInvMassPt[iCut]->SetYTitle("p_{T}(GeV/c)");
       fESDList[iCut]->Add(fHistoPhotonPairMatchedInvMassPt[iCut]);
     }
 
     if(((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->DoGammaSwappForBg()) {
-      fHistoMotherSwappingBackInvMassPt[iCut]     = new TH2F("ESD_Mother_SwappingBack_InvMass_Pt","ESD_Mother_SwappingBack_InvMass_Pt",400,0.4,1.2,nBinsPt, arrPtBinning);
+      fHistoMotherSwappingBackInvMassPt[iCut]     = new TH2F("ESD_Mother_SwappingBack_InvMass_Pt","ESD_Mother_SwappingBack_InvMass_Pt",100,0.4,1.2,nBinsPt, arrPtBinning);
       fHistoMotherSwappingBackInvMassPt[iCut]->SetXTitle("M_{inv}(GeV/c^{2})");
       fHistoMotherSwappingBackInvMassPt[iCut]->SetYTitle("p_{T}(GeV/c)");
       fESDList[iCut]->Add(fHistoMotherSwappingBackInvMassPt[iCut]);
 
-      fHistoMotherSwappingBackInvMassECalib[iCut]     = new TH2F("ESD_Mother_SwappingBack_InvMass_E_Calib","ESD_Mother_SwappingBack_InvMass_E_Calib",400,0.4,1.2,nBinsPt, arrPtBinning);
+      fHistoMotherSwappingBackInvMassECalib[iCut]     = new TH2F("ESD_Mother_SwappingBack_InvMass_E_Calib","ESD_Mother_SwappingBack_InvMass_E_Calib",100,0.4,1.2,nBinsPt, arrPtBinning);
       fHistoMotherSwappingBackInvMassECalib[iCut]->SetXTitle("M_{inv}(GeV/c^{2})");
       fHistoMotherSwappingBackInvMassECalib[iCut]->SetYTitle("E(GeV/c)");
       fESDList[iCut]->Add(fHistoMotherSwappingBackInvMassECalib[iCut]);
     }
 
     else {
-      fHistoDiffPi0SameGammaBackInvMassPt[iCut]     = new TH2F("ESD_Mother_DiffPi0SameGamma_InvMass_Pt","ESD_Mother_DiffPi0SameGamma_InvMass_Pt",400,0.4,1.2,nBinsPt, arrPtBinning);
+      fHistoDiffPi0SameGammaBackInvMassPt[iCut]     = new TH2F("ESD_Mother_DiffPi0SameGamma_InvMass_Pt","ESD_Mother_DiffPi0SameGamma_InvMass_Pt",100,0.4,1.2,nBinsPt, arrPtBinning);
       fHistoDiffPi0SameGammaBackInvMassPt[iCut]->SetXTitle("M_{inv}(GeV/c^{2})");
       fHistoDiffPi0SameGammaBackInvMassPt[iCut]->SetYTitle("p_{T}(GeV/c)");
       fESDList[iCut]->Add(fHistoDiffPi0SameGammaBackInvMassPt[iCut]);
 
-      fHistoSamePi0DiffGammaBackInvMassPt[iCut]     = new TH2F("ESD_Mother_SamePi0DiffGamma_InvMass_Pt","ESD_Mother_SamePi0DiffGamma_InvMass_Pt",400,0.4,1.2,nBinsPt, arrPtBinning);
+      fHistoSamePi0DiffGammaBackInvMassPt[iCut]     = new TH2F("ESD_Mother_SamePi0DiffGamma_InvMass_Pt","ESD_Mother_SamePi0DiffGamma_InvMass_Pt",100,0.4,1.2,nBinsPt, arrPtBinning);
       fHistoSamePi0DiffGammaBackInvMassPt[iCut]->SetXTitle("M_{inv}(GeV/c^{2})");
       fHistoSamePi0DiffGammaBackInvMassPt[iCut]->SetYTitle("p_{T}(GeV/c)");
       fESDList[iCut]->Add(fHistoSamePi0DiffGammaBackInvMassPt[iCut]);
@@ -1124,22 +1124,22 @@ void AliAnalysisTaskOmegaToPiZeroGamma::UserCreateOutputObjects(){
       fMCList[iCut]->Add(fHistoMCOmegaInAccInvMassPt[iCut]);
 
       if(fDoMesonQA>0){
-        fHistoMCAllOmegaYPt[iCut] = new TH2F("MC_AllOmega_Y_Pt","MC_AllOmega_Y_Pt",200,0,20,150,-1.5,1.5);
+        fHistoMCAllOmegaYPt[iCut] = new TH2F("MC_AllOmega_Y_Pt","MC_AllOmega_Y_Pt",nBinsPt, arrPtBinning,150,-1.5,1.5);
         fHistoMCAllOmegaYPt[iCut]->SetXTitle("p_{T,#omega}(GeV/c)");
         fHistoMCAllOmegaYPt[iCut]->SetYTitle("Y_{#omega}");
         fMCList[iCut]->Add(fHistoMCAllOmegaYPt[iCut]);
 
-        fHistoMCOmegaInAccYPt[iCut] = new TH2F("MC_OmegaInAcc_Y_Pt","MC_OmegaInAcc_Y_Pt",200,0,20,150,-1.5,1.5);
+        fHistoMCOmegaInAccYPt[iCut] = new TH2F("MC_OmegaInAcc_Y_Pt","MC_OmegaInAcc_Y_Pt",nBinsPt, arrPtBinning,150,-1.5,1.5);
         fHistoMCOmegaInAccYPt[iCut]->SetXTitle("p_{T,#omega}(GeV/c)");
         fHistoMCOmegaInAccYPt[iCut]->SetYTitle("Y_{#omega}");
         fMCList[iCut]->Add(fHistoMCOmegaInAccYPt[iCut]);
 
-        fHistoMCAllOmegaAlphaPt[iCut] = new TH2F("MC_AllOmega_Alpha_Pt","MC_AllOmega_Alpha_Pt",200,0,20,200,-1,1);
+        fHistoMCAllOmegaAlphaPt[iCut] = new TH2F("MC_AllOmega_Alpha_Pt","MC_AllOmega_Alpha_Pt",nBinsPt, arrPtBinning,200,-1,1);
         fHistoMCAllOmegaAlphaPt[iCut]->SetXTitle("p_{T,#omega}(GeV/c)");
         fHistoMCAllOmegaAlphaPt[iCut]->SetYTitle("#alpha_{#omega}");
         fMCList[iCut]->Add(fHistoMCAllOmegaAlphaPt[iCut]);
 
-        fHistoMCOmegaInAccAlphaPt[iCut] = new TH2F("MC_OmegaInAcc_Alpha_Pt","MC_OmegaInAcc_Alpha_Pt",200,0,20,200,-1,1);
+        fHistoMCOmegaInAccAlphaPt[iCut] = new TH2F("MC_OmegaInAcc_Alpha_Pt","MC_OmegaInAcc_Alpha_Pt",nBinsPt, arrPtBinning,200,-1,1);
         fHistoMCOmegaInAccAlphaPt[iCut]->SetXTitle("p_{T,#omega}(GeV/c)");
         fHistoMCOmegaInAccAlphaPt[iCut]->SetYTitle("#alpha_{#omega}");
         fMCList[iCut]->Add(fHistoMCOmegaInAccAlphaPt[iCut]);
@@ -1184,52 +1184,52 @@ void AliAnalysisTaskOmegaToPiZeroGamma::UserCreateOutputObjects(){
         fHistoMCOmegaInAccEtaPhi[iCut]->SetYTitle("#eta_{#omega}");
         fMCList[iCut]->Add(fHistoMCOmegaInAccEtaPhi[iCut]);
 
-        fHistoMCAllOmegaPiZeroAnglePt[iCut] = new TH2F("MC_AllOmegaPiZero_Angle_Pt","MC_AllOmegaPiZero_Angle_Pt",200,0,20,360,0,TMath::Pi());
-        fHistoMCAllOmegaPiZeroAnglePt[iCut]->SetYTitle("#theta_{#omega,#pi^{0}}");
+        fHistoMCAllOmegaPiZeroAnglePt[iCut] = new TH2F("MC_AllOmegaPiZero_Angle_Pt","MC_AllOmegaPiZero_Angle_Pt",nBinsPt, arrPtBinning,360,0,TMath::Pi());
         fHistoMCAllOmegaPiZeroAnglePt[iCut]->SetXTitle("#omega p_{T}(GeV/c)");
+        fHistoMCAllOmegaPiZeroAnglePt[iCut]->SetYTitle("#theta_{#omega,#pi^{0}}");
         fMCList[iCut]->Add(fHistoMCAllOmegaPiZeroAnglePt[iCut]);
 
-        fHistoMCAllPiZeroGammaAnglePt[iCut] = new TH2F("MC_AllPiZeroGamma_Angle_Pt","MC_AllPiZeroGamma_Angle_Pt",200,0,20,360,0,TMath::Pi());
+        fHistoMCAllPiZeroGammaAnglePt[iCut] = new TH2F("MC_AllPiZeroGamma_Angle_Pt","MC_AllPiZeroGamma_Angle_Pt",nBinsPt, arrPtBinning,360,0,TMath::Pi());
         fHistoMCAllPiZeroGammaAnglePt[iCut]->SetXTitle("#omega p_{T}(GeV/c)");
         fHistoMCAllPiZeroGammaAnglePt[iCut]->SetYTitle("#theta_{#pi^{0},#gamma}");
         fMCList[iCut]->Add(fHistoMCAllPiZeroGammaAnglePt[iCut]);
 
-        fHistoMCAllOmegaGammaAnglePt[iCut] = new TH2F("MC_AllOmegaGamma_Angle_Pt","MC_AllOmegaGamma_Angle_Pt",200,0,20,360,0,TMath::Pi());
+        fHistoMCAllOmegaGammaAnglePt[iCut] = new TH2F("MC_AllOmegaGamma_Angle_Pt","MC_AllOmegaGamma_Angle_Pt",nBinsPt, arrPtBinning,360,0,TMath::Pi());
         fHistoMCAllOmegaGammaAnglePt[iCut]->SetXTitle("#omega p_{T}(GeV/c)");
         fHistoMCAllOmegaGammaAnglePt[iCut]->SetYTitle("#theta_{#omega,#gamma}");
         fMCList[iCut]->Add(fHistoMCAllOmegaGammaAnglePt[iCut]);
 
-        fHistoMCInAccOmegaPiZeroAnglePt[iCut] = new TH2F("MC_InAccOmegaPiZero_Angle_Pt","MC_InAccOmegaPiZero_Angle_Pt",200,0,20,360,0,TMath::Pi());
+        fHistoMCInAccOmegaPiZeroAnglePt[iCut] = new TH2F("MC_InAccOmegaPiZero_Angle_Pt","MC_InAccOmegaPiZero_Angle_Pt",nBinsPt, arrPtBinning,360,0,TMath::Pi());
         fHistoMCInAccOmegaPiZeroAnglePt[iCut]->SetXTitle("p_{T,#omega}(GeV/c)");
         fHistoMCInAccOmegaPiZeroAnglePt[iCut]->SetYTitle("#theta_{#omega,#pi^{0}}");
         fMCList[iCut]->Add(fHistoMCInAccOmegaPiZeroAnglePt[iCut]);
 
-        fHistoMCInAccPiZeroGammaAnglePt[iCut] = new TH2F("MC_InAccPiZeroGamma_Angle_Pt","MC_InAccPiZeroGamma_Angle_Pt",200,0,20,360,0,TMath::Pi());
+        fHistoMCInAccPiZeroGammaAnglePt[iCut] = new TH2F("MC_InAccPiZeroGamma_Angle_Pt","MC_InAccPiZeroGamma_Angle_Pt",nBinsPt, arrPtBinning,360,0,TMath::Pi());
         fHistoMCInAccPiZeroGammaAnglePt[iCut]->SetXTitle("p_{T,#omega}(GeV/c)");
         fHistoMCInAccPiZeroGammaAnglePt[iCut]->SetYTitle("#theta_{#pi^{0},#gamma}");
         fMCList[iCut]->Add(fHistoMCInAccPiZeroGammaAnglePt[iCut]);
 
-        fHistoMCInAccOmegaGammaAnglePt[iCut] = new TH2F("MC_InAccOmegaGamma_Angle_Pt","MC_InAccOmegaGamma_Angle_Pt",200,0,20,360,0,TMath::Pi());
+        fHistoMCInAccOmegaGammaAnglePt[iCut] = new TH2F("MC_InAccOmegaGamma_Angle_Pt","MC_InAccOmegaGamma_Angle_Pt",nBinsPt, arrPtBinning,360,0,TMath::Pi());
         fHistoMCInAccOmegaGammaAnglePt[iCut]->SetXTitle("p_{T,#omega}(GeV/c)");
         fHistoMCInAccOmegaGammaAnglePt[iCut]->SetYTitle("#theta_{#omega,#gamma}");
         fMCList[iCut]->Add(fHistoMCInAccOmegaGammaAnglePt[iCut]);
 
-        fHistoMCAllOmegaPtPi0Pt[iCut] = new TH2F("MC_All_OmegaPt_Pi0Pt","MC_All_OmegaPt_Pi0Pt",200,0,20,nBinsPt, arrPtBinning);
+        fHistoMCAllOmegaPtPi0Pt[iCut] = new TH2F("MC_All_OmegaPt_Pi0Pt","MC_All_OmegaPt_Pi0Pt",nBinsPt, arrPtBinning,200,0,20);
         fHistoMCAllOmegaPtPi0Pt[iCut]->SetXTitle("#omega p_{T}(GeV/c)");
         fHistoMCAllOmegaPtPi0Pt[iCut]->SetYTitle("#pi^{0} p_{T}(GeV/c)");
         fMCList[iCut]->Add(fHistoMCAllOmegaPtPi0Pt[iCut]);
 
-        fHistoMCInAccOmegaPtPi0Pt[iCut] = new TH2F("MC_InAcc_OmegaPt_Pi0Pt","MC_InAcc_OmegaPt_Pi0Pt",200,0,20,nBinsPt, arrPtBinning);
+        fHistoMCInAccOmegaPtPi0Pt[iCut] = new TH2F("MC_InAcc_OmegaPt_Pi0Pt","MC_InAcc_OmegaPt_Pi0Pt",nBinsPt, arrPtBinning,200,0,20);
         fHistoMCInAccOmegaPtPi0Pt[iCut]->SetXTitle("#omega p_{T}(GeV/c)");
         fHistoMCInAccOmegaPtPi0Pt[iCut]->SetYTitle("#pi^{0} p_{T}(GeV/c)");
         fMCList[iCut]->Add(fHistoMCInAccOmegaPtPi0Pt[iCut]);
 
-        fHistoMCAllOmegaPtGammaPt[iCut] = new TH2F("MC_All_OmegaPt_GammaPt","MC_All_OmegaPt_GammaPt",200,0,20,nBinsPt, arrPtBinning);
+        fHistoMCAllOmegaPtGammaPt[iCut] = new TH2F("MC_All_OmegaPt_GammaPt","MC_All_OmegaPt_GammaPt",nBinsPt, arrPtBinning,200,0,20);
         fHistoMCAllOmegaPtGammaPt[iCut]->SetXTitle("#omega p_{T}(GeV/c)");
         fHistoMCAllOmegaPtGammaPt[iCut]->SetYTitle("#gamma p_{T}(GeV/c)");
         fMCList[iCut]->Add(fHistoMCAllOmegaPtGammaPt[iCut]);
 
-        fHistoMCInAccOmegaPtGammaPt[iCut] = new TH2F("MC_InAcc_OmegaPt_GammaPt","MC_InAcc_OmegaPt_GammaPt",200,0,20,nBinsPt, arrPtBinning);
+        fHistoMCInAccOmegaPtGammaPt[iCut] = new TH2F("MC_InAcc_OmegaPt_GammaPt","MC_InAcc_OmegaPt_GammaPt",nBinsPt, arrPtBinning,200,0,20);
         fHistoMCInAccOmegaPtGammaPt[iCut]->SetXTitle("#omega p_{T}(GeV/c)");
         fHistoMCInAccOmegaPtGammaPt[iCut]->SetYTitle("#gamma p_{T}(GeV/c)");
         fMCList[iCut]->Add(fHistoMCInAccOmegaPtGammaPt[iCut]);
@@ -1312,37 +1312,37 @@ void AliAnalysisTaskOmegaToPiZeroGamma::UserCreateOutputObjects(){
       fTrueList[iCut]->Add(fHistoTrueGammaFromOmegaPt[iCut]);
 
       if(fDoMesonQA>0){
-        fHistoTrueOmegaYPt[iCut] = new TH2F("True_Omega_Y_Pt","True_Omega_Y_Pt",200,0,20,150,-1.5,1.5);
+        fHistoTrueOmegaYPt[iCut] = new TH2F("True_Omega_Y_Pt","True_Omega_Y_Pt",nBinsPt, arrPtBinning,150,-1.5,1.5);
         fHistoTrueOmegaYPt[iCut]->SetXTitle("p_{T,#omega}(GeV/c)");
         fHistoTrueOmegaYPt[iCut]->SetYTitle("Y_{#omega}");
         fTrueList[iCut]->Add(fHistoTrueOmegaYPt[iCut]);
 
-        fHistoTrueOmegaAlphaPt[iCut] = new TH2F("True_Omega_Alpha_Pt","True_Omega_Alpha_Pt",200,0,20,200,-1,1);
+        fHistoTrueOmegaAlphaPt[iCut] = new TH2F("True_Omega_Alpha_Pt","True_Omega_Alpha_Pt",nBinsPt, arrPtBinning,200,-1,1);
         fHistoTrueOmegaAlphaPt[iCut]->SetXTitle("p_{T,#omega}(GeV/c)");
         fHistoTrueOmegaAlphaPt[iCut]->SetYTitle("#alpha_{#omega}");
         fTrueList[iCut]->Add(fHistoTrueOmegaAlphaPt[iCut]);
 
-        fHistoTruePi0FromOmegaYPt[iCut] = new TH2F("True_Pi0FromOmega_Y_Pt","True_Pi0FromOmega_Y_Pt",200,0,20,150,-1.5,1.5);
+        fHistoTruePi0FromOmegaYPt[iCut] = new TH2F("True_Pi0FromOmega_Y_Pt","True_Pi0FromOmega_Y_Pt",nBinsPt, arrPtBinning,150,-1.5,1.5);
         fHistoTruePi0FromOmegaYPt[iCut]->SetXTitle("p_{T,pi^{0}}(GeV/c)");
         fHistoTruePi0FromOmegaYPt[iCut]->SetYTitle("Y_{#pi^{0}}");
         fTrueList[iCut]->Add(fHistoTruePi0FromOmegaYPt[iCut]);
 
-        fHistoTruePi0FromOmegaAlphaPt[iCut] = new TH2F("True_Pi0FromOmega_Alpha_Pt","MC_Pi0FromOmega_Alpha_Pt",200,0,20,200,-1,1);
+        fHistoTruePi0FromOmegaAlphaPt[iCut] = new TH2F("True_Pi0FromOmega_Alpha_Pt","MC_Pi0FromOmega_Alpha_Pt",nBinsPt, arrPtBinning,200,-1,1);
         fHistoTruePi0FromOmegaAlphaPt[iCut]->SetXTitle("p_{T,pi^{0}}(GeV/c)");
         fHistoTruePi0FromOmegaAlphaPt[iCut]->SetYTitle("#alpha_{#pi^{0}}");
         fTrueList[iCut]->Add(fHistoTruePi0FromOmegaAlphaPt[iCut]);
 
-        fHistoTrueOmegaPi0AnglePt[iCut] = new TH2F("True_OmegaPiZero_Angle_Pt","True_OmegaPiZero_Angle_Pt",200,0,20,360,0,TMath::Pi());
+        fHistoTrueOmegaPi0AnglePt[iCut] = new TH2F("True_OmegaPiZero_Angle_Pt","True_OmegaPiZero_Angle_Pt",nBinsPt, arrPtBinning,360,0,TMath::Pi());
         fHistoTrueOmegaPi0AnglePt[iCut]->SetXTitle("#omega p_{T}(GeV/c)");
         fHistoTrueOmegaPi0AnglePt[iCut]->SetYTitle("#theta_{#omega,#pi^{0}}");
         fTrueList[iCut]->Add(fHistoTrueOmegaPi0AnglePt[iCut]);
 
-        fHistoTruePi0GammaAnglePt[iCut] = new TH2F("True_PiZeroGamma_Angle_Pt","True_PiZeroGamma_Angle_Pt",200,0,20,360,0,TMath::Pi());
+        fHistoTruePi0GammaAnglePt[iCut] = new TH2F("True_PiZeroGamma_Angle_Pt","True_PiZeroGamma_Angle_Pt",nBinsPt, arrPtBinning,360,0,TMath::Pi());
         fHistoTruePi0GammaAnglePt[iCut]->SetXTitle("#omega p_{T}(GeV/c)");
         fHistoTruePi0GammaAnglePt[iCut]->SetYTitle("#theta_{#pi_{0},#gamma}");
         fTrueList[iCut]->Add(fHistoTruePi0GammaAnglePt[iCut]);
 
-        fHistoTrueOmegaGammaAnglePt[iCut] = new TH2F("True_OmegaGamma_Angle_Pt","True_OmegaGamma_Angle_Pt",200,0,20,360,0,TMath::Pi());
+        fHistoTrueOmegaGammaAnglePt[iCut] = new TH2F("True_OmegaGamma_Angle_Pt","True_OmegaGamma_Angle_Pt",nBinsPt, arrPtBinning,360,0,TMath::Pi());
         fHistoTrueOmegaGammaAnglePt[iCut]->SetXTitle("#omega p_{T}(GeV/c)");
         fHistoTrueOmegaGammaAnglePt[iCut]->SetYTitle("#theta_{#omega,#gamma}");
         fTrueList[iCut]->Add(fHistoTrueOmegaGammaAnglePt[iCut]);
@@ -1382,7 +1382,7 @@ void AliAnalysisTaskOmegaToPiZeroGamma::UserCreateOutputObjects(){
         fHistoTrueDalitzPlot[iCut]->SetYTitle("#it{m}^{2}(#gamma_{1}#gamma_{2}) (GeV/#it{c}^{2})^{2}");
         fTrueList[iCut]->Add(fHistoTrueDalitzPlot[iCut]);
 
-        fHistoTrueOmegaPtGammaPt[iCut] = new TH2F("True_OmegaPt_GammaPt","True_OmegaPt_GammaPt",200,0,20,nBinsPt, arrPtBinning);
+        fHistoTrueOmegaPtGammaPt[iCut] = new TH2F("True_OmegaPt_GammaPt","True_OmegaPt_GammaPt",nBinsPt, arrPtBinning,200,0,20);
         fHistoTrueOmegaPtGammaPt[iCut]->SetXTitle("#omega p_{T}(GeV/c)");
         fHistoTrueOmegaPtGammaPt[iCut]->SetYTitle("#gamma p_{T}(GeV/c)");
         fTrueList[iCut]->Add(fHistoTrueOmegaPtGammaPt[iCut]);
@@ -4345,8 +4345,8 @@ void AliAnalysisTaskOmegaToPiZeroGamma::CalculateBackground(){
             }
 
 
-            cellIDRotatedPhoton = ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetCaloCellIdFromEtaPhi(lvRotationPhoton.Eta(), lvRotationPhoton.Phi());
-            cellIDRotatedPion = ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetCaloCellIdFromEtaPhi(lvRotationPion.Eta(), lvRotationPion.Phi());
+            cellIDRotatedPhoton = ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetCaloCellIdFromEtaPhi(lvRotationPhoton.Eta(), static_cast<double>((lvRotationPhoton.Phi()<0) ? lvRotationPhoton.Phi() + TMath::Pi()*2. : lvRotationPhoton.Phi()));
+            cellIDRotatedPion = ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetCaloCellIdFromEtaPhi(lvRotationPion.Eta(), static_cast<double>((lvRotationPion.Phi()<0) ? lvRotationPion.Phi() + TMath::Pi()*2. : lvRotationPion.Phi()));
 
             if(!fDoLightOutput){
               if(!(((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->CheckDistanceToBadChannelSwapping(cellIDRotatedPhoton, lvRotationPhoton.Phi(), fInputEvent))){

--- a/PWGGA/GammaConv/AliAnalysisTaskOmegaToPiZeroGamma.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskOmegaToPiZeroGamma.cxx
@@ -230,7 +230,8 @@ AliAnalysisTaskOmegaToPiZeroGamma::AliAnalysisTaskOmegaToPiZeroGamma(): AliAnaly
   fDoPiZeroGammaAngleCut(kFALSE),
   fTrackMatcherRunningMode(0),
   fRandom(0),
-  fGenPhaseSpace()
+  fGenPhaseSpace(),
+  fPhotonSelectionMode(0)
 {
 
 }
@@ -402,7 +403,8 @@ AliAnalysisTaskOmegaToPiZeroGamma::AliAnalysisTaskOmegaToPiZeroGamma(const char 
   fDoPiZeroGammaAngleCut(kFALSE),
   fTrackMatcherRunningMode(0),
   fRandom(0),
-  fGenPhaseSpace()
+  fGenPhaseSpace(),
+  fPhotonSelectionMode(0)
 {
   // Define output slots here
   DefineOutput(1, TList::Class());

--- a/PWGGA/GammaConv/AliAnalysisTaskOmegaToPiZeroGamma.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskOmegaToPiZeroGamma.h
@@ -40,6 +40,9 @@ class AliAnalysisTaskOmegaToPiZeroGamma : public AliAnalysisTaskSE {
     // Function to set correction task setting
     void SetCorrectionTaskSetting(TString setting) {fCorrTaskSetting = setting;}
 
+    // Function to set photon selection mode, called in the AddTask
+    void SetPhotonSelectionMode(Int_t mode) {fPhotonSelectionMode = mode;}
+
 
     // base functions for selecting photon and meson candidates in reconstructed data
     void ProcessClusters();
@@ -133,6 +136,10 @@ class AliAnalysisTaskOmegaToPiZeroGamma : public AliAnalysisTaskSE {
     void FillQAPlots ( AliAODConversionMother *omegacand, AliAODConversionMother *pi0cand,
       AliAODConversionPhoton *gamma0, AliAODConversionPhoton *gamma1, AliAODConversionPhoton *gamma2,
       TH2F* fHistoMotherRestGammaCosAnglePt, TH2F* fHistoMotherRestPi0CosAnglePt, TH2F* fHistoMotherDalitzPlot );
+
+    void PhotonSelectionCalo(std::set<uint> dropOutGammas_CALO);
+    void PhotonSelectionPCM(std::set<uint> dropOutGammas_PCM);
+    void PhotonSelectionMixed(std::set<uint> dropOutGammas_CALO, std::set<uint> dropOutGammas_PCM);
 
         // Function to enable MC label sorting
     void SetEnableSortingOfMCClusLabels (Bool_t enableSort) { fEnableSortForClusMC   = enableSort;}
@@ -342,12 +349,13 @@ class AliAnalysisTaskOmegaToPiZeroGamma : public AliAnalysisTaskSE {
     Int_t                   fTrackMatcherRunningMode;                           // CaloTrackMatcher running mode
     TRandom3                fRandom;                                            // random
     TGenPhaseSpace          fGenPhaseSpace;                                     // For generation of decays into pi0n and photon
+    Int_t                   fPhotonSelectionMode;                               // mode for the photon selection: 0 none, 1 normal (Cal-Cal, PCM-PCM), 2 strict (normal + Cal-PCM)
 
   private:
     AliAnalysisTaskOmegaToPiZeroGamma(const AliAnalysisTaskOmegaToPiZeroGamma&); // Prevent copy-construction
     AliAnalysisTaskOmegaToPiZeroGamma &operator=(const AliAnalysisTaskOmegaToPiZeroGamma&); // Prevent assignment
 
-    ClassDef(AliAnalysisTaskOmegaToPiZeroGamma, 15);
+    ClassDef(AliAnalysisTaskOmegaToPiZeroGamma, 16);
 };
 
 #endif

--- a/PWGGA/GammaConv/AliAnalysisTaskOmegaToPiZeroGamma.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskOmegaToPiZeroGamma.h
@@ -19,6 +19,7 @@
 #include "TGenPhaseSpace.h"
 #include <vector>
 #include <map>
+#include <set>
 
 class AliAnalysisTaskOmegaToPiZeroGamma : public AliAnalysisTaskSE {
   public:

--- a/PWGGA/GammaConv/macros/AddTask_OmegaToPiZeroGamma_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_OmegaToPiZeroGamma_pp.C
@@ -66,7 +66,6 @@ void AddTask_OmegaToPiZeroGamma_pp(
                                 TString   photonCutNumberV0Reader       = "",                     // 00000008400000000100000000 nom. B, 00000088400000000100000000 low B
                                 Int_t     enableQAMesonTask             = 1,                      // enable QA in AliAnalysisTaskGammaConvV1
                                 Int_t     enableQAPhotonTask            = 1,                      // enable additional QA task
-                                Bool_t    enableLightOutput             = kFALSE,                 // switch to run light output (only essential histograms for afterburner)
                                 Int_t     DoPiZeroGammaAngleCut         = kFALSE,                 // flag for enabling cut on pi0-gamma angle
                                 Double_t  lowerFactor                   = 0.75,                   // scale factor for lower limit in pi0-gamma angle cut
                                 Double_t  upperFactor                   = 2.5,                    // scale factor for upper limit in pi0-gamma angle cut
@@ -87,6 +86,7 @@ void AddTask_OmegaToPiZeroGamma_pp(
                                 Double_t  smearPar                      = 0.,                     // conv photon smearing params
                                 Double_t  smearParConst                 = 0.,                     // conv photon smearing params
                                 Bool_t    usePtDepSelectionWindowCut    = kFALSE,                 // use pt dependent meson selection window cut
+                                Int_t     PhotonSelectionMode           = 0,                      // 0 none, 1 normal (Cal-Cal, PCM-PCM), 2 strict (normal + Cal-PCM)
                                 TString   additionalTrainConfig         = "0"                     // additional counter for trainconfig, this has to be always the last parameter
               ) {
 
@@ -167,7 +167,7 @@ void AddTask_OmegaToPiZeroGamma_pp(
   Int_t isHeavyIon = 0;
 
   // fReconMethod = first digit of trainconfig
-  Int_t ReconMethod = trainConfig/100;
+  Int_t ReconMethod = trainConfig/1000;
 
   // ================== GetAnalysisManager ===============================
   AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
@@ -257,6 +257,7 @@ void AddTask_OmegaToPiZeroGamma_pp(
   task->SetlowerFactor(lowerFactor);
   task->SetupperFactor(upperFactor);
   task->SetTrackMatcherRunningMode(trackMatcherRunningMode);
+  task->SetPhotonSelectionMode(PhotonSelectionMode);
 
   //create cut handler
   CutHandlerPiZeroGamma cuts;
@@ -311,430 +312,601 @@ void AddTask_OmegaToPiZeroGamma_pp(
     cuts.AddCut("00010113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
 
   // cuts for ReconMethod==1 PCM-Cal-PCM
-  } else if(trainConfig == 101){ // EMCAL clusters pp 7 TeV
+  } else if(trainConfig == 1001){ // EMCAL clusters pp 7 TeV
     cuts.AddCut("00000113","00200009327000008250400000","1111111017032230000","0163103a00000010","0163103000000010"); // pion mass (0.08,0.145)
 
-  } else if(trainConfig == 102){ // EMCAL clusters pp 7 TeV
+  } else if(trainConfig == 1002){ // EMCAL clusters pp 7 TeV
     cuts.AddCut("00000113","00200009327000008250400000","1111111017032230000","0163103a00000010","0163103000000010"); // same as standard, for varying angle cut
 
-  } else if(trainConfig == 103){ // EMCAL clusters pp 7 TeV
+  } else if(trainConfig == 1003){ // EMCAL clusters pp 7 TeV
     cuts.AddCut("00000113","00200009327000008250400000","1111111017032230000","0163103a00000010","0163103000000010"); // same as standard, for varying angle cut
 
-  } else if(trainConfig == 104){ // EMCAL clusters pp 7 TeV
+  } else if(trainConfig == 1004){ // EMCAL clusters pp 7 TeV
     cuts.AddCut("00000113","00200009327000008250400000","1111111017032230000","0163103a00000010","0163103000000010"); // same as standard, for varying angle cut
 
-  } else if(trainConfig == 151){ // std 8TeV
+  } else if(trainConfig == 1051){ // std 8TeV
     cuts.AddCut("00010113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
     cuts.AddCut("00052113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
     cuts.AddCut("00081113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
 
-  } else if(trainConfig == 152){ // same as std 8TeV, for varying angle cut
+  } else if(trainConfig == 1052){ // same as std 8TeV, for varying angle cut
     cuts.AddCut("00010113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
     cuts.AddCut("00052113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
     cuts.AddCut("00081113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
 
-  } else if(trainConfig == 153){ // same as std 8TeV, for varying angle cut
+  } else if(trainConfig == 1053){ // same as std 8TeV, for varying angle cut
     cuts.AddCut("00010113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
     cuts.AddCut("00052113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
     cuts.AddCut("00081113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
 
-  } else if(trainConfig == 154){ // same as std 8TeV, for varying angle cut
+  } else if(trainConfig == 1054){ // same as std 8TeV, for varying angle cut
     cuts.AddCut("00010113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
     cuts.AddCut("00052113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
     cuts.AddCut("00081113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
-  } else if( trainConfig == 160) {
+  } else if(trainConfig == 1060) {
     //std MB 13TeV
     cuts.AddCut("00010113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
     cuts.AddCut("00052113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
     cuts.AddCut("00085113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
     cuts.AddCut("00083113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
-  } else if( trainConfig == 161) {
+  } else if(trainConfig == 1061) {
     //only MB 13TeV
     cuts.AddCut("00010113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
-  } else if( trainConfig == 162) {
+  } else if(trainConfig == 1062) {
     //only MB 13TeV EMcal + Dcal
     cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","01631031000000d0","01631031000000d0");
-  } else if( trainConfig == 163) {
+  } else if(trainConfig == 1063) {
     //EG2 13TeV EMcal + Dcal
     cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","01631031000000d0","01631031000000d0");
-  } else if( trainConfig == 164) {
+  } else if(trainConfig == 1064) {
     //EG1 13TeV EMcal + Dcal
     cuts.AddCut("0008d113","00200009327000008250400000","411791206f032230000","01631031000000d0","01631031000000d0");
 
   // cuts for ReconMethod==2 Cal-Cal-Cal
-  } else if(trainConfig == 201){ // EMCAL clusters pp 7 TeV
+  } else if(trainConfig == 2001){ // EMCAL clusters pp 7 TeV
     cuts.AddCut("00000113","00200009327000008250400000","1111111017032230000","0163103a00000010","0163103000000010"); // pion mass (0.08,0.145)
 
-  } else if(trainConfig == 202){ // EMCAL clusters pp 7 TeV
+  } else if(trainConfig == 2002){ // EMCAL clusters pp 7 TeV
     cuts.AddCut("00000113","00200009327000008250400000","1111111017032230000","0163103a00000010","0163103000000010"); // same as standard, for varying angle cut
 
-  } else if(trainConfig == 203){ // EMCAL clusters pp 7 TeV
+  } else if(trainConfig == 2003){ // EMCAL clusters pp 7 TeV
     cuts.AddCut("00000113","00200009327000008250400000","1111111017032230000","0163103a00000010","0163103000000010"); // same as standard, for varying angle cut
 
-  } else if(trainConfig == 204){ // EMCAL clusters pp 7 TeV
+  } else if(trainConfig == 2004){ // EMCAL clusters pp 7 TeV
     cuts.AddCut("00000113","00200009327000008250400000","1111111017032230000","0163103a00000010","0163103000000010"); // same as standard, for varying angle cut
 
-  } else if(trainConfig == 251){ // std 8TeV
+  } else if(trainConfig == 2051){ // std 8TeV
     cuts.AddCut("00010113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
     cuts.AddCut("00052113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
     cuts.AddCut("00081113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
 
-  } else if(trainConfig == 252){ // same as std 8TeV, for varying angle cut
+  } else if(trainConfig == 2052){ // same as std 8TeV, for varying angle cut
     cuts.AddCut("00010113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
     cuts.AddCut("00052113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
     cuts.AddCut("00081113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
 
-  } else if(trainConfig == 253){ // same as std 8TeV, for varying angle cut
+  } else if(trainConfig == 2053){ // same as std 8TeV, for varying angle cut
     cuts.AddCut("00010113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
     cuts.AddCut("00052113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
     cuts.AddCut("00081113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
 
-  } else if(trainConfig == 254){ // same as std 8TeV, for varying angle cut
+  } else if(trainConfig == 2054){ // same as std 8TeV, for varying angle cut
     cuts.AddCut("00010113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
     cuts.AddCut("00052113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
     cuts.AddCut("00081113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
 
-  } else if(trainConfig == 255){ // same as std 8TeV, for varying angle cut
+  } else if(trainConfig == 2055){ // same as std 8TeV, for varying angle cut
     cuts.AddCut("00010113","00200009327000008250400000","1111100067032230000","0163103100000010","0163103000000010"); // same as standard but without non lin
     cuts.AddCut("00052113","00200009327000008250400000","1111100067032230000","0163103100000010","0163103000000010");
     cuts.AddCut("00081113","00200009327000008250400000","1111100067032230000","0163103100000010","0163103000000010");
 
-    //  13TeV EMcal + DCal
-  } else if( trainConfig == 260) {
+
+    /////////////////////////////////
+    // 13 TeV
+    /////////////////////////////////
+
+    // EMCal + DCal
+  } else if( trainConfig == 2060) {
     // MB 13TeV EMcal + DCal
     cuts.AddCut("00010113","00200009327000008250400000","411791106f032230000","01631031000000d0","01631030000000d0");
     cuts.AddCut("00052113","00200009327000008250400000","411791106f032230000","01631031000000d0","01631030000000d0");
     cuts.AddCut("00085113","00200009327000008250400000","411791106f032230000","01631031000000d0","01631030000000d0");
     cuts.AddCut("00083113","00200009327000008250400000","411791106f032230000","01631031000000d0","01631030000000d0");
-  } else if( trainConfig == 261) {
+  } else if( trainConfig == 2061) {
     // MB 13TeV only EMCal
     cuts.AddCut("00010113","00200009327000008250400000","1111100067032230000","01631031000000d0","01631031000000d0");
-  } else if( trainConfig == 262) {
+  } else if( trainConfig == 2062) {
     // MB std NL 12 EMCal + DCal
     cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","01631031000000d0","01631031000000d0");
-  } else if( trainConfig == 263) {
+  } else if( trainConfig == 2063) {
     // MB 13TeV EMCal + DCal, Pi0 selection plus Gamma dropout
     cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","0163103b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout
     cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","01631036000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout
     cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","0163103c000000d0","01631031000000d0"); // 3 sigma Pi0 selection plus Gamma dropout
     cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","0163103d000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout
-  } else if( trainConfig == 264) {
+  } else if( trainConfig == 2064) {
     // MB 13TeV EMCal + DCal Background Variation (Swapping Method by Joshua)
-    cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","01631036000000d0","0r631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation
-    cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","01631036000000d0","0v631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS without constraints
-    cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","01631036000000d0","0x631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
-  } else if( trainConfig == 265) {
+    cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","0163103b000000d0","0r631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation
+    cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","0163103b000000d0","0v631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS without constraints
+    cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","0163103b000000d0","0x631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
+  } else if( trainConfig == 2065) {
     // MB 13TeV EMCal + DCal, Pi0 selection plus Gamma dropout, alpha cut pi0
-    cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","01631076000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for pi0
-    cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","01631056000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for pi0
-    cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","01631046000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for pi0
-    cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","01631086000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for pi0
-  } else if( trainConfig == 266) {
+    cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","0163107b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for pi0
+    cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","0163105b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for pi0
+    cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","0163104b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for pi0
+    cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","0163108b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for pi0
+  } else if( trainConfig == 2066) {
     // MB 13TeV EMCal + DCal, Pi0 selection plus Gamma dropout, alpha cut omega
-    cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","01631036000000d0","01631071000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for omega
-    cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","01631036000000d0","01631051000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for omega
-    cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","01631036000000d0","01631041000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for omega
-    cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","01631036000000d0","01631081000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for omega
-  } else if( trainConfig == 271) {
+    cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","0163103b000000d0","01631071000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for omega
+    cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","0163103b000000d0","01631051000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for omega
+    cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","0163103b000000d0","01631041000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for omega
+    cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","0163103b000000d0","01631081000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for omega
+  } else if( trainConfig == 2071) {
     // EG2 13TeV EMcal
     cuts.AddCut("0008e113","00200009327000008250400000","1111100067032230000","01631031000000d0","01631031000000d0");
-  } else if( trainConfig == 272) {
+  } else if( trainConfig == 2072) {
     // EG2 std NL 12 EMCal + DCal
     cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","01631031000000d0","01631031000000d0");
-  } else if( trainConfig == 273) {
+  } else if( trainConfig == 2073) {
     // EG2 13TeV EMcal + Dcal, Pi0 selection plus Gamma dropout
     cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","0163103b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout
     cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","01631036000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout
     cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","0163103c000000d0","01631031000000d0"); // 3 sigma Pi0 selection plus Gamma dropout
     cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","0163103d000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout
-  } else if( trainConfig == 274) {
+  } else if( trainConfig == 2074) {
     // EG2 13TeV EMcal + Dcal, Background Variation (Swapping Method by Joshua)
-    cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","01631036000000d0","0r631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation
-    cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","01631036000000d0","0v631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS without constraints
-    cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","01631036000000d0","0x631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
-  } else if( trainConfig == 275) {
+    cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","0163103b000000d0","0r631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation
+    cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","0163103b000000d0","0v631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS without constraints
+    cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","0163103b000000d0","0x631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
+  } else if( trainConfig == 2075) {
     // EG2 13TeV EMCal + DCal, Pi0 selection plus Gamma dropout, alpha cut pi0
-    cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","01631076000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for pi0
-    cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","01631056000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for pi0
-    cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","01631046000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for pi0
-    cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","01631086000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for pi0
-  } else if( trainConfig == 276) {
+    cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","0163107b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for pi0
+    cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","0163105b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for pi0
+    cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","0163104b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for pi0
+    cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","0163108b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for pi0
+  } else if( trainConfig == 2076) {
     // EG2 13TeV EMCal + DCal, Pi0 selection plus Gamma dropout, alpha cut omega
-    cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","01631036000000d0","01631071000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for omega
-    cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","01631036000000d0","01631051000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for omega
-    cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","01631036000000d0","01631041000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for omega
-    cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","01631036000000d0","01631081000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for omega
-  } else if( trainConfig == 281) {
+    cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","0163103b000000d0","01631071000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for omega
+    cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","0163103b000000d0","01631051000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for omega
+    cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","0163103b000000d0","01631041000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for omega
+    cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","0163103b000000d0","01631081000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for omega
+  } else if( trainConfig == 2081) {
     // EG1 13TeV EMcal
     cuts.AddCut("0008d113","00200009327000008250400000","1111100067032230000","01631031000000d0","01631031000000d0");
-  } else if( trainConfig == 282) {
+  } else if( trainConfig == 2082) {
     // EG1 13TeV EMcal + Dcal
     cuts.AddCut("0008d113","00200009327000008250400000","411791206f032230000","01631031000000d0","01631031000000d0");
-  } else if( trainConfig == 283) {
+  } else if( trainConfig == 2083) {
     // EG1 13TeV EMcal + Dcal, Pi0 selection plus Gamma dropout
     cuts.AddCut("0008d113","00200009327000008250400000","411791206f032230000","0163103b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout
     cuts.AddCut("0008d113","00200009327000008250400000","411791206f032230000","01631036000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout
     cuts.AddCut("0008d113","00200009327000008250400000","411791206f032230000","0163103c000000d0","01631031000000d0"); // 3 sigma Pi0 selection plus Gamma dropout
     cuts.AddCut("0008d113","00200009327000008250400000","411791206f032230000","0163103d000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout
-  } else if( trainConfig == 284) {
+  } else if( trainConfig == 2084) {
     // EG1 13TeV EMcal + Dcal, Background Variation (Swapping Method by Joshua)
-    cuts.AddCut("0008d113","00200009327000008250400000","411791206f032230000","01631036000000d0","0r631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation
-    cuts.AddCut("0008d113","00200009327000008250400000","411791206f032230000","01631036000000d0","0v631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS without constraints
-    cuts.AddCut("0008d113","00200009327000008250400000","411791206f032230000","01631036000000d0","0x631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
-  } else if( trainConfig == 285) {
+    cuts.AddCut("0008d113","00200009327000008250400000","411791206f032230000","0163103b000000d0","0r631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation
+    cuts.AddCut("0008d113","00200009327000008250400000","411791206f032230000","0163103b000000d0","0v631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS without constraints
+    cuts.AddCut("0008d113","00200009327000008250400000","411791206f032230000","0163103b000000d0","0x631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
+  } else if( trainConfig == 2085) {
     // EG1 13TeV EMCal + DCal, Pi0 selection plus Gamma dropout, alpha cut pi0
-    cuts.AddCut("0008d113","00200009327000008250400000","411791206f032230000","01631076000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for pi0
-    cuts.AddCut("0008d113","00200009327000008250400000","411791206f032230000","01631056000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for pi0
-    cuts.AddCut("0008d113","00200009327000008250400000","411791206f032230000","01631046000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for pi0
-    cuts.AddCut("0008d113","00200009327000008250400000","411791206f032230000","01631086000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for pi0
-  } else if( trainConfig == 286) {
+    cuts.AddCut("0008d113","00200009327000008250400000","411791206f032230000","0163107b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for pi0
+    cuts.AddCut("0008d113","00200009327000008250400000","411791206f032230000","0163105b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for pi0
+    cuts.AddCut("0008d113","00200009327000008250400000","411791206f032230000","0163104b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for pi0
+    cuts.AddCut("0008d113","00200009327000008250400000","411791206f032230000","0163108b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for pi0
+  } else if( trainConfig == 2086) {
     // EG1 13TeV EMCal + DCal, Pi0 selection plus Gamma dropout, alpha cut omega
     cuts.AddCut("0008d113","00200009327000008250400000","411791206f032230000","01631036000000d0","01631071000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for omega
     cuts.AddCut("0008d113","00200009327000008250400000","411791206f032230000","01631036000000d0","01631051000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for omega
     cuts.AddCut("0008d113","00200009327000008250400000","411791206f032230000","01631036000000d0","01631041000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for omega
     cuts.AddCut("0008d113","00200009327000008250400000","411791206f032230000","01631036000000d0","01631081000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for omega
 
+  } else if( trainConfig == 2160) {
+    // MB 13TeV PHOS
+    cuts.AddCut("00010113","00200009327000008250400000","24466190sa01cc00000","01631031000000d0","01631030000000d0");
+    cuts.AddCut("00052113","00200009327000008250400000","24466190sa01cc00000","01631031000000d0","01631030000000d0");
+    cuts.AddCut("00085113","00200009327000008250400000","24466190sa01cc00000","01631031000000d0","01631030000000d0");
+    cuts.AddCut("00083113","00200009327000008250400000","24466190sa01cc00000","01631031000000d0","01631030000000d0");
+  } else if( trainConfig == 2162) {
+    // MB std NL 12 PHOS
+    cuts.AddCut("00010113","00200009327000008250400000","24466190sa01cc00000","01631031000000d0","01631031000000d0");
+  } else if( trainConfig == 2163) {
+    // MB 13TeV PHOS, Pi0 selection plus Gamma dropout
+    cuts.AddCut("00010113","00200009327000008250400000","24466190sa01cc00000","0163103b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout
+    cuts.AddCut("00010113","00200009327000008250400000","24466190sa01cc00000","01631036000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout
+    cuts.AddCut("00010113","00200009327000008250400000","24466190sa01cc00000","0163103c000000d0","01631031000000d0"); // 3 sigma Pi0 selection plus Gamma dropout
+    cuts.AddCut("00010113","00200009327000008250400000","24466190sa01cc00000","0163103d000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout
+  } else if( trainConfig == 2164) {
+    // MB 13TeV PHOS Background Variation (Swapping Method by Joshua)
+    cuts.AddCut("00010113","00200009327000008250400000","24466190sa01cc00000","0163103b000000d0","0r631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation
+    cuts.AddCut("00010113","00200009327000008250400000","24466190sa01cc00000","0163103b000000d0","0v631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS without constraints
+    cuts.AddCut("00010113","00200009327000008250400000","24466190sa01cc00000","0163103b000000d0","0x631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
+  } else if( trainConfig == 2165) {
+    // MB 13TeV PHOS, Pi0 selection plus Gamma dropout, alpha cut pi0
+    cuts.AddCut("00010113","00200009327000008250400000","24466190sa01cc00000","0163107b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for pi0
+    cuts.AddCut("00010113","00200009327000008250400000","24466190sa01cc00000","0163105b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for pi0
+    cuts.AddCut("00010113","00200009327000008250400000","24466190sa01cc00000","0163104b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for pi0
+    cuts.AddCut("00010113","00200009327000008250400000","24466190sa01cc00000","0163108b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for pi0
+  } else if( trainConfig == 2166) {
+    // MB 13TeV PHOS, Pi0 selection plus Gamma dropout, alpha cut omega
+    cuts.AddCut("00010113","00200009327000008250400000","24466190sa01cc00000","0163103b000000d0","01631071000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for omega
+    cuts.AddCut("00010113","00200009327000008250400000","24466190sa01cc00000","0163103b000000d0","01631051000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for omega
+    cuts.AddCut("00010113","00200009327000008250400000","24466190sa01cc00000","0163103b000000d0","01631041000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for omega
+    cuts.AddCut("00010113","00200009327000008250400000","24466190sa01cc00000","0163103b000000d0","01631081000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for omega
+  } else if( trainConfig == 2172) {
+    // EG2 std NL 12 PHOS
+    cuts.AddCut("0008e113","00200009327000008250400000","24466190sa01cc00000","01631031000000d0","01631031000000d0");
+  } else if( trainConfig == 2173) {
+    // EG2 13TeV PHOS, Pi0 selection plus Gamma dropout
+    cuts.AddCut("0008e113","00200009327000008250400000","24466190sa01cc00000","0163103b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout
+    cuts.AddCut("0008e113","00200009327000008250400000","24466190sa01cc00000","01631036000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout
+    cuts.AddCut("0008e113","00200009327000008250400000","24466190sa01cc00000","0163103c000000d0","01631031000000d0"); // 3 sigma Pi0 selection plus Gamma dropout
+    cuts.AddCut("0008e113","00200009327000008250400000","24466190sa01cc00000","0163103d000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout
+  } else if( trainConfig == 2174) {
+    // EG2 13TeV PHOS, Background Variation (Swapping Method by Joshua)
+    cuts.AddCut("0008e113","00200009327000008250400000","24466190sa01cc00000","0163103b000000d0","0r631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation
+    cuts.AddCut("0008e113","00200009327000008250400000","24466190sa01cc00000","0163103b000000d0","0v631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS without constraints
+    cuts.AddCut("0008e113","00200009327000008250400000","24466190sa01cc00000","0163103b000000d0","0x631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
+  } else if( trainConfig == 2175) {
+    // EG2 13TeV PHOS, Pi0 selection plus Gamma dropout, alpha cut pi0
+    cuts.AddCut("0008e113","00200009327000008250400000","24466190sa01cc00000","0163107b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for pi0
+    cuts.AddCut("0008e113","00200009327000008250400000","24466190sa01cc00000","0163105b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for pi0
+    cuts.AddCut("0008e113","00200009327000008250400000","24466190sa01cc00000","0163104b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for pi0
+    cuts.AddCut("0008e113","00200009327000008250400000","24466190sa01cc00000","0163108b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for pi0
+  } else if( trainConfig == 2176) {
+    // EG2 13TeV PHOS, Pi0 selection plus Gamma dropout, alpha cut omega
+    cuts.AddCut("0008e113","00200009327000008250400000","24466190sa01cc00000","0163103b000000d0","01631071000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for omega
+    cuts.AddCut("0008e113","00200009327000008250400000","24466190sa01cc00000","0163103b000000d0","01631051000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for omega
+    cuts.AddCut("0008e113","00200009327000008250400000","24466190sa01cc00000","0163103b000000d0","01631041000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for omega
+    cuts.AddCut("0008e113","00200009327000008250400000","24466190sa01cc00000","0163103b000000d0","01631081000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for omega
+  } else if( trainConfig == 2182) {
+    // EG1 13TeV PHOS
+    cuts.AddCut("0008d113","00200009327000008250400000","24466190sa01cc00000","01631031000000d0","01631031000000d0");
+  } else if( trainConfig == 2183) {
+    // EG1 13TeV PHOS, Pi0 selection plus Gamma dropout
+    cuts.AddCut("0008d113","00200009327000008250400000","24466190sa01cc00000","0163103b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout
+    cuts.AddCut("0008d113","00200009327000008250400000","24466190sa01cc00000","01631036000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout
+    cuts.AddCut("0008d113","00200009327000008250400000","24466190sa01cc00000","0163103c000000d0","01631031000000d0"); // 3 sigma Pi0 selection plus Gamma dropout
+    cuts.AddCut("0008d113","00200009327000008250400000","24466190sa01cc00000","0163103d000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout
+  } else if( trainConfig == 2184) {
+    // EG1 13TeV PHOS, Background Variation (Swapping Method by Joshua)
+    cuts.AddCut("0008d113","00200009327000008250400000","24466190sa01cc00000","0163103b000000d0","0r631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation
+    cuts.AddCut("0008d113","00200009327000008250400000","24466190sa01cc00000","0163103b000000d0","0v631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS without constraints
+    cuts.AddCut("0008d113","00200009327000008250400000","24466190sa01cc00000","0163103b000000d0","0x631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
+  } else if( trainConfig == 2185) {
+    // EG1 13TeV PHOS, Pi0 selection plus Gamma dropout, alpha cut pi0
+    cuts.AddCut("0008d113","00200009327000008250400000","24466190sa01cc00000","0163107b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for pi0
+    cuts.AddCut("0008d113","00200009327000008250400000","24466190sa01cc00000","0163105b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for pi0
+    cuts.AddCut("0008d113","00200009327000008250400000","24466190sa01cc00000","0163104b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for pi0
+    cuts.AddCut("0008d113","00200009327000008250400000","24466190sa01cc00000","0163108b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for pi0
+  } else if( trainConfig == 2186) {
+    // EG1 13TeV PHOS, Pi0 selection plus Gamma dropout, alpha cut omega
+    cuts.AddCut("0008d113","00200009327000008250400000","24466190sa01cc00000","0163103b000000d0","01631071000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for omega
+    cuts.AddCut("0008d113","00200009327000008250400000","24466190sa01cc00000","0163103b000000d0","01631051000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for omega
+    cuts.AddCut("0008d113","00200009327000008250400000","24466190sa01cc00000","0163103b000000d0","01631041000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for omega
+    cuts.AddCut("0008d113","00200009327000008250400000","24466190sa01cc00000","0163103b000000d0","01631081000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for omega
+
 
   // cuts for ReconMethod==3 Cal-Cal-PCM
-  } else if(trainConfig == 301){ // EMCAL clusters pp 7 TeV
+  } else if(trainConfig == 3001){ // EMCAL clusters pp 7 TeV
     cuts.AddCut("00000113","00200009327000008250400000","1111111017032230000","0163103a00000010","0163103000000010"); // pion mass (0.08,0.145)
 
-  } else if(trainConfig == 302){ // EMCAL clusters pp 7 TeV
+  } else if(trainConfig == 3002){ // EMCAL clusters pp 7 TeV
     cuts.AddCut("00000113","00200009327000008250400000","1111111017032230000","0163103a00000010","0163103000000010"); // same as standard, for varying angle cut
 
-  } else if(trainConfig == 303){ // EMCAL clusters pp 7 TeV
+  } else if(trainConfig == 3003){ // EMCAL clusters pp 7 TeV
     cuts.AddCut("00000113","00200009327000008250400000","1111111017032230000","0163103a00000010","0163103000000010"); // same as standard, for varying angle cut
 
-  } else if(trainConfig == 304){ // EMCAL clusters pp 7 TeV
+  } else if(trainConfig == 3004){ // EMCAL clusters pp 7 TeV
     cuts.AddCut("00000113","00200009327000008250400000","1111111017032230000","0163103a00000010","0163103000000010"); // same as standard, for varying angle cut
 
-  } else if(trainConfig == 351){ // std 8TeV
+  } else if(trainConfig == 3051){ // std 8TeV
     cuts.AddCut("00010113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
     cuts.AddCut("00052113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
     cuts.AddCut("00081113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
 
-  } else if(trainConfig == 352){ // same as std 8TeV, for varying angle cut
+  } else if(trainConfig == 3052){ // same as std 8TeV, for varying angle cut
     cuts.AddCut("00010113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
     cuts.AddCut("00052113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
     cuts.AddCut("00081113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
 
-  } else if(trainConfig == 353){ // same as std 8TeV, for varying angle cut
+  } else if(trainConfig == 3053){ // same as std 8TeV, for varying angle cut
     cuts.AddCut("00010113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
     cuts.AddCut("00052113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
     cuts.AddCut("00081113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
 
-  } else if(trainConfig == 354){ // same as std 8TeV, for varying angle cut
+  } else if(trainConfig == 3054){ // same as std 8TeV, for varying angle cut
     cuts.AddCut("00010113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
     cuts.AddCut("00052113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
     cuts.AddCut("00081113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
 
-  } else if(trainConfig == 355){ // std 8TeV
+  } else if(trainConfig == 3055){ // std 8TeV
     cuts.AddCut("00010113","00200009327000008250400000","1111100067032230000","0163103100000010","0163103000000010"); // same as standard but wo non lin
     cuts.AddCut("00052113","00200009327000008250400000","1111100067032230000","0163103100000010","0163103000000010");
     cuts.AddCut("00081113","00200009327000008250400000","1111100067032230000","0163103100000010","0163103000000010");
 
-    // 13 TeV
-  } else if( trainConfig == 360) {
+  /////////////////////////////////
+  // 13 TeV
+  /////////////////////////////////
+  } else if( trainConfig == 3060) {
     // MB 13TeV PCM Photon with EMcal + DCal Pi0
     cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791106f032230000","01631031000000d0","01631030000000d0");
     cuts.AddCut("00052113","0dm00009f9730000dge0404000","411791106f032230000","01631031000000d0","01631030000000d0");
     cuts.AddCut("00085113","0dm00009f9730000dge0404000","411791106f032230000","01631031000000d0","01631030000000d0");
     cuts.AddCut("00083113","0dm00009f9730000dge0404000","411791106f032230000","01631031000000d0","01631030000000d0");
-  } else if( trainConfig == 261) {
+  } else if( trainConfig == 2061) {
     // MB 13TeV PCM Photon with EMcal Pi0
     cuts.AddCut("00010113","0dm00009f9730000dge0404000","1111100067032230000","01631031000000d0","01631031000000d0");
-  } else if( trainConfig == 362) {
+  } else if( trainConfig == 3062) {
     // MB std NL 12 PCM Photon with EMcal + DCal Pi0
     cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","01631031000000d0","01631031000000d0");
-  } else if( trainConfig == 363) {
+  } else if( trainConfig == 3063) {
     // MB 13TeV PCM Photon with EMcal + DCal Pi0, Pi0 selection plus Gamma dropout
     cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","0163103b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout
     cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","01631036000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout
     cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","0163103c000000d0","01631031000000d0"); // 3 sigma Pi0 selection plus Gamma dropout
     cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","0163103d000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout
-  } else if( trainConfig == 364) {
+  } else if( trainConfig == 3064) {
     // MB 13TeV PCM Photon with EMcal + DCal Pi0, Background Variation (Swapping Method by Joshua)
-    cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","01631036000000d0","0r631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation
-    cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","01631036000000d0","0v631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS without constraints
-    cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","01631036000000d0","0x631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
-  } else if( trainConfig == 365) {
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","0163103b000000d0","0r631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","0163103b000000d0","0v631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS without constraints
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","0163103b000000d0","0x631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
+  } else if( trainConfig == 3065) {
     // MB 13TeV PCM Photon with EMcal + DCal, Pi0 selection plus Gamma dropout, alpha cut pi0
-    cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","01631076000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for pi0
-    cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","01631056000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for pi0
-    cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","01631046000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for pi0
-    cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","01631086000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for pi0
-  } else if( trainConfig == 366) {
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","0163107b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for pi0
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","0163105b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for pi0
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","0163104b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for pi0
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","0163108b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for pi0
+  } else if( trainConfig == 3066) {
     // MB 13TeV PCM Photon with EMcal + DCal, Pi0 selection plus Gamma dropout, alpha cut omega
-    cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","01631036000000d0","01631071000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for omega
-    cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","01631036000000d0","01631051000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for omega
-    cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","01631036000000d0","01631041000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for omega
-    cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","01631036000000d0","01631081000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for omega
-  } else if( trainConfig == 371) {
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","0163103b000000d0","01631071000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for omega
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","0163103b000000d0","01631051000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for omega
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","0163103b000000d0","01631041000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for omega
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","0163103b000000d0","01631081000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for omega
+  } else if( trainConfig == 3071) {
     // EG2 13TeV PCM Photon with EMcal Pi0
     cuts.AddCut("0008e113","0dm00009f9730000dge0404000","1111100067032230000","01631031000000d0","01631031000000d0");
-  } else if( trainConfig == 372) {
+  } else if( trainConfig == 3072) {
     // EG2 std NL 12 PCM Photon with EMcal + DCal Pi0
     cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","01631031000000d0","01631031000000d0");
-  } else if( trainConfig == 373) {
+  } else if( trainConfig == 3073) {
     // EG2 13TeV EMcal + Dcal, Pi0 selection plus Gamma dropout
     cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","0163103b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout
     cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","01631036000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout
     cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","0163103c000000d0","01631031000000d0"); // 3 sigma Pi0 selection plus Gamma dropout
     cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","0163103d000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout
-  } else if( trainConfig == 374) {
+  } else if( trainConfig == 3074) {
     // EG2 13TeV EMcal + Dcal, Background Variation (Swapping Method by Joshua)
-    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","01631036000000d0","0r631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation
-    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","01631036000000d0","0v631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS without constraints
-    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","01631036000000d0","0x631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
-  } else if( trainConfig == 375) {
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","0163103b000000d0","0r631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","0163103b000000d0","0v631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS without constraints
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","0163103b000000d0","0x631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
+  } else if( trainConfig == 3075) {
     // EG2 13TeV PCM Photon with EMcal + DCal, Pi0 selection plus Gamma dropout, alpha cut pi0
-    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","01631076000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for pi0
-    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","01631056000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for pi0
-    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","01631046000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for pi0
-    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","01631086000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for pi0
-  } else if( trainConfig == 376) {
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","0163107b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for pi0
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","0163105b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for pi0
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","0163104b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for pi0
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","0163108b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for pi0
+  } else if( trainConfig == 3076) {
     // EG2 13TeV PCM Photon with EMcal + DCal, Pi0 selection plus Gamma dropout, alpha cut omega
-    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","01631036000000d0","01631071000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for omega
-    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","01631036000000d0","01631051000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for omega
-    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","01631036000000d0","01631041000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for omega
-    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","01631036000000d0","01631081000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for omega
-  } else if( trainConfig == 381) {
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","0163103b000000d0","01631071000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for omega
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","0163103b000000d0","01631051000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for omega
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","0163103b000000d0","01631041000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for omega
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","0163103b000000d0","01631081000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for omega
+  } else if( trainConfig == 3081) {
     // EG1 13TeV EMcal
     cuts.AddCut("0008d113","0dm00009f9730000dge0404000","1111100067032230000","01631031000000d0","01631031000000d0");
-  } else if( trainConfig == 382) {
+  } else if( trainConfig == 3082) {
     // EG1 13TeV EMcal + Dcal
     cuts.AddCut("0008d113","0dm00009f9730000dge0404000","411791206f032230000","01631031000000d0","01631031000000d0");
-  } else if( trainConfig == 383) {
+  } else if( trainConfig == 3083) {
     // EG1 13TeV EMcal + Dcal, Pi0 selection plus Gamma dropout
     cuts.AddCut("0008d113","0dm00009f9730000dge0404000","411791206f032230000","0163103b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout
     cuts.AddCut("0008d113","0dm00009f9730000dge0404000","411791206f032230000","01631036000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout
     cuts.AddCut("0008d113","0dm00009f9730000dge0404000","411791206f032230000","0163103c000000d0","01631031000000d0"); // 3 sigma Pi0 selection plus Gamma dropout
     cuts.AddCut("0008d113","0dm00009f9730000dge0404000","411791206f032230000","0163103d000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout
-  } else if( trainConfig == 384) {
+  } else if( trainConfig == 3084) {
     // EG1 13TeV EMcal + Dcal, Background Variation (Swapping Method by Joshua)
-    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","411791206f032230000","01631036000000d0","0r631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation
-    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","411791206f032230000","01631036000000d0","0v631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS without constraints
-    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","411791206f032230000","01631036000000d0","0x631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
-  } else if( trainConfig == 385) {
+    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","411791206f032230000","0163103b000000d0","0r631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation
+    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","411791206f032230000","0163103b000000d0","0v631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS without constraints
+    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","411791206f032230000","0163103b000000d0","0x631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
+  } else if( trainConfig == 3085) {
     // EG1 13TeV PCM Photon with EMcal + DCal, Pi0 selection plus Gamma dropout, alpha cut pi0
-    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","411791206f032230000","01631076000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for pi0
-    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","411791206f032230000","01631056000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for pi0
-    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","411791206f032230000","01631046000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for pi0
-    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","411791206f032230000","01631086000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for pi0
-  } else if( trainConfig == 386) {
+    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","411791206f032230000","0163107b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for pi0
+    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","411791206f032230000","0163105b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for pi0
+    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","411791206f032230000","0163104b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for pi0
+    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","411791206f032230000","0163108b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for pi0
+  } else if( trainConfig == 3086) {
     // EG1 13TeV PCM Photon with EMcal + DCal, Pi0 selection plus Gamma dropout, alpha cut omega
     cuts.AddCut("0008d113","0dm00009f9730000dge0404000","411791206f032230000","01631036000000d0","01631071000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for omega
     cuts.AddCut("0008d113","0dm00009f9730000dge0404000","411791206f032230000","01631036000000d0","01631051000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for omega
     cuts.AddCut("0008d113","0dm00009f9730000dge0404000","411791206f032230000","01631036000000d0","01631041000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for omega
     cuts.AddCut("0008d113","0dm00009f9730000dge0404000","411791206f032230000","01631036000000d0","01631081000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for omega
 
+    // PCM(gamma) - PHOS (pi0)
+  } else if( trainConfig == 3162) {
+    // MB std NL 12
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","24466190sa01cc00000","01631031000000d0","01631031000000d0");
+  } else if( trainConfig == 3163) {
+    // MB 13TeV, Pi0 selection plus Gamma dropout
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","24466190sa01cc00000","01631036000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103c000000d0","01631031000000d0"); // 3 sigma Pi0 selection plus Gamma dropout
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103d000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout
+  } else if( trainConfig == 3164) {
+    // MB 13TeV, Background Variation (Swapping Method by Joshua)
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103b000000d0","0r631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103b000000d0","0v631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS without constraints
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103b000000d0","0x631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
+  } else if( trainConfig == 3165) {
+    // MB 13TeV, Pi0 selection plus Gamma dropout, alpha cut pi0
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163107b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for pi0
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163105b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for pi0
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163104b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for pi0
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163108b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for pi0
+  } else if( trainConfig == 3166) {
+    // MB 13TeV, Pi0 selection plus Gamma dropout, alpha cut omega
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103b000000d0","01631071000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for omega
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103b000000d0","01631051000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for omega
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103b000000d0","01631041000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for omega
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103b000000d0","01631081000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for omega
+  } else if( trainConfig == 3172) {
+    // EG2 std NL 12
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","24466190sa01cc00000","01631031000000d0","01631031000000d0");
+  } else if( trainConfig == 3173) {
+    // EG2 13TeV, Pi0 selection plus Gamma dropout
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","24466190sa01cc00000","01631036000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103c000000d0","01631031000000d0"); // 3 sigma Pi0 selection plus Gamma dropout
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103d000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout
+  } else if( trainConfig == 3174) {
+    // EG2 13TeV, Background Variation (Swapping Method by Joshua)
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103b000000d0","0r631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103b000000d0","0v631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS without constraints
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103b000000d0","0x631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
+  } else if( trainConfig == 3175) {
+    // EG2 13TeV, Pi0 selection plus Gamma dropout, alpha cut pi0
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163107b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for pi0
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163105b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for pi0
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163104b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for pi0
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163108b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for pi0
+  } else if( trainConfig == 3176) {
+    // EG2 13TeV, Pi0 selection plus Gamma dropout, alpha cut omega
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103b000000d0","01631071000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for omega
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103b000000d0","01631051000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for omega
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103b000000d0","01631041000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for omega
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103b000000d0","01631081000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for omega
+  } else if( trainConfig == 3182) {
+    // EG1 13TeV
+    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","24466190sa01cc00000","01631031000000d0","01631031000000d0");
+  } else if( trainConfig == 3183) {
+    // EG1 13TeV, Pi0 selection plus Gamma dropout
+    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout
+    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","24466190sa01cc00000","01631036000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout
+    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103c000000d0","01631031000000d0"); // 3 sigma Pi0 selection plus Gamma dropout
+    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103d000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout
+  } else if( trainConfig == 3184) {
+    // EG1 13TeV, Background Variation (Swapping Method by Joshua)
+    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103b000000d0","0r631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation
+    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103b000000d0","0v631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS without constraints
+    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103b000000d0","0x631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
+  } else if( trainConfig == 3185) {
+    // EG1 13TeV, Pi0 selection plus Gamma dropout, alpha cut pi0
+    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163107b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for pi0
+    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163105b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for pi0
+    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163104b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for pi0
+    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163108b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for pi0
+  } else if( trainConfig == 3186) {
+    // EG1 13TeV, Pi0 selection plus Gamma dropout, alpha cut omega
+    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103b000000d0","01631071000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for omega
+    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103b000000d0","01631051000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for omega
+    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103b000000d0","01631041000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for omega
+    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103b000000d0","01631081000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for omega
 
 
   // cuts for ReconMethod==4 PCM-PCM-Cal
-  } else if(trainConfig == 401){ // EMCAL clusters pp 7 TeV
+  } else if(trainConfig == 4001){ // EMCAL clusters pp 7 TeV
     cuts.AddCut("00000113","00200009327000008250400000","1111111017032230000","0163103a00000010","0163103000000010"); // pion mass (0.08,0.145)
 
-  } else if(trainConfig == 402){ // EMCAL clusters pp 7 TeV
+  } else if(trainConfig == 4002){ // EMCAL clusters pp 7 TeV
     cuts.AddCut("00000113","00200009327000008250400000","1111111017032230000","0163103a00000010","0163103000000010"); // same as standard, for varying angle cut
 
-  } else if(trainConfig == 403){ // EMCAL clusters pp 7 TeV
+  } else if(trainConfig == 4003){ // EMCAL clusters pp 7 TeV
     cuts.AddCut("00000113","00200009327000008250400000","1111111017032230000","0163103a00000010","0163103000000010"); // same as standard, for varying angle cut
 
-  } else if(trainConfig == 404){ // EMCAL clusters pp 7 TeV
+  } else if(trainConfig == 4004){ // EMCAL clusters pp 7 TeV
     cuts.AddCut("00000113","00200009327000008250400000","1111111017032230000","0163103a00000010","0163103000000010"); // same as standard, for varying angle cut
 
-  } else if(trainConfig == 451){ // std 8TeV
+  } else if(trainConfig == 4051){ // std 8TeV
     cuts.AddCut("00010113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
     cuts.AddCut("00052113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
     cuts.AddCut("00081113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
 
-  } else if(trainConfig == 452){ // same as std 8TeV, for varying angle cut
+  } else if(trainConfig == 4052){ // same as std 8TeV, for varying angle cut
     cuts.AddCut("00010113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
     cuts.AddCut("00052113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
     cuts.AddCut("00081113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
 
-  } else if(trainConfig == 453){ // same as std 8TeV, for varying angle cut
+  } else if(trainConfig == 4053){ // same as std 8TeV, for varying angle cut
     cuts.AddCut("00010113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
     cuts.AddCut("00052113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
     cuts.AddCut("00081113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
 
-  } else if(trainConfig == 454){ // same as std 8TeV, for varying angle cut
+  } else if(trainConfig == 4054){ // same as std 8TeV, for varying angle cut
     cuts.AddCut("00010113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
     cuts.AddCut("00052113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
     cuts.AddCut("00081113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
 
-  } else if(trainConfig == 454){ // same as std 8TeV, for varying angle cut
+  } else if(trainConfig == 4054){ // same as std 8TeV, for varying angle cut
     cuts.AddCut("00010113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
     cuts.AddCut("00052113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
     cuts.AddCut("00081113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
-  } else if( trainConfig == 460) {
+  } else if( trainConfig == 4060) {
     //std MB 13TeV
     cuts.AddCut("00010113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
     cuts.AddCut("00052113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
     cuts.AddCut("00085113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
     cuts.AddCut("00083113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
-  } else if( trainConfig == 461) {
+  } else if( trainConfig == 4061) {
     //only MB 13TeV
     cuts.AddCut("00010113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
-  } else if( trainConfig == 462) {
+  } else if( trainConfig == 4062) {
     //only MB 13TeV EMcal + DCal
     cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","01631031000000d0","0163103000000010"); // NL 12
-  } else if( trainConfig == 463) {
+  } else if( trainConfig == 4063) {
     //EG2 13TeV EMcal + Dcal
     cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","01631031000000d0","01631031000000d0"); // NL 12
-  } else if( trainConfig == 464) {
+  } else if( trainConfig == 4064) {
     //EG1 13TeV EMcal + Dcal
     cuts.AddCut("0008d113","00200009327000008250400000","411791206f032230000","01631031000000d0","01631031000000d0"); // NL 12
 
   // cuts for ReconMethod==5 PCM-PCM-PCM
-  } else if(trainConfig == 501){ // EMCAL clusters pp 7 TeV
+  } else if(trainConfig == 5001){ // EMCAL clusters pp 7 TeV
     cuts.AddCut("00000113","00200009327000008250400000","1111111017032230000","0163103a00000010","0163103000000010"); // pion mass (0.08,0.145)
 
-  } else if(trainConfig == 502){ // EMCAL clusters pp 7 TeV
+  } else if(trainConfig == 5002){ // EMCAL clusters pp 7 TeV
     cuts.AddCut("00000113","00200009327000008250400000","1111111017032230000","0163103a00000010","0163103000000010"); // same as standard, for varying angle cut
 
-  } else if(trainConfig == 503){ // EMCAL clusters pp 7 TeV
+  } else if(trainConfig == 5003){ // EMCAL clusters pp 7 TeV
     cuts.AddCut("00000113","00200009327000008250400000","1111111017032230000","0163103a00000010","0163103000000010"); // same as standard, for varying angle cut
 
-  } else if(trainConfig == 504){ // EMCAL clusters pp 7 TeV
+  } else if(trainConfig == 5004){ // EMCAL clusters pp 7 TeV
     cuts.AddCut("00000113","00200009327000008250400000","1111111017032230000","0163103a00000010","0163103000000010"); // same as standard, for varying angle cut
 
-  } else if(trainConfig == 551){ // std 8TeV
+  } else if(trainConfig == 5051){ // std 8TeV
     cuts.AddCut("00010113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
     cuts.AddCut("00052113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
     cuts.AddCut("00081113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
 
-  } else if(trainConfig == 552){ // same as std 8TeV, for varying angle cut
+  } else if(trainConfig == 5052){ // same as std 8TeV, for varying angle cut
     cuts.AddCut("00010113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
     cuts.AddCut("00052113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
     cuts.AddCut("00081113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
 
-  } else if(trainConfig == 553){ // same as std 8TeV, for varying angle cut
+  } else if(trainConfig == 5053){ // same as std 8TeV, for varying angle cut
     cuts.AddCut("00010113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
     cuts.AddCut("00052113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
     cuts.AddCut("00081113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
 
-  } else if(trainConfig == 554){ // same as std 8TeV, for varying angle cut
+  } else if(trainConfig == 5054){ // same as std 8TeV, for varying angle cut
     cuts.AddCut("00010113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
     cuts.AddCut("00052113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
     cuts.AddCut("00081113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
 
-  } else if( trainConfig == 560) {
+  } else if( trainConfig == 5060) {
     //std MB 13TeV
     cuts.AddCut("00010113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
     cuts.AddCut("00052113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
     cuts.AddCut("00085113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
     cuts.AddCut("00083113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
-  } else if( trainConfig == 561) {
+  } else if( trainConfig == 5061) {
     //only MB 13TeV
     cuts.AddCut("00010113","00200009327000008250400000","1111111067032230000","0163103100000010","0163103000000010");
-  } else if( trainConfig == 562) {
+  } else if( trainConfig == 5062) {
     //only MB 13TeV EMcal + DCal
     cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","01631031000000d0","0163103000000010"); // NL 12
-  } else if( trainConfig == 563) {
+  } else if( trainConfig == 5063) {
     //EG2 13TeV EMcal + Dcal
     cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","01631031000000d0","01631031000000d0"); // NL 12
-  } else if( trainConfig == 564) {
+  } else if( trainConfig == 5064) {
     //EG1 13TeV EMcal + Dcal
     cuts.AddCut("0008d113","00200009327000008250400000","411791206f032230000","01631031000000d0","01631031000000d0"); // NL 12
   } else {

--- a/PWGGA/GammaConv/macros/AddTask_OmegaToPiZeroGamma_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_OmegaToPiZeroGamma_pp.C
@@ -426,21 +426,21 @@ void AddTask_OmegaToPiZeroGamma_pp(
     cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","0163103d000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout
   } else if( trainConfig == 2064) {
     // MB 13TeV EMCal + DCal Background Variation (Swapping Method by Joshua)
-    cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","0163103b000000d0","0r631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation
-    cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","0163103b000000d0","0v631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS without constraints
-    cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","0163103b000000d0","0x631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
+    cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","01631036000000d0","0r631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation
+    cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","01631036000000d0","0v631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS without constraints
+    cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","01631036000000d0","0x631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
   } else if( trainConfig == 2065) {
     // MB 13TeV EMCal + DCal, Pi0 selection plus Gamma dropout, alpha cut pi0
-    cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","0163107b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for pi0
-    cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","0163105b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for pi0
-    cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","0163104b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for pi0
-    cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","0163108b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for pi0
+    cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","01631076000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for pi0
+    cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","01631056000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for pi0
+    cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","01631046000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for pi0
+    cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","01631086000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for pi0
   } else if( trainConfig == 2066) {
     // MB 13TeV EMCal + DCal, Pi0 selection plus Gamma dropout, alpha cut omega
-    cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","0163103b000000d0","01631071000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for omega
-    cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","0163103b000000d0","01631051000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for omega
-    cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","0163103b000000d0","01631041000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for omega
-    cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","0163103b000000d0","01631081000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for omega
+    cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","01631036000000d0","01631071000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for omega
+    cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","01631036000000d0","01631051000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for omega
+    cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","01631036000000d0","01631041000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for omega
+    cuts.AddCut("00010113","00200009327000008250400000","411791206f032230000","01631036000000d0","01631081000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for omega
   } else if( trainConfig == 2071) {
     // EG2 13TeV EMcal
     cuts.AddCut("0008e113","00200009327000008250400000","1111100067032230000","01631031000000d0","01631031000000d0");
@@ -455,21 +455,21 @@ void AddTask_OmegaToPiZeroGamma_pp(
     cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","0163103d000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout
   } else if( trainConfig == 2074) {
     // EG2 13TeV EMcal + Dcal, Background Variation (Swapping Method by Joshua)
-    cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","0163103b000000d0","0r631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation
-    cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","0163103b000000d0","0v631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS without constraints
-    cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","0163103b000000d0","0x631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
+    cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","01631036000000d0","0r631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation
+    cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","01631036000000d0","0v631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS without constraints
+    cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","01631036000000d0","0x631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
   } else if( trainConfig == 2075) {
     // EG2 13TeV EMCal + DCal, Pi0 selection plus Gamma dropout, alpha cut pi0
-    cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","0163107b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for pi0
-    cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","0163105b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for pi0
-    cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","0163104b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for pi0
-    cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","0163108b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for pi0
+    cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","01631076000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for pi0
+    cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","01631056000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for pi0
+    cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","01631046000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for pi0
+    cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","01631086000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for pi0
   } else if( trainConfig == 2076) {
     // EG2 13TeV EMCal + DCal, Pi0 selection plus Gamma dropout, alpha cut omega
-    cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","0163103b000000d0","01631071000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for omega
-    cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","0163103b000000d0","01631051000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for omega
-    cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","0163103b000000d0","01631041000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for omega
-    cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","0163103b000000d0","01631081000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for omega
+    cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","01631036000000d0","01631071000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for omega
+    cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","01631036000000d0","01631051000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for omega
+    cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","01631036000000d0","01631041000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for omega
+    cuts.AddCut("0008e113","00200009327000008250400000","411791206f032230000","01631036000000d0","01631081000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for omega
   } else if( trainConfig == 2081) {
     // EG1 13TeV EMcal
     cuts.AddCut("0008d113","00200009327000008250400000","1111100067032230000","01631031000000d0","01631031000000d0");
@@ -484,15 +484,15 @@ void AddTask_OmegaToPiZeroGamma_pp(
     cuts.AddCut("0008d113","00200009327000008250400000","411791206f032230000","0163103d000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout
   } else if( trainConfig == 2084) {
     // EG1 13TeV EMcal + Dcal, Background Variation (Swapping Method by Joshua)
-    cuts.AddCut("0008d113","00200009327000008250400000","411791206f032230000","0163103b000000d0","0r631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation
-    cuts.AddCut("0008d113","00200009327000008250400000","411791206f032230000","0163103b000000d0","0v631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS without constraints
-    cuts.AddCut("0008d113","00200009327000008250400000","411791206f032230000","0163103b000000d0","0x631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
+    cuts.AddCut("0008d113","00200009327000008250400000","411791206f032230000","01631036000000d0","0r631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation
+    cuts.AddCut("0008d113","00200009327000008250400000","411791206f032230000","01631036000000d0","0v631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS without constraints
+    cuts.AddCut("0008d113","00200009327000008250400000","411791206f032230000","01631036000000d0","0x631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
   } else if( trainConfig == 2085) {
     // EG1 13TeV EMCal + DCal, Pi0 selection plus Gamma dropout, alpha cut pi0
-    cuts.AddCut("0008d113","00200009327000008250400000","411791206f032230000","0163107b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for pi0
-    cuts.AddCut("0008d113","00200009327000008250400000","411791206f032230000","0163105b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for pi0
-    cuts.AddCut("0008d113","00200009327000008250400000","411791206f032230000","0163104b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for pi0
-    cuts.AddCut("0008d113","00200009327000008250400000","411791206f032230000","0163108b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for pi0
+    cuts.AddCut("0008d113","00200009327000008250400000","411791206f032230000","01631076000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for pi0
+    cuts.AddCut("0008d113","00200009327000008250400000","411791206f032230000","01631056000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for pi0
+    cuts.AddCut("0008d113","00200009327000008250400000","411791206f032230000","01631046000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for pi0
+    cuts.AddCut("0008d113","00200009327000008250400000","411791206f032230000","01631086000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for pi0
   } else if( trainConfig == 2086) {
     // EG1 13TeV EMCal + DCal, Pi0 selection plus Gamma dropout, alpha cut omega
     cuts.AddCut("0008d113","00200009327000008250400000","411791206f032230000","01631036000000d0","01631071000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for omega
@@ -517,21 +517,21 @@ void AddTask_OmegaToPiZeroGamma_pp(
     cuts.AddCut("00010113","00200009327000008250400000","24466190sa01cc00000","0163103d000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout
   } else if( trainConfig == 2164) {
     // MB 13TeV PHOS Background Variation (Swapping Method by Joshua)
-    cuts.AddCut("00010113","00200009327000008250400000","24466190sa01cc00000","0163103b000000d0","0r631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation
-    cuts.AddCut("00010113","00200009327000008250400000","24466190sa01cc00000","0163103b000000d0","0v631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS without constraints
-    cuts.AddCut("00010113","00200009327000008250400000","24466190sa01cc00000","0163103b000000d0","0x631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
+    cuts.AddCut("00010113","00200009327000008250400000","24466190sa01cc00000","01631036000000d0","0r631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation
+    cuts.AddCut("00010113","00200009327000008250400000","24466190sa01cc00000","01631036000000d0","0v631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS without constraints
+    cuts.AddCut("00010113","00200009327000008250400000","24466190sa01cc00000","01631036000000d0","0x631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
   } else if( trainConfig == 2165) {
     // MB 13TeV PHOS, Pi0 selection plus Gamma dropout, alpha cut pi0
-    cuts.AddCut("00010113","00200009327000008250400000","24466190sa01cc00000","0163107b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for pi0
-    cuts.AddCut("00010113","00200009327000008250400000","24466190sa01cc00000","0163105b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for pi0
-    cuts.AddCut("00010113","00200009327000008250400000","24466190sa01cc00000","0163104b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for pi0
-    cuts.AddCut("00010113","00200009327000008250400000","24466190sa01cc00000","0163108b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for pi0
+    cuts.AddCut("00010113","00200009327000008250400000","24466190sa01cc00000","01631076000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for pi0
+    cuts.AddCut("00010113","00200009327000008250400000","24466190sa01cc00000","01631056000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for pi0
+    cuts.AddCut("00010113","00200009327000008250400000","24466190sa01cc00000","01631046000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for pi0
+    cuts.AddCut("00010113","00200009327000008250400000","24466190sa01cc00000","01631086000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for pi0
   } else if( trainConfig == 2166) {
     // MB 13TeV PHOS, Pi0 selection plus Gamma dropout, alpha cut omega
-    cuts.AddCut("00010113","00200009327000008250400000","24466190sa01cc00000","0163103b000000d0","01631071000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for omega
-    cuts.AddCut("00010113","00200009327000008250400000","24466190sa01cc00000","0163103b000000d0","01631051000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for omega
-    cuts.AddCut("00010113","00200009327000008250400000","24466190sa01cc00000","0163103b000000d0","01631041000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for omega
-    cuts.AddCut("00010113","00200009327000008250400000","24466190sa01cc00000","0163103b000000d0","01631081000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for omega
+    cuts.AddCut("00010113","00200009327000008250400000","24466190sa01cc00000","01631036000000d0","01631071000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for omega
+    cuts.AddCut("00010113","00200009327000008250400000","24466190sa01cc00000","01631036000000d0","01631051000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for omega
+    cuts.AddCut("00010113","00200009327000008250400000","24466190sa01cc00000","01631036000000d0","01631041000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for omega
+    cuts.AddCut("00010113","00200009327000008250400000","24466190sa01cc00000","01631036000000d0","01631081000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for omega
   } else if( trainConfig == 2172) {
     // EG2 std NL 12 PHOS
     cuts.AddCut("0008e113","00200009327000008250400000","24466190sa01cc00000","01631031000000d0","01631031000000d0");
@@ -543,21 +543,21 @@ void AddTask_OmegaToPiZeroGamma_pp(
     cuts.AddCut("0008e113","00200009327000008250400000","24466190sa01cc00000","0163103d000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout
   } else if( trainConfig == 2174) {
     // EG2 13TeV PHOS, Background Variation (Swapping Method by Joshua)
-    cuts.AddCut("0008e113","00200009327000008250400000","24466190sa01cc00000","0163103b000000d0","0r631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation
-    cuts.AddCut("0008e113","00200009327000008250400000","24466190sa01cc00000","0163103b000000d0","0v631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS without constraints
-    cuts.AddCut("0008e113","00200009327000008250400000","24466190sa01cc00000","0163103b000000d0","0x631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
+    cuts.AddCut("0008e113","00200009327000008250400000","24466190sa01cc00000","01631036000000d0","0r631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation
+    cuts.AddCut("0008e113","00200009327000008250400000","24466190sa01cc00000","01631036000000d0","0v631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS without constraints
+    cuts.AddCut("0008e113","00200009327000008250400000","24466190sa01cc00000","01631036000000d0","0x631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
   } else if( trainConfig == 2175) {
     // EG2 13TeV PHOS, Pi0 selection plus Gamma dropout, alpha cut pi0
-    cuts.AddCut("0008e113","00200009327000008250400000","24466190sa01cc00000","0163107b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for pi0
-    cuts.AddCut("0008e113","00200009327000008250400000","24466190sa01cc00000","0163105b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for pi0
-    cuts.AddCut("0008e113","00200009327000008250400000","24466190sa01cc00000","0163104b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for pi0
-    cuts.AddCut("0008e113","00200009327000008250400000","24466190sa01cc00000","0163108b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for pi0
+    cuts.AddCut("0008e113","00200009327000008250400000","24466190sa01cc00000","01631076000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for pi0
+    cuts.AddCut("0008e113","00200009327000008250400000","24466190sa01cc00000","01631056000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for pi0
+    cuts.AddCut("0008e113","00200009327000008250400000","24466190sa01cc00000","01631046000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for pi0
+    cuts.AddCut("0008e113","00200009327000008250400000","24466190sa01cc00000","01631086000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for pi0
   } else if( trainConfig == 2176) {
     // EG2 13TeV PHOS, Pi0 selection plus Gamma dropout, alpha cut omega
-    cuts.AddCut("0008e113","00200009327000008250400000","24466190sa01cc00000","0163103b000000d0","01631071000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for omega
-    cuts.AddCut("0008e113","00200009327000008250400000","24466190sa01cc00000","0163103b000000d0","01631051000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for omega
-    cuts.AddCut("0008e113","00200009327000008250400000","24466190sa01cc00000","0163103b000000d0","01631041000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for omega
-    cuts.AddCut("0008e113","00200009327000008250400000","24466190sa01cc00000","0163103b000000d0","01631081000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for omega
+    cuts.AddCut("0008e113","00200009327000008250400000","24466190sa01cc00000","01631036000000d0","01631071000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for omega
+    cuts.AddCut("0008e113","00200009327000008250400000","24466190sa01cc00000","01631036000000d0","01631051000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for omega
+    cuts.AddCut("0008e113","00200009327000008250400000","24466190sa01cc00000","01631036000000d0","01631041000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for omega
+    cuts.AddCut("0008e113","00200009327000008250400000","24466190sa01cc00000","01631036000000d0","01631081000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for omega
   } else if( trainConfig == 2182) {
     // EG1 13TeV PHOS
     cuts.AddCut("0008d113","00200009327000008250400000","24466190sa01cc00000","01631031000000d0","01631031000000d0");
@@ -569,21 +569,21 @@ void AddTask_OmegaToPiZeroGamma_pp(
     cuts.AddCut("0008d113","00200009327000008250400000","24466190sa01cc00000","0163103d000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout
   } else if( trainConfig == 2184) {
     // EG1 13TeV PHOS, Background Variation (Swapping Method by Joshua)
-    cuts.AddCut("0008d113","00200009327000008250400000","24466190sa01cc00000","0163103b000000d0","0r631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation
-    cuts.AddCut("0008d113","00200009327000008250400000","24466190sa01cc00000","0163103b000000d0","0v631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS without constraints
-    cuts.AddCut("0008d113","00200009327000008250400000","24466190sa01cc00000","0163103b000000d0","0x631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
+    cuts.AddCut("0008d113","00200009327000008250400000","24466190sa01cc00000","01631036000000d0","0r631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation
+    cuts.AddCut("0008d113","00200009327000008250400000","24466190sa01cc00000","01631036000000d0","0v631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS without constraints
+    cuts.AddCut("0008d113","00200009327000008250400000","24466190sa01cc00000","01631036000000d0","0x631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
   } else if( trainConfig == 2185) {
     // EG1 13TeV PHOS, Pi0 selection plus Gamma dropout, alpha cut pi0
-    cuts.AddCut("0008d113","00200009327000008250400000","24466190sa01cc00000","0163107b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for pi0
-    cuts.AddCut("0008d113","00200009327000008250400000","24466190sa01cc00000","0163105b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for pi0
-    cuts.AddCut("0008d113","00200009327000008250400000","24466190sa01cc00000","0163104b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for pi0
-    cuts.AddCut("0008d113","00200009327000008250400000","24466190sa01cc00000","0163108b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for pi0
+    cuts.AddCut("0008d113","00200009327000008250400000","24466190sa01cc00000","01631076000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for pi0
+    cuts.AddCut("0008d113","00200009327000008250400000","24466190sa01cc00000","01631056000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for pi0
+    cuts.AddCut("0008d113","00200009327000008250400000","24466190sa01cc00000","01631046000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for pi0
+    cuts.AddCut("0008d113","00200009327000008250400000","24466190sa01cc00000","01631086000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for pi0
   } else if( trainConfig == 2186) {
     // EG1 13TeV PHOS, Pi0 selection plus Gamma dropout, alpha cut omega
-    cuts.AddCut("0008d113","00200009327000008250400000","24466190sa01cc00000","0163103b000000d0","01631071000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for omega
-    cuts.AddCut("0008d113","00200009327000008250400000","24466190sa01cc00000","0163103b000000d0","01631051000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for omega
-    cuts.AddCut("0008d113","00200009327000008250400000","24466190sa01cc00000","0163103b000000d0","01631041000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for omega
-    cuts.AddCut("0008d113","00200009327000008250400000","24466190sa01cc00000","0163103b000000d0","01631081000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for omega
+    cuts.AddCut("0008d113","00200009327000008250400000","24466190sa01cc00000","01631036000000d0","01631071000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for omega
+    cuts.AddCut("0008d113","00200009327000008250400000","24466190sa01cc00000","01631036000000d0","01631051000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for omega
+    cuts.AddCut("0008d113","00200009327000008250400000","24466190sa01cc00000","01631036000000d0","01631041000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for omega
+    cuts.AddCut("0008d113","00200009327000008250400000","24466190sa01cc00000","01631036000000d0","01631081000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for omega
 
 
   // cuts for ReconMethod==3 Cal-Cal-PCM
@@ -647,21 +647,21 @@ void AddTask_OmegaToPiZeroGamma_pp(
     cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","0163103d000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout
   } else if( trainConfig == 3064) {
     // MB 13TeV PCM Photon with EMcal + DCal Pi0, Background Variation (Swapping Method by Joshua)
-    cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","0163103b000000d0","0r631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation
-    cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","0163103b000000d0","0v631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS without constraints
-    cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","0163103b000000d0","0x631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","0163103d000000d0","0r631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","0163103d000000d0","0v631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS without constraints
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","0163103d000000d0","0x631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
   } else if( trainConfig == 3065) {
     // MB 13TeV PCM Photon with EMcal + DCal, Pi0 selection plus Gamma dropout, alpha cut pi0
-    cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","0163107b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for pi0
-    cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","0163105b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for pi0
-    cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","0163104b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for pi0
-    cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","0163108b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for pi0
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","0163107d000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for pi0
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","0163105d000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for pi0
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","0163104d000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for pi0
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","0163108d000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for pi0
   } else if( trainConfig == 3066) {
     // MB 13TeV PCM Photon with EMcal + DCal, Pi0 selection plus Gamma dropout, alpha cut omega
-    cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","0163103b000000d0","01631071000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for omega
-    cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","0163103b000000d0","01631051000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for omega
-    cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","0163103b000000d0","01631041000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for omega
-    cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","0163103b000000d0","01631081000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for omega
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","0163103d000000d0","01631071000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for omega
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","0163103d000000d0","01631051000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for omega
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","0163103d000000d0","01631041000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for omega
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","411791206f032230000","0163103d000000d0","01631081000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for omega
   } else if( trainConfig == 3071) {
     // EG2 13TeV PCM Photon with EMcal Pi0
     cuts.AddCut("0008e113","0dm00009f9730000dge0404000","1111100067032230000","01631031000000d0","01631031000000d0");
@@ -676,21 +676,21 @@ void AddTask_OmegaToPiZeroGamma_pp(
     cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","0163103d000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout
   } else if( trainConfig == 3074) {
     // EG2 13TeV EMcal + Dcal, Background Variation (Swapping Method by Joshua)
-    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","0163103b000000d0","0r631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation
-    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","0163103b000000d0","0v631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS without constraints
-    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","0163103b000000d0","0x631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","01631034000000d0","0r631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","01631034000000d0","0v631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS without constraints
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","01631034000000d0","0x631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
   } else if( trainConfig == 3075) {
     // EG2 13TeV PCM Photon with EMcal + DCal, Pi0 selection plus Gamma dropout, alpha cut pi0
-    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","0163107b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for pi0
-    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","0163105b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for pi0
-    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","0163104b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for pi0
-    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","0163108b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for pi0
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","0163107d000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for pi0
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","0163105d000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for pi0
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","0163104d000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for pi0
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","0163108d000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for pi0
   } else if( trainConfig == 3076) {
     // EG2 13TeV PCM Photon with EMcal + DCal, Pi0 selection plus Gamma dropout, alpha cut omega
-    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","0163103b000000d0","01631071000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for omega
-    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","0163103b000000d0","01631051000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for omega
-    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","0163103b000000d0","01631041000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for omega
-    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","0163103b000000d0","01631081000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for omega
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","0163103d000000d0","01631071000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for omega
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","0163103d000000d0","01631051000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for omega
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","0163103d000000d0","01631041000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for omega
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","411791206f032230000","0163103d000000d0","01631081000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for omega
   } else if( trainConfig == 3081) {
     // EG1 13TeV EMcal
     cuts.AddCut("0008d113","0dm00009f9730000dge0404000","1111100067032230000","01631031000000d0","01631031000000d0");
@@ -705,21 +705,21 @@ void AddTask_OmegaToPiZeroGamma_pp(
     cuts.AddCut("0008d113","0dm00009f9730000dge0404000","411791206f032230000","0163103d000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout
   } else if( trainConfig == 3084) {
     // EG1 13TeV EMcal + Dcal, Background Variation (Swapping Method by Joshua)
-    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","411791206f032230000","0163103b000000d0","0r631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation
-    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","411791206f032230000","0163103b000000d0","0v631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS without constraints
-    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","411791206f032230000","0163103b000000d0","0x631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
+    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","411791206f032230000","0163103d000000d0","0r631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation
+    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","411791206f032230000","0163103d000000d0","0v631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS without constraints
+    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","411791206f032230000","0163103d000000d0","0x631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
   } else if( trainConfig == 3085) {
     // EG1 13TeV PCM Photon with EMcal + DCal, Pi0 selection plus Gamma dropout, alpha cut pi0
-    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","411791206f032230000","0163107b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for pi0
-    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","411791206f032230000","0163105b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for pi0
-    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","411791206f032230000","0163104b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for pi0
-    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","411791206f032230000","0163108b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for pi0
+    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","411791206f032230000","0163107d000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for pi0
+    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","411791206f032230000","0163105d000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for pi0
+    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","411791206f032230000","0163104d000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for pi0
+    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","411791206f032230000","0163108d000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for pi0
   } else if( trainConfig == 3086) {
     // EG1 13TeV PCM Photon with EMcal + DCal, Pi0 selection plus Gamma dropout, alpha cut omega
-    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","411791206f032230000","01631036000000d0","01631071000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for omega
-    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","411791206f032230000","01631036000000d0","01631051000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for omega
-    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","411791206f032230000","01631036000000d0","01631041000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for omega
-    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","411791206f032230000","01631036000000d0","01631081000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for omega
+    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","411791206f032230000","0163103d000000d0","01631071000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for omega
+    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","411791206f032230000","0163103d000000d0","01631051000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for omega
+    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","411791206f032230000","0163103d000000d0","01631041000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for omega
+    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","411791206f032230000","0163103d000000d0","01631081000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for omega
 
     // PCM(gamma) - PHOS (pi0)
   } else if( trainConfig == 3162) {
@@ -733,21 +733,21 @@ void AddTask_OmegaToPiZeroGamma_pp(
     cuts.AddCut("00010113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103d000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout
   } else if( trainConfig == 3164) {
     // MB 13TeV, Background Variation (Swapping Method by Joshua)
-    cuts.AddCut("00010113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103b000000d0","0r631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation
-    cuts.AddCut("00010113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103b000000d0","0v631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS without constraints
-    cuts.AddCut("00010113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103b000000d0","0x631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103d000000d0","0r631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103d000000d0","0v631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS without constraints
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103d000000d0","0x631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
   } else if( trainConfig == 3165) {
     // MB 13TeV, Pi0 selection plus Gamma dropout, alpha cut pi0
-    cuts.AddCut("00010113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163107b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for pi0
-    cuts.AddCut("00010113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163105b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for pi0
-    cuts.AddCut("00010113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163104b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for pi0
-    cuts.AddCut("00010113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163108b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for pi0
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163107d000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for pi0
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163105d000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for pi0
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163104d000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for pi0
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163108d000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for pi0
   } else if( trainConfig == 3166) {
     // MB 13TeV, Pi0 selection plus Gamma dropout, alpha cut omega
-    cuts.AddCut("00010113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103b000000d0","01631071000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for omega
-    cuts.AddCut("00010113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103b000000d0","01631051000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for omega
-    cuts.AddCut("00010113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103b000000d0","01631041000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for omega
-    cuts.AddCut("00010113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103b000000d0","01631081000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for omega
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103d000000d0","01631071000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for omega
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103d000000d0","01631051000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for omega
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103d000000d0","01631041000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for omega
+    cuts.AddCut("00010113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103d000000d0","01631081000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for omega
   } else if( trainConfig == 3172) {
     // EG2 std NL 12
     cuts.AddCut("0008e113","0dm00009f9730000dge0404000","24466190sa01cc00000","01631031000000d0","01631031000000d0");
@@ -759,21 +759,21 @@ void AddTask_OmegaToPiZeroGamma_pp(
     cuts.AddCut("0008e113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103d000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout
   } else if( trainConfig == 3174) {
     // EG2 13TeV, Background Variation (Swapping Method by Joshua)
-    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103b000000d0","0r631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation
-    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103b000000d0","0v631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS without constraints
-    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103b000000d0","0x631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103d000000d0","0r631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103d000000d0","0v631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS without constraints
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103d000000d0","0x631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
   } else if( trainConfig == 3175) {
     // EG2 13TeV, Pi0 selection plus Gamma dropout, alpha cut pi0
-    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163107b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for pi0
-    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163105b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for pi0
-    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163104b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for pi0
-    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163108b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for pi0
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163107d000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for pi0
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163105d000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for pi0
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163104d000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for pi0
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163108d000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for pi0
   } else if( trainConfig == 3176) {
     // EG2 13TeV, Pi0 selection plus Gamma dropout, alpha cut omega
-    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103b000000d0","01631071000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for omega
-    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103b000000d0","01631051000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for omega
-    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103b000000d0","01631041000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for omega
-    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103b000000d0","01631081000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for omega
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103d000000d0","01631071000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for omega
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103d000000d0","01631051000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for omega
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103d000000d0","01631041000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for omega
+    cuts.AddCut("0008e113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103d000000d0","01631081000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for omega
   } else if( trainConfig == 3182) {
     // EG1 13TeV
     cuts.AddCut("0008d113","0dm00009f9730000dge0404000","24466190sa01cc00000","01631031000000d0","01631031000000d0");
@@ -785,21 +785,21 @@ void AddTask_OmegaToPiZeroGamma_pp(
     cuts.AddCut("0008d113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103d000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout
   } else if( trainConfig == 3184) {
     // EG1 13TeV, Background Variation (Swapping Method by Joshua)
-    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103b000000d0","0r631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation
-    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103b000000d0","0v631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS without constraints
-    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103b000000d0","0x631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
+    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103d000000d0","0r631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation
+    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103d000000d0","0v631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS without constraints
+    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103d000000d0","0x631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
   } else if( trainConfig == 3185) {
     // EG1 13TeV, Pi0 selection plus Gamma dropout, alpha cut pi0
-    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163107b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for pi0
-    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163105b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for pi0
-    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163104b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for pi0
-    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163108b000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for pi0
+    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163107d000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for pi0
+    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163105d000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for pi0
+    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163104d000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for pi0
+    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163108d000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for pi0
   } else if( trainConfig == 3186) {
     // EG1 13TeV, Pi0 selection plus Gamma dropout, alpha cut omega
-    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103b000000d0","01631071000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for omega
-    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103b000000d0","01631051000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for omega
-    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103b000000d0","01631041000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for omega
-    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103b000000d0","01631081000000d0"); // 1 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for omega
+    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103d000000d0","01631071000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for omega
+    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103d000000d0","01631051000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for omega
+    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103d000000d0","01631041000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for omega
+    cuts.AddCut("0008d113","0dm00009f9730000dge0404000","24466190sa01cc00000","0163103d000000d0","01631081000000d0"); // 4 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for omega
 
 
   // cuts for ReconMethod==4 PCM-PCM-Cal

--- a/PWGGA/GammaConv/macros/AddTask_OmegaToPiZeroGamma_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_OmegaToPiZeroGamma_pp.C
@@ -1002,7 +1002,7 @@ void AddTask_OmegaToPiZeroGamma_pp(
     analysisClusterCuts[i]->InitializeCutsFromCutString((cuts.GetClusterCut(i)).Data());
     ClusterCutList->Add(analysisClusterCuts[i]);
     analysisClusterCuts[i]->SetExtendedMatchAndQA(enableExtMatchAndQA);
-    analysisClusterCuts[i]->SetFillCutHistograms("");
+    // analysisClusterCuts[i]->SetFillCutHistograms("");
 
     analysisNeutralPionCuts[i] = new AliConversionMesonCuts();
     analysisNeutralPionCuts[i]->SetLightOutput(runLightOutput);

--- a/PWGMM/Lumi/vdM/VdmStability/AliAnalysisTaskVdmStability.cxx
+++ b/PWGMM/Lumi/vdM/VdmStability/AliAnalysisTaskVdmStability.cxx
@@ -166,8 +166,8 @@ void AliAnalysisTaskVdmStability::UserExec(Option_t *)
     //Check if V0 event
     TString ftc = fEvent->GetFiredTriggerClasses();
     if (ftc.Contains("CINT7-B"))
-        fIsV0ANDfired = kFALSE;
-    else fIsV0ANDfired = kTRUE;
+        fIsV0ANDfired = kTRUE;
+    else fIsV0ANDfired = kFALSE;
     if (!fIsV0ANDfired) return;
     
     //check if T0 trigger was fired


### PR DESCRIPTION
Added PHOS configs (changed train configs to 4 digits just to be safe)
Fixed bug which disabled the EtaPhiMaps for the swapping background method
Modified standard photon selection range to be what currently looks best