### PR TITLE
Add dir to make unique IDs

### DIFF
--- a/PWGHF/correlationHF/AliAnalysisTaskDHFeCorr.h
+++ b/PWGHF/correlationHF/AliAnalysisTaskDHFeCorr.h
@@ -77,8 +77,9 @@ namespace AliDHFeCorr {
     typedef struct AliDMeson {
     public:
         AliAODRecoDecayHF *fRecoObj{nullptr};
-        Int_t fRunNumber{0}; ///<PID of the grid job used to create the tree
-        Int_t fEventNumber{0}; ///< Number of the event
+        UInt_t fRunNumber{0}; ///<PID of the grid job used to create the tree
+        UInt_t fDirNumber{0};
+        UInt_t fEventNumber{0}; ///< Number of the event
         UInt_t fID{0}; ///< D meson id in the event
         Bool_t fIsParticleCandidate{kFALSE}; ///< Particle hypotheses at reconstruction level
         UInt_t fLabel{0};
@@ -118,12 +119,12 @@ namespace AliDHFeCorr {
         Float_t fAngleD0dkpPisoft{-999.};
 
         //Single-track information
-        std::vector<Float_t> fPtDaughters;
-        std::vector<Float_t> fD0Daughters;
-        std::vector<UInt_t> fIDDaughters; ///< ID obtained using GetID()
+        std::vector<Float_t> fPtDaughters{std::vector<Float_t> ()};
+        std::vector<Float_t> fD0Daughters{std::vector<Float_t> ()};
+        std::vector<UInt_t> fIDDaughters{std::vector<UInt_t> ()}; ///< ID obtained using GetID()
 
-        std::array<std::vector<Float_t>, 3> fNSigmaTPCDaughters; ///< The PID TPC response (n )sigma
-        std::array<std::vector<Float_t>, 3> fNSigmaTOFDaughters; ///< The PID TOF response (n sigma)
+        std::array<std::vector<Float_t>, 3> fNSigmaTPCDaughters{std::array<std::vector<Float_t>, 3>()}; ///< The PID TPC response (n )sigma
+        std::array<std::vector<Float_t>, 3> fNSigmaTOFDaughters{std::array<std::vector<Float_t>, 3>()}; ///< The PID TOF response (n sigma)
 
         //MC Level information
         Float_t fPtMC{-999.};///< Transverse momentum (MC information)
@@ -135,6 +136,7 @@ namespace AliDHFeCorr {
 
     typedef struct AliEvent {
         UInt_t fRunNumber{0};
+        UInt_t fDirNumber{0};
         UInt_t fEventNumber{0};
 
         Float_t fVtxZ{-999.};
@@ -153,11 +155,14 @@ namespace AliDHFeCorr {
     public:
         AliElectron() = default;
 
-        AliElectron(AliAODTrack* track, Int_t run_number, Long_t event_number,
+        ~AliElectron(){};
+
+        AliElectron(AliAODTrack* track, UInt_t run_number,  UInt_t dir_number, UInt_t event_number,
                 AliAODEvent *aod_event, AliPIDResponse *pid_response) {
 
             fTrack = track;
             fRunNumber = run_number;
+            fDirNumber = dir_number;
             fEventNumber = event_number;
             fID = TMath::Abs(track->GetID());
 
@@ -187,11 +192,21 @@ namespace AliDHFeCorr {
 
             fTPCNSigma = pid_response->NumberOfSigmasTPC(track, AliPID::kElectron);
             fTOFNSigma = pid_response->NumberOfSigmasTOF(track, AliPID::kElectron);
+
+            fInvMassPartnersULS = std::vector<Float_t>();
+            fInvMassPartnersLS = std::vector<Float_t>();
+            fPtPartnersULS = std::vector<Float_t>();
+            fPtPartnersLS = std::vector<Float_t>();
+            fCrossedRowsTPCPartnersULS = std::vector<UShort_t>();
+            fCrossedRowsTPCPartnersLS = std::vector<UShort_t>();
+            fPartnersULSID = std::vector<UInt_t>();
+            fPartnersLSID = std::vector<UInt_t>();
         }
 
         AliAODTrack *fTrack{nullptr};
 
         UInt_t fRunNumber{0};
+        UInt_t fDirNumber{0};
         UInt_t fEventNumber{0};
 
         UInt_t fID{0};
@@ -214,16 +229,16 @@ namespace AliDHFeCorr {
         Float_t fTOFNSigma{-999.};
 
         //Partner variables
-        std::vector<Float_t> fInvMassPartnersULS; //mass of the ULS partners
-        std::vector<Float_t> fInvMassPartnersLS; //mass of the LS partners
-        std::vector<Float_t> fPtPartnersULS; //Pt of the ULS partners
-        std::vector<Float_t> fPtPartnersLS; //Pt of the LS partners
-        std::vector<UShort_t> fCrossedRowsTPCPartnersULS; //Pt of the LS partners
-        std::vector<UShort_t> fCrossedRowsTPCPartnersLS; //Pt of the LS partners
+        std::vector<Float_t> fInvMassPartnersULS{std::vector<Float_t>()}; //mass of the ULS partners
+        std::vector<Float_t> fInvMassPartnersLS{std::vector<Float_t>()}; //mass of the LS partners
+        std::vector<Float_t> fPtPartnersULS{std::vector<Float_t>()}; //Pt of the ULS partners
+        std::vector<Float_t> fPtPartnersLS{std::vector<Float_t>()}; //Pt of the LS partners
+        std::vector<UShort_t> fCrossedRowsTPCPartnersULS{std::vector<UShort_t>()}; //Pt of the LS partners
+        std::vector<UShort_t> fCrossedRowsTPCPartnersLS{std::vector<UShort_t>()}; //Pt of the LS partners
 
 
-        std::vector<UInt_t> fPartnersULSID; //unique ID of the ULS partners
-        std::vector<UInt_t> fPartnersLSID; //unique ID of the LS partners
+        std::vector<UInt_t> fPartnersULSID{std::vector<UInt_t>()}; //unique ID of the ULS partners
+        std::vector<UInt_t> fPartnersLSID{std::vector<UInt_t>()}; //unique ID of the LS partners
 
         //MC information
         UInt_t fLabel{0};
@@ -246,9 +261,10 @@ namespace AliDHFeCorr {
         AliParticleMC() = default;
 
         AliParticleMC(AliAODMCParticle *particle,
-                      UInt_t run_number = 0, UInt_t ev_number = 0, UInt_t label = 0, UShort_t origin = 0) {
+                      UInt_t run_number = 0, UInt_t dir_number = 0, UInt_t ev_number = 0, UInt_t label = 0, UShort_t origin = 0) {
             fMCParticle = particle;
             fRunNumber = run_number;
+            fDirNumber = dir_number;
             fEventNumber = ev_number;
             fLabel = label;
             fOrigin = origin;
@@ -270,6 +286,7 @@ namespace AliDHFeCorr {
 
         AliAODMCParticle *fMCParticle{nullptr};
         UInt_t fRunNumber{0};
+        UInt_t fDirNumber{0};
         UInt_t fEventNumber{0};
 
         UInt_t fLabel{0};
@@ -526,15 +543,12 @@ private:
 
     //Event Properties.
     UInt_t fRunNumber{0}; ///< Run number
+    int fDirNumber{-1};
     UInt_t fEventNumber{0}; ///< Unique number for each event
+    std::string fCurrentFile;
 
     Float_t fVtxZ{-999.}; ///< Vertex Z
-    Float_t fCentrality{-999.};
-
-
-    //Values used to determine the unique event ID
-    int fDirNum{-1};
-    std::string fCurrentFile;
+    Float_t fCentrality{-999.};    
 
     //Stores the current electron and D meson to save in the tree
     AliDHFeCorr::AliElectron fElectron; ///< Electron information that will be used in the fElectronTree


### PR DESCRIPTION
In some cases (~3% of data), the old scheme to generate the unique event numbers was not working, because there were too many events in the AOD. To fix that, I have added the number of the directory as a separate variable, and then the unique ID can be generated by combining the RunNumber + Directory + Event Number.