### PR TITLE
fix-Reverting the "fArrayDStartoD0pi"-renaming in DFilter task

### DIFF
--- a/PWGHF/jetsHF/AliAnalysisTaskDJetCorrelations.cxx
+++ b/PWGHF/jetsHF/AliAnalysisTaskDJetCorrelations.cxx
@@ -268,9 +268,9 @@ Bool_t AliAnalysisTaskDJetCorrelations::Run()
         return kFALSE;
     }
 
-    TClonesArray *arrayDmesontoDaughters=nullptr;
+    TClonesArray *arrayDStartoD0pi=nullptr;
 
-    // 1. using AOD: Finding the above TClonesArray* arrayDmesontoDaughters
+    // 1. using AOD: Finding the above TClonesArray* arrayDStartoD0pi
     if (!aodEvent && AODEvent() && IsStandardAOD()) {
 
         // In case there is an AOD handler writing a standard AOD, use the AOD
@@ -284,19 +284,19 @@ Bool_t AliAnalysisTaskDJetCorrelations::Run()
         if(aodHandler->GetExtensions()) {
             AliAODExtension *ext = (AliAODExtension*)aodHandler->GetExtensions()->FindObject("AliAOD.VertexingHF.root");
             AliAODEvent *aodFromExt = ext->GetAOD();
-            arrayDmesontoDaughters=(TClonesArray*)aodFromExt->GetList()->FindObject(fBranchName.Data());
+            arrayDStartoD0pi=(TClonesArray*)aodFromExt->GetList()->FindObject(fBranchName.Data());
         }
     }
     else if(aodEvent){
-        arrayDmesontoDaughters=(TClonesArray*)aodEvent->GetList()->FindObject(fBranchName.Data());
+        arrayDStartoD0pi=(TClonesArray*)aodEvent->GetList()->FindObject(fBranchName.Data());
     }
 
     // check #2: if the TClonesArray not found.
-    if (!arrayDmesontoDaughters) {
+    if (!arrayDStartoD0pi) {
         AliInfo(Form("Could not find array %s, skipping the event",fBranchName.Data()));
         //  return;
     }
-    else AliDebug(2, Form("Found %d vertices",arrayDmesontoDaughters->GetEntriesFast()));
+    else AliDebug(2, Form("Found %d vertices",arrayDStartoD0pi->GetEntriesFast()));
 
     // 2. array for MC
     TClonesArray* mcArray = nullptr;
@@ -636,7 +636,7 @@ void AliAnalysisTaskDJetCorrelations::CreateMCResponseMatrix(AliEmcalJet* MCjet,
     Double_t JetPtGen = MCjet->Pt();
     Double_t JetEtaGen = MCjet->Eta();
     Double_t DPtGen = Dgen->Pt();
-    //Double_t JetnTrkGen = MCjet->GetNumberOfTracks();//unused variable
+    Double_t JetnTrkGen = MCjet->GetNumberOfTracks();//unused variable
     AliAODMCParticle* DTrk = (AliAODMCParticle*)Dgen;
     Double_t DYGen = DTrk->Y();
     Int_t pdg = DTrk->GetPdgCode();

--- a/PWGHF/jetsHF/AliAnalysisTaskDmesonsFilterCJ.cxx
+++ b/PWGHF/jetsHF/AliAnalysisTaskDmesonsFilterCJ.cxx
@@ -89,7 +89,7 @@ AliAnalysisTaskDmesonsFilterCJ::AliAnalysisTaskDmesonsFilterCJ() :
   fMCHeader(0),
   fCounter(0),
   fRan(0),
-  fArrayDmesontoDaughters(0),
+  fArrayDStartoD0pi(0),
   fMCarray(0),
   fCandidateArray(0),
   fSideBandArray(0),
@@ -169,7 +169,7 @@ AliAnalysisTaskDmesonsFilterCJ::AliAnalysisTaskDmesonsFilterCJ(const char *name,
   fMCHeader(0),
   fCounter(0),
   fRan(0),
-  fArrayDmesontoDaughters(0),
+  fArrayDStartoD0pi(0),
   fMCarray(0),
   fCandidateArray(0),
   fSideBandArray(0),
@@ -428,7 +428,7 @@ void AliAnalysisTaskDmesonsFilterCJ::ExecOnce()
   fAodEvent = dynamic_cast<AliAODEvent*>(fInputEvent);
 
   if (fAodEvent) {
-    fArrayDmesontoDaughters = dynamic_cast<TClonesArray*>(fAodEvent->GetList()->FindObject(fBranchName.Data()));
+    fArrayDStartoD0pi = dynamic_cast<TClonesArray*>(fAodEvent->GetList()->FindObject(fBranchName.Data()));
   }
   else {
     if (AODEvent() && IsStandardAOD()) {
@@ -443,7 +443,7 @@ void AliAnalysisTaskDmesonsFilterCJ::ExecOnce()
       if(aodHandler->GetExtensions()) {
         AliAODExtension *ext = (AliAODExtension*)aodHandler->GetExtensions()->FindObject("AliAOD.VertexingHF.root");
         AliAODEvent *aodFromExt = ext->GetAOD();
-        fArrayDmesontoDaughters = (TClonesArray*)aodFromExt->GetList()->FindObject(fBranchName.Data());
+        fArrayDStartoD0pi = (TClonesArray*)aodFromExt->GetList()->FindObject(fBranchName.Data());
       }
       else {
         AliError(Form("This task need an AOD event! Task '%s' will be disabled!", GetName()));
@@ -453,14 +453,14 @@ void AliAnalysisTaskDmesonsFilterCJ::ExecOnce()
     }
   }
 
-  if (fArrayDmesontoDaughters) {
-    TString objname(fArrayDmesontoDaughters->GetClass()->GetName());
+  if (fArrayDStartoD0pi) {
+    TString objname(fArrayDStartoD0pi->GetClass()->GetName());
     TClass cls(objname);
     if (!cls.InheritsFrom("AliAODRecoDecayHF2Prong")) {
       AliError(Form("%s: Objects of type %s in %s are not inherited from AliAODRecoDecayHF2Prong! Task will be disabled!",
-                    GetName(), cls.GetName(), fArrayDmesontoDaughters->GetName()));
+                    GetName(), cls.GetName(), fArrayDStartoD0pi->GetName()));
       fInhibitTask = kTRUE;
-      fArrayDmesontoDaughters = 0;
+      fArrayDStartoD0pi = 0;
       return;
     }
   }
@@ -534,7 +534,7 @@ Bool_t AliAnalysisTaskDmesonsFilterCJ::Run()
 
     AliDebug(2, "Event selected");
 
-    const Int_t nD = fArrayDmesontoDaughters->GetEntriesFast();
+    const Int_t nD = fArrayDStartoD0pi->GetEntriesFast();
     AliDebug(2, Form("Found %d vertices", nD));
     if (!fUseMCInfo) fHistStat->Fill(2, nD);
  
@@ -585,7 +585,7 @@ Bool_t AliAnalysisTaskDmesonsFilterCJ::Run()
                 // loop over reco D candidates to find a match to MC
                 Int_t isRecoD = kFALSE;
                 for (Int_t icharm = 0; icharm < nD; icharm++) {  
-                    charmCand = static_cast<AliAODRecoDecayHF2Prong*>(fArrayDmesontoDaughters->At(icharm)); // D candidates
+                    charmCand = static_cast<AliAODRecoDecayHF2Prong*>(fArrayDStartoD0pi->At(icharm)); // D candidates
                     if (!charmCand) continue;
                     if(!(vHF->FillRecoCand(fAodEvent,charmCand))) continue;
                     
@@ -672,7 +672,7 @@ Bool_t AliAnalysisTaskDmesonsFilterCJ::Run()
         for (Int_t icharm = 0; icharm < nD; icharm++) {   //loop over D candidates
             Int_t isSelected = 0;
     
-            AliAODRecoDecayHF2Prong* charmCand = static_cast<AliAODRecoDecayHF2Prong*>(fArrayDmesontoDaughters->At(icharm)); // D candidates
+            AliAODRecoDecayHF2Prong* charmCand = static_cast<AliAODRecoDecayHF2Prong*>(fArrayDStartoD0pi->At(icharm)); // D candidates
             if (!charmCand) continue;
             if(!(vHF->FillRecoCand(fAodEvent,charmCand))) continue;
     

--- a/PWGHF/jetsHF/AliAnalysisTaskDmesonsFilterCJ.h
+++ b/PWGHF/jetsHF/AliAnalysisTaskDmesonsFilterCJ.h
@@ -143,13 +143,13 @@ class AliAnalysisTaskDmesonsFilterCJ : public AliAnalysisTaskEmcal
   
 
   Bool_t          fUseMCInfo;               //! Use MC info
-  Bool_t          fBuildRMEff;		        //! MC RM or efficiency studies
-  Bool_t          fUsePythia;		        //! Use Pythia info only for MC
-  Bool_t          fMultPythiaHeader;	    //! Use Pythia info only, with multiple Pythia events per one MB event
-  Int_t           fPythiaEvent;			    //! Pythia event to be analysed, for MC with more than one Pythia event
+  Bool_t          fBuildRMEff;              //! MC RM or efficiency studies
+  Bool_t          fUsePythia;               //! Use Pythia info only for MC
+  Bool_t          fMultPythiaHeader;        //! Use Pythia info only, with multiple Pythia events per one MB event
+  Int_t           fPythiaEvent;             //! Pythia event to be analysed, for MC with more than one Pythia event
   Bool_t          fUseHijing;               //! Use only Hijing info for MC
-  Bool_t          fUseRejTracks;	        //! Reject tracks for JES systematics
-  Double_t        fTrackIneff;		        //! Tracking inefficiency for JES systematics
+  Bool_t          fUseRejTracks;            //! Reject tracks for JES systematics
+  Double_t        fTrackIneff;              //! Tracking inefficiency for JES systematics
   Bool_t          fUseReco;                 //! use reconstructed tracks when running on MC
   UInt_t          fCandidateType;           //! Dstar or D0
   TString         fCandidateName;           //! Dstar or D0
@@ -169,10 +169,10 @@ class AliAnalysisTaskDmesonsFilterCJ : public AliAnalysisTaskEmcal
   Bool_t          fRejectDfromB;            //! reject D mesons coming from a B meson decay (MC)
   Bool_t          fKeepOnlyDfromB;          //! only accept D mesons coming from a B meson decay (MC)
   AliAODEvent    *fAodEvent;                //!
-  AliAODMCHeader *fMCHeader;		        //!
+  AliAODMCHeader *fMCHeader;                //!
   AliNormalizationCounter *fCounter;        //! AliNormalizationCounter
-  TRandom3	     *fRan;			            //! Random number generator
-  TClonesArray   *fArrayDmesontoDaughters;  //! Common array for a D meson going to its own daughters
+  TRandom3	     *fRan;                     //! Random number generator
+  TClonesArray   *fArrayDStartoD0pi;        //! Why not a common array for a D meson going to its own daughters.. e.g. fArrayDmesontoDaughters
   TClonesArray   *fMCarray;                 //!
   TClonesArray   *fCandidateArray;          //! contains candidates selected by AliRDHFCuts
   TClonesArray   *fSideBandArray;           //! contains candidates selected by AliRDHFCuts::IsSelected(kTracks), to be used for side bands (DStar case only!!)


### PR DESCRIPTION
Hi all,

"fArrayDStartoD0pi" was renamed recently in DFilter task to check how it affected. And this affected the Container input provided to AliEmcalJetTask. So fixing this mistake I did few days back. Another renaming in Correlations task is also reverted just to be safe.

Best, Auro