### PR TITLE
Including the background for the analysis

### DIFF
--- a/PWGCF/FEMTOSCOPY/macros/AddTaskGeorgiosNTuple.C
+++ b/PWGCF/FEMTOSCOPY/macros/AddTaskGeorgiosNTuple.C
@@ -59,15 +59,15 @@ AliAnalysisTaskSE *AddTaskGeorgiosNTuple() {
   //Cascade Cuts
   AliFemtoDreamCascadeCuts* CascadeXiBGRCuts = AliFemtoDreamCascadeCuts::XiCuts(false, false);
   CascadeXiBGRCuts->SetXiCharge(-1);
-  AliFemtoDreamTrackCuts *XiNegCuts = AliFemtoDreamTrackCuts::Xiv0PionCuts(false, true, false);
-  XiNegCuts->SetCheckTPCRefit(false);//for nanos this is already done while prefiltering
-  AliFemtoDreamTrackCuts *XiPosCuts = AliFemtoDreamTrackCuts::Xiv0ProtonCuts(false, true, false);
-  XiPosCuts->SetCheckTPCRefit(false);
-  AliFemtoDreamTrackCuts *XiBachCuts = AliFemtoDreamTrackCuts::XiBachPionCuts(false, true, false);
-  XiBachCuts->SetCheckTPCRefit(false);
-  CascadeXiBGRCuts->Setv0Negcuts(XiNegCuts);
-  CascadeXiBGRCuts->Setv0PosCuts(XiPosCuts);
-  CascadeXiBGRCuts->SetBachCuts(XiBachCuts);
+  AliFemtoDreamTrackCuts *XiBGRNegCuts = AliFemtoDreamTrackCuts::Xiv0PionCuts(false, true, false);
+  XiBGRNegCuts->SetCheckTPCRefit(false);//for nanos this is already done while prefiltering
+  AliFemtoDreamTrackCuts *XiBGRPosCuts = AliFemtoDreamTrackCuts::Xiv0ProtonCuts(false, true, false);
+  XiBGRPosCuts->SetCheckTPCRefit(false);
+  AliFemtoDreamTrackCuts *XiBGRBachCuts = AliFemtoDreamTrackCuts::XiBachPionCuts(false, true, false);
+  XiBGRBachCuts->SetCheckTPCRefit(false);
+  CascadeXiBGRCuts->Setv0Negcuts(XiBGRNegCuts);
+  CascadeXiBGRCuts->Setv0PosCuts(XiBGRPosCuts);
+  CascadeXiBGRCuts->SetBachCuts(XiBGRBachCuts);
   CascadeXiBGRCuts->SetPDGCodeCasc(3312);                
   CascadeXiBGRCuts->SetPDGCodev0(3122);
   CascadeXiBGRCuts->SetPDGCodePosDaug(2212);
@@ -76,18 +76,18 @@ AliAnalysisTaskSE *AddTaskGeorgiosNTuple() {
   //AntiCascade cuts
   AliFemtoDreamCascadeCuts* AntiCascadeXiBGRCuts = AliFemtoDreamCascadeCuts::XiCuts(false, false);
   AntiCascadeXiBGRCuts->SetXiCharge(1);
-  AliFemtoDreamTrackCuts *AntiXiNegCuts = AliFemtoDreamTrackCuts::Xiv0ProtonCuts(false, true, false);
-  AntiXiNegCuts->SetCutCharge(-1);
-  AntiXiNegCuts->SetCheckTPCRefit(false);
-  AliFemtoDreamTrackCuts *AntiXiPosCuts = AliFemtoDreamTrackCuts::Xiv0PionCuts(false, true, false);
-  AntiXiPosCuts->SetCutCharge(1);
-  AntiXiPosCuts->SetCheckTPCRefit(false);
-  AliFemtoDreamTrackCuts *AntiXiBachCuts =AliFemtoDreamTrackCuts::XiBachPionCuts(false, true, false);
-  AntiXiBachCuts->SetCutCharge(1);
-  AntiXiBachCuts->SetCheckTPCRefit(false);
-  AntiCascadeXiBGRCuts->Setv0Negcuts(AntiXiNegCuts);
-  AntiCascadeXiBGRCuts->Setv0PosCuts(AntiXiPosCuts);
-  AntiCascadeXiBGRCuts->SetBachCuts(AntiXiBachCuts);
+  AliFemtoDreamTrackCuts *AntiXiBGRNegCuts = AliFemtoDreamTrackCuts::Xiv0ProtonCuts(false, true, false);
+  AntiXiBGRNegCuts->SetCutCharge(-1);
+  AntiXiBGRNegCuts->SetCheckTPCRefit(false);
+  AliFemtoDreamTrackCuts *AntiXiBGRPosCuts = AliFemtoDreamTrackCuts::Xiv0PionCuts(false, true, false);
+  AntiXiBGRPosCuts->SetCutCharge(1);
+  AntiXiBGRPosCuts->SetCheckTPCRefit(false);
+  AliFemtoDreamTrackCuts *AntiXiBGRBachCuts =AliFemtoDreamTrackCuts::XiBachPionCuts(false, true, false);
+  AntiXiBGRBachCuts->SetCutCharge(1);
+  AntiXiBGRBachCuts->SetCheckTPCRefit(false);
+  AntiCascadeXiBGRCuts->Setv0Negcuts(AntiXiBGRNegCuts);
+  AntiCascadeXiBGRCuts->Setv0PosCuts(AntiXiBGRPosCuts);
+  AntiCascadeXiBGRCuts->SetBachCuts(AntiXiBGRBachCuts);
   AntiCascadeXiBGRCuts->SetPDGCodeCasc(-3312);
   AntiCascadeXiBGRCuts->SetPDGCodev0(-3122);
   AntiCascadeXiBGRCuts->SetPDGCodePosDaug(211);


### PR DESCRIPTION
Opening the Cuts to include the background of the Lambdas Xis. Also correct renaming of some variables to avoid overwriting.