### PR TITLE
PWGPP-584, ATO-465 - Update of event selection information for skimmed data

### DIFF
--- a/PWGPP/AliAnalysisTaskFilteredTree.cxx
+++ b/PWGPP/AliAnalysisTaskFilteredTree.cxx
@@ -3274,6 +3274,70 @@ void  AliAnalysisTaskFilteredTree::SetDefaultAliasesHighPt(TTree *tree){
   TStatToolkit::AddMetadata(tree, "mult.AxisTitle","N_{prim}");
   TStatToolkit::AddMetadata(tree, "ntracks.Title","N_{tr}");
   TStatToolkit::AddMetadata(tree, "ntracks.AxisTitle","N_{tr} (prim+sec+pile-up)");
+  //
+   /// dEdx and TPC ncl aliases
+  tree->SetAlias("mdEdx", "50./esdTrack.fTPCsignal");
+  tree->SetAlias("dEdxExpPion",Form("AliPIDtools::BetheBlochAleph(%d,0+esdTrack.fIp.P()/0.13597)",pidHash));
+  for (Int_t i=0; i<4; i++){
+    tree->SetAlias(Form("ratioTotMax%d",i) , Form("fTPCdEdxInfo.GetSignalTot(%d)/fTPCdEdxInfo.GetSignalMax(%d)",i,i));
+    tree->SetAlias(Form("logTotMax%d",i) , Form("log(fTPCdEdxInfo.GetSignalTot(%d)/fTPCdEdxInfo.GetSignalMax(%d))",i,i));
+    tree->SetAlias(Form("logQMaxMIP%d",i) , Form("log(0.02+0.98*fTPCdEdxInfo.GetSignalTot(%d)/dEdxExpPion)",i));
+    tree->SetAlias(Form("logQTotMIP%d",i) , Form("log(0.02+0.98*fTPCdEdxInfo.GetSignalMax(%d)/dEdxExpPion)",i));
+  }
+
+  tree->SetAlias("ratioTotMax0", "fTPCdEdxInfo.GetSignalTot(0)/fTPCdEdxInfo.GetSignalMax(0)");
+  tree->SetAlias("ratioTotMax1", "fTPCdEdxInfo.GetSignalTot(1)/fTPCdEdxInfo.GetSignalMax(1)");
+  tree->SetAlias("ratioTotMax2", "fTPCdEdxInfo.GetSignalTot(2)/fTPCdEdxInfo.GetSignalMax(2)");
+  tree->SetAlias("ratioTotMax3", "fTPCdEdxInfo.GetSignalTot(3)/fTPCdEdxInfo.GetSignalMax(3)");
+  tree->SetAlias("logRatioTot03", "log(fTPCdEdxInfo.GetSignalTot(0)/fTPCdEdxInfo.GetSignalTot(3))");
+  tree->SetAlias("logRatioTot13", "log(fTPCdEdxInfo.GetSignalTot(1)/fTPCdEdxInfo.GetSignalTot(3))");
+  tree->SetAlias("logRatioTot23", "log(fTPCdEdxInfo.GetSignalTot(2)/fTPCdEdxInfo.GetSignalTot(3))");
+  tree->SetAlias("logRatioMax03", "log(fTPCdEdxInfo.GetSignalMax(0)/fTPCdEdxInfo.GetSignalMax(3))");  //
+  tree->SetAlias("logRatioMax13", "log(fTPCdEdxInfo.GetSignalMax(1)/fTPCdEdxInfo.GetSignalMax(3))");  //
+  tree->SetAlias("logRatioMax23", "log(fTPCdEdxInfo.GetSignalMax(2)/fTPCdEdxInfo.GetSignalMax(3))");
+  tree->SetAlias("logRatioTot01", "log(fTPCdEdxInfo.GetSignalTot(0)/fTPCdEdxInfo.GetSignalTot(1))");
+  tree->SetAlias("logRatioTot12", "log(fTPCdEdxInfo.GetSignalTot(1)/fTPCdEdxInfo.GetSignalTot(2))");
+  tree->SetAlias("logRatioTot02", "log(fTPCdEdxInfo.GetSignalTot(0)/fTPCdEdxInfo.GetSignalTot(2))");
+  tree->SetAlias("logRatioMax01", "log(fTPCdEdxInfo.GetSignalMax(0)/fTPCdEdxInfo.GetSignalMax(1))");  //
+  tree->SetAlias("logRatioMax12", "log(fTPCdEdxInfo.GetSignalMax(1)/fTPCdEdxInfo.GetSignalMax(2))");  //
+  tree->SetAlias("logRatioMax02", "log(fTPCdEdxInfo.GetSignalMax(0)/fTPCdEdxInfo.GetSignalMax(2))");  //
+  /// Faction of clusters and n-crossed rows
+  tree->SetAlias("nclFractionROCA", "(esdTrack.GetTPCClusterInfo(3,0)+0)");
+  tree->SetAlias("nclFractionROC0", "(esdTrack.GetTPCClusterInfo(3,0,0,63)+0)");
+  tree->SetAlias("nclFractionROC1", "(esdTrack.GetTPCClusterInfo(3,0,64,128)+0)");
+  tree->SetAlias("nclFractionROC2", "(esdTrack.GetTPCClusterInfo(3,0,129,159)+0)");
+  tree->SetAlias("nclFractionROC3", "(esdTrack.GetTPCClusterInfo(3,0)+0)");
+  tree->SetAlias("ncrROCA", "(esdTrack.GetTPCClusterInfo(3,1)+0)");
+  tree->SetAlias("nCross0", "esdTrack.fTPCdEdxInfo.GetNumberOfCrossedRows(0)");
+  tree->SetAlias("nCross1", "esdTrack.fTPCdEdxInfo.GetNumberOfCrossedRows(1)");
+  tree->SetAlias("nCross2", "esdTrack.fTPCdEdxInfo.GetNumberOfCrossedRows(2)");
+  tree->SetAlias("nFraction0", "esdTrack.GetTPCClusterInfo(1,0,0,62)");
+  tree->SetAlias("nFraction1", "esdTrack.GetTPCClusterInfo(1,0,63,127)");
+  tree->SetAlias("nFraction2", "esdTrack.GetTPCClusterInfo(1,0,127,159)");
+  tree->SetAlias("nFraction3", "esdTrack.GetTPCClusterInfo(1,0,0,159)");
+  tree->SetAlias("n3Fraction0", "esdTrack.GetTPCClusterInfo(3,0,0,62)");
+  tree->SetAlias("n3Fraction1", "esdTrack.GetTPCClusterInfo(3,0,63,127)");
+  tree->SetAlias("n3Fraction2", "esdTrack.GetTPCClusterInfo(3,0,127,159)");
+  tree->SetAlias("n3Fraction3", "esdTrack.GetTPCClusterInfo(3,0,0,159)");
+  //
+  for (Int_t i = 0; i < 3; i++) {
+    TStatToolkit::AddMetadata(tree, Form("nCross%d.AxisTitle", i), Form("# crossed (ROC%d)", i));
+    TStatToolkit::AddMetadata(tree, Form("nclFractionROC%d.AxisTitle", i), Form("fraction of cl (ROC%d)", i));
+    TStatToolkit::AddMetadata(tree, Form("nFraction%d.AxisTitle", i), Form("p_{cl1}(ROC%d)", i));
+    TStatToolkit::AddMetadata(tree, Form("n3Fraction%d.AxisTitle", i), Form("p_{cl3}(ROC%d)", i));
+  }
+  for (Int_t i = 0; i < 4; i++) {
+    TStatToolkit::AddMetadata(tree, Form("ratioTotMax%d.AxisTitle", i), Form("Q_{max%d}/Q_{tot%d}", i, i));
+    TStatToolkit::AddMetadata(tree, Form("logTotMax%d.AxisTitle", i), Form("log(Q_{max%d}/Q_{tot%d})", i, i));
+    TStatToolkit::AddMetadata(tree, Form("ratioTotMax%d.Title", i), Form("Q_{max%d}/Q_{tot%d}", i, i));
+    TStatToolkit::AddMetadata(tree, Form("logTotMax%d.Title", i), Form("log(Q_{max%d}/Q_{tot%d})", i, i));
+  }
+  for (Int_t i = 0; i < 3; i++) {
+    for (Int_t j = i + 1; j < 4; j++) {
+      TStatToolkit::AddMetadata(tree, Form("logRatioMax%d%d.AxisTitle", i, j), Form("log(Q_{MaxRPC%d}/Q_{MaxROC%d})", i, j));
+      TStatToolkit::AddMetadata(tree, Form("logRatioTot%d%d.AxisTitle", i, j), Form("log(Q_{TotRPC%d}/Q_{TotROC%d})", i, j));
+    }
+  }
 }
 
 /// ## Calculate diff between MC snapshot (AliTrackReference)  and reconstructed reco parameters (AliExternalTrackParam)

--- a/PWGPP/AliESDtools.cxx
+++ b/PWGPP/AliESDtools.cxx
@@ -76,6 +76,7 @@
 #include "AliMathBase.h"
 #include "AliESDTOFHit.h"
 #include "AliTOFGeometry.h"
+#include "AliESDZDC.h"
 
 ClassImp(AliESDtools)
 AliESDtools*  AliESDtools::fgInstance;
@@ -875,6 +876,24 @@ Int_t AliESDtools::DumpEventVariables() {
   const AliESDTZERO *esdTzero = fEvent->GetESDTZERO();
   const Double32_t *t0Amp=esdTzero->GetT0amplitude();
   const Double32_t *t0Time=esdTzero->GetT0time();
+  //  ZDC amplitude  and timers
+  AliESDZDC* esdZDC = fEvent->GetESDZDC();
+  TMatrixF zdcTime(32,4);
+  TMatrixF zdcEnergy(8,5);
+  for (int i0=0; i0<32; i0++)
+    for (int i1=0; i1<5; i1++){
+      zdcTime(i0,i1)=esdZDC->GetZDCTDCData(i0,i1);
+    }
+  for (int i=0; i<5; i++){
+    zdcEnergy(0,i)=esdZDC->GetZN1TowerEnergy()[i];
+    zdcEnergy(1,i)=esdZDC->GetZN2TowerEnergy()[i];
+    zdcEnergy(2,i)=esdZDC->GetZP1TowerEnergy()[i];
+    zdcEnergy(3,i)=esdZDC->GetZP2TowerEnergy()[i];
+    zdcEnergy(4,i)=esdZDC->GetZN1TowerEnergyLR()[i];
+    zdcEnergy(5,i)=esdZDC->GetZN2TowerEnergyLR()[i];
+    zdcEnergy(6,i)=esdZDC->GetZP1TowerEnergyLR()[i];
+    zdcEnergy(7,i)=esdZDC->GetZP2TowerEnergyLR()[i];
+  }
   //
 
   for (Int_t i=0;i<24;i++) { tZeroMult[i] = (Float_t) t0Amp[i]; }
@@ -968,6 +987,9 @@ Int_t AliESDtools::DumpEventVariables() {
                      "onlineMultMap.="       <<&onlineMultMap          <<  // online multiplicity bitmask
                      "offlineMultMap.="       <<&offlineMultMap        <<  // offline multiplicity bitmask
                      //
+                     "zdcTime.="            <<&zdcTime                 <<  //zdc time matrix
+                     "zdcEnergy.="            <<&zdcEnergy             <<  //zdc energy matrix
+                     //
                      "tZeroTime.="           << &tZeroTime             <<  // T0 time
                      "vZeroTime.="           << &vZeroTime             <<  // V0 time
                      "tZeroMult.="           << &tZeroMult             <<  // T0 multiplicity
@@ -992,7 +1014,7 @@ Int_t AliESDtools::DumpEventVariables() {
                      "nTOFclusters="<<nTOFclusters<<                       // tof mutliplicity estimators
                      "nTOFhits="<<nTOFhits<<
                      "nTOFmatches="<<nTOFmatches<<
-                     "nCaloClusters="<<nCaloClusters<<                     // calorimeter mutltiplicity estimators
+                     "nCaloClusters="<<nCaloClusters<<                     // calorimeter multiplicity estimators
                      "\n";
 
   return 0;

--- a/PWGPP/AliESDtools.cxx
+++ b/PWGPP/AliESDtools.cxx
@@ -844,6 +844,8 @@ Int_t AliESDtools::DumpEventVariables() {
   Int_t tpcClusterMultiplicity   = fEvent->GetNumberOfTPCClusters();
   Int_t tpcTrackBeforeClean=fEvent->GetNTPCTrackBeforeClean();
   const AliMultiplicity *multObj = fEvent->GetMultiplicity();
+  TBits onlineMultMap = multObj->GetFastOrFiredChips();
+  TBits offlineMultMap = multObj->GetFiredChipMap();
 
   Int_t itsNumberOfTracklets   = multObj->GetNumberOfTracklets();
 
@@ -956,6 +958,9 @@ Int_t AliESDtools::DumpEventVariables() {
                      "tpcTrackBeforeClean=" << tpcTrackBeforeClean <<   // tpc track before cleaning
                      "itsTracklets="         << itsNumberOfTracklets   <<  // number of ITS tracklets
                      "centrality.="          <<&centrality<<                // vector of centrality estimators
+                     //
+                     "onlineMultMap.="       <<&onlineMultMap          <<  // online multiplicity bitmask
+                     "offlineMultMap.="       <<&offlineMultMap        <<  // offline multiplicity bitmask
                      //
                      "tZeroMult.="           << &tZeroMult             <<  // T0 multiplicity
                      "vZeroMult.="           << &vZeroMult             <<  // V0 multiplicity

--- a/PWGPP/AliESDtools.cxx
+++ b/PWGPP/AliESDtools.cxx
@@ -857,6 +857,9 @@ Int_t AliESDtools::DumpEventVariables() {
   TVectorF phiCountCITSOnly(36);
   TVectorF tZeroMult(24);  for (Int_t i=1;i<24;i++) tZeroMult[i] = 0.f;
   TVectorF vZeroMult(64);  for (Int_t i=1;i<64;i++) vZeroMult[i] = 0.f;
+  TVectorF tZeroTime(24);  for (Int_t i=1;i<24;i++) tZeroTime[i] = 0.f;
+  TVectorF vZeroTime(64);  for (Int_t i=1;i<64;i++) vZeroTime[i] = 0.f;
+
   TVectorF itsClustersPerLayer(6); for (Int_t i=1;i<6;i++) itsClustersPerLayer[i] = 0.f;
   //
   for (Int_t i=1;i<37;i++){
@@ -870,11 +873,14 @@ Int_t AliESDtools::DumpEventVariables() {
   //
   // Additional counters for ITS TPC V0 and T0
   const AliESDTZERO *esdTzero = fEvent->GetESDTZERO();
-  const Double32_t *t0amp=esdTzero->GetT0amplitude();
+  const Double32_t *t0Amp=esdTzero->GetT0amplitude();
+  const Double32_t *t0Time=esdTzero->GetT0time();
   //
 
-  for (Int_t i=0;i<24;i++) { tZeroMult[i] = (Float_t) t0amp[i]; }
+  for (Int_t i=0;i<24;i++) { tZeroMult[i] = (Float_t) t0Amp[i]; }
+  for (Int_t i=0;i<24;i++) { tZeroTime[i] = (Float_t) t0Time[i]; }
   for (Int_t i=0;i<64;i++) { vZeroMult[i] = fEvent->GetVZEROData()-> GetMultiplicity(i); }
+  for (Int_t i=0;i<64;i++) { vZeroTime[i] = fEvent->GetVZEROData()-> GetTime(i); }
   for (Int_t i=0;i<6;i++)  { itsClustersPerLayer[i] = multObj->GetNumberOfITSClusters(i); }
   Int_t runNumber=fEvent->GetRunNumber();
   Double_t timeStampS=fEvent->GetTimeStamp();
@@ -949,7 +955,7 @@ Int_t AliESDtools::DumpEventVariables() {
                      "vz="                   << fVz                    <<  // vertex Z
                      "tpcvz="                << TPCvZ                 <<
                      "spdvz="                << SPDvZ                 <<
-                     "tpcMult="              << TPCMult               <<  //  TPC multiplicity
+                     "tpcMult="              << TPCMult               <<  //  TPC multiplicityf
                      "eventMult="            << eventMult             <<  //  event multiplicity
                      "eventMultESD="         << eventMultESD           <<  //  event multiplicity ESD
                      "nTracksStored="        << nTracksStored          <<  // number of sored tracks
@@ -962,6 +968,8 @@ Int_t AliESDtools::DumpEventVariables() {
                      "onlineMultMap.="       <<&onlineMultMap          <<  // online multiplicity bitmask
                      "offlineMultMap.="       <<&offlineMultMap        <<  // offline multiplicity bitmask
                      //
+                     "tZeroTime.="           << &tZeroTime             <<  // T0 time
+                     "vZeroTime.="           << &vZeroTime             <<  // V0 time
                      "tZeroMult.="           << &tZeroMult             <<  // T0 multiplicity
                      "vZeroMult.="           << &vZeroMult             <<  // V0 multiplicity
                      "itsClustersPerLayer.=" << &itsClustersPerLayer   <<  // its clusters per layer

--- a/PWGPP/AliESDtools.cxx
+++ b/PWGPP/AliESDtools.cxx
@@ -77,6 +77,7 @@
 #include "AliESDTOFHit.h"
 #include "AliTOFGeometry.h"
 #include "AliESDZDC.h"
+#include "AliTriggerAnalysis.h"
 
 ClassImp(AliESDtools)
 AliESDtools*  AliESDtools::fgInstance;
@@ -111,6 +112,8 @@ AliESDtools::AliESDtools():
   fStreamer(nullptr)
 {
   fgInstance=this;
+  fTriggerAnalysis=new AliTriggerAnalysis;
+
 }
 
 /// Initialize tool - set ESD address and book histogram counters
@@ -847,6 +850,12 @@ Int_t AliESDtools::DumpEventVariables() {
   const AliMultiplicity *multObj = fEvent->GetMultiplicity();
   TBits onlineMultMap = multObj->GetFastOrFiredChips();
   TBits offlineMultMap = multObj->GetFiredChipMap();
+  AliESDZDC* esdZDC = fEvent->GetESDZDC();
+  bool isLaserEvent =  fTriggerAnalysis->IsLaserWarmUpTPCEvent(fEvent);
+  bool isHVdip =  fTriggerAnalysis->IsHVdipTPCEvent(fEvent);
+  bool isIncomplete = fTriggerAnalysis->IsIncompleteEvent(fEvent);
+  bool isZnaHit = esdZDC->IsZNAhit();
+  bool isZncHit = esdZDC->IsZNChit();
 
   Int_t itsNumberOfTracklets   = multObj->GetNumberOfTracklets();
 
@@ -877,7 +886,6 @@ Int_t AliESDtools::DumpEventVariables() {
   const Double32_t *t0Amp=esdTzero->GetT0amplitude();
   const Double32_t *t0Time=esdTzero->GetT0time();
   //  ZDC amplitude  and timers
-  AliESDZDC* esdZDC = fEvent->GetESDZDC();
   TMatrixF zdcTime(32,4);
   TMatrixF zdcEnergy(8,5);
   for (int i0=0; i0<32; i0++)
@@ -971,7 +979,14 @@ Int_t AliESDtools::DumpEventVariables() {
                      "timeStampS="           << timeStampS            <<  // time stamp in seconds -event building
                      "timestamp="            << timeStamp             <<  // more precise timestamp based on LHC clock
                      "triggerMask="          << triggerMask           <<  //trigger mask
-                     "vz="                   << fVz                    <<  // vertex Z
+                     //
+                     "isLaserEvent="        <<isLaserEvent           <<  // fTriggerAnalysis->IsLaserWarmUpTPCEvent(fEvent);
+                     "isHVdip="             <<isHVdip                <<  // fTriggerAnalysis->IsHVdipTPCEvent(fEvent);
+                     "isIncomplete="        <<isIncomplete           <<  // fTriggerAnalysis->IsIncompleteEvent(fEvent);
+                     "isZnaHit="            <<isZnaHit               <<  //esdZDC->IsZNAhit();
+                     "isZncHit="            << isZncHit              <<  // esdZDC->IsZNChit();
+                     //
+                     "vz="                   << fVz                   <<  // vertex Z
                      "tpcvz="                << TPCvZ                 <<
                      "spdvz="                << SPDvZ                 <<
                      "tpcMult="              << TPCMult               <<  //  TPC multiplicityf

--- a/PWGPP/AliESDtools.h
+++ b/PWGPP/AliESDtools.h
@@ -10,6 +10,7 @@ class TH1F;
 class AliExternalTrackParam;
 class AliESDEvent;
 class AliESDfriend;
+class AliTriggerAnalysis;
 //class TVectorF;
 #include "TNamed.h"
 
@@ -53,6 +54,7 @@ class AliESDtools : public TNamed {
   TTree *fESDtree;                                //! esd Tree pointer - class is not owner
   AliESDEvent * fEvent;                           //! esd event pointer - class is not owner
   AliPIDResponse   * fPIDResponse;                //! PID response object
+  AliTriggerAnalysis *fTriggerAnalysis;           //! tigger analysis
   Bool_t   fTaskMode;                             // analysis task mode
   TH1F *fHisITSVertex;                            // ITS z vertex histogram
   TH1F *fHisTPCVertexA;                           // TPC z vertex A side

--- a/PWGPP/macros/AddTaskFilteredTree.C
+++ b/PWGPP/macros/AddTaskFilteredTree.C
@@ -72,10 +72,10 @@ AliAnalysisTask* AddTaskFilteredTree(TString outputFile="")
   //
   AliAnalysisTaskFilteredTree *task = new AliAnalysisTaskFilteredTree("AliAnalysisTaskFilteredTree");
   //task->SetUseMCInfo(hasMC);
-  //task->SetLowPtTrackDownscaligF(1.e4);
-  //task->SetLowPtV0DownscaligF(1.e2);
-  task->SetLowPtTrackDownscaligF(1.e5);
-  task->SetLowPtV0DownscaligF(2.e3);
+  task->SetLowPtTrackDownscaligF(5.e3);
+  task->SetLowPtV0DownscaligF(5.e2);
+  //task->SetLowPtTrackDownscaligF(1.e5);
+  //task->SetLowPtV0DownscaligF(2.e3);
   task->SetProcessAll(kTRUE);
   task->SetProcessCosmics(kTRUE);
   if (gSystem->Getenv("AliAnalysisTaskFilteredTree_SetLowPtTrackDownscalingF")) {


### PR DESCRIPTION
## Goal: 
Enable to replay event selection
Updating event information for skimmed data.
More to be added in following commits related to the sphericity estimators and multiplicity QA https://alice.its.cern.ch/jira/browse/PWGPP-550

## Modifications
See more details in https://alice.its.cern.ch/jira/browse/PWGPP-584

* PWGPP-584 - pileup information as calculated in ESD before cleaning
  * commit acd652163ac9d19b570544f357f885d2781a9a02
* AliTriggerAnalysis::IsSPDOnVsOfPileup - Variables added
  *commitd 4ab6d67be6e8f9b61bf4bccb0a6535bcec7f159
* AliTriggerAnalysis::T0Decision AliTriggerAnalysis::T0Trigger  AliTriggerAnalysis::V0Trigger​_
  * commit 73e9e76e158b784b81dcae1fde25688975c0e055
* ZDC information to store raw time and Energy
  * commit c1a161a50ef2a06c7611a1e265442963d02887e2
* Adding subset of Boolen variables from AliTriggerAnalysis
  * commit 3dbbb4c93620b713bee90949501f945cff8dacae
* PWGPP-584, ATO-465 - remove deep secondaries nuclei to reduce skimmed data  volume in MC
  * commit 2ef4b27f88c6e6fda81641c61b968ddf091d7d1f
* PWGPP-584, ATO-465 0 using MC true +MB information for Nuclei skimming + bug fix in Filter - 
  * commit 8018d772ce96a31375b3368614d886d969674d02
* new default downsampling - PWGPP/macros/AddTaskFilteredTree.C
  * commit a502084308b694dca01429c07c1a34f3213e763