### PR TITLE
PWGPP-550, ATO-465 - adding barrel multiplicty and sum pt counters

### DIFF
--- a/PWGPP/AliAnalysisTaskFilteredTree.cxx
+++ b/PWGPP/AliAnalysisTaskFilteredTree.cxx
@@ -88,6 +88,7 @@
 #include "TVectorD.h"
 #include "TStatToolkit.h"
 #include "AliESDtools.h"
+#include "TVectorF.h"
 using namespace std;
 
 ClassImp(AliAnalysisTaskFilteredTree)
@@ -1559,15 +1560,20 @@ void AliAnalysisTaskFilteredTree::ProcessAll(AliESDEvent *const esdEvent, AliMCE
 	    "indexNearestComb="<<indexNearestComb;   // index of  nearest track for constrained track
 
           if (mcEvent){
+            Int_t multMCTracksAll= mcEvent->GetNumberOfTracks();
             static AliTrackReference refDummy;
             if (!refITS) refITS = &refDummy;
             if (!refTRD) refTRD = &refDummy;
             if (!refTOF) refTOF = &refDummy;
             if (!refEMCAL) refEMCAL = &refDummy;
             if (!refPHOS) refPHOS = &refDummy;
+            TVectorF vtxMCS(3,vtxMC.GetArray());
 	    downscaleCounter++;
             (*fTreeSRedirector)<<"highPt"<<	
               "multMCTrueTracks="<<multMCTrueTracks<<   // mC track multiplicities
+              "multMCTracksAll="<<  multMCTracksAll<<   //  mcEvent->GetNumberOfTracks();
+              "mcStackSize="<<mcStackSize<<      // MC stack sides - tack->GetNtrack();
+              "vtxMC.="<< &vtxMCS<<
               "nrefITS="<<nrefITS<<              // number of track references in the ITS
               "nrefTPC="<<nrefTPC<<              // number of track references in the TPC
               "nrefTRD="<<nrefTRD<<              // number of track references in the TRD

--- a/PWGPP/AliESDtools.h
+++ b/PWGPP/AliESDtools.h
@@ -25,6 +25,7 @@ class AliESDtools : public TNamed {
   Int_t  CacheITSVertexInformation(Bool_t doReset=1, Double_t dcaCut=0.05,  Double_t dcaZcut=0.15);
   Int_t  CacheTOFEventInformation(Bool_t dumpStreamer=0);
   Int_t CalculateEventVariables();
+  Int_t  FillTrackCounters();
   void TPCVertexFit(TH1F *hisVertex);
   Int_t  GetNearestTrack(const AliExternalTrackParam * trackMatch, Int_t indexSkip, AliESDEvent*event, Int_t trackType, Int_t paramType, AliExternalTrackParam & paramNearest);
   void   ProcessITSTPCmatchOut(AliESDEvent *const esdEvent, AliESDfriend *const esdFriend, TTreeStream *pcstream);
@@ -71,6 +72,11 @@ class AliESDtools : public TNamed {
   TH1F             * fHistPhiTPCCounterCITS;      // helper histogram phi counters
   TH1F             * fHistPhiITSCounterA;         // helper histogram phi counters
   TH1F             * fHistPhiITSCounterC;         // helper histogram phi counters
+  //
+  TH2S             * fHist2DTrackletsCounter;     // 2D tracklet Phi x tgl norm histogram
+  TH2S             * fHist2DTrackCounter;         // 2D track Phi x tgl histogram
+  TH2F             * fHist2DTrackSumPt;           // 2D track Phi x tgl sum pt histogram
+  //
   TVectorF         * fCacheTrackCounters;         // track counter
   TVectorF         * fCacheTrackTPCCountersZ;     // track counter with DCA z cut
   TVectorF         * fCacheTrackdEdxRatio;        // dEdx info counter


### PR DESCRIPTION
### PWGPP-550, ATO-465 - adding barrel multiplicity and sum pt counters
```
"hist2DTrackletsCounter.=" <<fHist2DTrackletsCounter<<    // 2D tracklet Phi x tgl norm histogram
"hist2DTrackCounter.="   << fHist2DTrackCounter<<        // 2D track Phi x tgl histogram
 "hist2DTrackSumPt.="     << fHist2DTrackSumPt<<          // 2D track Phi x tgl sum pt histogram
````
### PWGPP-550, ATO-465 - adding MC multiplicity information