### PR TITLE
DRAFT: Reject AOD events for which the relabeling of photon candidate…

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvV1.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvV1.cxx
@@ -352,7 +352,8 @@ AliAnalysisTaskGammaConvV1::AliAnalysisTaskGammaConvV1(): AliAnalysisTaskSE(),
   fEnableClusterCutsForTrigger(kFALSE),
   fDoMaterialBudgetWeightingOfGammasForTrueMesons(kFALSE),
   tBrokenFiles(NULL),
-  fFileNameBroken(NULL)
+  fFileNameBroken(NULL),
+  fFileWasAlreadyReported(kFALSE)
 {
 
 }
@@ -650,7 +651,8 @@ AliAnalysisTaskGammaConvV1::AliAnalysisTaskGammaConvV1(const char *name):
   fEnableClusterCutsForTrigger(kFALSE),
   fDoMaterialBudgetWeightingOfGammasForTrueMesons(kFALSE),
   tBrokenFiles(NULL),
-  fFileNameBroken(NULL)
+  fFileNameBroken(NULL),
+  fFileWasAlreadyReported(kFALSE)
 {
   // Define output slots here
   DefineOutput(1, TList::Class());
@@ -2241,11 +2243,11 @@ void AliAnalysisTaskGammaConvV1::UserCreateOutputObjects(){
     }
 
   }
-  if (fIsMC > 0){
-    tBrokenFiles = new TTree("BrokenFiles", "BrokenFiles");
-    tBrokenFiles->Branch("fileName",&fFileNameBroken);
-    fOutputContainer->Add(tBrokenFiles);
-  }
+  // create tree to store broken files
+  tBrokenFiles = new TTree("BrokenFiles", "BrokenFiles");
+  tBrokenFiles->Branch("fileName",&fFileNameBroken);
+  fOutputContainer->Add(tBrokenFiles);
+
   OpenFile(1);
   PostData(1, fOutputContainer);
   Int_t nContainerOutput = 2;
@@ -2266,6 +2268,8 @@ void AliAnalysisTaskGammaConvV1::UserCreateOutputObjects(){
 //_____________________________________________________________________________
 Bool_t AliAnalysisTaskGammaConvV1::Notify()
 {
+  fFileWasAlreadyReported = kFALSE;
+
   for(Int_t iCut = 0; iCut<fnCuts;iCut++){
     if (((AliConvEventCuts*)fEventCutArray->At(iCut))->GetPeriodEnum() == AliConvEventCuts::kNoPeriod && ((AliConvEventCuts*)fV0Reader->GetEventCuts())->GetPeriodEnum() != AliConvEventCuts::kNoPeriod){
         ((AliConvEventCuts*)fEventCutArray->At(iCut))->SetPeriodEnumExplicit(((AliConvEventCuts*)fV0Reader->GetEventCuts())->GetPeriodEnum());
@@ -2313,17 +2317,15 @@ void AliAnalysisTaskGammaConvV1::UserExec(Option_t *)
 
   Int_t eventQuality = ((AliConvEventCuts*)fV0Reader->GetEventCuts())->GetEventQuality();
   if(fInputEvent->IsIncompleteDAQ()==kTRUE) eventQuality = 2;  // incomplete event
-  // Event Not Accepted due to MC event missing or because it is incomplere or  wrong trigger for V0ReaderV1 => skip broken events/files
+  // Event Not Accepted due to MC event missing or because it is incomplete or  wrong trigger for V0ReaderV1 => skip broken events/files
   if(eventQuality == 2 || eventQuality == 3){
-    // write out name of broken file for first event
-    if (fIsMC > 0){
-      if (fInputEvent->IsA()==AliESDEvent::Class()){
-        if (((AliESDEvent*)fInputEvent)->GetEventNumberInFile() == 0){
-          fFileNameBroken = new TObjString(Form("%s",((TString)fV0Reader->GetCurrentFileName()).Data()));
-          if (tBrokenFiles) tBrokenFiles->Fill();
-          delete fFileNameBroken;
-        }
-      }
+    // write out name of broken file if it has not been done already
+    if(!fFileWasAlreadyReported){
+      fFileNameBroken = new TObjString(Form("%s",((TString)fV0Reader->GetCurrentFileName()).Data()));
+      AliInfo(Form("Adding %s to tree of broken files.", fFileNameBroken->GetString().Data()));
+      tBrokenFiles->Fill();
+      delete fFileNameBroken;
+      fFileWasAlreadyReported = kTRUE;
     }
 
     for(Int_t iCut = 0; iCut<fnCuts; iCut++){

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvV1.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvV1.h
@@ -408,7 +408,7 @@ class AliAnalysisTaskGammaConvV1 : public AliAnalysisTaskSE {
 
     AliAnalysisTaskGammaConvV1(const AliAnalysisTaskGammaConvV1&); // Prevent copy-construction
     AliAnalysisTaskGammaConvV1 &operator=(const AliAnalysisTaskGammaConvV1&); // Prevent assignment
-    ClassDef(AliAnalysisTaskGammaConvV1, 48);
+    ClassDef(AliAnalysisTaskGammaConvV1, 49);
 };
 
 #endif

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvV1.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvV1.h
@@ -402,6 +402,7 @@ class AliAnalysisTaskGammaConvV1 : public AliAnalysisTaskSE {
     Bool_t                            fDoMaterialBudgetWeightingOfGammasForTrueMesons;
     TTree*                            tBrokenFiles;                               // tree for keeping track of broken files
     TObjString*                       fFileNameBroken;                            // string object for broken file name
+    Bool_t                            fFileWasAlreadyReported;                    // to store if the current file was already marked broken 
 
   private:
 

--- a/PWGGA/GammaConvBase/AliConvEventCuts.h
+++ b/PWGGA/GammaConvBase/AliConvEventCuts.h
@@ -389,6 +389,10 @@ class AliConvEventCuts : public AliAnalysisCuts {
       Bool_t    SetSelectSubTriggerClass (Int_t selectSpecialSubTriggerClass);
       Bool_t    SetRejectExtraSignalsCut (Int_t extraSignal);
       Bool_t    SetVertexCut(Int_t vertexCut);
+      void    SetEventQuality(Int_t value)                                          { if (fEventQuality) {
+                                                                                        AliWarning(Form("Changing fEventQuality from %i to %i", fEventQuality, value));
+                                                                                      }
+                                                                                      fEventQuality = value                                     ; }  
       void    SetPeriodEnum (TString periodName);
       void    SetPeriodEnumExplicit ( PeriodVar periodEnum )                        { fPeriodEnum = periodEnum                                  ; }
       void    SetCorrectionTaskSetting(TString setting)                             { fCorrTaskSetting = setting                                ; }

--- a/PWGGA/GammaConvBase/AliV0ReaderV1.h
+++ b/PWGGA/GammaConvBase/AliV0ReaderV1.h
@@ -123,7 +123,7 @@ class AliV0ReaderV1 : public AliAnalysisTaskSE {
     void               RelabelAODs(Bool_t relabel=kTRUE)                {fRelabelAODs=relabel; return;}
     Bool_t             AreAODsRelabeled()                               {return fRelabelAODs;}
     Int_t              IsReaderPerformingRelabeling()                   {return fPreviousV0ReaderPerformsAODRelabeling;}
-    void               RelabelAODPhotonCandidates(AliAODConversionPhoton *PhotonCandidate);
+    Bool_t             RelabelAODPhotonCandidates(AliAODConversionPhoton *PhotonCandidate);
     void               SetPeriodName(TString name)                      {fPeriodName = name;
                                                                          AliInfo(Form("Set PeriodName to: %s",fPeriodName.Data()));
                                                                          return;}

--- a/PWGGA/GammaConvBase/AliV0ReaderV1.h
+++ b/PWGGA/GammaConvBase/AliV0ReaderV1.h
@@ -286,7 +286,7 @@ class AliV0ReaderV1 : public AliAnalysisTaskSE {
     AliV0ReaderV1 &operator=(const AliV0ReaderV1 &ref);
 
 
-    ClassDef(AliV0ReaderV1, 22)
+    ClassDef(AliV0ReaderV1, 23)
 
 };
 


### PR DESCRIPTION
…s fails (DATA & MC)

This change impacts only scenarios where the relabeling of AOD photon
candidates is performed within the AliV0Reader and NOT within the actual
AliAnalysisTask.

General info: After an event has passed the V0Reader's event selection,
the photon candidates are getting imported from the delta AOD file and
relabeled. This means that for every photon (skipping the candidate from now on)
from the delta AOD file its daughter tracks are tried to match with
two tracks from the set of all tracks within the event and relabeled on
success.

Before this change: If for a photon the relabeling fails (i.e. that
 the photon's daughter tracks can't be found within the event), then
its daughter tracks are set to negative and the photon will create
an entry under 'no tracks' in the
GammaConvV1_...->ConvCuts_...->IsPhotonSelected histogram and there
will be an error message. The event will not get rejected. The log
can get big since the error is shown for each photon where it fails.

With this change: If for a photon the relabeling fails, it will create
an entry in the same histogram as above. In addition, the quality of the
event will be set to 2 such that all AnalysisTasks which check the event
quality (I guess all) will reject this event. This will become visible
in the GammaConvV1_...->Cut Number...->...ESD Histograms->NEvents
histogram under 'Miss MC or inc. ev.' An error is shown at maximum once
per event (even less since it would be identical AliErrors)
Moreover, the filename of the current AOD file be added to the tree
of broken files. (Only for the GammaConvV1 task with this change)

The problem with failing relabeling was observed at GA_PbPb_AOD_MC
trainrun 1544, file /alice/sim/2019/LHC19h2a/297481/AOD/027/
also see: https://alice.its.cern.ch/jira/browse/ALIROOT-8304