### PR TITLE
PWGPP-584,ATO-465: MC histogram counters/sumPt and IsPileup

### DIFF
--- a/PWGPP/AliAnalysisTaskFilteredTree.cxx
+++ b/PWGPP/AliAnalysisTaskFilteredTree.cxx
@@ -319,7 +319,7 @@ void AliAnalysisTaskFilteredTree::UserCreateOutputObjects()
 }
 
 //_____________________________________________________________________________
-void AliAnalysisTaskFilteredTree::UserExec(Option_t *) 
+void AliAnalysisTaskFilteredTree::UserExec(Option_t *)
 {
   //
   // Called for each event
@@ -361,7 +361,7 @@ void AliAnalysisTaskFilteredTree::UserExec(Option_t *)
   }
   fESDtool->Init(NULL,fESD);
   fESDtool->CalculateEventVariables();
-
+  fESDtool->SetMCEvent(fMC);
   fESDtool->DumpEventVariables();
 
   //if set, use the environment variables to set the downscaling factors
@@ -2142,7 +2142,7 @@ void AliAnalysisTaskFilteredTree::ProcessV0(AliESDEvent *const esdEvent, AliMCEv
       }
 
       downscaleCounter++;
-      if (gid==0 && fMCEvent) {
+      if (gid==0 && fMC) {
         TString fileName(AliAnalysisManager::GetAnalysisManager()->GetTree()->GetCurrentFile()->GetName());
         fileName += TString::Format("%d", esdEvent->GetEventNumberInFile());
         gid = fileName.Hash();

--- a/PWGPP/AliAnalysisTaskFilteredTree.cxx
+++ b/PWGPP/AliAnalysisTaskFilteredTree.cxx
@@ -1253,6 +1253,12 @@ void AliAnalysisTaskFilteredTree::ProcessAll(AliESDEvent *const esdEvent, AliMCE
       {
         do //artificial loop (once) to make the continue statements jump out of the MC part
         {
+          if (gid==0) {
+            // generate GID from the file name and event number
+            TString fileName(AliAnalysisManager::GetAnalysisManager()->GetTree()->GetCurrentFile()->GetName());
+            fileName += TString::Format("%d", esdEvent->GetEventNumberInFile());
+            gid = fileName.Hash();
+          }
           multMCTrueTracks = GetMCTrueTrackMult(mcEvent,evtCuts,accCuts);
           //
           // global track
@@ -2136,6 +2142,11 @@ void AliAnalysisTaskFilteredTree::ProcessV0(AliESDEvent *const esdEvent, AliMCEv
       }
 
       downscaleCounter++;
+      if (gid==0 && fMCEvent) {
+        TString fileName(AliAnalysisManager::GetAnalysisManager()->GetTree()->GetCurrentFile()->GetName());
+        fileName += TString::Format("%d", esdEvent->GetEventNumberInFile());
+        gid = fileName.Hash();
+      }
       (*fTreeSRedirector)<<"V0s"<<
         "gid="<<gid<<                         //  global id of event
         "fLowPtV0DownscaligF="<<fLowPtV0DownscaligF<<

--- a/PWGPP/AliESDtools.cxx
+++ b/PWGPP/AliESDtools.cxx
@@ -80,6 +80,7 @@
 #include "AliESDHeader.h"
 #include "AliTriggerAnalysis.h"
 #include "AliESDUtils.h"
+#include "AliAnalysisManager.h"
 
 ClassImp(AliESDtools)
 AliESDtools*  AliESDtools::fgInstance;
@@ -968,6 +969,12 @@ Int_t AliESDtools::DumpEventVariables() {
   ULong64_t bunchCrossID = (ULong64_t)fEvent->GetBunchCrossNumber();
   ULong64_t periodID     = (ULong64_t)fEvent->GetPeriodNumber();
   ULong64_t gid = ((periodID << 36) | (orbitID << 12) | bunchCrossID);
+  // generate GID from the file name and event number
+  if (gid==0 && AliAnalysisManager::GetAnalysisManager()) {
+    TString fileName(AliAnalysisManager::GetAnalysisManager()->GetTree()->GetCurrentFile()->GetName());
+    fileName += TString::Format("%d", fEvent->GetEventNumberInFile());
+    gid = fileName.Hash();
+  }
   Short_t   eventMult = fEvent->GetNumberOfTracks();
   ULong64_t triggerMask = fEvent->GetTriggerMask();
   const Int_t  kNEstimators=27;

--- a/PWGPP/AliESDtools.cxx
+++ b/PWGPP/AliESDtools.cxx
@@ -912,13 +912,15 @@ Bool_t AliESDtools::IsPileup(Int_t index) {
 /// \return
 Int_t AliESDtools::FillMCCounters() {
   const Float_t kPileUpCut = 0.001;
+  const Float_t kPtCut=0.005; //
   if (!fMCEvent) return 0;
   AliStack *stack = fMCEvent->Stack();
   if (!stack) return 0;
   Int_t nPart = stack->GetNtrack();
   AliGenCocktailEventHeader *cocktailHeader = dynamic_cast<AliGenCocktailEventHeader *> (fMCEvent->GenEventHeader());
   TList *lgen = cocktailHeader ?  cocktailHeader->GetHeaders():nullptr;
-
+  fHist2DMCCounter->Reset();
+  fHist2DMCSumPt->Reset();
   for (Int_t iMc = 0; iMc < nPart; ++iMc) {
     if (lgen){
       AliMCParticle *mcPart = (AliMCParticle *) fMCEvent->GetTrack(iMc);
@@ -932,15 +934,16 @@ Int_t AliESDtools::FillMCCounters() {
     // only charged particles
     if (!particle->GetPDG()) continue;
     Double_t charge = particle->GetPDG()->Charge() / 3.;
-    if (TMath::Abs(charge) < 0.001) continue;
+    if (TMath::Abs(charge) < 0.5) continue;
     // physical primary
     Bool_t prim = stack->IsPhysicalPrimary(iMc);
     if (!prim) continue;
+    if (particle->Pt()<kPtCut) continue;
     Float_t phi = TMath::ATan2(particle->Py(), particle->Px());
     if (phi<0) phi+=TMath::TwoPi();
     Float_t tgl= particle->Pz()/particle->Pt();
     fHist2DMCCounter->Fill(phi,tgl);
-    fHist2DMCCounter->Fill(phi,tgl,particle->Pt());
+    fHist2DMCSumPt->Fill(phi,tgl,particle->Pt());
   }
 }
 

--- a/PWGPP/AliESDtools.h
+++ b/PWGPP/AliESDtools.h
@@ -11,6 +11,7 @@ class AliExternalTrackParam;
 class AliESDEvent;
 class AliESDfriend;
 class AliTriggerAnalysis;
+class AliMCEvent;
 //class TVectorF;
 #include "TNamed.h"
 
@@ -20,12 +21,15 @@ class AliESDtools : public TNamed {
   void Init(TTree* tree, AliESDEvent *event= nullptr);
   void SetStreamer(TTreeSRedirector *streamer){fStreamer=streamer;}
   static Double_t LoadESD(Int_t entry, Int_t verbose=0);
+  void SetMCEvent(AliMCEvent*event){fMCEvent=event;}
+  Bool_t IsPileup(Int_t index);
   /// caching
   Int_t  CacheTPCEventInformation();
   Int_t  CacheITSVertexInformation(Bool_t doReset=1, Double_t dcaCut=0.05,  Double_t dcaZcut=0.15);
   Int_t  CacheTOFEventInformation(Bool_t dumpStreamer=0);
   Int_t CalculateEventVariables();
   Int_t  FillTrackCounters();
+  Int_t  FillMCCounters();
   void TPCVertexFit(TH1F *hisVertex);
   Int_t  GetNearestTrack(const AliExternalTrackParam * trackMatch, Int_t indexSkip, AliESDEvent*event, Int_t trackType, Int_t paramType, AliExternalTrackParam & paramNearest);
   void   ProcessITSTPCmatchOut(AliESDEvent *const esdEvent, AliESDfriend *const esdFriend, TTreeStream *pcstream);
@@ -54,6 +58,7 @@ class AliESDtools : public TNamed {
   Int_t fVerbose;                                 // verbosity flag
   TTree *fESDtree;                                //! esd Tree pointer - class is not owner
   AliESDEvent * fEvent;                           //! esd event pointer - class is not owner
+  AliMCEvent *       fMCEvent;                    //! pointer to MCevent if available
   AliPIDResponse   * fPIDResponse;                //! PID response object
   AliTriggerAnalysis *fTriggerAnalysis;           //! tigger analysis
   Bool_t   fTaskMode;                             // analysis task mode
@@ -76,6 +81,8 @@ class AliESDtools : public TNamed {
   TH2S             * fHist2DTrackletsCounter;     // 2D tracklet Phi x tgl norm histogram
   TH2S             * fHist2DTrackCounter;         // 2D track Phi x tgl histogram
   TH2F             * fHist2DTrackSumPt;           // 2D track Phi x tgl sum pt histogram
+  TH2S             * fHist2DMCCounter;            // 2D MC primary Phi x tgl histogram  - filled optionaly if MC available
+  TH2F             * fHist2DMCSumPt;              // 2D MC primary Phi x tgl sum pt histogram - filled optionaly if MC available
   //
   TVectorF         * fCacheTrackCounters;         // track counter
   TVectorF         * fCacheTrackTPCCountersZ;     // track counter with DCA z cut


### PR DESCRIPTION
## PWGPP-584, ATO-465 - adding MC construct of GID

## MC histograms filled and stored per event
```
fHist2DMCCounter    = new TH2S("fHist2DMCCounter"," 2D MC particle Phi x tgl histogram", 18,0,TMath::TwoPi(),32,-4,4);
fHist2DMCSumPt      = new TH2F("fHist2DMCSumPt","2D MC particle Phi x tgl sum pt histogram", 36,0,TMath::TwoPi(),32,-4,4);
```
## IsPileUp implemented, using Generator index:
```
 Int_t theGen = mcPart->GetGeneratorIndex();
  AliGenEventHeader *gh = (AliGenEventHeader *) lgen->At(theGen);
  Double_t timeNs = gh->InteractionTime() * 1e9;
  if (TMath::Abs(timeNs) > kPileUpCut) return kTRUE;
```
