### PR TITLE
PWGPP-584,ATO-465: adding MC true event information vertex+event times

### DIFF
--- a/PWGPP/AliESDtools.cxx
+++ b/PWGPP/AliESDtools.cxx
@@ -1123,7 +1123,7 @@ Int_t AliESDtools::DumpEventVariables() {
         (*eventInfoMC)(i,3)=gh->InteractionTime() * 1e9;
         (*eventInfoMC)(i,4)=gh->NProduced();
         gh->PrimaryVertex(primVtx);
-        for (Int_t j=0; i<3; j++) (*eventInfoMC)(i,j)=primVtx[j];
+        for (Int_t j=0; j<3; j++) (*eventInfoMC)(i,j)=primVtx[j];
       }
     }
   }


### PR DESCRIPTION
## Pile-up simulation observation using event skimmed data:
MC true information summary dumped to the event trees as a matrix:
* columns (X,Y,Z, time, mult)
* row - per generator in cocktail

See details and example queries in JIRA:  https://alice.its.cern.ch/jira/browse/PWGPP-584?focusedCommentId=245972&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-245972

