### PR TITLE
Define fGlobalBC consistently for collision and trigger table

### DIFF
--- a/RUN3/AliAnalysisTaskAO2Dconverter.cxx
+++ b/RUN3/AliAnalysisTaskAO2Dconverter.cxx
@@ -556,7 +556,7 @@ void AliAnalysisTaskAO2Dconverter::UserExec(Option_t *)
   //---------------------------------------------------------------------------
   // Trigger data
   
-  trigger.fGlobalBC = GetEventIdAsLong(fESD->GetHeader());
+  trigger.fGlobalBC = evtid;
   trigger.fTriggerMask = fESD->GetTriggerMask();
   FillTree(kTrigger);
   


### PR DESCRIPTION
@pzhristov @jgrosseo. Shouldn't we use for consistency the new definition of the fGlobalBC also for the trigger table? I don't think we emulate the trigger decision for MC at this moment so I dont think it currently makes any difference. But I was wondering if for consistency we should update the definition also in this case. Thanks for your feedback and sorry in advance if I misunderstood the problem here. GM