### PR TITLE
fix wrapper to be used in root 6 aclic and interpreted mode

### DIFF
--- a/PWGJE/EMCALJetTasks/AliFJWrapper.h
+++ b/PWGJE/EMCALJetTasks/AliFJWrapper.h
@@ -4,14 +4,11 @@
 #include <vector>
 #include <TString.h>
 
-#if ROOT_VERSION_CODE < ROOT_VERSION(6,0,0)
 #if !defined(__CINT__)
-#endif
 
 #include "AliLog.h"
 #include "FJ_includes.h"
 #include "AliJetShape.h"
-
 
 class AliFJWrapper
 {
@@ -247,10 +244,8 @@ class AliFJWrapper
   AliFJWrapper(const AliFJWrapper& wrapper);
   AliFJWrapper& operator = (const AliFJWrapper& wrapper);
 };
-#endif
-#if ROOT_VERSION_CODE < ROOT_VERSION(6,0,0)
-#endif
-#endif
+#endif /*__CINT__*/
+#endif /*AliFJWrapper_H*/
 
 #ifdef AliFJWrapper_CXX
 #undef AliFJWrapper_CXX

--- a/PWGJE/EMCALJetTasks/AliFJWrapper.h
+++ b/PWGJE/EMCALJetTasks/AliFJWrapper.h
@@ -1,10 +1,13 @@
 #ifndef AliFJWrapper_H
 #define AliFJWrapper_H
 
-#if !defined(__CINT__)
-
 #include <vector>
 #include <TString.h>
+
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,0,0)
+#if !defined(__CINT__)
+#endif
+
 #include "AliLog.h"
 #include "FJ_includes.h"
 #include "AliJetShape.h"
@@ -244,6 +247,8 @@ class AliFJWrapper
   AliFJWrapper(const AliFJWrapper& wrapper);
   AliFJWrapper& operator = (const AliFJWrapper& wrapper);
 };
+#endif
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,0,0)
 #endif
 #endif
 
@@ -1721,13 +1726,4 @@ Double32_t AliFJWrapper::NSubjettinessDerivativeSub(Int_t N, Int_t Algorithm, Do
   else return -2;
 
 }
-
-
-
-
-
-
-
-
-
 #endif

--- a/PWGJE/EMCALJetTasks/AliFJWrapper.h
+++ b/PWGJE/EMCALJetTasks/AliFJWrapper.h
@@ -4,7 +4,7 @@
 #include <vector>
 #include <TString.h>
 
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,0,0)
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,0,0)
 #if !defined(__CINT__)
 #endif
 
@@ -248,7 +248,7 @@ class AliFJWrapper
   AliFJWrapper& operator = (const AliFJWrapper& wrapper);
 };
 #endif
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,0,0)
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,0,0)
 #endif
 #endif
 

--- a/PWGJE/EMCALJetTasks/PWGJEEMCALJetTasksLinkDef.h
+++ b/PWGJE/EMCALJetTasks/PWGJEEMCALJetTasksLinkDef.h
@@ -251,7 +251,7 @@
 #ifdef HAVE_FASTJET
 // Classes which need direct access only to Fastjet objects (not
 // needed if wrapped into ALICE objects)
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,0,0)
+#ifdef __CLING__
 #pragma link C++ class AliFJWrapper;
 #endif
 #pragma link C++ class AliEmcalJetUtility+;

--- a/PWGJE/EMCALJetTasks/PWGJEEMCALJetTasksLinkDef.h
+++ b/PWGJE/EMCALJetTasks/PWGJEEMCALJetTasksLinkDef.h
@@ -251,7 +251,7 @@
 #ifdef HAVE_FASTJET
 // Classes which need direct access only to Fastjet objects (not
 // needed if wrapped into ALICE objects)
-#if ROOT_VERSION_CODE > ROOT_VERSION(6,0,0)
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,0,0)
 #pragma link C++ class AliFJWrapper;
 #endif
 #pragma link C++ class AliEmcalJetUtility+;

--- a/PWGJE/EMCALJetTasks/PWGJEEMCALJetTasksLinkDef.h
+++ b/PWGJE/EMCALJetTasks/PWGJEEMCALJetTasksLinkDef.h
@@ -251,6 +251,9 @@
 #ifdef HAVE_FASTJET
 // Classes which need direct access only to Fastjet objects (not
 // needed if wrapped into ALICE objects)
+#if ROOT_VERSION_CODE > ROOT_VERSION(6,0,0)
+#pragma link C++ class AliFJWrapper;
+#endif
 #pragma link C++ class AliEmcalJetUtility+;
 #pragma link C++ class AliEmcalJetUtilityGenSubtractor+;
 #pragma link C++ class AliEmcalJetUtilityConstSubtractor+;


### PR DESCRIPTION
It would be good to check these changes on root5, they should keep root 5 unaffected but allow the improvements in root 6. 