### PR TITLE
PWG/EMCAL: Added final shaper + testbeam correction to correction framework

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.cxx
@@ -1278,7 +1278,34 @@ Float_t AliEMCALRecoUtils::CorrectClusterEnergyLinearity(AliVCluster* cluster)
       
       break;
     }  
+    case kTestBeamShaper:
+    {
+      // THIS PARAMETRIZATION HAS TO BE USED TOGETHER WITH THE SHAPER NONLINEARITY: 
+      // Final parametrization of testbeam data points, 
+      // includes also points for E>100 GeV and determined on shaper corrected data.
 
+    //  fNonLinearityParams[0] = 1.91897;
+    //  fNonLinearityParams[1] = 0.0264988;
+    //  fNonLinearityParams[2] = 0.965663;
+    //  fNonLinearityParams[3] = -187.501;
+    //  fNonLinearityParams[4] = 2762.51;
+      energy /= ( 1.0505 * (fNonLinearityParams[0] + fNonLinearityParams[1] * TMath::Log(energy) ) / ( 1 + ( fNonLinearityParams[2] * TMath::Exp( ( energy - fNonLinearityParams[3] ) / fNonLinearityParams[4] ) ) ) );
+      
+      break;
+    }
+    case kTestBeamFinalMC:
+    {
+      // Final parametrization of testbeam MC points, 
+      // includes also points for E>100 GeV
+
+    //  fNonLinearityParams[0] = 1.09357;
+    //  fNonLinearityParams[1] = 0.0192266;
+    //  fNonLinearityParams[2] = 0.291993;
+    //  fNonLinearityParams[3] = 370.927;
+    //  fNonLinearityParams[4] = 694.656;
+      energy /= ( 1.00 * (fNonLinearityParams[0] + fNonLinearityParams[1] * TMath::Log(energy) ) / ( 1 + ( fNonLinearityParams[2] * TMath::Exp( ( energy - fNonLinearityParams[3] ) / fNonLinearityParams[4] ) ) ) );
+      break;
+    }
     
     case kNoCorrection:
       AliDebug(2,"No correction on the energy\n");
@@ -1479,7 +1506,7 @@ if (fNonLinearityFunction == kPCMv1) {
     fNonLinearityParams[4] = 0.;
     fNonLinearityParams[5] = 0.;
     fNonLinearityParams[6] = 0.;
-  }
+}
 
  if (fNonLinearityFunction == kPCMplusBTCv1) {
    // test beam corrected values convoluted with symmetric meson decays values
@@ -1510,6 +1537,21 @@ if (fNonLinearityFunction == kPCMv1) {
    fNonLinearityParams[4] =  1.0;
    fNonLinearityParams[5] =  0.0;
    fNonLinearityParams[6] =  0.0;
+ }
+
+ if (fNonLinearityFunction == kTestBeamShaper) {
+   fNonLinearityParams[0] =  1.91897;
+   fNonLinearityParams[1] =  0.0264988;
+   fNonLinearityParams[2] =  0.965663;
+   fNonLinearityParams[3] =  -187.501;
+   fNonLinearityParams[4] =  2762.51;
+ }
+ if (fNonLinearityFunction == kTestBeamFinalMC) {
+   fNonLinearityParams[0] =  1.09357;
+   fNonLinearityParams[1] =  0.0192266;
+   fNonLinearityParams[2] =  0.291993;
+   fNonLinearityParams[3] =  370.927;
+   fNonLinearityParams[4] =  694.656;
  }
 }
 

--- a/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.h
+++ b/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.h
@@ -70,7 +70,8 @@ public:
   void     Print(const Option_t*) const;
 
   /// Non linearity enum list of possible parametrizations. 
-  /// Recomended for data kBeamTestCorrectedv3 and for simulation kPi0MCv3
+  /// Recomended for data kTestBeamShaper and for simulation kTestBeamFinalMC
+  /// (this also requires enableShaperCorrection: true in the .yaml configuration for data)
   enum     NonlinearityFunctions
   { 
     kPi0MC   = 0, kPi0GammaGamma = 1,
@@ -86,7 +87,9 @@ public:
     kPCMsysv1 = 16,            // variation of kPCMv1 to calculate systematics
     kBeamTestCorrectedv4 = 17, // Different parametrization of v3 but similar, improve E>100 GeV linearity
     kBeamTestNS = 18,          // Custom fit of all avail. TB points and E>100 GeV data
-    kPi0MCNS = 19              // Custom fit of all avail. TB points and E>100 GeV MC
+    kPi0MCNS = 19,             // Custom fit of all avail. TB points and E>100 GeV MC
+    kTestBeamShaper = 20,      // Final/official fit of all avail. TB points and E>100 GeV data corrected for shaper NL
+    kTestBeamFinalMC = 21      // Final/official fit of all avail. TB points and E>100 GeV MC
   };
 
   /// Cluster position enum list of possible algoritms

--- a/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.h
+++ b/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.h
@@ -628,7 +628,7 @@ private:
   Bool_t     fMCGenerToAcceptForTrack;   ///<  Activate the removal of tracks entering the track matching that come from a particular generator
   
   /// \cond CLASSIMP
-  ClassDef(AliEMCALRecoUtils, 33) ;
+  ClassDef(AliEMCALRecoUtils, 34) ;
   /// \endcond
 
 };

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterNonLinearity.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterNonLinearity.cxx
@@ -34,7 +34,9 @@ const std::map <std::string, AliEMCALRecoUtils::NonlinearityFunctions> AliEmcalC
     { "kPCMsysv1", AliEMCALRecoUtils::kPCMsysv1 },
     { "kBeamTestCorrectedv4", AliEMCALRecoUtils::kBeamTestCorrectedv4 },
     { "kBeamTestNS", AliEMCALRecoUtils::kBeamTestNS },
-    { "kPi0MCNS", AliEMCALRecoUtils::kPi0MCNS }
+    { "kPi0MCNS", AliEMCALRecoUtils::kPi0MCNS },
+    { "kTestBeamShaper", AliEMCALRecoUtils::kTestBeamShaper },
+    { "kTestBeamFinalMC", AliEMCALRecoUtils::kTestBeamFinalMC }
 };
 
 /**

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterNonLinearityMCAfterburner.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterNonLinearityMCAfterburner.cxx
@@ -186,11 +186,13 @@ Bool_t AliEmcalCorrectionClusterNonLinearityMCAfterburner::Run()
 //________________________________________________________________________
 TString AliEmcalCorrectionClusterNonLinearityMCAfterburner::SummarizeMCProductions(TString namePeriod)
 {
+  // Globally valid testbeam fine tuning (separate values for Run1 and Run2)
+  if ( namePeriod.CompareTo("kTestBeamFinalMCRun2") == 0  )    return "kTestBeamFinalMCRun2";
+  else if ( namePeriod.CompareTo("kTestBeamFinalMCRun1") == 0  )    return "kTestBeamFinalMCRun1";
   //...MC anchored to 2015 Data...
-  //
   // pp 13 TeV
   // - 2015 MB pass 2
-  if ( namePeriod.CompareTo("LHC15P2Pyt8") == 0 ||
+  else if ( namePeriod.CompareTo("LHC15P2Pyt8") == 0 ||
       namePeriod.CompareTo("LHC17i4") == 0 ||
       namePeriod.CompareTo("LHC17i4_2") == 0 ||
       namePeriod.CompareTo("LHC17g7") == 0 )              return "kPP13T15P2Pyt8";
@@ -367,6 +369,31 @@ void AliEmcalCorrectionClusterNonLinearityMCAfterburner::InitNonLinearityParam(T
     //. . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
     //These are the standard parameters extracted from the PCM method (one hit in EMCal + one converted gamma)
     case kPCM_EMCal:
+      // globally valid Run2 fine tuning for the testbeam+shaper corrected clusters
+      if( namePeriod=="kTestBeamFinalMCRun2") {
+        fNonLinearityAfterburnerFunction = 1;
+        //There are no extracted parameters yet
+        //Iteration-1 paramters
+        fNLAfterburnerPara[0] = 0.987912;
+        fNLAfterburnerPara[1] = -2.94105;
+        fNLAfterburnerPara[2] = -0.273207;
+        //Iteration-2 parameters
+        fNLAfterburnerPara[3] = 0;
+        fNLAfterburnerPara[4] = 0;
+        fNLAfterburnerPara[5] = 0;
+      }
+      if( namePeriod=="kTestBeamFinalMCRun1") {
+        fNonLinearityAfterburnerFunction = 1;
+        //There are no extracted parameters yet
+        //Iteration-1 paramters
+        fNLAfterburnerPara[0] = 0.987912;
+        fNLAfterburnerPara[1] = -2.94105;
+        fNLAfterburnerPara[2] = -0.273207;
+        //Iteration-2 parameters
+        fNLAfterburnerPara[3] = -0.0125; // Run1 additional correction factor of 1.25%
+        fNLAfterburnerPara[4] = 0;
+        fNLAfterburnerPara[5] = 0;
+      }
       // pp 5.02 TeV (2015) - LHC15n
       if( namePeriod=="k16h3" ||  namePeriod=="k17e2" || namePeriod == "k18j3") {
         fNonLinearityAfterburnerFunction = 1;


### PR DESCRIPTION
This PR introduces the final testbeam nonlinearity to the correction framework.
The following settings need to be selected in order to correctly activate it:

Settings for Data:
CellEnergy:
    enableShaperCorrection: true 
ClusterNonLinearity:
    enabled: true
    nonLinFunct: kTestBeamShaper

Settings for MC:
ClusterNonLinearity:
    enabled: true
    nonLinFunct: kTestBeamFinalMC
ClusterNonLinearityMCAfterburner:
    enabled: true
    afterburnerVersion: kPCM_EMCal
    setMCPeriod: "kTestBeamFinalMCRun2" # for Run1 choose kTestBeamFinalMCRun1
