### PR TITLE
ATO-465 - adding SQL query options and example usage using csvkit

### DIFF
--- a/PWGPP/macros/pcalimonitorCSV.sh
+++ b/PWGPP/macros/pcalimonitorCSV.sh
@@ -10,6 +10,7 @@ init(){
 "List of functions:"
 dumpCSV
 printSummary
+examleUsage
 exampleCase
 HELP_USAGE
 }
@@ -35,14 +36,31 @@ printSummary(){
   "makeDirs"
   Input:
         $1 - production csv
-        $2 - query
+        $2 - selection
+        $3 - where sort statements
   Output:
        JIRA print
   Example usage:
-     printSummary JobID,RunNo,input_events,wall_time,outputsize,outputsize/input_events table
+     printSummary JobID,RunNo,input_events,wall_time,outputsize,outputsize/input_events table "where input_events>10000"
 HELP_USAGE
-    [[ $# -ne 2 ]] &&return
-    csvsql --query "select $1 from '$2'" $2.csv | csvlook -l
+    [[ $# -lt 2 ]] &&return
+    echo csvsql --query "select $1 from '$2' '${3}' " $2.csv
+    csvsql --query "select $1 from '$2' ${3} " $2.csv | csvlook -l
+
+}
+
+exampleUsage(){
+    helpCat<<HELP_USAGE
+    exampleUsage
+    This is example usage of the pcalimonitorCSV.sh
+HELP_USAGE
+    source $AliPhysics_SRC/PWGPP/macros/pcalimonitorCSV.sh
+    dumpCSV https://alimonitor.cern.ch/prod/jobs.jsp?t=20831 table.csv
+    printSummary JobID,RunNo,input_events,wall_time,outputsize,outputsize/input_events table
+    #
+    dumpCSV https://alimonitor.cern.ch/prod/jobs.jsp?t=20831 table.csv
+    printSummary JobID,RunNo,input_events,wall_time,outputsize,outputsize/input_events table "where input_events>40000 ORDER BY input_events DESC"
+
 }
 
 exampleCase(){


### PR DESCRIPTION
# ATO-465 - adding SQL query options and example usage using csvkit
JIRA printing of the production summary 

* adding where  and sorting option

### Example usage for test https://alice.its.cern.ch/jira/browse/ALIROOT-8431  https://alimonitor.cern.ch/prod/jobs.jsp?t=20831
```
source $AliPhysics_SRC/PWGPP/macros/pcalimonitorCSV.sh
dumpCSV https://alimonitor.cern.ch/prod/jobs.jsp?t=20831 table.csv
printSummary JobID,RunNo,input_events,wall_time,outputsize,outputsize/input_events table "where input_events>40000 ORDER BY input_events DESC"
```
| line_numbers |         JobID |   RunNo | input_events |  wall_time |      outputsize | outputsize/input_events |
| ------------ | ------------- | ------- | ------------ | ---------- | --------------- | ----------------------- |
|            1 | 1.839.914.830 | 296.749 |   15.653.367 | 5.485,344… | 306.018.845.625 |             19.549,714… |
|            2 | 1.839.994.665 | 296.750 |   14.899.729 | 2.658,789… | 256.676.483.677 |             17.226,923… |
|            3 | 1.839.914.314 | 296.690 |   11.090.006 | 2.494,581… | 203.074.473.104 |             18.311,485… |
|            4 | 1.839.914.822 | 296.694 |    8.184.536 | 2.253,062… | 159.391.216.134 |             19.474,680… |
|            5 | 1.845.875.591 | 296.787 |    5.087.997 |   727,384… |  32.884.375.747 |              6.463,128… |
|            6 | 1.839.998.147 | 296.784 |    5.023.658 |   745,350… |  72.449.724.971 |             14.421,707… |
|            7 | 1.839.999.841 | 296.785 |    2.986.318 |   449,167… |  43.115.045.283 |             14.437,527… |
|            8 | 1.839.997.166 | 296.781 |    1.321.687 |   231,066… |  19.375.511.457 |             14.659,682… |
|            9 | 1.845.873.297 | 296.786 |    1.205.416 |   173,331… |   7.818.630.146 |              6.486,251… |
|           10 | 1.839.914.777 | 296.691 |    1.015.889 |   222,337… |  19.314.317.847 |             19.012,232… |
|           11 | 1.839.996.943 | 296.752 |      721.063 |    82,703… |   8.411.942.150 |             11.666,029… |
|           12 | 1.839.914.783 | 296.693 |      515.526 |   240,372… |  10.025.005.490 |             19.446,169… |
|           13 | 1.845.876.239 | 296.790 |      239.329 |    55,499… |   2.606.690.529 |             10.891,662… |


