### PR TITLE
EMCal Single Channel Calibration

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.cxx
@@ -55,6 +55,7 @@ AliEMCALRecoUtils::AliEMCALRecoUtils():
   fNonLinearityFunction(0),               fNonLinearThreshold(0),                 fUseShaperNonlin(kFALSE),
   fSmearClusterEnergy(kFALSE),            fRandom(),
   fCellsRecalibrated(kFALSE),             fRecalibration(kFALSE),                 fUse1Drecalib(kFALSE),                  fEMCALRecalibrationFactors(),
+  fCellsSingleChannelRecalibrated(kFALSE),fSingleChannelRecalibration(kFALSE),    fEMCALSingleChannelRecalibrationFactors(),
   fConstantTimeShift(0),                  fTimeRecalibration(kFALSE),             fEMCALTimeRecalibrationFactors(),       fLowGain(kFALSE),
   fUseL1PhaseInTimeRecalibration(kFALSE), fEMCALL1PhaseInTimeRecalibration(),
   fIsParRun(kFALSE),                      fCurrentParNumber(0),                   fNPars(0),                              fGlobalEventID(NULL),
@@ -112,6 +113,8 @@ AliEMCALRecoUtils::AliEMCALRecoUtils(const AliEMCALRecoUtils & reco)
   fCellsRecalibrated(reco.fCellsRecalibrated),
   fRecalibration(reco.fRecalibration),                       fUse1Drecalib(reco.fUse1Drecalib),                   
   fEMCALRecalibrationFactors(NULL),
+  fCellsSingleChannelRecalibrated(reco.fCellsRecalibrated),
+  fSingleChannelRecalibration(reco.fRecalibration),          fEMCALSingleChannelRecalibrationFactors(NULL),
   fConstantTimeShift(reco.fConstantTimeShift),  
   fTimeRecalibration(reco.fTimeRecalibration),               fEMCALTimeRecalibrationFactors(NULL),
   fLowGain(reco.fLowGain),
@@ -171,6 +174,14 @@ AliEMCALRecoUtils::AliEMCALRecoUtils(const AliEMCALRecoUtils & reco)
     for(int ism = 0; ism < reco.fEMCALRecalibrationFactors->GetEntries(); ism++) fEMCALRecalibrationFactors->AddAt(reco.fEMCALRecalibrationFactors->At(ism), ism);
   }
 
+  if(reco.fEMCALSingleChannelRecalibrationFactors) {
+    // Copy constructor - not taking ownership over calibration histograms
+    fEMCALSingleChannelRecalibrationFactors = new TObjArray(reco.fEMCALSingleChannelRecalibrationFactors->GetEntries());
+    fEMCALSingleChannelRecalibrationFactors->SetOwner(false);
+    for(int ism = 0; ism < reco.fEMCALSingleChannelRecalibrationFactors->GetEntries(); ism++) fEMCALSingleChannelRecalibrationFactors->AddAt(reco.fEMCALSingleChannelRecalibrationFactors->At(ism), ism);
+  }
+
+  
   if(reco.fEMCALTimeRecalibrationFactors) {
     // Copy constructor - not taking ownership over calibration histograms
     fEMCALTimeRecalibrationFactors = new TObjArray(reco.fEMCALTimeRecalibrationFactors->GetEntries());
@@ -349,6 +360,14 @@ AliEMCALRecoUtils & AliEMCALRecoUtils::operator = (const AliEMCALRecoUtils & rec
     fEMCALRecalibrationFactors->SetOwner(false);
     for(int ism = 0; ism < reco.fEMCALRecalibrationFactors->GetEntries(); ism++) fEMCALRecalibrationFactors->AddAt(reco.fEMCALRecalibrationFactors->At(ism), ism);
   }
+
+  if(fEMCALSingleChannelRecalibrationFactors) delete fEMCALSingleChannelRecalibrationFactors;
+  if(reco.fEMCALSingleChannelRecalibrationFactors) {
+    // Copy constructor - not taking ownership over calibration histograms
+    fEMCALSingleChannelRecalibrationFactors = new TObjArray(reco.fEMCALSingleChannelRecalibrationFactors->GetEntries());
+    fEMCALSingleChannelRecalibrationFactors->SetOwner(false);
+    for(int ism = 0; ism < reco.fEMCALSingleChannelRecalibrationFactors->GetEntries(); ism++) fEMCALSingleChannelRecalibrationFactors->AddAt(reco.fEMCALSingleChannelRecalibrationFactors->At(ism), ism);
+  }
   
   if(fEMCALTimeRecalibrationFactors) delete fEMCALTimeRecalibrationFactors;
   if(reco.fEMCALTimeRecalibrationFactors) {
@@ -379,7 +398,12 @@ AliEMCALRecoUtils::~AliEMCALRecoUtils()
   { 
     delete fEMCALRecalibrationFactors;
   }  
-  
+
+  if (fEMCALSingleChannelRecalibrationFactors) 
+  { 
+    delete fEMCALSingleChannelRecalibrationFactors;
+  }  
+
   if (fEMCALTimeRecalibrationFactors) 
   { 
     delete fEMCALTimeRecalibrationFactors;
@@ -1928,6 +1952,41 @@ void AliEMCALRecoUtils::InitEMCALRecalibrationFactors1D()
 }
 
 ///
+/// Init EMCAL single channel energy calibration factors container
+///
+//_____________________________________________________
+void AliEMCALRecoUtils::InitEMCALSingleChannelRecalibrationFactors()
+{
+  AliDebug(2,"AliCalorimeterUtils::InitEMCALSingleChannelRecalibrationFactors()");
+  
+  // In order to avoid rewriting the same histograms
+  Bool_t oldStatus = TH1::AddDirectoryStatus();
+  TH1::AddDirectory(kFALSE);
+  
+  fEMCALSingleChannelRecalibrationFactors = new TObjArray(22);
+  for (int i = 0; i < 22; i++) 
+    fEMCALSingleChannelRecalibrationFactors->Add(new TH2F(Form("EMCALSCCalibMap_Mod%d",i),
+							  Form("EMCALSCCalibMap_Mod%d",i),  48, 0, 48, 24, 0, 24));
+  //Init the histograms with 1
+  for (Int_t sm = 0; sm < 22; sm++) 
+  {
+    for (Int_t i = 0; i < 48; i++) 
+    {
+      for (Int_t j = 0; j < 24; j++) 
+      {
+        SetEMCALSingleChannelRecalibrationFactor(sm,i,j,1.);
+      }
+    }
+  }
+  
+  fEMCALSingleChannelRecalibrationFactors->SetOwner(kTRUE);
+  fEMCALSingleChannelRecalibrationFactors->Compress();
+  
+  // In order to avoid rewriting the same histograms
+  TH1::AddDirectory(oldStatus);    
+}
+
+///
 /// Init EMCAL time calibration shifts container
 ///
 //_________________________________________________________
@@ -2099,6 +2158,7 @@ void AliEMCALRecoUtils::RecalibrateClusterEnergy(const AliEMCALGeometry* geom,
   Int_t   absId  =-1;
   Int_t   icol   =-1, irow =-1, imod=1;
   Float_t factor = 1, frac = 0;
+  Float_t factorSC = 1;
   Int_t   absIdMax = -1;
   Float_t emax     = 0;
   
@@ -2126,13 +2186,27 @@ void AliEMCALRecoUtils::RecalibrateClusterEnergy(const AliEMCALGeometry* geom,
       AliDebug(2,Form("AliEMCALRecoUtils::RecalibrateClusterEnergy - recalibrate cell: module %d, col %d, row %d, cell fraction %f,recalibration factor %f, cell energy %f\n",
                       imod,icol,irow,frac,factor,cells->GetCellAmplitude(absId)));
       
-    } 
-    
-    energy += cells->GetCellAmplitude(absId)*factor*frac;
-    
-    if (emax < cells->GetCellAmplitude(absId)*factor*frac) 
+    }
+    if (!fCellsSingleChannelRecalibrated && IsSingleChannelRecalibrationOn()) 
     {
-      emax     = cells->GetCellAmplitude(absId)*factor*frac;
+      // Single Channel  
+      Int_t iTower = -1, iIphi = -1, iIeta = -1; 
+      geom->GetCellIndex(absId,imod,iTower,iIphi,iIeta); 
+      if (fEMCALSingleChannelRecalibrationFactors->GetEntries() <= imod) 
+        continue;
+      geom->GetCellPhiEtaIndexInSModule(imod,iTower,iIphi, iIeta,irow,icol);      
+      factorSC = GetEMCALSingleChannelRecalibrationFactor(imod,icol,irow);
+      
+      AliDebug(2,Form("AliEMCALRecoUtils::RecalibrateClusterEnergy - sinlge channel recalibrate cell: module %d, col %d, row %d, cell fraction %f,recalibration factor %f, cell energy %f\n",
+                      imod,icol,irow,frac,factorSC,cells->GetCellAmplitude(absId)));
+      
+    }
+    
+    energy += cells->GetCellAmplitude(absId)*factor*factorSC*frac;
+    
+    if (emax < cells->GetCellAmplitude(absId)*factor*factorSC*frac) 
+    {
+      emax     = cells->GetCellAmplitude(absId)*factor*factorSC*frac;
       absIdMax = absId;
     }
   }
@@ -4194,7 +4268,41 @@ TH2F * AliEMCALRecoUtils::GetEMCALChannelRecalibrationFactors(Int_t iSM) const{
     }
     return hist;
   }
+}
 
+/*
+ Setting EMCAL and DCAL single channel calibration factors using a map
+ */
+void AliEMCALRecoUtils::SetEMCALSingleChannelRecalibrationFactors(const TObjArray *map) { 
+  if(fEMCALSingleChannelRecalibrationFactors) fEMCALSingleChannelRecalibrationFactors->Clear();
+  else {
+    fEMCALSingleChannelRecalibrationFactors = new TObjArray(map->GetEntries());
+    fEMCALSingleChannelRecalibrationFactors->SetOwner(true);
+  }
+  if(!fEMCALSingleChannelRecalibrationFactors->IsOwner()){
+    // Must claim ownership since the new objects are owend by this instance
+    fEMCALSingleChannelRecalibrationFactors->SetOwner(kTRUE);
+  }
+  for(int i = 0; i < map->GetEntries(); i++){
+    TH2F *hist = dynamic_cast<TH2F *>(map->At(i));
+    if(!hist) continue;
+    this->SetEMCALSingleChannelRecalibrationFactors(i, hist);
+  }
+}
+
+/*
+ Setting EMCAL and DCAL single channel calibration factors using an SM by SM histogram
+ */
+void AliEMCALRecoUtils::SetEMCALSingleChannelRecalibrationFactors(Int_t iSM , const TH2F* h) { 
+  if(!fEMCALSingleChannelRecalibrationFactors){
+    fEMCALSingleChannelRecalibrationFactors = new TObjArray(iSM);
+    fEMCALSingleChannelRecalibrationFactors->SetOwner(true);
+  }
+  if(fEMCALSingleChannelRecalibrationFactors->GetEntries() <= iSM) fEMCALSingleChannelRecalibrationFactors->Expand(iSM+1);
+  if(fEMCALSingleChannelRecalibrationFactors->At(iSM)) fEMCALSingleChannelRecalibrationFactors->RemoveAt(iSM);
+  TH2F *clone = new TH2F(*h);
+  clone->SetDirectory(NULL);
+  fEMCALSingleChannelRecalibrationFactors->AddAt(clone,iSM); 
 }
 
 void AliEMCALRecoUtils::SetEMCALChannelStatusMap(const TObjArray *map) { 

--- a/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.h
+++ b/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.h
@@ -206,6 +206,24 @@ public:
   void     SwitchOffRunDepCorrection()                   { fUseRunCorrectionFactors = kFALSE ; }
   void     SwitchOnRunDepCorrection()                    { fUseRunCorrectionFactors = kTRUE  ; 
                                                            SwitchOnRecalibration()           ; }      
+  // Single Channel Calibration
+  Bool_t   IsSingleChannelRecalibrationOn()                     const { return fSingleChannelRecalibration ; }
+  void     SwitchOffSingleChannelRecalibration()                      { fSingleChannelRecalibration = kFALSE ; }
+  void     SwitchOnSingleChannelRecalibration()                       { fSingleChannelRecalibration = kTRUE  ; 
+                                                                        if(!fEMCALSingleChannelRecalibrationFactors)InitEMCALSingleChannelRecalibrationFactors() ; }
+  void     InitEMCALSingleChannelRecalibrationFactors() ;
+  TObjArray* GetEMCALSingleChannelRecalibrationFactorsArray()   const { return fEMCALSingleChannelRecalibrationFactors ; }
+  TH2F *   GetEMCALSingleChannelRecalibrationFactors(Int_t iSM)     const { return (TH2F*)fEMCALSingleChannelRecalibrationFactors->At(iSM) ; }	
+  Float_t  GetEMCALSingleChannelRecalibrationFactor(Int_t iSM , Int_t iCol, Int_t iRow) const { 
+    if(fEMCALSingleChannelRecalibrationFactors) 
+      return (Float_t) ((TH2F*)fEMCALSingleChannelRecalibrationFactors->At(iSM))->GetBinContent(iCol,iRow); 
+    else return 1 ; } 
+  void     SetEMCALSingleChannelRecalibrationFactors(const TObjArray *map);
+  void     SetEMCALSingleChannelRecalibrationFactors(Int_t iSM , const TH2F* h);
+  void     SetEMCALSingleChannelRecalibrationFactor(Int_t iSM , Int_t iCol, Int_t iRow, Double_t c = 1) { 
+    if(!fEMCALSingleChannelRecalibrationFactors) InitEMCALSingleChannelRecalibrationFactors() ;
+    ((TH2F*)fEMCALSingleChannelRecalibrationFactors->At(iSM))->SetBinContent(iCol,iRow,c) ; }
+  
   // Time Recalibration
   void     SetUseOneHistForAllBCs(Bool_t useOneHist)     { fDoUseMergedBC = useOneHist ; }
   void     SetConstantTimeShift(Float_t shift)           { fConstantTimeShift = shift  ; }
@@ -539,7 +557,12 @@ private:
   Bool_t     fRecalibration;             ///< Switch on or off the recalibration
   Bool_t     fUse1Drecalib;              ///< Flag to use one dimensional recalibration histogram
   TObjArray* fEMCALRecalibrationFactors; ///< Array of histograms with map of recalibration factors, EMCAL
-    
+
+  // Single Channel Energy Recalibration 
+  Bool_t     fCellsSingleChannelRecalibrated;         ///< Internal bool to check if cells (time/energy) where recalibrated and not recalibrate them when recalculating different things
+  Bool_t     fSingleChannelRecalibration;             ///< Switch on or off the single channel calibration
+  TObjArray* fEMCALSingleChannelRecalibrationFactors; ///< Array of histograms with map of single channel calibration factors, EMCAL and DCAL
+  
   // Time Recalibration 
   Float_t    fConstantTimeShift;         ///< Apply a 600 ns (+15.8) time shift in case of simulation, shift in ns.
   Bool_t     fTimeRecalibration;         ///< Switch on or off the time recalibration

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellSingleChannelCalibration.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellSingleChannelCalibration.cxx
@@ -1,0 +1,241 @@
+// AliEmcalCorrectionCellSingleChannelCalibration
+//
+
+#include <TObjArray.h>
+#include <TFile.h>
+#include "AliEMCALGeometry.h"
+#include "AliOADBContainer.h"
+#include "AliEMCALRecoUtils.h"
+#include "AliAODEvent.h"
+#include "AliDataFile.h"
+
+#include "AliEmcalCorrectionCellSingleChannelCalibration.h"
+
+/// \cond CLASSIMP
+ClassImp(AliEmcalCorrectionCellSingleChannelCalibration);
+/// \endcond
+
+// Actually registers the class with the base class
+RegisterCorrectionComponent<AliEmcalCorrectionCellSingleChannelCalibration> AliEmcalCorrectionCellSingleChannelCalibration::reg("AliEmcalCorrectionCellSingleChannelCalibration");
+
+/**
+ * Default constructor
+ */
+AliEmcalCorrectionCellSingleChannelCalibration::AliEmcalCorrectionCellSingleChannelCalibration() :
+  AliEmcalCorrectionComponent("AliEmcalCorrectionCellSingleChannelCalibration")
+  ,fCellSingleChannelEnergyDistBefore(0)
+  ,fCellSingleChannelEnergyDistAfter(0)
+  ,fUseAutomaticRecalib(1)
+  ,fCustomRecalibFilePath("")
+{
+}
+
+/**
+ * Destructor
+ */
+AliEmcalCorrectionCellSingleChannelCalibration::~AliEmcalCorrectionCellSingleChannelCalibration()
+{
+}
+
+/**
+ * Initialize and configure the component.
+ */
+Bool_t AliEmcalCorrectionCellSingleChannelCalibration::Initialize()
+{
+  // Initialization
+  AliEmcalCorrectionComponent::Initialize();
+  
+  AliWarning("Init EMCAL cell single channel recalibration");
+  
+  if(fFilepass.Contains("LHC14a1a")) fUseAutomaticRecalib = kTRUE;
+
+  // check the YAML configuration if a custom energy calibration is requested (default is empty string "")
+  GetProperty("customRecalibFilePath",fCustomRecalibFilePath);
+
+  if (!fRecoUtils)
+    fRecoUtils  = new AliEMCALRecoUtils;
+    
+  fRecoUtils->SetPositionAlgorithm(AliEMCALRecoUtils::kPosTowerGlobal);
+
+  return kTRUE;
+}
+
+/**
+ * Create run-independent objects for output. Called before running over events.
+ */
+void AliEmcalCorrectionCellSingleChannelCalibration::UserCreateOutputObjects()
+{   
+  AliEmcalCorrectionComponent::UserCreateOutputObjects();
+
+  if (fCreateHisto){
+    fCellSingleChannelEnergyDistBefore = new TH1F("hCellSingleChannelEnergyDistBefore","hCellSingleChannelEnergyDistBefore;E_{cell} (GeV)",1000,0,10);
+    fOutput->Add(fCellSingleChannelEnergyDistBefore);
+    fCellSingleChannelEnergyDistAfter = new TH1F("hCellSingleChannelEnergyDistAfter","hCellSingleChannelEnergyDistAfter;E_{cell} (GeV)",1000,0,10);
+    fOutput->Add(fCellSingleChannelEnergyDistAfter);
+  }
+}
+
+/**
+ * Called for each event to process the event data.
+ */
+Bool_t AliEmcalCorrectionCellSingleChannelCalibration::Run()
+{
+  AliEmcalCorrectionComponent::Run();
+  
+  if (!fEventManager.InputEvent()) {
+    AliError("Event ptr = 0, returning");
+    return kFALSE;
+  }
+  
+  CheckIfRunChanged();
+  
+  // CONFIGURE THE RECO UTILS -------------------------------------------------
+  fRecoUtils->SwitchOnRecalibration();
+  
+  // START PROCESSING ---------------------------------------------------------
+  // Test if cells present
+  if (fCaloCells->GetNumberOfCells()<=0)
+  {
+    AliDebug(2, Form("Number of EMCAL cells = %d, returning", fCaloCells->GetNumberOfCells()));
+    return kFALSE;
+  }
+  
+  // mark the cells not recalibrated
+  fRecoUtils->ResetCellsCalibrated();
+  
+  
+  if(fCreateHisto)
+    FillCellQA(fCellSingleChannelEnergyDistBefore); // "before" QA
+  
+  // CELL RECALIBRATION -------------------------------------------------------
+  // update cell objects
+  UpdateCells();
+  
+  if(fCreateHisto)
+    FillCellQA(fCellSingleChannelEnergyDistAfter); // "after" QA
+  
+  // switch off recalibrations so those are not done multiple times
+  // this is just for safety, the recalibrated flag of cell object
+  // should not allow for farther processing anyways
+  fRecoUtils->SwitchOffRecalibration();
+
+  return kTRUE;
+}
+
+/**
+ * Initialize the energy calibration.
+ */
+Int_t AliEmcalCorrectionCellSingleChannelCalibration::InitRecalib()
+{
+  if (!fEventManager.InputEvent())
+    return 0;
+  
+  AliInfo("Initialising recalibration factors");
+  
+  // init default maps first
+  if (!fRecoUtils->GetEMCALRecalibrationFactorsArray())
+    fRecoUtils->InitEMCALRecalibrationFactors() ;
+  
+  Int_t runRC = fEventManager.InputEvent()->GetRunNumber();
+  
+  std::unique_ptr<AliOADBContainer> contRF;
+  std::unique_ptr<TFile> recalibFile;
+  if (fBasePath!="")
+  { //if fBasePath specified
+    AliInfo(Form("Loading Recalib OADB from given path %s",fBasePath.Data()));
+
+    recalibFile = std::unique_ptr<TFile>(TFile::Open(Form("%s/EMCALSingleChannelCalibrations.root",fBasePath.Data()),"read"));
+    if (!recalibFile || recalibFile->IsZombie())
+    {
+      AliFatal(Form("EMCALSingleChannelCalibrations.root not found in %s",fBasePath.Data()));
+      return 0;
+    }
+    
+    contRF = std::unique_ptr<AliOADBContainer>(static_cast<AliOADBContainer *>(recalibFile->Get("AliEMCALSingleChannelCoefficient")));
+  }
+  else if (fCustomRecalibFilePath!="")
+  { //if custom recalib requested
+    AliInfo(Form("Loading custom Recalib OADB from given path %s",fCustomRecalibFilePath.Data()));
+        
+    recalibFile = std::unique_ptr<TFile>(TFile::Open(Form("%s",fCustomRecalibFilePath.Data()),"read"));
+    if (!recalibFile || recalibFile->IsZombie())
+    {
+      AliFatal(Form("Recalibration file not found. Provided path was: %s",fCustomRecalibFilePath.Data()));
+      return 0;
+    }
+    
+    contRF = std::unique_ptr<AliOADBContainer>(static_cast<AliOADBContainer *>(recalibFile->Get("AliEMCALSingleChannelCoefficient")));
+  }
+  else
+  { // Else choose the one in the $ALICE_PHYSICS directory
+    AliInfo("Loading Recalib OADB from OADB/EMCAL");
+    
+    recalibFile = std::unique_ptr<TFile>(TFile::Open(AliDataFile::GetFileNameOADB("EMCAL/EMCALSingleChannelCalibrations.root").data(),"read"));
+    if (!recalibFile || recalibFile->IsZombie())
+    {
+      AliFatal("OADB/EMCAL/EMCALSingleChannelCalibrations.root was not found");
+      return 0;
+    }
+    
+    contRF = std::unique_ptr<AliOADBContainer>(static_cast<AliOADBContainer *>(recalibFile->Get("AliEMCALSingleChannelCoefficient")));
+  }
+  if(!contRF) {
+    AliFatal("No OADB container found");
+    return 0;
+  }
+  contRF->SetOwner(true);
+  
+  TObjArray *recal=(TObjArray*)contRF->GetObject(runRC);
+  if (!recal)
+  {
+    AliFatal(Form("No Objects for run: %d",runRC));
+    return 2;
+  }
+  
+  //AliDebug(1, recalib->Print());
+  
+  Int_t sms = fGeom->GetEMCGeometry()->GetNumberOfSuperModules();
+  for (Int_t i=0; i<sms; ++i)
+  {
+    TH2F *h = fRecoUtils->GetEMCALSingleChannelRecalibrationFactors(i);
+    if (h)
+      delete h;
+    h = (TH2F*)recal->FindObject(Form("EMCALSCCalibMap_Mod%d",i));
+    if (!h)
+    {
+      AliFatal(Form("Could not load EMCALSCCalibMap_Mod%d",i));
+      continue;
+    }
+    h->SetDirectory(0);
+    fRecoUtils->SetEMCALSingleChannelRecalibrationFactors(i,h);
+  }
+  
+  return 1;
+}
+
+/**
+ * This function is called if the run changes (it inherits from the base component),
+ * to load a new energy calibration and fill relevant variables.
+ */
+Bool_t AliEmcalCorrectionCellSingleChannelCalibration::CheckIfRunChanged()
+{
+  Bool_t runChanged = AliEmcalCorrectionComponent::CheckIfRunChanged();
+  
+  if (runChanged) {
+    // init recalibration factors
+    if(fUseAutomaticRecalib)
+    {
+      Int_t fInitRecalib = InitRecalib();
+      if (fInitRecalib==0) {
+        AliError("InitRecalib returned false, returning");
+      }
+      if (fInitRecalib==1) {
+        AliWarning("InitRecalib OK");
+      }
+      if (fInitRecalib>1) {
+        AliWarning(Form("No recalibration available: %d - %s", fEventManager.InputEvent()->GetRunNumber(), fFilepass.Data()));
+      }
+    }
+  }
+  return runChanged;
+}

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellSingleChannelCalibration.h
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellSingleChannelCalibration.h
@@ -1,0 +1,59 @@
+#ifndef ALIEMCALCORRECTIONCELLSINGLECHANNELCALIBRATION_H
+#define ALIEMCALCORRECTIONCELLSINGLECHANNELCALIBRATION_H
+
+#include "AliEmcalCorrectionComponent.h"
+
+/**
+ * @class AliEmcalCorrectionCellSingleChannelCalibration
+ * @ingroup EMCALCOREFW
+ * @brief Energy calibration correction using single channel calibration in the EMCal correction framework.
+ *
+ * Performs energy calibration of cells, using OADB calibration. The original cell information in the event **will be overwritten**.
+ *
+ * Based on code in AliEMCALTenderSupply.
+ *
+ * @author Deepa Thomas (Utrecht University), AliEMCALTenderSupply
+ * @author Jiri Kral (University of Jyvaskyla), AliEMCALTenderSupply mods/rewrite
+ * @author Salvatore Aiola, make AliEMCALTenderSupply work for AODs
+ * @author C. Loizides, make AliEMCALTenderSupply work for AODs
+ * @author Gustavo Conesa, LPSC-Grenoble, AliEMCALTenderSupply several mods.
+ * @author Raymond Ehlers <raymond.ehlers@yale.edu>, Yale University, centralize EMCal corrections using components
+ * @author James Mulligan <james.mulligan@yale.edu>, Yale University, centralize EMCal corrections using components
+ * @author Dhruv Dixit <dhruvdixit@berkeley.edu>, University of California, Berkeley, AliEmcalCorrectionCellSingleChannelCalibration
+ * @date March 17, 2019
+ */
+
+class AliEmcalCorrectionCellSingleChannelCalibration : public AliEmcalCorrectionComponent {
+ public:
+  AliEmcalCorrectionCellSingleChannelCalibration();
+  virtual ~AliEmcalCorrectionCellSingleChannelCalibration();
+
+  // Sets up and runs the task
+  Bool_t Initialize();
+  void UserCreateOutputObjects();
+  Bool_t Run();
+  Bool_t CheckIfRunChanged();
+  
+ protected:
+  TH1F* fCellSingleChannelEnergyDistBefore;        //!<! cell energy distribution, before energy calibration
+  TH1F* fCellSingleChannelEnergyDistAfter;         //!<! cell energy distribution, after energy calibration
+
+private:
+  Int_t                  InitRecalib();
+  
+  // Change to false if experts
+  Bool_t                 fUseAutomaticRecalib;       ///< On by default the check in the OADB of the energy recalibration
+  TString                fCustomRecalibFilePath;     ///< Empty string by default the path to the OADB file of the custom energy recalibration
+  
+  AliEmcalCorrectionCellSingleChannelCalibration(const AliEmcalCorrectionCellSingleChannelCalibration &);               // Not implemented
+  AliEmcalCorrectionCellSingleChannelCalibration &operator=(const AliEmcalCorrectionCellSingleChannelCalibration &);    // Not implemented
+
+  // Allows the registration of the class so that it is availble to be used by the correction task.
+  static RegisterCorrectionComponent<AliEmcalCorrectionCellSingleChannelCalibration> reg;
+
+  /// \cond CLASSIMP
+  ClassDef(AliEmcalCorrectionCellSingleChannelCalibration, 4); // EMCal cell energy correction component
+  /// \endcond
+};
+
+#endif /* ALIEMCALCORRECTIONCELLSINGLECHANNELCALIBRATION_H */

--- a/PWG/EMCAL/EMCALtasks/CMakeLists.txt
+++ b/PWG/EMCAL/EMCALtasks/CMakeLists.txt
@@ -71,6 +71,7 @@ set(SRCS
   AliEmcalCorrectionComponent.cxx
   AliEmcalCorrectionCellBadChannel.cxx
   AliEmcalCorrectionCellEnergy.cxx
+  AliEmcalCorrectionCellSingleChannelCalibration.cxx
   AliEmcalCorrectionCellTimeCalib.cxx
   AliEmcalCorrectionCellEmulateCrosstalk.cxx
   AliEmcalCorrectionCellCombineCollections.cxx

--- a/PWG/EMCAL/EMCALtasks/PWGEMCALtasksLinkDef.h
+++ b/PWG/EMCAL/EMCALtasks/PWGEMCALtasksLinkDef.h
@@ -38,6 +38,7 @@
 #pragma link C++ class  AliEmcalCorrectionComponent+;
 #pragma link C++ class  AliEmcalCorrectionCellBadChannel+;
 #pragma link C++ class  AliEmcalCorrectionCellEnergy+;
+#pragma link C++ class  AliEmcalCorrectionCellSingleChannelCalibration+;
 #pragma link C++ class  AliEmcalCorrectionCellTimeCalib+;
 #pragma link C++ class  AliEmcalCorrectionCellEmulateCrosstalk+;
 #pragma link C++ class  AliEmcalCorrectionCellCombineCollections+;

--- a/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
+++ b/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
@@ -65,6 +65,12 @@ CellEnergy:                                         # Cell Energy correction com
     load1DRecalibFactors: false                     # Flag to load a 1D energy recalibration histogram
     cellsNames:                                     # Names of the cells input objects which should be attached to the correction
         - defaultCells                              # This object is defined above in the cells section of the input objects
+CellSingleChannelCalibration:                       # Cell Single Channel Energy correction component
+    enabled: false                                  # Whether to enable the task
+    createHistos: false                             # Whether the task should create output histograms
+    customRecalibFilePath: ""                       # Full path including .root file for custom recalibration object
+    cellsNames:                                     # Names of the cells input objects which should be attached to the correction
+        - defaultCells                              # This object is defined above in the cells section of the input objects
 CellBadChannel:                                     # Bad channel removal at the cell level component
     enabled: false                                  # Whether to enable the task
     createHistos: false                             # Whether the task should create output histograms


### PR DESCRIPTION
A new task was written for the single channel calibration and it has been added to the EMCal Correction Framework. By default, the task is disabled and currently only calibrates runs from LHC15o. Merge is needed so that the version is available on the grid for testing.