### PR TITLE
Adding QA histograms to SD and Spectrum tasks

### DIFF
--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetEnergyScale.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetEnergyScale.cxx
@@ -118,6 +118,53 @@ void AliAnalysisTaskEmcalJetEnergyScale::UserCreateOutputObjects(){
     fHistos->CreateTHnSparse("hPtCorr", "Correlation det pt / part pt", 6, corrbinning, "s");
     fHistos->CreateTHnSparse("hJetfindingEfficiency", "Jet finding efficiency", 3, effbinning, "s");
   }
+
+  // A bit of QA stuff
+  fHistos->CreateTH2("hQANEFPtPart", "Neutral energy fraction at part. level; p_{t} (GeV/c); NEF", 350, 0., 350., 100, 0., 1.);
+  fHistos->CreateTH2("hQANEFPtDet", "Neutral energy fraction at det. level; p_{t} (GeV/c); NEF", 350, 0., 350., 100, 0., 1.);
+  fHistos->CreateTH2("hQAZchPtPart", "z_{ch,max} at part. level; p_{t} (GeV/c); z_{ch,max}", 350, 0., 350., 100, 0., 1.);
+  fHistos->CreateTH2("hQAZchPtDet", "z_{ch,max} at det. level; p_{t} (GeV/c); z_{ch,max}", 350, 0., 350., 100, 0., 1.);
+  fHistos->CreateTH2("hQAZnePtPart", "z_{ne,max} at part. level; p_{t} (GeV/c); z_{ne,max}", 350, 0., 350., 100, 0., 1.);
+  fHistos->CreateTH2("hQAZnePtDet", "z_{ne,max} at det. level; p_{t} (GeV/c); z_{ne,max}", 350, 0., 350., 100, 0., 1.);
+  fHistos->CreateTH2("hQANChPtPart", "Number of charged constituents at part. level; p_{t} (GeV/c); N_{ch}", 350, 0., 350., 100, 0., 100.);
+  fHistos->CreateTH2("hQANChPtDet", "Number of charged constituents at det. level; p_{t} (GeV/c); N_{ch}", 350, 0., 350., 100, 0., 100.);
+  fHistos->CreateTH2("hQANnePtPart", "Number of neutral constituents at part. level; p_{t} (GeV/c); N_{ne}", 350, 0., 350., 100, 0., 100.);
+  fHistos->CreateTH2("hQANnePtDet", "Number of neutral constituents at det. level; p_{t} (GeV/c); N_{ne}", 350, 0., 350., 100, 0., 100.);
+  fHistos->CreateTH2("hQAConstPtChPart", "p_{t} of charged constituents (part. level); p_{t,j} (GeV/c); p_{t,ch} (GeV/c", 350, 0., 350., 350., 0., 350.);
+  fHistos->CreateTH2("hQAConstPtChDet", "p_{t} of charged constituents (det. level); p_{t,j} (GeV/c); p_{t,ch} (GeV/c", 350, 0., 350., 350., 0., 350.);
+  fHistos->CreateTH2("hQAConstPtNePart", "p_{t} of neutral constituents (part. level); p_{t,j} (GeV/c); p_{t,ne} (GeV/c)", 350, 0., 350., 350., 0., 350.);
+  fHistos->CreateTH2("hQAConstPtNeDet", "p_{t} of neutral constituents (det. level); p_{t,j} (GeV/c); p_{t,ne} (GeV/c)", 350, 0., 350., 350., 0., 350.);
+  fHistos->CreateTH2("hQAConstPtChMaxPart", "p_{t} of max charged constituents (part. level); p_{t,j} (GeV/c); p_{t,ch} (GeV/c", 350, 0., 350., 350., 0., 350.);
+  fHistos->CreateTH2("hQAConstPtChMaxDet", "p_{t} of max charged constituents (det. level); p_{t,j} (GeV/c); p_{t,ch} (GeV/c", 350, 0., 350., 350., 0., 350.);
+  fHistos->CreateTH2("hQAConstPtNeMaxPart", "p_{t} of max neutral constituents (part. level); p_{t,j} (GeV/c); p_{t,ne} (GeV/c)", 350, 0., 350., 350., 0., 350.);
+  fHistos->CreateTH2("hQAConstPtNeMaxDet", "p_{t} of max neutral constituents (det. level); p_{t,j} (GeV/c); p_{t,ne} (GeV/c)", 350, 0., 350., 350., 0., 350.);
+  fHistos->CreateTH2("hQAEtaPhiPart", "#eta vs. #phi for selected part. level jets; #eta; #phi", 100, -1., 1., 100, 0., 7.);
+  fHistos->CreateTH2("hQAEtaPhiDet", "#eta vs. #phi for selected det. level jets; #eta; #phi", 100, -1., 1., 100, 0., 7.);
+  fHistos->CreateTH2("hQAEtaPhiConstChPart", "#eta vs. #phi for charged constituents (part. level); #eta; #phi", 100, -1., 1., 100, 0., 7.);
+  fHistos->CreateTH2("hQAEtaPhiConstChDet", "#eta vs. #phi for charged constituents (det. level); #eta; #phi", 100, -1., 1., 100, 0., 7.);
+  fHistos->CreateTH2("hQAEtaPhiConstNePart", "#eta vs. #phi for neutral constituents (part. level); #eta; #phi", 100, -1., 1., 100, 0., 7.);
+  fHistos->CreateTH2("hQAEtaPhiConstNeDet", "#eta vs. #phi for neutral constituents (det. level); #eta; #phi", 100, -1., 1., 100, 0., 7.);
+  fHistos->CreateTH2("hQAEtaPhiConstMaxChPart", "#eta vs. #phi for max charged constituents (part. level); #eta; #phi", 100, -1., 1., 100, 0., 7.);
+  fHistos->CreateTH2("hQAEtaPhiConstMaxChDet", "#eta vs. #phi for max charged constituents (det. level); #eta; #phi", 100, -1., 1., 100, 0., 7.);
+  fHistos->CreateTH2("hQAEtaPhiConstMaxNePart", "#eta vs. #phi for max neutral constituents (part. level); #eta; #phi", 100, -1., 1., 100, 0., 7.);
+  fHistos->CreateTH2("hQAEtaPhiConstMaxNeDet", "#eta vs. #phi for max neutral constituents (det. level); #eta; #phi", 100, -1., 1., 100, 0., 7.);
+  fHistos->CreateTH2("hQADeltaRChargedPart", "#DeltaR vs. p_{t,jet} of charged constituents (part. level); p_{t, jet} (GeV/c); #DeltaR", 350., 0., 350, 100, 0., 1.);
+  fHistos->CreateTH2("hQADeltaRChargedDet", "#DeltaR vs. p_{t,jet} of charged constituents (det. level); p_{t, jet} (GeV/c); #DeltaR", 350., 0., 350, 100, 0., 1.);
+  fHistos->CreateTH2("hQADeltaRNeutralPart", "#DeltaR vs. p_{t,jet} of neutral constituents (part. level); p_{t, jet} (GeV/c); #DeltaR", 350., 0., 350, 100, 0., 1);
+  fHistos->CreateTH2("hQADeltaRNeutralDet", "#DeltaR vs. p_{t,jet} of neutral constituents (det. level); p_{t, jet} (GeV/c); #DeltaR", 350., 0., 350, 100, 0., 1);
+  fHistos->CreateTH2("hQADeltaRMaxChargedPart", "#DeltaR vs. p_{t,jet} of charged constituents (part. level); p_{t, jet} (GeV/c); #DeltaR", 350., 0., 350, 100, 0., 1.);
+  fHistos->CreateTH2("hQADeltaRMaxChargedDet", "#DeltaR vs. p_{t,jet} of charged constituents (det. level); p_{t, jet} (GeV/c); #DeltaR", 350., 0., 350, 100, 0., 1.);
+  fHistos->CreateTH2("hQADeltaRMaxNeutralPart", "#DeltaR vs. p_{t,jet} of neutral constituents (part. level); p_{t, jet} (GeV/c); #DeltaR", 350., 0., 350, 100, 0., 1);
+  fHistos->CreateTH2("hQADeltaRMaxNeutralDet", "#DeltaR vs. p_{t,jet} of neutral constituents (det. level); p_{t, jet} (GeV/c); #DeltaR", 350., 0., 350, 100, 0., 1);
+  fHistos->CreateTH2("hQAJetAreaVsJetPtPart", "Jet area vs. jet pt at particle level; p_{t} (GeV/c); Area", 350, 0., 350., 100, 0., 1.);
+  fHistos->CreateTH2("hQAJetAreaVsJetPtDet", "Jet area vs. jet pt at detector level; p_{t} (GeV/c); Area", 350, 0., 350., 100, 0., 1.);
+  fHistos->CreateTH2("hQAJetAreaVsNEFPart", "Jet area vs. NEF at particle level; NEF; Area", 100, 0., 1., 100, 0., 1.);
+  fHistos->CreateTH2("hQAJetAreaVsNEFDet", "Jet area vs. NEF at detector level; NEF; Area", 100, 0., 1., 100, 0., 1.);
+  fHistos->CreateTH2("hQAJetAreaVsNConstPart", "Jet area vs. number of consituents at particle level; Number of constituents; Area", 101, -0.5, 100.5, 100, 0., 1.);
+  fHistos->CreateTH2("hQAJetAreaVsNConstDet", "Jet area vs. number of consituents at detector level; Number of constituents; Area", 101, -0.5, 100.5, 100, 0., 1.);
+  fHistos->CreateTH1("hQAMatchingDRAbs", "Distance between part. level jet and  det. level jet", 100, 0., 1.);
+  fHistos->CreateTH1("hQAMatchingDRel", "Distance between part. level jet and  det. level jet", 100, 0., 1.);
+  fHistos->CreateTH1("hFracPtHardPart", "Part. level jet Pt relative to the Pt-hard of the event", 100, 0., 10.);
   for(auto h : *(fHistos->GetListOfHistograms())) fOutput->Add(h);
 
   fSampleSplitter = new TRandom;
@@ -164,6 +211,9 @@ Bool_t AliAnalysisTaskEmcalJetEnergyScale::Run(){
     AliErrorStream() << "At least one jet container missing, exiting ..." << std::endl;
     return false;
   }
+  AliClusterContainer *clusters(detjets->GetClusterContainer());
+  AliTrackContainer *tracks(static_cast<AliTrackContainer *>(detjets->GetParticleContainer()));
+  AliParticleContainer *particles(partjets->GetParticleContainer());
   AliDebugStream(1) << "Have both jet containers: part(" << partjets->GetNAcceptedJets() << "|" << partjets->GetNJets() << "), det(" << detjets->GetNAcceptedJets() << "|" << detjets->GetNJets() << ")" << std::endl;
 
   std::vector<AliEmcalJet *> acceptedjets;
@@ -200,6 +250,103 @@ Bool_t AliAnalysisTaskEmcalJetEnergyScale::Run(){
     } else {
       fHistos->FillTH2("hJetResponseFineNoClosure", detpt, partjet->Pt());
     }
+
+    // Fill QA histograms
+    fHistos->FillTH2("hQANEFPtPart", partjet->Pt(), partjet->NEF());
+    fHistos->FillTH2("hQANEFPtDet", detjet->Pt(), detjet->NEF());
+    fHistos->FillTH2("hQAEtaPhiPart", partjet->Eta(), TVector2::Phi_0_2pi(partjet->Phi()));
+    fHistos->FillTH2("hQAEtaPhiDet", detjet->Eta(), TVector2::Phi_0_2pi(detjet->Phi()));
+    auto deltaR = TMath::Abs(partjet->DeltaR(detjet));
+    fHistos->FillTH1("hQAMatchingDRAbs", deltaR);
+    fHistos->FillTH1("hQAMatchingDRel", deltaR/partjets->GetJetRadius());
+    TVector3 jetvecDet(detjet->Px(), detjet->Py(), detjet->Px());
+    if(clusters){
+      auto leadcluster = detjet->GetLeadingCluster(clusters->GetArray());
+      fHistos->FillTH2("hQANnePtDet", detjet->Pt(), detjet->GetNumberOfClusters());
+
+      for(auto iclust = 0; iclust < detjet->GetNumberOfClusters(); iclust++) {
+        auto cluster = detjet->Cluster(iclust);
+        TLorentzVector clustervec;
+        cluster->GetMomentum(clustervec, fVertex, (AliVCluster::VCluUserDefEnergy_t)clusters->GetDefaultClusterEnergy());
+        fHistos->FillTH2("hQAConstPtNeDet", detjet->Pt(), clustervec.Pt());
+        fHistos->FillTH2("hQAEtaPhiConstNeDet", clustervec.Eta(), TVector2::Phi_0_2pi(clustervec.Phi()));
+        fHistos->FillTH2("hQADeltaRNeutralDet", detjet->Pt(), jetvecDet.DeltaR(clustervec.Vect()));
+      }
+
+      if(leadcluster){
+        TLorentzVector ptvec;
+        leadcluster->GetMomentum(ptvec, fVertex, (AliVCluster::VCluUserDefEnergy_t)clusters->GetDefaultClusterEnergy());
+        fHistos->FillTH2("hQAZnePtDet", detjet->Pt(), detjet->GetZ(ptvec.Px(), ptvec.Py(), ptvec.Pz()));
+        fHistos->FillTH2("hQAConstPtNeMaxDet", detjet->Pt(), ptvec.Pt());
+        fHistos->FillTH2("hQAEtaPhiConstMaxNeDet", ptvec.Eta(), TVector2::Phi_0_2pi(ptvec.Phi()));
+        fHistos->FillTH2("hQADeltaRMaxNeutralDet", detjet->Pt(), jetvecDet.DeltaR(ptvec.Vect()));
+      }
+    }
+    if(tracks){
+      fHistos->FillTH2("hQANChPtDet", detjet->Pt(),  detjet->GetNumberOfTracks());
+      auto leadingtrack = detjet->GetLeadingTrack(tracks->GetArray());
+
+      for(int itrk = 0; itrk < detjet->GetNumberOfTracks(); itrk++) {
+        auto trk = detjet->Track(itrk);
+        fHistos->FillTH2("hQAConstPtChPart", detjet->Pt(), trk->Pt());
+        fHistos->FillTH2("hQAEtaPhiConstChDet", trk->Eta(), TVector2::Phi_0_2pi(trk->Phi()));
+        fHistos->FillTH2("hQADeltaRChargedDet", detjet->Pt(), detjet->DeltaR(trk));
+      }
+      
+      if(leadingtrack){
+        fHistos->FillTH2("hQAZchPtDet", detjet->Pt(), detjet->GetZ(leadingtrack->Px(), leadingtrack->Py(), leadingtrack->Pz()));
+        fHistos->FillTH2("hQAConstPtChMaxDet", detjet->Pt(), leadingtrack->Pt());
+        fHistos->FillTH2("hQAEtaPhiConstMaxChDet", leadingtrack->Eta(), leadingtrack->Phi());
+        fHistos->FillTH2("hQADeltaRMaxChargedDet", detjet->Pt(), detjet->DeltaR(leadingtrack));
+      }
+    }
+    if(particles){
+      AliVParticle *leadingcharged(nullptr), *leadingneutral(nullptr);
+      int ncharged(0), nneutral(0);
+      for(int ipart = 0; ipart < partjet->GetNumberOfTracks(); ipart++) {
+        auto particle = partjet->Track(ipart);
+        if(particle->Charge()) {
+          ncharged++;
+          fHistos->FillTH2("hQAConstPtChPart", partjet->Pt(), particle->Pt());
+          fHistos->FillTH2("hQAEtaPhiConstChPart", particle->Eta(), TVector2::Phi_0_2pi(particle->Phi()));
+          fHistos->FillTH2("hQADeltaRChargedPart", partjet->Pt(), partjet->DeltaR(particle));
+          if(!leadingcharged) leadingcharged = particle;
+          else {
+            if(particle->E() > leadingcharged->E()) leadingcharged = particle;
+          }
+        } else {
+          nneutral++;
+          fHistos->FillTH2("hQAConstPtNePart", partjet->Pt(), particle->Pt());
+          fHistos->FillTH2("hQAEtaPhiConstNePart", particle->Eta(), TVector2::Phi_0_2pi(particle->Phi()));
+          fHistos->FillTH2("hQADeltaRNeutralPart", partjet->Pt(), partjet->DeltaR(particle));
+          if(!leadingneutral) leadingneutral = particle;
+          else {
+            if(particle->E() > leadingneutral->E()) leadingneutral = particle;
+          }
+        }
+      }
+      if(leadingcharged) {
+        fHistos->FillTH2("hQAConstPtChMaxPart", partjet->Pt(), leadingcharged->Pt());
+        fHistos->FillTH2("hQAEtaPhiConstMaxChPart", leadingcharged->Eta(), TVector2::Phi_0_2pi(leadingcharged->Phi()));
+        fHistos->FillTH2("hQAZchPtPart", partjet->Pt(), partjet->GetZ(leadingcharged));
+        fHistos->FillTH2("hQADeltaRMaxChargedPart", partjet->Pt(), partjet->DeltaR(leadingcharged));
+      }
+      if(leadingneutral) {
+        fHistos->FillTH2("hQAConstPtNeMaxPart", partjet->Pt(), leadingneutral->Pt());
+        fHistos->FillTH2("hQAEtaPhiConstMaxNePart", leadingneutral->Eta(), TVector2::Phi_0_2pi(leadingneutral->Phi()));
+        fHistos->FillTH2("hQAZnePtPart", partjet->Pt(), partjet->GetZ(leadingneutral));
+        fHistos->FillTH2("hQADeltaRMaxNeutralPart", partjet->Pt(), partjet->DeltaR(leadingneutral));
+      }
+      fHistos->FillTH2("hQANChPtPart", partjet->Pt(), ncharged);
+      fHistos->FillTH2("hQANnePtPart", partjet->Pt(), nneutral);
+    }
+    fHistos->FillTH2("hQAJetAreaVsJetPtPart", partjet->Pt(), partjet->Area());
+    fHistos->FillTH2("hQAJetAreaVsJetPtDet", detjet->Pt(), detjet->Area());
+    fHistos->FillTH2("hQAJetAreaVsNEFPart", partjet->NEF(), partjet->Area());
+    fHistos->FillTH2("hQAJetAreaVsNEFDet", detjet->NEF(), detjet->Area());
+    fHistos->FillTH2("hQAJetAreaVsNConstPart", partjet->GetNumberOfTracks(), partjet->Area());
+    fHistos->FillTH2("hQAJetAreaVsNConstDet", detjet->GetNumberOfClusters() + detjet->GetNumberOfTracks(), detjet->Area());
+    fHistos->FillTH1("hFracPtHardPart", partjet->Pt()/fPtHard);
   }
 
   // efficiency x acceptance: Add histos for all accepted and reconstucted accepted jets

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetEnergySpectrum.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetEnergySpectrum.cxx
@@ -148,9 +148,18 @@ void AliAnalysisTaskEmcalJetEnergySpectrum::UserCreateOutputObjects(){
   fHistos->CreateTH2("hQAConstPtNe", "p_{t} of neutral constituents; p_{t,j} (GeV/c); p_{t,ne} (GeV/c)", 350, 0., 350., 350., 0., 350.);
   fHistos->CreateTH2("hQAConstPtChMax", "p_{t} of max charged constituents; p_{t,j} (GeV/c); p_{t,ch} (GeV/c", 350, 0., 350., 350., 0., 350.);
   fHistos->CreateTH2("hQAConstPtNeMax", "p_{t} of max neutral constituents; p_{t,j} (GeV/c); p_{t,ne} (GeV/c)", 350, 0., 350., 350., 0., 350.);
-  fHistos->CreateTH2("hQAEtaPhi", "eta-phi histogram for selected jets; #eta; #phi", 100, -1., 1., 100, 0., 7.);
-  fHistos->CreateTH2("hQAEtaPhiConstCh", "eta-phi histogram for selected jets; #eta; #phi", 100, -1., 1., 100, 0., 7.);
-  fHistos->CreateTH2("hQAEtaPhiConstNe", "eta-phi histogram for selected jets; #eta; #phi", 100, -1., 1., 100, 0., 7.);
+  fHistos->CreateTH2("hQAEtaPhi", "#eta vs. #phi for selected jets; #eta; #phi", 100, -1., 1., 100, 0., 7.);
+  fHistos->CreateTH2("hQAEtaPhiConstCh", "#eta vs. #phi for charged constituents; #eta; #phi", 100, -1., 1., 100, 0., 7.);
+  fHistos->CreateTH2("hQAEtaPhiConstNe", "#eta vs. #phi for neutral constituents; #eta; #phi", 100, -1., 1., 100, 0., 7.);
+  fHistos->CreateTH2("hQAEtaPhiMaxConstCh", "#eta vs. #phi for max charged constituents; #eta; #phi", 100, -1., 1., 100, 0., 7.);
+  fHistos->CreateTH2("hQAEtaPhiMaxConstNe", "#eta vs. #phi for max neutral constituents; #eta; #phi", 100, -1., 1., 100, 0., 7.);
+  fHistos->CreateTH2("hQADeltaRCharged", "#DeltaR vs. p_{t,jet} of charged constituents; p_{t, jet} (GeV/c); #DeltaR", 350., 0., 350, 100, 0., 1.);
+  fHistos->CreateTH2("hQADeltaRNeutral", "#DeltaR vs. p_{t,jet} of neutral constituents; p_{t, jet} (GeV/c); #DeltaR", 350., 0., 350, 100, 0., 1);
+  fHistos->CreateTH2("hQADeltaRMaxCharged", "#DeltaR vs. p_{t,jet} of charged constituents; p_{t, jet} (GeV/c); #DeltaR", 350., 0., 350, 100, 0., 1.);
+  fHistos->CreateTH2("hQADeltaRMaxNeutral", "#DeltaR vs. p_{t,jet} of neutral constituents; p_{t, jet} (GeV/c); #DeltaR", 350., 0., 350, 100, 0., 1);
+  fHistos->CreateTH2("hQAJetAreaVsJetPt", "Jet area vs. jet pt at detector level; p_{t} (GeV/c); Area", 350, 0., 350., 100, 0., 1.);
+  fHistos->CreateTH2("hQAJetAreaVsNEF", "Jet area vs. NEF at detector level; NEF; Area", 100, 0., 1., 100, 0., 1.);
+  fHistos->CreateTH2("hQAJetAreaVsNConst", "Jet area vs. number of consituents at detector level; Number of constituents; Area", 101, -0.5, 100.5, 100, 0., 1.);
 
   for(auto h : *fHistos->GetListOfHistograms()) fOutput->Add(h);
   PostData(1, fOutput);
@@ -234,6 +243,7 @@ bool AliAnalysisTaskEmcalJetEnergySpectrum::Run(){
     // removed in order to reduce the memory consumption.
     fHistos->FillTH2("hQANEFPt", ptjet, j->NEF(), weight);
     fHistos->FillTH2("hQAEtaPhi", j->Eta(), j->Phi(), weight);
+    TVector3 jetvec(j->Px(), j->Py(), j->Pz());
     if(clusters){
       auto leadcluster = j->GetLeadingCluster(clusters->GetArray());
       if(leadcluster) {
@@ -241,6 +251,8 @@ bool AliAnalysisTaskEmcalJetEnergySpectrum::Run(){
         leadcluster->GetMomentum(ptvec, fVertex, (AliVCluster::VCluUserDefEnergy_t)clusters->GetDefaultClusterEnergy());
         fHistos->FillTH2("hQAZnePt", ptjet, j->GetZ(ptvec.Px(), ptvec.Py(), ptvec.Pz()), weight);
         fHistos->FillTH2("hQAConstPtNeMax", ptjet, ptvec.Pt(), weight);
+        fHistos->FillTH2("hQAEtaPhiMaxConstNe", ptvec.Eta(), TVector2::Phi_0_2pi(ptvec.Phi()));
+        fHistos->FillTH2("hQADeltaRMaxNeutral", ptjet, jetvec.DeltaR(ptvec.Vect()));
       } else {
         fHistos->FillTH2("hQAZnePt", ptjet, 0., weight);
         fHistos->FillTH2("hQAConstPtNeMax", ptjet, 0., weight);
@@ -251,6 +263,7 @@ bool AliAnalysisTaskEmcalJetEnergySpectrum::Run(){
         cluster->GetMomentum(ptvec, fVertex,(AliVCluster::VCluUserDefEnergy_t)clusters->GetDefaultClusterEnergy());
         fHistos->FillTH2("hQAConstPtNe", ptjet, ptvec.Pt(), weight);
         fHistos->FillTH2("hQAEtaPhiConstNe", ptvec.Eta(), TVector2::Phi_0_2pi(ptvec.Phi()));
+        fHistos->FillTH2("hQADeltaRNeutral", ptjet, jetvec.DeltaR(ptvec.Vect()));
       }
     }
     if(tracks){
@@ -258,6 +271,8 @@ bool AliAnalysisTaskEmcalJetEnergySpectrum::Run(){
       if(leadingtrack) {
         fHistos->FillTH2("hQAZchPt", ptjet, j->GetZ(leadingtrack->Px(), leadingtrack->Py(), leadingtrack->Pz()), weight);
         fHistos->FillTH2("hQAConstPtChMax", ptjet, leadingtrack->Pt(), weight);
+        fHistos->FillTH2("hQAEtaPhiMaxConstCh", leadingtrack->Eta(), TVector2::Phi_0_2pi(leadingtrack->Phi()));
+        fHistos->FillTH2("hQADeltaRMaxCharged", ptjet, j->DeltaR(leadingtrack));
       } else {
         fHistos->FillTH2("hQAZchPt", ptjet, 0., weight);
         fHistos->FillTH2("hQAConstPtChMax", ptjet, 0., weight);
@@ -266,10 +281,14 @@ bool AliAnalysisTaskEmcalJetEnergySpectrum::Run(){
         auto track = j->Track(ich);
         fHistos->FillTH2("hQAConstPtCh", ptjet, track->Pt(), weight);
         fHistos->FillTH2("hQAEtaPhiConstCh", track->Eta(), TVector2::Phi_0_2pi(track->Phi()), weight);
+        fHistos->FillTH2("hQADeltaRCharged", ptjet, j->DeltaR(track), weight);
       }
     }
     fHistos->FillTH2("hQANChPt", ptjet, j->GetNumberOfTracks(), weight);
     fHistos->FillTH2("hQANnePt", ptjet, j->GetNumberOfClusters(), weight);
+    fHistos->FillTH2("hQAJetAreaVsJetPt", j->Pt(), j->Area(), weight);
+    fHistos->FillTH2("hQAJetAreaVsNEF", j->NEF(), j->Area(), weight);
+    fHistos->FillTH2("hQAJetAreaVsNConstDet", j->GetNumberOfClusters() + j->GetNumberOfTracks(), j->Area(), weight);
   }
 
   double maxdata[6];

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalSoftDropData.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalSoftDropData.cxx
@@ -124,12 +124,26 @@ void AliAnalysisTaskEmcalSoftDropData::UserCreateOutputObjects() {
 
   // A bit of QA stuff
   fHistos->CreateTH2("hQANEFPt", "Neutral energy fraction; p_{t} (GeV/c); NEF", 350, 0., 350., 100, 0., 1.);
+  fHistos->CreateTH2("hQAEtaPhi", "#eta vs. #phi for selected jets; #eta; #phi", 100, -1., 1., 100, 0., 7.);
   fHistos->CreateTH2("hQAZchPt", "z_{ch,max}; p_{t} (GeV/c); z_{ch,max}", 350, 0., 350., 100, 0., 1.);
   fHistos->CreateTH2("hQAZnePt", "z_{ne,max}; p_{t} (GeV/c); z_{ne,max}", 350, 0., 350., 100, 0., 1.);
   fHistos->CreateTH2("hQANChPt", "Number of charged constituents; p_{t} (GeV/c); N_{ch}", 350, 0., 350., 100, 0., 100.);
   fHistos->CreateTH2("hQANnePt", "Number of neutral constituents; p_{t} (GeV/c); N_{ne}", 350, 0., 350., 100, 0., 100.);
-  fHistos->CreateTH2("hSDUsedChargedPtjvPtc", "p_{t,j} vs. p_{t,const} for tracks used in SD", 350., 0., 350., 350, 0., 350.);
-  fHistos->CreateTH2("hSDUsedNeutralPtjvPtc", "p_{t,j} vs. p_{t,const} for clusters used in SD", 350., 0., 350., 350, 0., 350.);
+  fHistos->CreateTH2("hQAJetAreaVsJetPt", "Jet area vs. jet pt at detector level; p_{t} (GeV/c); Area", 350, 0., 350., 100, 0., 1.);
+  fHistos->CreateTH2("hQAJetAreaVsNEF", "Jet area vs. NEF at detector level; NEF; Area", 100, 0., 1., 100, 0., 1.);
+  fHistos->CreateTH2("hQAJetAreaVsNConst", "Jet area vs. number of consituents at detector level; Number of constituents; Area", 101, -0.5, 100.5, 100, 0., 1.);
+  fHistos->CreateTH2("hSDUsedChargedPtjvPtc", "p_{t,j} vs. p_{t,const} for tracks used in SD; p_{t,j} (GeV/c); p_{t,ch} (GeV/c", 350., 0., 350., 350, 0., 350.);
+  fHistos->CreateTH2("hSDUsedNeutralPtjvPtc", "p_{t,j} vs. p_{t,const} for clusters used in SD; p_{t,j} (GeV/c); p_{t,ne} (GeV/c)", 350., 0., 350., 350, 0., 350.);
+  fHistos->CreateTH2("hSDUsedChargedPtjvPtcMax", "p_{t,j} vs. p_{t,const} for max tracks used in SD; p_{t,j} (GeV/c); p_{t,ch} (GeV/c", 350, 0., 350., 350., 0., 350.);
+  fHistos->CreateTH2("hSDUsedNeutralPtjvPcMax", "p_{t,j} vs. p_{t,const} for max clusters used in SD; p_{t,j} (GeV/c); p_{t,ne} (GeV/c)", 350, 0., 350., 350., 0., 350.);
+  fHistos->CreateTH2("hSDUsedChargedEtaPhi", "#eta-phi for tracks used in SD; #eta; #phi", 100, -1., 1., 100, 0., 7.);
+  fHistos->CreateTH2("hSDUsedNeutralEtaPhi", "#eta vs. #phi for clusters used in SD; #eta; #phi", 100, -1., 1., 100, 0., 7.);
+  fHistos->CreateTH2("hSDUsedChargedEtaPhiMax", "#eta-phi for tracks used in SD; #eta; #phi", 100, -1., 1., 100, 0., 7.);
+  fHistos->CreateTH2("hSDUsedNeutralEtaPhiMax", "#eta vs. #phi for clusters used in SD; #eta; #phi", 100, -1., 1., 100, 0., 7.);
+  fHistos->CreateTH2("hSDUsedChargedDR", "#DeltaR vs. p_{t,jet} for tracks used in SD; p_{t,jet}; #DeltaR", 100, -1., 1., 100, 0., 7.);
+  fHistos->CreateTH2("hSDUsedNeutralDR", "#DeltaR vs. p_{t,jet} for clusters used in SD; p_{t,jet}; #DeltaR", 100, -1., 1., 100, 0., 7.);
+  fHistos->CreateTH2("hSDUsedChargedDRMax", "#DeltaR vs. p_{t,jet} for tracks used in SD; p_{t,jet}; #DeltaR", 100, -1., 1., 100, 0., 7.);
+  fHistos->CreateTH2("hSDUsedNeutralDRMax", "#DeltaR vs. p_{t,jet} for clusters used in SD; p_{t,jet}; #DeltaR", 100, -1., 1., 100, 0., 7.);
 
   for(auto h : *fHistos->GetListOfHistograms()) fOutput->Add(h);
   PostData(1, fOutput);
@@ -198,6 +212,7 @@ Bool_t AliAnalysisTaskEmcalSoftDropData::Run() {
     // Those plots have been in before (as part of the Tree) but were 
     // removed in order to reduce the disk space consumption.
     fHistos->FillTH2("hQANEFPt", jet->Pt(), jet->NEF(), weight);
+    fHistos->FillTH2("hQAEtaPhi", jet->Eta(), jet->Phi(), weight);
     if(clusters){
       auto leadcluster = jet->GetLeadingCluster(clusters->GetArray());
       if(leadcluster){
@@ -212,6 +227,9 @@ Bool_t AliAnalysisTaskEmcalSoftDropData::Run() {
     }
     fHistos->FillTH2("hQANChPt", jet->Pt(), jet->GetNumberOfTracks(), weight);
     fHistos->FillTH2("hQANnePt", jet->Pt(), jet->GetNumberOfClusters(), weight);
+    fHistos->FillTH2("hQAJetAreaVsJetPt", jet->Pt(), jet->Area(), weight);
+    fHistos->FillTH2("hQAJetAreaVsNEF", jet->NEF(), jet->Area(), weight);
+    fHistos->FillTH2("hQAJetAreaVsNConstDet", jet->GetNumberOfClusters() + jet->GetNumberOfTracks(), jet->Area(), weight);
   }
   return true;
 }
@@ -244,8 +262,10 @@ TBinning *AliAnalysisTaskEmcalSoftDropData::GetRgBinning(double R) const {
 std::vector<double> AliAnalysisTaskEmcalSoftDropData::MakeSoftdrop(const AliEmcalJet &jet, double jetradius, const AliParticleContainer *tracks, const AliClusterContainer *clusters) {
   const int kClusterOffset = 30000; // In order to handle tracks and clusters in the same index space the cluster index needs and offset, large enough so that there is no overlap with track indices
   std::vector<fastjet::PseudoJet> constituents;
+  fastjet::PseudoJet inputjet(jet.Px(), jet.Py(), jet.Pz(), jet.E());
   bool isMC = dynamic_cast<const AliMCParticleContainer *>(tracks);
   AliDebugStream(2) << "Make new jet substrucutre for " << (isMC ? "MC" : "data") << " jet: Number of tracks " << jet.GetNumberOfTracks() << ", clusters " << jet.GetNumberOfClusters() << std::endl;
+  fastjet::PseudoJet *maxcharged(nullptr), *maxneutral(nullptr);
   if(tracks && (fUseChargedConstituents || isMC)){                    // Neutral particles part of particle container in case of MC
     AliDebugStream(1) << "Jet substructure: Using charged constituents" << std::endl;
     for(int itrk = 0; itrk < jet.GetNumberOfTracks(); itrk++){
@@ -256,7 +276,21 @@ std::vector<double> AliAnalysisTaskEmcalSoftDropData::MakeSoftdrop(const AliEmca
       constituentTrack.set_user_index(jet.TrackAt(itrk));
       constituents.push_back(constituentTrack);
       fHistos->FillTH2("hSDUsedChargedPtjvPtc", jet.Pt(), constituentTrack.pt());
+      fHistos->FillTH2("hSDUsedChargedEtaPhi", constituentTrack.eta(), TVector2::Phi_0_2pi(constituentTrack.phi()));
+      fHistos->FillTH2("hSDUsedChargedDR", inputjet.pt(), inputjet.delta_R(constituentTrack));
+      auto &currentconstituent = constituents.back();
+      if(!maxcharged) {
+        maxcharged = &currentconstituent;
+      } else {
+        if(currentconstituent.pt() > maxcharged->pt())
+          maxcharged = &currentconstituent;
+      }
     }
+  }
+  if(maxcharged) {
+    fHistos->FillTH2("hSDUsedChargedPtjvPtcMax", jet.Pt(), maxcharged->pt());
+    fHistos->FillTH2("hSDUsedChargedEtaPhiMax", maxcharged->eta(), TVector2::Phi_0_2pi(maxcharged->phi()));
+    fHistos->FillTH2("hSDUsedChargedDRMax", inputjet.pt(), inputjet.delta_R(*maxcharged));
   }
 
   if(clusters && fUseNeutralConstituents){
@@ -269,7 +303,21 @@ std::vector<double> AliAnalysisTaskEmcalSoftDropData::MakeSoftdrop(const AliEmca
       constituentCluster.set_user_index(jet.ClusterAt(icl) + kClusterOffset);
       constituents.push_back(constituentCluster);
       fHistos->FillTH2("hSDUsedNeutralPtjvPtc", jet.Pt(), constituentCluster.pt());
+      fHistos->FillTH2("hSDUsedNeutralEtaPhi", constituentCluster.eta(), TVector2::Phi_0_2pi(constituentCluster.phi()));
+      fHistos->FillTH2("hSDUsedNeutralDR", inputjet.pt(), inputjet.delta_R(constituentCluster));
+      auto &currentconstituent = constituents.back();
+      if(!maxneutral) {
+        maxneutral = &currentconstituent;
+      } else {
+        if(currentconstituent.pt() > maxneutral->pt())
+          maxneutral = &currentconstituent;
+      }
     }
+  }
+  if(maxneutral){
+    fHistos->FillTH2("hSDUsedNeutralPtjvPcMax", jet.Pt(), maxneutral->pt());
+    fHistos->FillTH2("hSDUsedNeutralEtaPhiMax", maxneutral->eta(), TVector2::Phi_0_2pi(maxneutral->phi()));
+    fHistos->FillTH2("hSDUsedNeutralDRMax", inputjet.pt(), inputjet.delta_R(*maxneutral));
   }
 
   AliDebugStream(3) << "Found " << constituents.size() << " constituents for jet with pt=" << jet.Pt() << " GeV/c" << std::endl;

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalSoftDropResponse.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalSoftDropResponse.cxx
@@ -295,6 +295,14 @@ void AliAnalysisTaskEmcalSoftDropResponse::UserCreateOutputObjects()
       fHistManager.CreateTH2(Form("hQANChPtDet_%d", cent), Form("Number of charged constituents at det. level, %d centrality bin; p_{t} (GeV/c); N_{ch}", cent), 350, 0., 350., 100, 0., 100.);
       fHistManager.CreateTH2(Form("hQANnePtPart_%d", cent), Form("Number of neutral constituents at part. level, %d centrality bin; p_{t} (GeV/c); N_{ne}", cent), 350, 0., 350., 100, 0., 100.);
       fHistManager.CreateTH2(Form("hQANnePtDet_%d", cent), Form("Number of neutral constituents at det. level, %d centrality bin; p_{t} (GeV/c); N_{ne}", cent), 350, 0., 350., 100, 0., 100.);
+      fHistManager.CreateTH2(Form("hQAJetAreaVsJetPtPart_%d", cent), Form("Jet area vs. jet pt at particle level (%d centrality bin); p_{t} (GeV/c); Area", cent), 350, 0., 350., 100, 0., 1.);
+      fHistManager.CreateTH2(Form("hQAJetAreaVsJetPtDet_%d", cent), Form("Jet area vs. jet pt at detector level (%d centrality bin); p_{t} (GeV/c); Area", cent), 350, 0., 350., 100, 0., 1.);
+      fHistManager.CreateTH2(Form("hQAJetAreaVsNEFPart_%d", cent), Form("Jet area vs. NEF at particle level (%d centrality bin); NEF; Area", cent), 100, 0., 1., 100, 0., 1.);
+      fHistManager.CreateTH2(Form("hQAJetAreaVsNEFDet_%d", cent), Form("Jet area vs. NEF at detector level (%d centrality bin); NEF; Area", cent), 100, 0., 1., 100, 0., 1.);
+      fHistManager.CreateTH2(Form("hQAJetAreaVsNConstPart_%d", cent), Form("Jet area vs. number of consituents at particle level (%d centrality bin); Number of constituents; Area", cent), 101, -0.5, 100.5, 100, 0., 1.);
+      fHistManager.CreateTH2(Form("hQAJetAreaVsNConstDet_%d", cent), Form("Jet area vs. number of consituents at detector level (%d centrality bin); Number of constituents; Area", cent), 101, -0.5, 100.5, 100, 0., 1.);
+      fHistManager.CreateTH1(Form("hQAMatchingDRAbs_%d", cent), Form("Distance between part. level jet and  det. level jet (%d centrality bin)", cent), 100, 0., 1.);
+      fHistManager.CreateTH1(Form("hQAMatchingDRAbs_%d", cent), Form("Distance between part. level jet and  det. level jet (%d centrality bin)", cent), 100, 0., 1.);
     }
   }
   else
@@ -405,13 +413,41 @@ void AliAnalysisTaskEmcalSoftDropResponse::UserCreateOutputObjects()
     fHistManager.CreateTH2("hQANChPtDet", "Number of charged constituents at det. level; p_{t} (GeV/c); N_{ch}", 350, 0., 350., 100, 0., 100.);
     fHistManager.CreateTH2("hQANnePtPart", "Number of neutral constituents at part. level; p_{t} (GeV/c); N_{ne}", 350, 0., 350., 100, 0., 100.);
     fHistManager.CreateTH2("hQANnePtDet", "Number of neutral constituents at det. level; p_{t} (GeV/c); N_{ne}", 350, 0., 350., 100, 0., 100.);
+    fHistManager.CreateTH2("hQAJetAreaVsJetPtPart", "Jet area vs. jet pt at particle level; p_{t} (GeV/c); Area", 350, 0., 350., 100, 0., 1.);
+    fHistManager.CreateTH2("hQAJetAreaVsJetPtDet", "Jet area vs. jet pt at detector level; p_{t} (GeV/c); Area", 350, 0., 350., 100, 0., 1.);
+    fHistManager.CreateTH2("hQAJetAreaVsNEFPart", "Jet area vs. NEF at particle level; NEF; Area", 100, 0., 1., 100, 0., 1.);
+    fHistManager.CreateTH2("hQAJetAreaVsNEFDet", "Jet area vs. NEF at detector level; NEF; Area", 100, 0., 1., 100, 0., 1.);
+    fHistManager.CreateTH2("hQAJetAreaVsNConstPart", "Jet area vs. number of consituents at particle level; Number of constituents; Area", 101, -0.5, 100.5, 100, 0., 1.);
+    fHistManager.CreateTH2("hQAJetAreaVsNConstDet", "Jet area vs. number of consituents at detector level; Number of constituents; Area", 101, -0.5, 100.5, 100, 0., 1.);
+    fHistManager.CreateTH1("hQAMatchingDRAbs", "Distance between part. level jet and  det. level jet", 100, 0., 1.);
+    fHistManager.CreateTH1("hQAMatchingDRel", "Distance between part. level jet and  det. level jet", 100, 0., 1.);
   }
 
   // a bit of QA stuff
-  fHistManager.CreateTH2("hSDUsedChargedPtjvPtcPart", "p_{t,j} vs. p_{t,const} for tracks used in SD", 350., 0., 350., 350, 0., 350.);
-  fHistManager.CreateTH2("hSDUsedChargedPtjvPtcDet", "p_{t,j} vs. p_{t,const} for tracks used in SD", 350., 0., 350., 350, 0., 350.);
-  fHistManager.CreateTH2("hSDUsedNeutralPtjvPtcPart", "p_{t,j} vs. p_{t,const} for clusters used in SD", 350., 0., 350., 350, 0., 350.);
-  fHistManager.CreateTH2("hSDUsedNeutralPtjvPtcDet", "p_{t,j} vs. p_{t,const} for clusters used in SD", 350., 0., 350., 350, 0., 350.);
+  fHistManager.CreateTH2("hSDUsedChargedPtjvPtcPart", "p_{t,j} vs. p_{t,const} for tracks used in SD (part. level); p_{t,j} (GeV/c); p_{t,ch} (GeV/c)", 350., 0., 350., 350, 0., 350.);
+  fHistManager.CreateTH2("hSDUsedChargedPtjvPtcDet", "p_{t,j} vs. p_{t,const} for tracks used in SD (det. level); p_{t,j} (GeV/c); p_{t,ch} (GeV/c)", 350., 0., 350., 350, 0., 350.);
+  fHistManager.CreateTH2("hSDUsedNeutralPtjvPtcPart", "p_{t,j} vs. p_{t,const} for clusters used in SD (part. level); p_{t,j} (GeV/c); p_{t,ne} (GeV/c)", 350., 0., 350., 350, 0., 350.);
+  fHistManager.CreateTH2("hSDUsedNeutralPtjvPtcDet", "p_{t,j} vs. p_{t,const} for clusters used in SD (det. level); p_{t,j} (GeV/c); p_{t,ne} (GeV/c)", 350., 0., 350., 350, 0., 350.);
+  fHistManager.CreateTH2("hSDUsedChargedPtjvPtcMaxPart", "p_{t,j} vs. p_{t,const} for max tracks used in SD (part. level); p_{t,j} (GeV/c); p_{t,ch} (GeV/c)", 350, 0., 350., 350., 0., 350.);
+  fHistManager.CreateTH2("hSDUsedChargedPtjvPtcMaxDet", "p_{t,j} vs. p_{t,const} for max tracks used in SD (det. level); p_{t,j} (GeV/c); p_{t,ch} (GeV/c)", 350, 0., 350., 350., 0., 350.);
+  fHistManager.CreateTH2("hSDUsedNeutralPtjvPcMaxPart", "p_{t,j} vs. p_{t,const} for max clusters used in SD (part. level); p_{t,j} (GeV/c); p_{t,ne} (GeV/c)", 350, 0., 350., 350., 0., 350.);
+  fHistManager.CreateTH2("hSDUsedNeutralPtjvPcMaxDet", "p_{t,j} vs. p_{t,const} for max clusters used in SD (det. level); p_{t,j} (GeV/c); p_{t,ne} (GeV/c)", 350, 0., 350., 350., 0., 350.);
+  fHistManager.CreateTH2("hSDUsedChargedEtaPhiPart", "#eta-phi for tracks used in SD (part. level); #eta; #phi", 100, -1., 1., 100, 0., 7.);
+  fHistManager.CreateTH2("hSDUsedChargedEtaPhiDet", "#eta-phi for tracks used in SD (det. level); #eta; #phi", 100, -1., 1., 100, 0., 7.);
+  fHistManager.CreateTH2("hSDUsedNeutralEtaPhiPart", "#eta vs. #phi for clusters used in SD (part. level); #eta; #phi", 100, -1., 1., 100, 0., 7.);
+  fHistManager.CreateTH2("hSDUsedNeutralEtaPhiDet", "#eta vs. #phi for clusters used in SD (det. level); #eta; #phi", 100, -1., 1., 100, 0., 7.);
+  fHistManager.CreateTH2("hSDUsedChargedEtaPhiMaxPart", "#eta-phi for tracks used in SD (part. level); #eta; #phi", 100, -1., 1., 100, 0., 7.);
+  fHistManager.CreateTH2("hSDUsedChargedEtaPhiMaxDet", "#eta-phi for tracks used in SD (det. level); #eta; #phi", 100, -1., 1., 100, 0., 7.);
+  fHistManager.CreateTH2("hSDUsedNeutralEtaPhiMaxPart", "#eta vs. #phi for clusters used in SD (part. level); #eta; #phi", 100, -1., 1., 100, 0., 7.);
+  fHistManager.CreateTH2("hSDUsedNeutralEtaPhiMaxDet", "#eta vs. #phi for clusters used in SD (det. level); #eta; #phi", 100, -1., 1., 100, 0., 7.);
+  fHistManager.CreateTH2("hSDUsedChargedDRPart", "#DeltaR vs. p_{t,jet} for tracks used in SD (part. level); p_{t,jet}; #DeltaR", 100, -1., 1., 100, 0., 7.);
+  fHistManager.CreateTH2("hSDUsedChargedDRDet", "#DeltaR vs. p_{t,jet} for tracks used in SD (det. level); p_{t,jet}; #DeltaR", 100, -1., 1., 100, 0., 7.);
+  fHistManager.CreateTH2("hSDUsedNeutralDRPart", "#DeltaR vs. p_{t,jet} for clusters used in SD (part. level); p_{t,jet}; #DeltaR", 100, -1., 1., 100, 0., 7.);
+  fHistManager.CreateTH2("hSDUsedNeutralDRDet", "#DeltaR vs. p_{t,jet} for clusters used in SD (det. level); p_{t,jet}; #DeltaR", 100, -1., 1., 100, 0., 7.);
+  fHistManager.CreateTH2("hSDUsedChargedDRMaxPart", "#DeltaR vs. p_{t,jet} for tracks used in SD (part. level); p_{t,jet}; #DeltaR", 100, -1., 1., 100, 0., 7.);
+  fHistManager.CreateTH2("hSDUsedChargedDRMaxDet", "#DeltaR vs. p_{t,jet} for tracks used in SD (det. level); p_{t,jet}; #DeltaR", 100, -1., 1., 100, 0., 7.);
+  fHistManager.CreateTH2("hSDUsedNeutralDRMaxPart", "#DeltaR vs. p_{t,jet} for clusters used in SD (part. level); p_{t,jet}; #DeltaR", 100, -1., 1., 100, 0., 7.);
+  fHistManager.CreateTH2("hSDUsedNeutralDRMaxDet", "#DeltaR vs. p_{t,jet} for clusters used in SD (det. level); p_{t,jet}; #DeltaR", 100, -1., 1., 100, 0., 7.);
   fHistManager.CreateTH1("hFracPtHardPart", "Part. level jet Pt relative to the Pt-hard of the event", 100, 0., 10.);
 
   for (auto h : *fHistManager.GetListOfHistograms())
@@ -567,16 +603,17 @@ bool AliAnalysisTaskEmcalSoftDropResponse::Run()
         znedet = detjet->GetZ(ptvec.Px(), ptvec.Py(), ptvec.Pz());
       }
     }
-      if(tracks){
-        nchdet = detjet->GetNumberOfTracks();
-        auto leadingtrack = detjet->GetLeadingTrack(tracks->GetArray());
-        if(leadingtrack) zchdet = detjet->GetZ(leadingtrack->Px(), leadingtrack->Py(), leadingtrack->Pz());
-      }
+    if(tracks){
+      nchdet = detjet->GetNumberOfTracks();
+      auto leadingtrack = detjet->GetLeadingTrack(tracks->GetArray());
+      if(leadingtrack) zchdet = detjet->GetZ(leadingtrack->Px(), leadingtrack->Py(), leadingtrack->Pz());
+    }
 
     try
     {
       softdropDet = MakeSoftdrop(*detjet, detLevelJets->GetJetRadius(), tracks, clusters);
       softdropPart = MakeSoftdrop(*partjet, partLevelJets->GetJetRadius(), particles, nullptr);
+      auto deltaR = TMath::Abs(partjet->DeltaR(detjet));
       bool untaggedDet = softdropDet[0] < fZcut,
            untaggedPart = softdropPart[0] < fZcut;
       Double_t pointZg[4] = {softdropDet[0], detjet->Pt(), softdropPart[0], partjet->Pt()},
@@ -592,6 +629,14 @@ bool AliAnalysisTaskEmcalSoftDropResponse::Run()
         // fill QA histograms
         fHistManager.FillTH2(Form("hQANEFPtDet_%d", fCentBin), detjet->Pt(), detjet->NEF());
         fHistManager.FillTH2(Form("hQANEFPtPart_%d", fCentBin), partjet->Pt(), partjet->NEF());
+        fHistManager.FillTH2(Form("hQAJetAreaVsJetPtPart_%d", fCentBin), partjet->Pt(), partjet->Area());
+        fHistManager.FillTH2(Form("hQAJetAreaVsJetPtDet_%d", fCentBin), detjet->Pt(), detjet->Area());
+        fHistManager.FillTH2(Form("hQAJetAreaVsNEFPart_%d", fCentBin), partjet->NEF(), partjet->Area());
+        fHistManager.FillTH2(Form("hQAJetAreaVsNEFDet_%d", fCentBin), detjet->NEF(), detjet->Area());
+        fHistManager.FillTH2(Form("hQAJetAreaVsNConstPart_%d", fCentBin), partjet->GetNumberOfTracks(), partjet->Area());
+        fHistManager.FillTH2(Form("hQAJetAreaVsNConstDet_%d", fCentBin), detjet->GetNumberOfClusters() + detjet->GetNumberOfTracks(), detjet->Area());
+        fHistManager.FillTH1(Form("hQAMatchingDRAbs_%d", fCentBin), deltaR);
+        fHistManager.FillTH1(Form("hQAMatchingDRel_%d", fCentBin), deltaR / detLevelJets->GetJetRadius());
         if(fUseChargedConstituents) {
           fHistManager.FillTH2(Form("hQAZchPtDet_%d", fCentBin), detjet->Pt(), zchdet);
           fHistManager.FillTH2(Form("hQAZchPtPart_%d", fCentBin), detjet->Pt(), zchpart);
@@ -635,6 +680,14 @@ bool AliAnalysisTaskEmcalSoftDropResponse::Run()
         znepart = stat[3];
         fHistManager.FillTH2("hQANEFPtDet", detjet->Pt(), detjet->NEF());
         fHistManager.FillTH2("hQANEFPtPart", partjet->Pt(), partjet->NEF());
+        fHistManager.FillTH2("hQAJetAreaVsJetPtPart", partjet->Pt(), partjet->Area());
+        fHistManager.FillTH2("hQAJetAreaVsJetPtDet", detjet->Pt(), detjet->Area());
+        fHistManager.FillTH2("hQAJetAreaVsNEFPart", partjet->NEF(), partjet->Area());
+        fHistManager.FillTH2("hQAJetAreaVsNEFDet", detjet->NEF(), detjet->Area());
+        fHistManager.FillTH2("hQAJetAreaVsNConstPart", partjet->GetNumberOfTracks(), partjet->Area());
+        fHistManager.FillTH2("hQAJetAreaVsNConstDet", detjet->GetNumberOfClusters() + detjet->GetNumberOfTracks(), detjet->Area());
+        fHistManager.FillTH1("hQAMatchingDRAbs", deltaR);
+        fHistManager.FillTH1("hQAMatchingDRel", deltaR / detLevelJets->GetJetRadius());
         if(fUseChargedConstituents) {
           fHistManager.FillTH2("hQAZchPtDet", detjet->Pt(), zchdet);
           fHistManager.FillTH2("hQAZchPtPart", detjet->Pt(), zchpart);
@@ -847,6 +900,8 @@ std::vector<double> AliAnalysisTaskEmcalSoftDropResponse::MakeSoftdrop(const Ali
   std::vector<fastjet::PseudoJet> constituents;
   bool isMC = dynamic_cast<const AliMCParticleContainer *>(tracks);
   AliDebugStream(2) << "Make new jet substrucutre for " << (isMC ? "MC" : "data") << " jet: Number of tracks " << jet.GetNumberOfTracks() << ", clusters " << jet.GetNumberOfClusters() << std::endl;
+  fastjet::PseudoJet *maxcharged(nullptr), *maxneutral(nullptr);
+  fastjet::PseudoJet inputjet(jet.Px(), jet.Py(), jet.Pz(), jet.E());
   if (tracks && (fUseChargedConstituents || isMC))
   { // Neutral particles part of particle container in case of MC
     AliDebugStream(1) << "Jet substructure: Using charged constituents" << std::endl;
@@ -860,11 +915,39 @@ std::vector<double> AliAnalysisTaskEmcalSoftDropResponse::MakeSoftdrop(const Ali
       fastjet::PseudoJet constituentTrack(track->Px(), track->Py(), track->Pz(), track->E());
       constituentTrack.set_user_index(jet.TrackAt(itrk));
       constituents.push_back(constituentTrack);
+      auto &currentconstituent = constituents.back();
       if(isMC) {
-        if(track->Charge()) fHistManager.FillTH2("hSDUsedChargedPtjvPtcPart", jet.Pt(), constituentTrack.pt());
-        else fHistManager.FillTH2("hSDUsedNeutralPtjvPtcPart", jet.Pt(), constituentTrack.pt());
+        if(track->Charge()) {
+          fHistManager.FillTH2("hSDUsedChargedPtjvPtcPart", jet.Pt(), constituentTrack.pt());
+          fHistManager.FillTH2("hSDUsedChargedEtaPhiPart", constituentTrack.eta(), TVector2::Phi_0_2pi(constituentTrack.phi()));
+          fHistManager.FillTH2("hSDUsedChargedDRPart", inputjet.pt(), inputjet.delta_R(constituentTrack));
+          if(!maxcharged) {
+            maxcharged = &currentconstituent;
+          } else {
+            if(currentconstituent.pt() > maxcharged->pt())
+            maxcharged = &currentconstituent;
+          }
+        } else {
+          fHistManager.FillTH2("hSDUsedNeutralPtjvPtcPart", jet.Pt(), constituentTrack.pt());
+          fHistManager.FillTH2("hSDUsedNeutralEtaPhiPart", constituentTrack.eta(), TVector2::Phi_0_2pi(constituentTrack.phi()));
+          fHistManager.FillTH2("hSDUsedNeutralDRPart", inputjet.pt(), inputjet.delta_R(constituentTrack));
+          if(!maxneutral) {
+            maxneutral = &currentconstituent;
+          } else {
+            if(currentconstituent.pt() > maxcharged->pt())
+            maxneutral = &currentconstituent;
+          }
+        }
       } else {
         fHistManager.FillTH2("hSDUsedChargedPtjvPtcDet", jet.Pt(), constituentTrack.pt());
+        fHistManager.FillTH2("hSDUsedChargedEtaPhiDet", constituentTrack.eta(), TVector2::Phi_0_2pi(constituentTrack.phi()));
+        fHistManager.FillTH2("hSDUsedChargedDRDet", inputjet.pt(), inputjet.delta_R(constituentTrack));
+        if(!maxcharged) {
+          maxcharged = &currentconstituent;
+        } else {
+          if(currentconstituent.pt() > maxcharged->pt())
+          maxcharged = &currentconstituent;
+        }
       }
     }
   }
@@ -881,8 +964,42 @@ std::vector<double> AliAnalysisTaskEmcalSoftDropResponse::MakeSoftdrop(const Ali
       constituentCluster.set_user_index(jet.ClusterAt(icl) + kClusterOffset);
       constituents.push_back(constituentCluster);
       fHistManager.FillTH2("hSDUsedNeutralPtjvPtcDet", jet.Pt(), constituentCluster.pt());
+      fHistManager.FillTH2("hSDUsedNeutralEtaPhiDet", constituentCluster.eta(), TVector2::Phi_0_2pi(constituentCluster.phi()));
+      fHistManager.FillTH2("hSDUsedNeutralDRDet", inputjet.pt(), inputjet.delta_R(constituentCluster));
+      auto &currentconstituent = constituents.back();
+      if(!maxneutral) {
+        maxneutral = &currentconstituent;
+      } else {
+        if(currentconstituent.pt() > maxneutral->pt())
+          maxneutral = &currentconstituent;
+      }
     }
   }
+
+  if(maxcharged) {
+    if(isMC) {
+      fHistManager.FillTH2("hSDUsedChargedPtjvPtcMaxPart", jet.Pt(), maxcharged->pt());
+      fHistManager.FillTH2("hSDUsedChargedEtaPhiMaxPart", maxcharged->eta(), TVector2::Phi_0_2pi(maxcharged->phi()));
+      fHistManager.FillTH2("hSDUsedChargedDRMaxPart", inputjet.pt(), inputjet.delta_R(*maxcharged));
+    } else {
+      fHistManager.FillTH2("hSDUsedChargedPtjvPtcMaxDet", jet.Pt(), maxcharged->pt());
+      fHistManager.FillTH2("hSDUsedChargedEtaPhiMaxDet", maxcharged->eta(), TVector2::Phi_0_2pi(maxcharged->phi()));
+      fHistManager.FillTH2("hSDUsedChargedDRMaxDet", inputjet.pt(), inputjet.delta_R(*maxcharged));
+    }
+  }
+
+  if(maxneutral) {
+    if(isMC) {
+      fHistManager.FillTH2("hSDUsedNeutralPtjvPcMaxPart", jet.Pt(), maxneutral->pt());
+      fHistManager.FillTH2("hSDUsedNeutralEtaPhiMaxPart", maxneutral->eta(), TVector2::Phi_0_2pi(maxneutral->phi()));
+      fHistManager.FillTH2("hSDUsedNeutralDRMaxPart", inputjet.pt(), inputjet.delta_R(*maxneutral));
+    } else {
+      fHistManager.FillTH2("hSDUsedNeutralPtjvPcMaxDet", jet.Pt(), maxneutral->pt());
+      fHistManager.FillTH2("hSDUsedNeutralEtaPhiMaxDet", maxneutral->eta(), TVector2::Phi_0_2pi(maxneutral->phi()));
+      fHistManager.FillTH2("hSDUsedNeutralDRMaxDet", inputjet.pt(), inputjet.delta_R(*maxneutral));
+    }
+  }
+
 
   AliDebugStream(3) << "Found " << constituents.size() << " constituents for jet with pt=" << jet.Pt() << " GeV/c" << std::endl;
   if (!constituents.size())


### PR DESCRIPTION
- Jet area (vs. pt, NEF, Nconst)
- (Max.) constituent Eta-phi
- (Max.) constituent distance to the main jet axis
In case of response tasks:
- Histograms for both part. and det. level jets
- Histograms for Matching deltaR between part.
  level jet and det. level jet