### PR TITLE
PWGDQ EtaReconstruction: Implemented secondary PID track cuts, fixed …

### DIFF
--- a/PWGDQ/dielectron/core/AliAnalysisTaskEtaReconstruction.cxx
+++ b/PWGDQ/dielectron/core/AliAnalysisTaskEtaReconstruction.cxx
@@ -95,7 +95,7 @@ AliAnalysisTaskEtaReconstruction::AliAnalysisTaskEtaReconstruction(): AliAnalysi
                                                                               , fLowerMassCutPrimaries(), fUpperMassCutPrimaries(), fMassCutSecondaries(), fUpperPrimSecPreFilterMass(), fLowerPrimSecPreFilterMass(), fUpperSecSecPreFilterMass(), fLowerSecSecPreFilterMass(), fV0OnFlyStatus()
                                                                               , fSinglePrimaryLegMCSignal(), fSingleSecondaryLegMCSignal(), fPrimaryPairMCSignal(), fSecondaryPairMCSignal(), fFourPairMCSignal(), fPrimaryDielectronPairNotFromSameMother(), fSecondaryDielectronPairNotFromSameMother()
                                                                               , fGeneratorName(""), fGeneratorMCSignalName(""), fGeneratorULSSignalName(""), fGeneratorHashs(), fGeneratorMCSignalHashs(), fGeneratorULSSignalHashs(), fPIDResponse(0x0), fEvent(0x0), fMC(0x0), fTrack(0x0), isAOD(false), fSelectPhysics(false), fTriggerMask(0)
-                                                                              , fTrackCuts_primary_PreFilter(), fTrackCuts_primary_standard(), fTrackCuts_secondary_PreFilter(), fPairCuts_primary(), fPairCuts_secondary_PreFilter(), fPairCuts_secondary_standard(), fUsedVars(0x0)
+                                                                              , fTrackCuts_primary_PreFilter(), fTrackCuts_primary_standard(), fTrackCuts_secondary_PreFilter(), fTrackCuts_secondary_standard(), fPairCuts_primary(), fPairCuts_secondary_PreFilter(), fPairCuts_secondary_standard(), fUsedVars(0x0)
                                                                               , fSupportMCSignal(0), fSupportCutsetting(0)
                                                                               , fHistEvents(0x0), fHistEventStat(0x0), fHistCentrality(0x0), fHistVertex(0x0), fHistVertexContibutors(0x0), fHistNTracks(0x0)
                                                                               , fMinCentrality(0.), fMaxCentrality(100), fCentralityFile(0x0), fCentralityFilename(""), fHistCentralityCorrection(0x0)
@@ -131,7 +131,7 @@ AliAnalysisTaskEtaReconstruction::AliAnalysisTaskEtaReconstruction(const char * 
                                                                               , fLowerMassCutPrimaries(), fUpperMassCutPrimaries(), fMassCutSecondaries(), fUpperPrimSecPreFilterMass(), fLowerPrimSecPreFilterMass(), fUpperSecSecPreFilterMass(), fLowerSecSecPreFilterMass(), fV0OnFlyStatus()
                                                                               , fSinglePrimaryLegMCSignal(), fSingleSecondaryLegMCSignal(), fPrimaryPairMCSignal(), fSecondaryPairMCSignal(), fFourPairMCSignal(), fPrimaryDielectronPairNotFromSameMother(), fSecondaryDielectronPairNotFromSameMother()
                                                                               , fGeneratorName(""), fGeneratorMCSignalName(""), fGeneratorULSSignalName(""), fGeneratorHashs(), fGeneratorMCSignalHashs(), fGeneratorULSSignalHashs(), fPIDResponse(0x0), fEvent(0x0), fMC(0x0), fTrack(0x0), isAOD(false), fSelectPhysics(false), fTriggerMask(0)
-                                                                              , fTrackCuts_primary_PreFilter(), fTrackCuts_primary_standard(), fTrackCuts_secondary_PreFilter(), fPairCuts_primary(), fPairCuts_secondary_PreFilter(), fPairCuts_secondary_standard(), fUsedVars(0x0)
+                                                                              , fTrackCuts_primary_PreFilter(), fTrackCuts_primary_standard(), fTrackCuts_secondary_PreFilter(), fTrackCuts_secondary_standard(), fPairCuts_primary(), fPairCuts_secondary_PreFilter(), fPairCuts_secondary_standard(), fUsedVars(0x0)
                                                                               , fSupportMCSignal(0), fSupportCutsetting(0)
                                                                               , fHistEvents(0x0), fHistEventStat(0x0), fHistCentrality(0x0), fHistVertex(0x0), fHistVertexContibutors(0x0), fHistNTracks(0x0)
                                                                               , fMinCentrality(0.), fMaxCentrality(100), fCentralityFile(0x0), fCentralityFilename(""), fHistCentralityCorrection(0x0)
@@ -1371,7 +1371,7 @@ void AliAnalysisTaskEtaReconstruction::UserExec(Option_t* option){
       DoGenAndGenSmearTwoPairing(&fGenSmearedNegPart_secondary, &fGenSmearedPosPart_secondary, !PrimaryPair, SmearedPair, centralityWeight);
     }
                                                                                 // if (fdebug) std::cout << "Do primary two reconstructed pairing" << std::endl;
-    DoRecTwoPairing(fRecNegPart_primary, fRecPosPart_primary, fPrimaryPairMCSignal,  PrimaryPair, centralityWeight);
+    DoRecTwoPairing(fRecNegPart_primary, fRecPosPart_primary, fPrimaryPairMCSignal,  PrimaryPair, centralityWeight); // ! Note: use for secondaries is commented out, since secondaries are selected with V0-Finder
                                                                                 // if (fdebug) std::cout << "Do secondary two reconstructed pairing" << std::endl;
     // DoRecTwoPairing(fRecNegPart_secondary, fRecPosPart_secondary, fSecondaryPairMCSignal, !PrimaryPair, centralityWeight);
     DoRecTwoPairingV0(fSecondaryPairMCSignal);
@@ -1379,8 +1379,10 @@ void AliAnalysisTaskEtaReconstruction::UserExec(Option_t* option){
                                                                                 // if (fdebug) std::cout << __LINE__ << " DEBUG_AnalysisTask: Size of Vectors after TwoPairing, " << std::endl <<
                                                                                 // " fRecNegPart_primary = " << fRecNegPart_primary.size() << std::endl <<
                                                                                 // " fRecPosPart_primary = " << fRecPosPart_primary.size() << std::endl <<
-                                                                                // /*" fGenPairVec_primary = "   << fGenPairVec_primary.size()   << " fGenSmearedPairVec_primary =   " << fGenSmearedPairVec_primary.size()   << */" fRecPairVec_primary =   " << fRecPairVec_primary.size()   << std::endl <<
-                                                                                // /*" fGenPairVec_secondary = " << fGenPairVec_secondary.size() << " fGenSmearedPairVec_secondary = " << fGenSmearedPairVec_secondary.size() << */" fRecPairVec_secondary = " << fRecV0Pair.size()/*fRecPairVec_secondary.size()*/ << std::endl;
+                                                                                // /*" fGenPairVec_primary = "   << fGenPairVec_primary.size()   << " fGenSmearedPairVec_primary =   " << fGenSmearedPairVec_primary.size()   << */
+                                                                                // " fRecPairVec_primary =   " << fRecPairVec_primary.size()   << std::endl <<
+                                                                                // /*" fGenPairVec_secondary = " << fGenPairVec_secondary.size() << " fGenSmearedPairVec_secondary = " << fGenSmearedPairVec_secondary.size() << */
+                                                                                // " fRecPairVec_secondary = " << fRecV0Pair.size()/*fRecPairVec_secondary.size()*/ << std::endl;
 
 
 
@@ -1414,10 +1416,12 @@ void AliAnalysisTaskEtaReconstruction::UserExec(Option_t* option){
     // #############################################
                                                                                 // if (fdebug) std::cout << "Do generated four pairing" << std::endl;
     DoFourPairing(fGenPairVec_primary, fGenPairVec_secondary, !ReconstructedPair, !SmearedPair, centralityWeight);
+                                                                                // if(fdebug) std::cout << __LINE__ << " DEBUG_AnalysisTask: Line cout " << std::endl;
     if(fArrResoPt){
       // if (fdebug) std::cout << "Do generated smeared four pairing" << std::endl;
       DoFourPairing(fGenSmearedPairVec_primary, fGenSmearedPairVec_secondary, !ReconstructedPair, SmearedPair, centralityWeight);
     }
+                                                                                // if(fdebug) std::cout << __LINE__ << " DEBUG_AnalysisTask: Line cout " << std::endl;
 
     // #############################################
     // #     DoFourPairing Reconstructed           #
@@ -1432,8 +1436,10 @@ void AliAnalysisTaskEtaReconstruction::UserExec(Option_t* option){
                                                                                 // if (fdebug) std::cout << __LINE__ << " DEBUG_AnalysisTask: Size of Vectors after applying PreFilters, " << std::endl <<
                                                                                 // " fRecNegPart_primary = " << fRecNegPart_primary.size() << std::endl <<
                                                                                 // " fRecPosPart_primary = " << fRecPosPart_primary.size() << std::endl <<
-                                                                                // /*" fGenPairVec_primary = "   << fGenPairVec_primary.size()   << " fGenSmearedPairVec_primary =   " << fGenSmearedPairVec_primary.size()   << */" fRecPairVec_primary =   " << fRecPairVec_primary.size()   << std::endl <<
-                                                                                // /*" fGenPairVec_secondary = " << fGenPairVec_secondary.size() << " fGenSmearedPairVec_secondary = " << fGenSmearedPairVec_secondary.size() << */" fRecPairVec_secondary = " << fRecV0Pair.size()/*fRecPairVec_secondary.size()*/ << std::endl;
+                                                                                // /*" fGenPairVec_primary = "   << fGenPairVec_primary.size()   << " fGenSmearedPairVec_primary =   " << fGenSmearedPairVec_primary.size()   << */
+                                                                                // " fRecPairVec_primary =   " << fRecPairVec_primary.size()   << std::endl <<
+                                                                                // /*" fGenPairVec_secondary = " << fGenPairVec_secondary.size() << " fGenSmearedPairVec_secondary = " << fGenSmearedPairVec_secondary.size() << */
+                                                                                // " fRecPairVec_secondary = " << fRecV0Pair.size()/*fRecPairVec_secondary.size()*/ << std::endl;
 
     // Clear Primary Part Vector and do TwoPairing again with pos/neg particle vectors reduced by PreFilter
     fRecPairVec_primary.clear();
@@ -1442,17 +1448,30 @@ void AliAnalysisTaskEtaReconstruction::UserExec(Option_t* option){
                                                                                 // if (fdebug) std::cout << __LINE__ << " DEBUG_AnalysisTask: Size of Vectors after the second primary pairing, " << std::endl <<
                                                                                 // " fRecNegPart_primary = " << fRecNegPart_primary.size() << std::endl <<
                                                                                 // " fRecPosPart_primary = " << fRecPosPart_primary.size() << std::endl <<
-                                                                                // /*" fGenPairVec_primary = "   << fGenPairVec_primary.size()   << " fGenSmearedPairVec_primary =   " << fGenSmearedPairVec_primary.size()   << */" fRecPairVec_primary =   " << fRecPairVec_primary.size()   << std::endl <<
-                                                                                // /*" fGenPairVec_secondary = " << fGenPairVec_secondary.size() << " fGenSmearedPairVec_secondary = " << fGenSmearedPairVec_secondary.size() << */" fRecPairVec_secondary = " << fRecV0Pair.size()/*fRecPairVec_secondary.size()*/ << std::endl;
+                                                                                // /*" fGenPairVec_primary = "   << fGenPairVec_primary.size()   << " fGenSmearedPairVec_primary =   " << fGenSmearedPairVec_primary.size()   << */
+                                                                                // " fRecPairVec_primary =   " << fRecPairVec_primary.size()   << std::endl <<
+                                                                                // /*" fGenPairVec_secondary = " << fGenPairVec_secondary.size() << " fGenSmearedPairVec_secondary = " << fGenSmearedPairVec_secondary.size() << */
+                                                                                // " fRecPairVec_secondary = " << fRecV0Pair.size()/*fRecPairVec_secondary.size()*/ << std::endl;
 
     // ################################
     // #      Apply Standard Cut      #
     // ################################
                                                                                 // if(fdebug) std::cout << __LINE__ << " Apply StandardCuts for Pairing " << std::endl;
-    ApplyStandardCutsAndFillHists(&fRecPairVec_primary, fTrackCuts_primary_standard ,  TrackCuts,  PairPrimary, centralityWeight);
-    ApplyStandardCutsAndFillHists(&fRecPairVec_primary, fPairCuts_primary           , !TrackCuts,  PairPrimary, centralityWeight);
-    // ApplyStandardCutsAndFillHists(&fRecV0Pair         , fPairCuts_secondary_standard,  TrackCuts, !PairPrimary, centralityWeight); // track cuts on secondaries not implemented yet
-    ApplyStandardCutsAndFillHists(&fRecV0Pair         , fPairCuts_secondary_standard, !TrackCuts, !PairPrimary, centralityWeight);
+    ApplyStandardCutsAndFillHists(&fRecPairVec_primary, fTrackCuts_primary_standard  ,  TrackCuts,  PairPrimary, centralityWeight);
+    ApplyStandardCutsAndFillHists(&fRecPairVec_primary, fPairCuts_primary            , !TrackCuts,  PairPrimary, centralityWeight);
+    ApplyStandardCutsAndFillHists(&fRecV0Pair         , fTrackCuts_secondary_standard,  TrackCuts, !PairPrimary, centralityWeight);
+    ApplyStandardCutsAndFillHists(&fRecV0Pair         , fPairCuts_secondary_standard , !TrackCuts, !PairPrimary, centralityWeight);
+
+
+                                                                                // if (fdebug) std::cout << __LINE__ << " DEBUG_AnalysisTask: Size of Vectors after applying standard cuts, " << std::endl <<
+                                                                                // " fRecNegPart_primary = " << fRecNegPart_primary.size() << std::endl <<
+                                                                                // " fRecPosPart_primary = " << fRecPosPart_primary.size() << std::endl <<
+                                                                                // /*" fGenPairVec_primary = "   << fGenPairVec_primary.size()   << " fGenSmearedPairVec_primary =   " << fGenSmearedPairVec_primary.size()   << */
+                                                                                // " fRecPairVec_primary =   " << fRecPairVec_primary.size()   << std::endl <<
+                                                                                // /*" fGenPairVec_secondary = " << fGenPairVec_secondary.size() << " fGenSmearedPairVec_secondary = " << fGenSmearedPairVec_secondary.size() << */
+                                                                                // " fRecPairVec_secondary = " << fRecV0Pair.size()/*fRecPairVec_secondary.size()*/ << std::endl;
+
+
 
     // ################################
     // #      Do actual pairing       #
@@ -2180,17 +2199,19 @@ void AliAnalysisTaskEtaReconstruction::ApplyStandardCutsAndFillHists (std::vecto
       AliVParticle* negTrack = fEvent->GetTrack(fPairVec->at(iPair).GetFirstDaughter());
       AliVParticle* posTrack = fEvent->GetTrack(fPairVec->at(iPair).GetSecondDaughter());
 
-      int poslabel = posTrack->GetLabel();
       int neglabel = negTrack->GetLabel();
-      int absposlabel = TMath::Abs(poslabel);
+      int poslabel = posTrack->GetLabel();
       int absneglabel = TMath::Abs(neglabel);
+      int absposlabel = TMath::Abs(poslabel);
 
+      Particle negPart  = CreateParticle(negTrack);
+      Particle posPart  = CreateParticle(posTrack);
 
       // ###############################
       // Track cuts on primary pair
       // ###############################
       if(TrackCuts == kTRUE){
-
+                                                                                // if(fdebug) std::cout << __LINE__ << " Cout Debug: Apply standard priamry track cuts. " << std::endl;
         //  ---------- RECONSTRUCTED Tracks  ---------- //
         // Check if pos and neg Track are passing cut selections
         std::vector<bool> selected_posTrack(fCutsetting.size(), kFALSE); // vector which stores if track is accepted by [i]-th selection cut
@@ -2216,18 +2237,21 @@ void AliAnalysisTaskEtaReconstruction::ApplyStandardCutsAndFillHists (std::vecto
           iPair--;
           continue;
         }
-
         std::vector<Bool_t> mcSignal_acc_posPart(fSinglePrimaryLegMCSignal.size(), kFALSE); // vector which stores if track is accepted by [i]-th mcsignal
         std::vector<Bool_t> mcSignal_acc_negPart(fSinglePrimaryLegMCSignal.size(), kFALSE); // vector which stores if track is accepted by [i]-th mcsignal
         CheckSinglePrimaryLegMCsignals(mcSignal_acc_posPart, absposlabel);
         CheckSinglePrimaryLegMCsignals(mcSignal_acc_negPart, absneglabel);
 
-        Particle posPart  = CreateParticle(posTrack);
-        Particle negPart  = CreateParticle(negTrack);
+
         posPart.isMCSignal_primary   = mcSignal_acc_posPart;
         negPart.isMCSignal_primary   = mcSignal_acc_negPart;
         posPart.isReconstructed_primary = selected_posTrack;
         negPart.isReconstructed_primary = selected_negTrack;
+
+        fPairVec->at(iPair).SetDauthersAreReconstructed(selected_negTrack,selected_posTrack);
+
+        AliVParticle* mcPosPart = fMC->GetTrack(absposlabel);
+        AliVParticle* mcNegPart = fMC->GetTrack(absneglabel);
 
         // check if MCSignal and isReconstructed for positive primary track
         if (posPart.fCharge > 0) {
@@ -2236,6 +2260,7 @@ void AliAnalysisTaskEtaReconstruction::ApplyStandardCutsAndFillHists (std::vecto
               if (posPart.isMCSignal_primary[i] == kTRUE) {
                 if (posPart.isReconstructed_primary[j] == kTRUE){
                   dynamic_cast<TH3D*>(fHistRecPrimaryPosPart.at(j * posPart.isMCSignal_primary.size() + i))->Fill(posPart.fPt, posPart.fEta, posPart.fPhi, centralityWeight);
+                  FillTrackHistograms_Primary(posTrack, mcPosPart, j, i); // Fill primary track support histograms
                 }// is selected by cutsetting
               } // is selected by MC signal
             } // end of loop over all cutsettings
@@ -2249,6 +2274,7 @@ void AliAnalysisTaskEtaReconstruction::ApplyStandardCutsAndFillHists (std::vecto
               if (negPart.isMCSignal_primary[i] == kTRUE) {
                 if (negPart.isReconstructed_primary[j] == kTRUE){
                   dynamic_cast<TH3D*>(fHistRecPrimaryNegPart.at(j * negPart.isMCSignal_primary.size() + i))->Fill(negPart.fPt, negPart.fEta, negPart.fPhi, centralityWeight);
+                  FillTrackHistograms_Primary(negTrack, mcNegPart, j, i); // Fill primary track support histograms
                 }// is selected by cutsetting
               } // is selected by MC signal
             } // end of loop over all cutsettings
@@ -2258,12 +2284,11 @@ void AliAnalysisTaskEtaReconstruction::ApplyStandardCutsAndFillHists (std::vecto
 
 
 
-
       // ###############################
       // Pair cuts on primary pair
       // ###############################
       else if (TrackCuts == kFALSE) {
-
+                                                                                // if(fdebug) std::cout << __LINE__ << " Cout Debug: Apply standard primary pair cuts. " << std::endl;
         AliDielectronPair *pair = new AliDielectronPair;
         pair->SetKFUsage(false);
         pair->SetTracks(static_cast<AliVTrack*>(negTrack), 11, static_cast<AliVTrack*>(posTrack), -11);
@@ -2272,6 +2297,7 @@ void AliAnalysisTaskEtaReconstruction::ApplyStandardCutsAndFillHists (std::vecto
         // Check if pair is passing cut selections
         std::vector<bool> selected(fCutsetting.size(), kFALSE); // vector which stores if pair is accepted by [i]-th selection cut
         for (UInt_t iCut=0; iCut<fCutsetting.size(); ++iCut){ // loop over all specified cutInstances
+          if (fPairVec->at(iPair).fFirstPartIsReconstructed[iCut] == kFALSE || fPairVec->at(iPair).fSecondPartIsReconstructed[iCut] == kFALSE) continue;  //check if both daughters are reconstructed
           UInt_t selectedMask=( 1 << fCutsetting.at(iCut)->GetCuts()->GetEntries())-1;
           // cutting logic taken from AliDielectron::FillTrackArrays()          FillPairArrays()
           // apply pair cuts
@@ -2333,30 +2359,115 @@ void AliAnalysisTaskEtaReconstruction::ApplyStandardCutsAndFillHists (std::vecto
       // Get V0 from Event, selected trough V0ID stored in TwoPair and is set in reconstructed secondary two pairing
       Int_t fV0ID = fPairVec->at(iPair).GetV0ID();
       AliAODv0* fV0 = ((AliAODEvent*)fEvent)->GetV0(fV0ID);
-      AliAODTrack *posTrack = (AliAODTrack *) (fV0->GetSecondaryVtx()->GetDaughter(0));
-      AliAODTrack *negTrack = (AliAODTrack *) (fV0->GetSecondaryVtx()->GetDaughter(1));
+      AliAODTrack *TrackD1 = (AliAODTrack *) (fV0->GetSecondaryVtx()->GetDaughter(0));
+      AliAODTrack *TrackD2 = (AliAODTrack *) (fV0->GetSecondaryVtx()->GetDaughter(1));
 
+      int labelD1 = TrackD1->GetLabel();
+      int labelD2 = TrackD2->GetLabel();
+      int absD1label = TMath::Abs(labelD1);
+      int absD2label = TMath::Abs(labelD2);
 
+      Particle PartD1  = CreateParticle(TrackD1);
+      Particle PartD2  = CreateParticle(TrackD2);
+
+      // ###############################
+      // Track cuts on secondary tracks
+      // ###############################
       if (TrackCuts == kTRUE) {
-        // ###############################
-        // Track cuts on secondary pair   *** not implemented yet ***
-        // ###############################
+                                                                                // if(fdebug) std::cout << __LINE__ << " Cout Debug: Apply standard secondary track cuts. " << std::endl;
+        // Check if Daughter1 and Daughter2 Tracks are passing cut selections
+        std::vector<bool> selected_TrackD1(fCutsetting.size(), kFALSE); // vector which stores if track is accepted by [i]-th selection cut
+        for (UInt_t iCut=0; iCut<fCutsetting.size(); ++iCut){ // loop over all specified cutInstances
+          UInt_t selectedMask_TrackD1=( 1 << fCutsetting.at(iCut)->GetCuts()->GetEntries())-1;
+          // cutting logic taken from AliDielectron::FillTrackArrays()          FillPairArrays()
+          // apply track cuts
+          UInt_t cutMask_TrackD1 = fCutsetting.at(iCut)->IsSelected(TrackD1);
+          if (cutMask_TrackD1 == selectedMask_TrackD1) {selected_TrackD1[iCut] = kTRUE; /*std::cout << "reconstructed TRUE" << std::endl;*/}
+        }
+        std::vector<bool> selected_TrackD2(fCutsetting.size(), kFALSE); // vector which stores if track is accepted by [i]-th selection cut
+        for (UInt_t iCut=0; iCut<fCutsetting.size(); ++iCut){ // loop over all specified cutInstances
+          UInt_t selectedMask_TrackD2=( 1 << fCutsetting.at(iCut)->GetCuts()->GetEntries())-1;
+          // cutting logic taken from AliDielectron::FillTrackArrays()          FillPairArrays()
+          // apply track cuts
+          UInt_t cutMask_TrackD2 = fCutsetting.at(iCut)->IsSelected(TrackD2);
+          if (cutMask_TrackD2 == selectedMask_TrackD2) {selected_TrackD2[iCut] = kTRUE; /*std::cout << "reconstructed TRUE" << std::endl;*/}
+        }
+        // ##########################################################
+        // check if at least one is selected by cuts otherwise remove this pair from vector
+        if ((CheckIfOneIsTrue(selected_TrackD1) == kFALSE) || (CheckIfOneIsTrue(selected_TrackD2) == kFALSE)) {
+          fPairVec->erase(fPairVec->begin()+iPair);
+          iPair--;
+          continue;
+        }
+
+        std::vector<Bool_t> mcSignal_acc_TrackD1(fSingleSecondaryLegMCSignal.size(), kFALSE); // vector which stores if track is accepted by [i]-th mcsignal
+        std::vector<Bool_t> mcSignal_acc_TrackD2(fSingleSecondaryLegMCSignal.size(), kFALSE); // vector which stores if track is accepted by [i]-th mcsignal
+        CheckSingleSecondaryLegMCsignals(mcSignal_acc_TrackD1, absD1label);
+        CheckSingleSecondaryLegMCsignals(mcSignal_acc_TrackD2, absD2label);
+
+        PartD1.isMCSignal_secondary   = mcSignal_acc_TrackD1;
+        PartD2.isMCSignal_secondary   = mcSignal_acc_TrackD2;
+        PartD1.isReconstructed_secondary = selected_TrackD1;
+        PartD2.isReconstructed_secondary = selected_TrackD2;
+
+        fPairVec->at(iPair).SetDauthersAreReconstructed(selected_TrackD1,selected_TrackD2);
+
+        AliVParticle* mcPartD1 = fMC->GetTrack(absD1label);
+        AliVParticle* mcPartD2 = fMC->GetTrack(absD2label);
+
+
+        // check if MCSignal and isReconstructed for positive primary track
+        for (unsigned int i = 0; i < PartD1.isMCSignal_secondary.size(); ++i){
+          for (unsigned int j = 0; j < PartD1.isReconstructed_secondary.size(); ++j){
+            if (PartD1.isMCSignal_secondary[i] == kTRUE) {
+              if (PartD1.isReconstructed_secondary[j] == kTRUE){
+                if (PartD1.fCharge > 0) {
+                  dynamic_cast<TH3D*>(fHistRecSecondaryPosPart.at(j * PartD1.isMCSignal_secondary.size() + i))->Fill(PartD1.fPt, PartD1.fEta, PartD1.fPhi, centralityWeight);
+                  // FillTrackHistograms_Secondary(TrackD1, mcPartD1, j, i); // Fill secondary track support histograms
+                } // end if particle positive
+                if (PartD1.fCharge < 0) {
+                  dynamic_cast<TH3D*>(fHistRecSecondaryNegPart.at(j * PartD1.isMCSignal_secondary.size() + i))->Fill(PartD1.fPt, PartD1.fEta, PartD1.fPhi, centralityWeight);
+                  // FillTrackHistograms_Secondary(TrackD1, mcPartD1, j, i); // Fill secondary track support histograms
+                } // end if particle negative
+              }// is selected by cutsetting
+            } // is selected by MC signal
+          } // end of loop over all cutsettings
+        } // end of loop over all MCsignals
+        // check if MCSignal and isReconstructed for negative primaryTrack
+        for (unsigned int i = 0; i < PartD2.isMCSignal_secondary.size(); ++i){
+          for (unsigned int j = 0; j < PartD2.isReconstructed_secondary.size(); ++j){
+            if (PartD2.isMCSignal_secondary[i] == kTRUE) {
+              if (PartD2.isReconstructed_secondary[j] == kTRUE){
+                if (PartD2.fCharge > 0) {
+                  dynamic_cast<TH3D*>(fHistRecSecondaryPosPart.at(j * PartD2.isMCSignal_secondary.size() + i))->Fill(PartD2.fPt, PartD2.fEta, PartD2.fPhi, centralityWeight);
+                  // FillTrackHistograms_Secondary(TrackD2, mcPartD2, j, i); // Fill secondary track support histograms
+                } // end if particle positive
+                if (PartD2.fCharge < 0) {
+                  dynamic_cast<TH3D*>(fHistRecSecondaryNegPart.at(j * PartD2.isMCSignal_secondary.size() + i))->Fill(PartD2.fPt, PartD2.fEta, PartD2.fPhi, centralityWeight);
+                  // FillTrackHistograms_Secondary(TrackD2, mcPartD2, j, i); // Fill secondary track support histograms
+                } // end if particle negative
+              }// is selected by cutsetting
+            } // is selected by MC signal
+          } // end of loop over all cutsettings
+        } // end of loop over all MCsignals
       } // end if TrackCuts true
+
 
 
       // ###############################
       // Pair cuts on secondary pair
       // ###############################
       else if(TrackCuts == kFALSE) {
-
+                                                                                // if(fdebug) std::cout << __LINE__ << " Cout Debug: Apply standard secondary pair cuts. " << std::endl;
         AliDielectronPair *pair = new AliDielectronPair;
         pair->SetKFUsage(false);
-        pair->SetTracks(static_cast<AliAODTrack*>(negTrack), 11, static_cast<AliAODTrack*>(posTrack), -11);
+        pair->SetTracks(static_cast<AliAODTrack*>(TrackD2), 11, static_cast<AliAODTrack*>(TrackD1), -11);
 
         //  ---------- RECONSTRUCTED Pairs with PAIR  ---------- //
         // Check if pair is passing cut selections
         std::vector<bool> selected(fCutsetting.size(), kFALSE); // vector which stores if pair is accepted by [i]-th selection cut
         for (UInt_t iCut=0; iCut<fCutsetting.size(); ++iCut){ // loop over all specified cutInstances
+          if (fPairVec->at(iPair).fFirstPartIsReconstructed[iCut] == kFALSE || fPairVec->at(iPair).fSecondPartIsReconstructed[iCut] == kFALSE) continue;  //check if both daughters are reconstructed
           UInt_t selectedMask=( 1 << fCutsetting.at(iCut)->GetCuts()->GetEntries())-1;
           // cutting logic taken from AliDielectron::FillTrackArrays()          FillPairArrays()
           // apply pair cuts
@@ -2387,12 +2498,12 @@ void AliAnalysisTaskEtaReconstruction::ApplyStandardCutsAndFillHists (std::vecto
 
 
         // track label, points back to MC track
-        Int_t posTrackLabel = TMath::Abs(posTrack->GetLabel());
-        Int_t negTrackLabel = TMath::Abs(negTrack->GetLabel());
+        Int_t TrackD1Label = TMath::Abs(TrackD1->GetLabel());
+        Int_t TrackD2Label = TMath::Abs(TrackD2->GetLabel());
 
         // Fill secondary support histos
-        AliVParticle* mcPosPart = fMC->GetTrack(posTrackLabel);
-        AliVParticle* mcNegPart = fMC->GetTrack(negTrackLabel);
+        AliVParticle* mcPosPart = fMC->GetTrack(TrackD1Label);
+        AliVParticle* mcNegPart = fMC->GetTrack(TrackD2Label);
 
 
         for (unsigned int i = 0; i < fPairVec->at(iPair).isReconstructed_secondary.size(); ++i){
@@ -2400,13 +2511,13 @@ void AliAnalysisTaskEtaReconstruction::ApplyStandardCutsAndFillHists (std::vecto
             for (unsigned int j = 0; j < mcTwoSignal_acc.size(); ++j){
               if (mcTwoSignal_acc[j] == kTRUE){
                 fHistRecSecondaryPair.at(  i *   mcTwoSignal_acc.size() + j)->Fill(mass, pairpt, weight * centralityWeight);
-                FillTrackHistograms_Secondary(posTrack, mcPosPart, i, j); // Fill secondary support histograms
-                FillTrackHistograms_Secondary(negTrack, mcNegPart, i, j); // Fill secondary support histograms
-                FillPairHistograms_Secondary(pair, i, j);                    // Fill pair secondary histograms
-              }// is selected by cutsetting
-            } // end of loop over all cutsettings
-          } // is selected by MCSignal
-        } // end of loop over all MCsignals
+                FillTrackHistograms_Secondary(TrackD1, mcPosPart, i, j); // Fill track secondary support histograms
+                FillTrackHistograms_Secondary(TrackD2, mcNegPart, i, j); // Fill track secondary support histograms
+                FillPairHistograms_Secondary(pair, i, j);                 // Fill pair  secondary support histograms
+              } // is selected by MCSignal
+            } // end of loop over all MCsignals
+          } // is selected by cutsetting
+        } // end of loop over all cutsettings
         delete pair;
       } // end if TrackCuts false
     } // end if Pair secondary
@@ -2623,7 +2734,7 @@ void AliAnalysisTaskEtaReconstruction::DoRecTwoPairing(std::vector<Particle> fRe
       if (CheckIfOneIsTrue(mcTwoSignal_acc) == kFALSE) continue;
 
       std::vector<bool> selected_primary(fPairCuts_primary.size(), kFALSE); // vector which stores if track is accepted by [i]-th selection cut
-      std::vector<bool> selected_secondary(fPairCuts_secondary_standard.size(), kFALSE); // vector which stores if track is accepted by [i]-th selection cut
+      // std::vector<bool> selected_secondary(fPairCuts_secondary_standard.size(), kFALSE); // vector which stores if track is accepted by [i]-th selection cut
       if (PartPrimary == kTRUE) {
         //  ---------- RECONSTRUCTED for PAIR  ---------- //
         // Check if particle is passing primary selection cuts
@@ -2633,26 +2744,32 @@ void AliAnalysisTaskEtaReconstruction::DoRecTwoPairing(std::vector<Particle> fRe
           // apply track cuts
           UInt_t cutMask_primary = fPairCuts_primary.at(iCut)->IsSelected(pair);
           if (cutMask_primary == selectedMask_primary) {selected_primary[iCut] = kTRUE; /*std::cout << "sec_reconstructed TRUE" << std::endl;*/}
-        }
+        }                                                                      // if (fdebug) std::cout << __LINE__ << " DEBUG_AnalysisTask: Size of Vectors after applying standard cuts, " << std::endl <<
+                                                                                // " fRecNegPart_primary = " << fRecNegPart_primary.size() << std::endl <<
+                                                                                // " fRecPosPart_primary = " << fRecPosPart_primary.size() << std::endl <<
+                                                                                // /*" fGenPairVec_primary = "   << fGenPairVec_primary.size()   << " fGenSmearedPairVec_primary =   " << fGenSmearedPairVec_primary.size()   << */
+                                                                                // " fRecPairVec_primary =   " << fRecPairVec_primary.size()   << std::endl <<
+                                                                                // /*" fGenPairVec_secondary = " << fGenPairVec_secondary.size() << " fGenSmearedPairVec_secondary = " << fGenSmearedPairVec_secondary.size() << */
+                                                                                // " fRecPairVec_secondary = " << fRecV0Pair.size()/*fRecPairVec_secondary.size()*/ << std::endl;
         // ##########################################################
         // check if at least one is selected by cuts otherwise skip this particle
         if (CheckIfOneIsTrue(selected_primary) == kFALSE) continue;
       }
 
-      else if (PartPrimary == kFALSE) {
-        //  ---------- RECONSTRUCTED for PAIR  ---------- //
-        // Check if particle is passing secondary selection cuts
-        for (UInt_t iCut=0; iCut<fPairCuts_secondary_standard.size(); ++iCut){ // loop over all specified cutInstances
-          UInt_t selectedMask_secondary=( 1 << fPairCuts_secondary_standard.at(iCut)->GetCuts()->GetEntries())-1;
-          // cutting logic taken from AliDielectron::FillTrackArrays()          FillPairArrays()
-          // apply track cuts
-          UInt_t cutMask_secondary = fPairCuts_secondary_standard.at(iCut)->IsSelected(pair);
-          if (cutMask_secondary == selectedMask_secondary) {selected_secondary[iCut] = kTRUE; /*std::cout << "sec_reconstructed TRUE" << std::endl;*/}
-        }
-        // ##########################################################
-        // check if at least one is selected by cuts otherwise skip this particle
-        if (CheckIfOneIsTrue(selected_secondary) == kFALSE) continue;
-      }
+      // else if (PartPrimary == kFALSE) {
+      //   //  ---------- RECONSTRUCTED for PAIR  ---------- //
+      //   // Check if particle is passing secondary selection cuts
+      //   for (UInt_t iCut=0; iCut<fPairCuts_secondary_standard.size(); ++iCut){ // loop over all specified cutInstances
+      //     UInt_t selectedMask_secondary=( 1 << fPairCuts_secondary_standard.at(iCut)->GetCuts()->GetEntries())-1;
+      //     // cutting logic taken from AliDielectron::FillTrackArrays()          FillPairArrays()
+      //     // apply track cuts
+      //     UInt_t cutMask_secondary = fPairCuts_secondary_standard.at(iCut)->IsSelected(pair);
+      //     if (cutMask_secondary == selectedMask_secondary) {selected_secondary[iCut] = kTRUE; /*std::cout << "sec_reconstructed TRUE" << std::endl;*/}
+      //   }
+      //   // ##########################################################
+      //   // check if at least one is selected by cuts otherwise skip this particle
+      //   if (CheckIfOneIsTrue(selected_secondary) == kFALSE) continue;
+      // }
       // Construct pair variables from LorentzVectors
       TLorentzVector Lvec1;
       TLorentzVector Lvec2;
@@ -2661,7 +2778,7 @@ void AliAnalysisTaskEtaReconstruction::DoRecTwoPairing(std::vector<Particle> fRe
       TLorentzVector LvecM = Lvec1 + Lvec2;
       double mass = LvecM.M();
       if (fDoMassCut == kTRUE && PartPrimary == kTRUE  && (fLowerMassCutPrimaries >= mass || mass >= fUpperMassCutPrimaries)) continue; // mass cut for primaries
-      if (fDoMassCut == kTRUE && PartPrimary == kFALSE && mass >= fMassCutSecondaries   ) continue; // mass cut for primaries
+      // if (fDoMassCut == kTRUE && PartPrimary == kFALSE && mass >= fMassCutSecondaries   ) continue; // mass cut for primaries
       double pairpt = LvecM.Pt();
       double weight = 1.;
       if (fCocktailFile) {
@@ -2735,16 +2852,16 @@ void AliAnalysisTaskEtaReconstruction::DoRecTwoPairing(std::vector<Particle> fRe
 
       if (PartPrimary == kTRUE) {
         MotherParticle.isReconstructed_primary   = selected_primary;
-        MotherParticle.SetDauthersAreReconstructed(fRecNegPart[neg_i].isReconstructed_primary, fRecPosPart[pos_i].isReconstructed_primary);
+        // MotherParticle.SetDauthersAreReconstructed(fRecNegPart[neg_i].isReconstructed_primary, fRecPosPart[pos_i].isReconstructed_primary);
         MotherParticle.SetMCTwoSignal_acc_prim(mcTwoSignal_acc);
         fRecPairVec_primary.push_back(MotherParticle);
       }
-      else if (PartPrimary == kFALSE) {
-        MotherParticle.isReconstructed_secondary = selected_secondary;
-        MotherParticle.SetDauthersAreReconstructed(fRecNegPart[neg_i].isReconstructed_secondary, fRecPosPart[pos_i].isReconstructed_secondary);
-        MotherParticle.SetMCTwoSignal_acc_sec(mcTwoSignal_acc);
-        fRecPairVec_secondary.push_back(MotherParticle);
-      }
+      // else if (PartPrimary == kFALSE) {
+      //   MotherParticle.isReconstructed_secondary = selected_secondary;
+      //   MotherParticle.SetDauthersAreReconstructed(fRecNegPart[neg_i].isReconstructed_secondary, fRecPosPart[pos_i].isReconstructed_secondary);
+      //   MotherParticle.SetMCTwoSignal_acc_sec(mcTwoSignal_acc);
+      //   fRecPairVec_secondary.push_back(MotherParticle);
+      // }
 
                                                                                 // if(fdebug){ std::cout << __LINE__ << " DEBUG_AnalysisTask: Mother Particlel: Pt = " << MotherParticle.fPt <<
                                                                                 // ", Eta = " << MotherParticle.fEta <<
@@ -3255,6 +3372,7 @@ void AliAnalysisTaskEtaReconstruction::DoFourPairing(std::vector<TwoPair> fPairV
 
         // Check if electrons are from MCSignal Generator
               // if (!fGenPosPart_primary[prim_i].GetMCSignalPair() || !fGenNegPart_primary[prim_i].GetMCSignalPair() || !fGenNegPart_secondary[sec_i].GetMCSignalPair() || !fGenPosPart_secondary[sec_i].GetMCSignalPair()) continue;
+                                                                                // if(fdebug) std::cout << __LINE__ << " DEBUG_AnalysisTask: Line cout " << std::endl;
 
         // Apply MC signals
         // Check if it is according to mcsignals
@@ -3369,8 +3487,8 @@ void AliAnalysisTaskEtaReconstruction::DoFourPairing(std::vector<TwoPair> fPairV
           } // end of loop over all MCsignals
         }
       }
+                                                                                // if(fdebug) std::cout << __LINE__ << " DEBUG_AnalysisTask: 4Pair with mass = " << mass << std::endl;
       if (CaseRec == kTRUE) {
-        // if(fdebug) std::cout << __LINE__ << " DEBUG_AnalysisTask: 4Pair with mass = " << mass << std::endl;
         for (unsigned int i = 0; i < mcSignal_acc.size(); ++i){
           if (mcSignal_acc[i] == kTRUE){
             for (unsigned int j = 0; j < fPairVec_primary[prim_i].fFirstPartIsReconstructed.size(); ++j){

--- a/PWGDQ/dielectron/core/AliAnalysisTaskEtaReconstruction.h
+++ b/PWGDQ/dielectron/core/AliAnalysisTaskEtaReconstruction.h
@@ -165,9 +165,10 @@ public:
 
 
    // Track cuts setter
-   void   AddTrackCuts_primary_standard  (AliAnalysisFilter* filter)  {fTrackCuts_primary_standard.push_back(filter);}
-   void   AddTrackCuts_primary_PreFilter  (AliAnalysisFilter* filter) {fTrackCuts_primary_PreFilter.push_back(filter);}
-   void   AddTrackCuts_secondary_PreFilter  (AliAnalysisFilter* filter) {fTrackCuts_secondary_PreFilter.push_back(filter);}
+   void   AddTrackCuts_primary_PreFilter   (AliAnalysisFilter* filter) {fTrackCuts_primary_PreFilter.push_back(filter);}
+   void   AddTrackCuts_secondary_PreFilter (AliAnalysisFilter* filter) {fTrackCuts_secondary_PreFilter.push_back(filter);}
+   void   AddTrackCuts_primary_standard    (AliAnalysisFilter* filter) {fTrackCuts_primary_standard.push_back(filter);}
+   void   AddTrackCuts_secondary_standard  (AliAnalysisFilter* filter) {fTrackCuts_secondary_standard.push_back(filter);}
 
    // Pair cuts setter
    void   AddPairCuts_primary  (AliAnalysisFilter* filter) {fPairCuts_primary.push_back(filter);}
@@ -399,6 +400,7 @@ private:
   std::vector<AliAnalysisFilter*> fTrackCuts_primary_PreFilter;
   std::vector<AliAnalysisFilter*> fTrackCuts_primary_standard;
   std::vector<AliAnalysisFilter*> fTrackCuts_secondary_PreFilter;
+  std::vector<AliAnalysisFilter*> fTrackCuts_secondary_standard;
   std::vector<AliAnalysisFilter*> fPairCuts_primary;
   std::vector<AliAnalysisFilter*> fPairCuts_secondary_PreFilter;
   std::vector<AliAnalysisFilter*> fPairCuts_secondary_standard;

--- a/PWGDQ/dielectron/macrosLMEE/AddTask_feisenhut_EtaReconstruction.C
+++ b/PWGDQ/dielectron/macrosLMEE/AddTask_feisenhut_EtaReconstruction.C
@@ -190,17 +190,6 @@ AliAnalysisTaskEtaReconstruction* AddTask_feisenhut_EtaReconstruction(TString na
   // #########################################################
   // #                set track cutsettings                  #
   // #########################################################
-  // Adding standard primary electron track cutsettings
-  TObjArray*  arrNames_prim=names_Prim_Track_standard_Cuts.Tokenize(";");
-
-  const Int_t nDie=arrNames_prim->GetEntriesFast();
-  for (int iCut = 0; iCut < nDie; ++iCut){
-    TString cutDefinition(arrNames_prim->At(iCut)->GetName());
-    AliAnalysisFilter* filter = SetupTrackCutsAndSettings(cutDefinition, isAOD);
-    task->AddTrackCuts_primary_standard(filter);
-    DoAdditionalWork(task);
-  }
-
   // Adding PreFilter primary electron track cutsettings
   TObjArray*  arrNames_prim=names_Prim_Track_PreFilter_Cuts.Tokenize(";");
   const Int_t nDie=arrNames_prim->GetEntriesFast();
@@ -213,13 +202,35 @@ AliAnalysisTaskEtaReconstruction* AddTask_feisenhut_EtaReconstruction(TString na
   }
 
   // Adding PreFilter secondary electron track cutsettings
-  TObjArray*  arrNames_sec=names_Sec_Track_PreFilter_Cuts.Tokenize(";");
-  const Int_t nDie=arrNames_sec->GetEntriesFast();
+  TObjArray*  arrNames_sec_PreFilter=names_Sec_Track_PreFilter_Cuts.Tokenize(";");
+  const Int_t nDie=arrNames_sec_PreFilter->GetEntriesFast();
 
   for (int iCut = 0; iCut < nDie; ++iCut){
-    TString cutDefinition(arrNames_sec->At(iCut)->GetName());
+    TString cutDefinition(arrNames_sec_PreFilter->At(iCut)->GetName());
     AliAnalysisFilter* filter = SetupTrackCutsAndSettings(cutDefinition, isAOD);
     task->AddTrackCuts_secondary_PreFilter(filter);
+    DoAdditionalWork(task);
+  }
+
+  // Adding standard primary electron track cutsettings
+  TObjArray*  arrNames_prim=names_Prim_Track_standard_Cuts.Tokenize(";");
+
+  const Int_t nDie=arrNames_prim->GetEntriesFast();
+  for (int iCut = 0; iCut < nDie; ++iCut){
+    TString cutDefinition(arrNames_prim->At(iCut)->GetName());
+    AliAnalysisFilter* filter = SetupTrackCutsAndSettings(cutDefinition, isAOD);
+    task->AddTrackCuts_primary_standard(filter);
+    DoAdditionalWork(task);
+  }
+
+  // Adding standard secondary electron track cutsettings
+  TObjArray*  arrNames_sec_track=names_Sec_Track_standard_Cuts.Tokenize(";");
+
+  const Int_t nDie=arrNames_sec_track->GetEntriesFast();
+  for (int iCut = 0; iCut < nDie; ++iCut){
+    TString cutDefinition(arrNames_sec_track->At(iCut)->GetName());
+    AliAnalysisFilter* filter = SetupTrackCutsAndSettings(cutDefinition, isAOD);
+    task->AddTrackCuts_secondary_standard(filter);
     DoAdditionalWork(task);
   }
 

--- a/PWGDQ/dielectron/macrosLMEE/Config_feisenhut_EtaReconstruction.C
+++ b/PWGDQ/dielectron/macrosLMEE/Config_feisenhut_EtaReconstruction.C
@@ -8,7 +8,8 @@ TString names_Prim_Track_PreFilter_Cuts=("JPID_sum_pt75_PreFilter;JPID_sum1_pt75
 // ################################################################
 // ################# PreFilter Track Cut Secondary ################
 // ################################################################
-TString names_Sec_Track_PreFilter_Cuts=("noPID_V0OnTheFly,trackkV0");
+//         !!!!!!!    actually not in use     !!!!!!
+TString names_Sec_Track_PreFilter_Cuts=("noPID_V0_PreFilter;track_V0_PreFilter");
 
 // ################################################################
 // ################# Standard Track Cut Primary ###################
@@ -23,7 +24,7 @@ TString names_Prim_Track_standard_Cuts=("JPID_sum_pt75;JPID_sum1_pt75_sec_kV0");
 // ################################################################
 // ############### Standard Track Cut Secondary ###################
 // ################################################################
-//                        *** MISSING ***
+TString names_Sec_Track_standard_Cuts=("noPID_V0_standard;track_V0_standard");
 
 
 
@@ -83,17 +84,17 @@ Bool_t SetITSCorrection = kFALSE;
 Bool_t SetTOFCorrection = kFALSE;
 
 
-bool debug = true;
+bool debug = false;
 
 bool DoPairing         = true;
 bool DoFourPairing     = true;
 bool UsePreFilter      = true;
 bool UseSecPreFilter   = true;
-bool DoMassCut         = false;
+bool DoMassCut         = true;
 bool V0OnFlyStatus     = true; // true stands for OnFlyStatus:aktive ; false means deaktivated
 // bool DoULSLS   = true;
 
-bool UseMCDataSig   = false;
+bool UseMCDataSig   = false; // if it is selected true the running time is increasing drastically, Reducing time for example by mass cut.
 
 bool GetResolutionFromAlien = kTRUE;
 // std::string resoFilename = "resolution_PbPb2015_0080_deltaXvsP_cut5_noKinematicCuts.root";
@@ -338,7 +339,6 @@ AliAnalysisFilter* SetupTrackCutsAndSettings(TString cutDefinition, Bool_t isAOD
 
   if (cutDefinition == "noPID"){
     AnaCut.SetPIDAna(LMEECutLib::kNoPID_Pt20);
-    // AnaCut.SetPIDAna(LMEECutLib::kNoPID_noKinCuts);
     AnaCut.SetTrackSelectionAna(LMEECutLib::kDefaultNoTrackCuts);
     AnaCut.SetPairCutsAna(LMEECutLib::kNoPairCutsAna);
 
@@ -406,10 +406,11 @@ AliAnalysisFilter* SetupTrackCutsAndSettings(TString cutDefinition, Bool_t isAOD
   /////////////////////////////////////////////////////////
   //             secondary track cut settings            //
   /////////////////////////////////////////////////////////
-  else if (cutDefinition == "noPID_V0OnTheFly" || cutDefinition == "trackkV0"){
-    AnaCut.SetPIDAna(LMEECutLib::kNoPID_Pt20);
+  else if (cutDefinition == "noPID_V0_PreFilter" || cutDefinition == "noPID_V0_standard" || cutDefinition == "track_V0_PreFilter"){
+    // AnaCut.SetPIDAna(LMEECutLib::kNoPID_Pt20);
+    AnaCut.SetPIDAna(LMEECutLib::kNoKinPIDCuts);
     // AnaCut.SetTrackSelectionAna(LMEECutLib::kDefaultNoTrackCuts);
-    AnaCut.SetTrackSelectionAna(LMEECutLib::kV0track);
+    AnaCut.SetTrackSelectionAna(LMEECutLib::kDefaultNoTrackCuts);
     AnaCut.SetPairCutsAna(LMEECutLib::kNoPairCutsAna);
     AnaCut.SetCentrality(centrality);
     AnaCut.SetStandardCut();
@@ -423,6 +424,16 @@ AliAnalysisFilter* SetupTrackCutsAndSettings(TString cutDefinition, Bool_t isAOD
   //   AnaCut.SetCentrality(centrality);
   //   AnaCut.SetStandardCut();
   // }
+
+  else if (cutDefinition == "track_V0_standard"){
+    AnaCut.SetPIDAna(LMEECutLib::kPID_V0_TPC_Pt20);
+    // AnaCut.SetTrackSelectionAna(LMEECutLib::kDefaultNoTrackCuts);
+    AnaCut.SetTrackSelectionAna(LMEECutLib::kDefaultNoTrackCuts);
+    AnaCut.SetPairCutsAna(LMEECutLib::kNoPairCutsAna);
+    AnaCut.SetCentrality(centrality);
+    AnaCut.SetStandardCut();
+  }
+
 
   // else if (cutDefinition == "JPID_sum_pt75_secondary"){
   //   AnaCut.SetPIDAna(LMEECutLib::kPID_Jeromian_01);
@@ -464,9 +475,7 @@ AliAnalysisFilter* SetupTrackCutsAndSettings(TString cutDefinition, Bool_t isAOD
   //             secondary pair cut settings             //
   /////////////////////////////////////////////////////////
   else if (cutDefinition == "pairkV0"){
-    // AnaCut.SetPIDAna(LMEECutLib::kPIDcut_TEST);
     AnaCut.SetPIDAna(LMEECutLib::kNoPID_Pt20);
-    // AnaCut.SetPIDAna(LMEECutLib::kNoPID_noKinCuts);
     // AnaCut.SetPIDAna(LMEECutLib::kPID_Jeromian_01);
     // AnaCut.SetTrackSelectionAna(LMEECutLib::kTRACKcut_1_secondary);
     AnaCut.SetTrackSelectionAna(LMEECutLib::kDefaultNoTrackCuts);
@@ -476,9 +485,7 @@ AliAnalysisFilter* SetupTrackCutsAndSettings(TString cutDefinition, Bool_t isAOD
   }
 
   else if (cutDefinition == "pairkV0_PreFilter"){
-    // AnaCut.SetPIDAna(LMEECutLib::kPIDcut_TEST);
     AnaCut.SetPIDAna(LMEECutLib::kNoPID_Pt20);
-    // AnaCut.SetPIDAna(LMEECutLib::kNoPID_noKinCuts);
     // AnaCut.SetPIDAna(LMEECutLib::kPID_Jeromian_01);
     // AnaCut.SetTrackSelectionAna(LMEECutLib::kV0OnTheFly);
     // AnaCut.SetTrackSelectionAna(LMEECutLib::kTRACKcut_1_secondary);
@@ -1385,29 +1392,29 @@ void AddFourPairMCSignal(AliAnalysisTaskEtaReconstruction* task){
 
 
 //________________________________________________________
-    // task->AddFourPairMCSignal(FourElePair1_FinalState);
-    // task->AddFourPairMCSignal(FourElePair2_Secondary_from_Photon);
-    //
-    // task->AddFourPairMCSignal(FourElePair1_FinalState_Dalitz);
-    // task->AddFourPairMCSignal(FourElePair2_Secondary_from_Photon_Dalitz);
-    //
-    // task->AddFourPairMCSignal(FourElePair1_FromPion);
-    // task->AddFourPairMCSignal(FourElePair2_FromPion);
+    task->AddFourPairMCSignal(FourElePair1_FinalState);
+    task->AddFourPairMCSignal(FourElePair2_Secondary_from_Photon);
+
+    task->AddFourPairMCSignal(FourElePair1_FinalState_Dalitz);
+    task->AddFourPairMCSignal(FourElePair2_Secondary_from_Photon_Dalitz);
+
+    task->AddFourPairMCSignal(FourElePair1_FromPion);
+    task->AddFourPairMCSignal(FourElePair2_FromPion);
 
     task->AddFourPairMCSignal(FourElePair1_FromPion_Dalitz);
     task->AddFourPairMCSignal(FourElePair2_FromPion_Dalitz);
-    //
-    // task->AddFourPairMCSignal(FourElePair1_FromEta);
-    // task->AddFourPairMCSignal(FourElePair2_FromEta);
-    //
-    // task->AddFourPairMCSignal(FourElePair1_FromEta_Dalitz);
-    // task->AddFourPairMCSignal(FourElePair2_FromEta_Dalitz);
-    //
-    // task->AddFourPairMCSignal(FourElePair1_MissMatchPionEta_Dalitz);
-    // task->AddFourPairMCSignal(FourElePair2_MissMatchPionEta_Dalitz);
-    //
-    // task->AddFourPairMCSignal(FourElePair1_MissMatchEtaPion_Dalitz);
-    // task->AddFourPairMCSignal(FourElePair2_MissMatchEtaPion_Dalitz);
+
+    task->AddFourPairMCSignal(FourElePair1_FromEta);
+    task->AddFourPairMCSignal(FourElePair2_FromEta);
+
+    task->AddFourPairMCSignal(FourElePair1_FromEta_Dalitz);
+    task->AddFourPairMCSignal(FourElePair2_FromEta_Dalitz);
+
+    task->AddFourPairMCSignal(FourElePair1_MissMatchPionEta_Dalitz);
+    task->AddFourPairMCSignal(FourElePair2_MissMatchPionEta_Dalitz);
+
+    task->AddFourPairMCSignal(FourElePair1_MissMatchEtaPion_Dalitz);
+    task->AddFourPairMCSignal(FourElePair2_MissMatchEtaPion_Dalitz);
 
     if(UseMCDataSig) task->AddFourPairMCSignal(FourAnyPartPair1_FinalState);
     if(UseMCDataSig) task->AddFourPairMCSignal(FourAnyPartPair2_Secondary);

--- a/PWGDQ/dielectron/macrosLMEE/LMEECutLib_feisenhut.C
+++ b/PWGDQ/dielectron/macrosLMEE/LMEECutLib_feisenhut.C
@@ -68,8 +68,8 @@ public:
     kPID_Jeromian_01_PreFilter,
     kPID_Jeromian_01_pt200,
     kPIDcut_1_pt75,
-    kPIDcut_TEST,
-    kNoPID_noKinCuts
+    kPID_V0_TPC_Pt20,
+    kNoKinPIDCuts
     };
   enum LMEEPIDPre{
     kStandardPre
@@ -82,7 +82,7 @@ public:
     kTRACKcut_2_PreFilter,
     kTRACKcut_1_secondary,
     kDefaultNoTrackCuts,
-    kV0track
+    kV0track_PreFilter
   };
   enum LMEETrackSelectionPre{
     kPrefilter_cut1
@@ -789,6 +789,7 @@ AliAnalysisCuts* LMEECutLib::GetPIDCutsAna(AnalysisCut AnaCut) {
   etaRange120->AddCut(AliDielectronVarManager::kEta, -1.20, 1.20);
   AliDielectronVarCuts *etaRange150 = new AliDielectronVarCuts("etaRange150","etaRange150");
   etaRange150->AddCut(AliDielectronVarManager::kEta, -1.50, 1.50);
+  AliDielectronVarCuts *noEtaCut = new AliDielectronVarCuts("noEtaCut","noEtaCut");
   // pt range:
   AliDielectronVarCuts *ptRange400to8000 = new AliDielectronVarCuts("ptRange400to8000","ptRange400to8000");
   ptRange400to8000->AddCut(AliDielectronVarManager::kPt, 0.4, 8.0);
@@ -808,7 +809,7 @@ AliAnalysisCuts* LMEECutLib::GetPIDCutsAna(AnalysisCut AnaCut) {
   ptRange200to8000->AddCut(AliDielectronVarManager::kPt, 0.2, 8.0);
   AliDielectronVarCuts *ptRange20to100000 = new AliDielectronVarCuts("ptRange20to100000","ptRange20to100000");
   ptRange20to100000->AddCut(AliDielectronVarManager::kPt, 0.02, 100.0);
-
+  AliDielectronVarCuts *noPtCut = new AliDielectronVarCuts("noPtCut","noPtCut");
 
   // PDG Code PID
   AliDielectronVarCuts *PDGelectron = new AliDielectronVarCuts("PDGelectron","PDGelectron");
@@ -908,12 +909,8 @@ AliAnalysisCuts* LMEECutLib::GetPIDCutsAna(AnalysisCut AnaCut) {
   PIDcut_1->AddCut(AliDielectronPID::kITS,AliPID::kElectron, -3.5, 0.5 , 0. ,100., kFALSE);
   PIDcut_1->AddCut(AliDielectronPID::kTOF,AliPID::kElectron, -2.5 , 3.0 , 0. ,100., kFALSE, AliDielectronPID::kIfAvailable);
 
-  AliDielectronPID *PIDcut_TEST = new AliDielectronPID("PIDcut_TEST","PIDcut_TEST");
-  PIDcut_TEST->AddCut(AliDielectronPID::kTPC,AliPID::kElectron, -1000.0, 1000.0 , 0. ,100., kFALSE);
-  // PIDcut_TEST->AddCut(AliDielectronPID::kTPC,AliPID::kElectron, -2.0, 3.5 , 0. ,100., kFALSE);
-  // PIDcut_TEST->AddCut(AliDielectronPID::kTPC,AliPID::kPion, -99, 3.5 , 0. ,100., kTRUE);
-  // PIDcut_TEST->AddCut(AliDielectronPID::kITS,AliPID::kElectron, -3.5, 0.5 , 0. ,100., kFALSE);
-  // PIDcut_TEST->AddCut(AliDielectronPID::kTOF,AliPID::kElectron, -2.5 , 3.0 , 0. ,100., kFALSE, AliDielectronPID::kIfAvailable);
+  AliDielectronPID *PIDcut_V0_TPC_Pt20 = new AliDielectronPID("PIDcut_V0_TPC_Pt20","PIDcut_V0_TPC_Pt20");
+  PIDcut_V0_TPC_Pt20->AddCut(AliDielectronPID::kTPC,AliPID::kElectron, -3.0, 3.0 , 0. ,100., kFALSE, AliDielectronPID::kIfAvailable);
 
 
 
@@ -1308,6 +1305,9 @@ AliAnalysisCuts* LMEECutLib::GetPIDCutsAna(AnalysisCut AnaCut) {
   //-----------------------------------------------
   switch (AnaCut.GetPIDAna()) {
 
+    case kNoKinPIDCuts:
+      pidCuts = LMEECutLib::SetKinematics(noEtaCut, noPtCut, PIDnoneExisting, AnaCut);;
+      break;
     case kNoPID_Pt75:
       pidCuts = LMEECutLib::SetKinematics(etaRange080, ptRange75to8000, PIDnoneExisting, AnaCut);;
       break;
@@ -1316,9 +1316,6 @@ AliAnalysisCuts* LMEECutLib::GetPIDCutsAna(AnalysisCut AnaCut) {
       break;
     case kNoPID_Pt200:
       pidCuts = LMEECutLib::SetKinematics(etaRange080, ptRange200to8000, PIDnoneExisting, AnaCut);;
-      break;
-    case kNoPID_noKinCuts:
-      pidCuts = LMEECutLib::SetKinematics(etaRange150, ptRange20to100000, PIDnoneExisting, AnaCut);;
       break;
     case kPID_Jeromian_01:
       pidCuts = LMEECutLib::SetKinematics(etaRange080, ptRange75to8000, Jeromian_01_sum, AnaCut);;
@@ -1332,8 +1329,8 @@ AliAnalysisCuts* LMEECutLib::GetPIDCutsAna(AnalysisCut AnaCut) {
     case kPIDcut_1_pt75:
       pidCuts = LMEECutLib::SetKinematics(etaRange080, ptRange75to8000, PIDcut_1, AnaCut);;
       break;
-    case kPIDcut_TEST:
-      pidCuts = LMEECutLib::SetKinematics(etaRange080, ptRange75to8000, PIDcut_TEST, AnaCut);;
+    case kPID_V0_TPC_Pt20:
+      pidCuts = LMEECutLib::SetKinematics(noEtaCut, noPtCut, PIDcut_V0_TPC_Pt20, AnaCut);;
       break;
 
     default: cout << "No Analysis PID Cut defined " << endl;
@@ -1519,30 +1516,30 @@ AliAnalysisCuts* LMEECutLib::GetTrackSelectionAna(AnalysisCut AnaCut) {
       trackCuts = cgTrackCutsAnaSPDfirst;
       break;
 
-    case kV0track:
-      // primarily meant for inclusion, for quite pure sample...
-      AliDielectronV0Cuts *gammaV0Cuts = new AliDielectronV0Cuts("gammaV0Cuts","gammaV0Cuts");
-      gammaV0Cuts->SetV0finder(AliDielectronV0Cuts::kOnTheFly);  // kAll(default), kOffline or kOnTheFly
-      // gammaV0Cuts->SetPdgCodes(22,11,11); // mother, daughter1 and 2
-      // gammaV0Cuts->AddCut(AliDielectronVarManager::kCosPointingAngle, TMath::Cos(0.02),   1.0,  kFALSE);
-      // gammaV0Cuts->AddCut(AliDielectronVarManager::kChi2NDF,                       0.0,  10.0,  kFALSE);
-      // gammaV0Cuts->AddCut(AliDielectronVarManager::kLegDist,                       0.0,   0.25, kFALSE);
-      // gammaV0Cuts->AddCut(AliDielectronVarManager::kR,                             3.0,  90.0,  kFALSE);
-      // gammaV0Cuts->AddCut(AliDielectronVarManager::kPsiPair,                       0.0,   0.05, kFALSE);
-      // gammaV0Cuts->AddCut(AliDielectronVarManager::kM,                             0.0,   0.05, kFALSE);
-      // gammaV0Cuts->AddCut(AliDielectronVarManager::kArmPt,                         0.0,   0.02, kFALSE);
-      // gammaV0Cuts->AddCut(AliDielectronVarManager::kArmAlpha,                     -0.35,  0.35, kFALSE); // should increase purity...
-      // gammaV0Cuts->SetExcludeTracks(kTRUE);
-      // // gammaV0Cuts->SetExcludeTracks(kFALSE); (standard?)
-      // AliDielectronVarCuts* trackCutsAOD =new AliDielectronVarCuts("trackCutsAOD","trackCutsAOD");
-      // trackCutsAOD->AddCut(AliDielectronVarManager::kTPCchi2Cl,    0.0,   4.0);
-      // trackCutsAOD->AddCut(AliDielectronVarManager::kNFclsTPCr,     100.0, 160.0);
-      // trackCutsAOD->AddCut(AliDielectronVarManager::kNFclsTPCfCross,     0.8, 1.1);
-      cgTrackCutsV0select = new AliDielectronCutGroup("cgTrackCutsV0select","cgTrackCutsV0select",AliDielectronCutGroup::kCompAND);
-      cgTrackCutsV0select->AddCut(gammaV0Cuts);
-      // cgTrackCutsV0select->AddCut(trackCutsAOD);
-      trackCuts = cgTrackCutsV0select;
-      break;
+    // case kV0track_PreFilter:
+    //   // primarily meant for inclusion, for quite pure sample...
+    //   AliDielectronV0Cuts *gammaV0Cuts = new AliDielectronV0Cuts("gammaV0Cuts","gammaV0Cuts");
+    //   gammaV0Cuts->SetV0finder(AliDielectronV0Cuts::kOnTheFly);  // kAll(default), kOffline or kOnTheFly
+    //   // gammaV0Cuts->SetPdgCodes(22,11,11); // mother, daughter1 and 2
+    //   // gammaV0Cuts->AddCut(AliDielectronVarManager::kCosPointingAngle, TMath::Cos(0.02),   1.0,  kFALSE);
+    //   // gammaV0Cuts->AddCut(AliDielectronVarManager::kChi2NDF,                       0.0,  10.0,  kFALSE);
+    //   // gammaV0Cuts->AddCut(AliDielectronVarManager::kLegDist,                       0.0,   0.25, kFALSE);
+    //   // gammaV0Cuts->AddCut(AliDielectronVarManager::kR,                             3.0,  90.0,  kFALSE);
+    //   // gammaV0Cuts->AddCut(AliDielectronVarManager::kPsiPair,                       0.0,   0.05, kFALSE);
+    //   // gammaV0Cuts->AddCut(AliDielectronVarManager::kM,                             0.0,   0.05, kFALSE);
+    //   // gammaV0Cuts->AddCut(AliDielectronVarManager::kArmPt,                         0.0,   0.02, kFALSE);
+    //   // gammaV0Cuts->AddCut(AliDielectronVarManager::kArmAlpha,                     -0.35,  0.35, kFALSE); // should increase purity...
+    //   // gammaV0Cuts->SetExcludeTracks(kTRUE);
+    //   // // gammaV0Cuts->SetExcludeTracks(kFALSE); (standard?)
+    //   // AliDielectronVarCuts* trackCutsAOD =new AliDielectronVarCuts("trackCutsAOD","trackCutsAOD");
+    //   // trackCutsAOD->AddCut(AliDielectronVarManager::kTPCchi2Cl,    0.0,   4.0);
+    //   // trackCutsAOD->AddCut(AliDielectronVarManager::kNFclsTPCr,     100.0, 160.0);
+    //   // trackCutsAOD->AddCut(AliDielectronVarManager::kNFclsTPCfCross,     0.8, 1.1);
+    //   cgTrackCutsV0select = new AliDielectronCutGroup("cgTrackCutsV0select","cgTrackCutsV0select",AliDielectronCutGroup::kCompAND);
+    //   cgTrackCutsV0select->AddCut(gammaV0Cuts);
+    //   // cgTrackCutsV0select->AddCut(trackCutsAOD);
+    //   trackCuts = cgTrackCutsV0select;
+    //   break;
 
     // case kNone:
       // trackCuts = GetTrackCuts(kNoTrackCuts);


### PR DESCRIPTION
…plotting of empty support histograms

I implemented a PID track cut to select electrons as the daughters of the V0s.
Furthermore i fixed an issue, which caused that spescifc support histograms did not became filled.