### PR TITLE
PWGGA/GammaConv: reenable rejection of events for which aod relabelin…

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvV1.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvV1.cxx
@@ -2316,7 +2316,7 @@ void AliAnalysisTaskGammaConvV1::UserExec(Option_t *)
   }
 
   Int_t eventQuality = ((AliConvEventCuts*)fV0Reader->GetEventCuts())->GetEventQuality();
-  if(fInputEvent->IsIncompleteDAQ()==kTRUE) eventQuality = 2;  // incomplete event
+  if(fInputEvent->IsIncompleteDAQ()==kTRUE || fV0Reader->GetErrorAODRelabeling()) eventQuality = 2;  // incomplete event or relabeling failed
   // Event Not Accepted due to MC event missing or because it is incomplete or  wrong trigger for V0ReaderV1 => skip broken events/files
   if(eventQuality == 2 || eventQuality == 3){
     // write out name of broken file if it has not been done already

--- a/PWGGA/GammaConvBase/AliV0ReaderV1.cxx
+++ b/PWGGA/GammaConvBase/AliV0ReaderV1.cxx
@@ -96,6 +96,7 @@ AliV0ReaderV1::AliV0ReaderV1(const char *name) : AliAnalysisTaskSE(name),
   fDeltaAODFilename("AliAODGammaConversion.root"),
   fRelabelAODs(kFALSE),
   fPreviousV0ReaderPerformsAODRelabeling(0),
+  fErrorAODRelabeling(kFALSE),
   fEventIsSelected(kFALSE),
   fNumberOfPrimaryTracks(0),
   fNumberOfTPCoutTracks(0),
@@ -678,7 +679,7 @@ Bool_t AliV0ReaderV1::ProcessEvent(AliVEvent *inputEvent,AliMCEvent *mcEvent)
     ProcessESDV0s();
   }
   if(fInputEvent->IsA()==AliAODEvent::Class() ){
-    GetAODConversionGammas();
+    fErrorAODRelabeling = !GetAODConversionGammas();
   }
 
   return kTRUE;

--- a/PWGGA/GammaConvBase/AliV0ReaderV1.h
+++ b/PWGGA/GammaConvBase/AliV0ReaderV1.h
@@ -124,6 +124,7 @@ class AliV0ReaderV1 : public AliAnalysisTaskSE {
     Bool_t             AreAODsRelabeled()                               {return fRelabelAODs;}
     Int_t              IsReaderPerformingRelabeling()                   {return fPreviousV0ReaderPerformsAODRelabeling;}
     Bool_t             RelabelAODPhotonCandidates(AliAODConversionPhoton *PhotonCandidate);
+    Bool_t             GetErrorAODRelabeling()                          {return fErrorAODRelabeling;}
     void               SetPeriodName(TString name)                      {fPeriodName = name;
                                                                          AliInfo(Form("Set PeriodName to: %s",fPeriodName.Data()));
                                                                          return;}
@@ -210,6 +211,7 @@ class AliV0ReaderV1 : public AliAnalysisTaskSE {
     TString        fDeltaAODFilename;             // set filename for delta/satellite aod
     Bool_t         fRelabelAODs;                  //
     Int_t          fPreviousV0ReaderPerformsAODRelabeling; // 0->not set, meaning V0Reader has not yet determined if it should do AODRelabeling, 1-> V0Reader perfomrs relabeling, 2-> previous V0Reader in list perfomrs relabeling
+    Bool_t         fErrorAODRelabeling;           // to remember if for the current event an error occured  while retrieving and relabeling of the gammas
     Bool_t         fEventIsSelected;
     Int_t          fNumberOfPrimaryTracks;        // Number of Primary Tracks in AOD or ESD
     Int_t          fNumberOfTPCoutTracks;         // Number of TPC Tracks with TPCout flag


### PR DESCRIPTION
…g fails

but reject from within the AnalysisTask and not the V0Reader. This is
necessary since otherwise other AnalysisTasks, which do not have
conversion photons, would miss these events unnecessarily.