### PR TITLE
FemtoNanoLD: deuterons: fix mass sq, change cuts

### DIFF
--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliAnalysisTaskNanoLD.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliAnalysisTaskNanoLD.cxx
@@ -172,14 +172,14 @@ void AliAnalysisTaskNanoLD::UserCreateOutputObjects() {
   fAntiLambdaList = fAntiLambda->GetQAHists();
 
   // Mass squared plots
-  fDeuteronMassSqTOF = new TH2F("fDeuteronMassSqTOF", "Deuterons", 5, 0. ,5., 16, 0., 8.);
+  fDeuteronMassSqTOF = new TH2F("fDeuteronMassSqTOF", "Deuterons", 50, 0. ,5., 400, 0., 8.);
   fDeuteronMassSqTOF->GetXaxis()->SetTitle("p_T (GeV/c)");
-  fDeuteronMassSqTOF->GetYaxis()->SetTitle("m^2 (GeV/c)^2");
+  fDeuteronMassSqTOF->GetYaxis()->SetTitle("m^2 (GeV/c^2)^2");
   fDeuteronList->Add(fDeuteronMassSqTOF);
 
   fAntiDeuteronMassSqTOF = new TH2F("fAntiDeuteronMassSqTOF", "AntiDeuterons", 50, 0. ,5., 400, 0., 8.);
   fAntiDeuteronMassSqTOF->GetXaxis()->SetTitle("p_T (GeV/c)");
-  fAntiDeuteronMassSqTOF->GetYaxis()->SetTitle("m^2 (GeV/c)^2");
+  fAntiDeuteronMassSqTOF->GetYaxis()->SetTitle("m^2 (GeV/c^2)^2");
   fAntiDeuteronList->Add(fAntiDeuteronMassSqTOF);
 
   fResultsQA = new TList();

--- a/PWGCF/FEMTOSCOPY/macros/AddTaskFemtoNanoLD.C
+++ b/PWGCF/FEMTOSCOPY/macros/AddTaskFemtoNanoLD.C
@@ -55,8 +55,17 @@ AliAnalysisTaskSE *AddTaskFemtoNanoLD(bool fullBlastQA = false,
     DeuteronCuts->SetFilterBit(256);
   }
   else if (suffix == "2") {
-    DeuteronCuts->SetFilterBit(768);
+    DeuteronCuts->SetPID(AliPID::kDeuteron, 999.);
+  }
+  else if (suffix == "3") {
+    DeuteronCuts->SetFilterBit(256);
+    DeuteronCuts->SetPID(AliPID::kDeuteron, 999.);
     //DeuteronCuts->SetCutITSPID(1.4, -2., 1e30);
+  }
+  else if (suffix == "4") {
+    DeuteronCuts->SetFilterBit(256);
+    DeuteronCuts->SetDCAVtxZ(5.);
+    DeuteronCuts->SetDCAVtxXY(5.);
   }
 
   // Track Cuts for Anti-Deuterons
@@ -85,8 +94,17 @@ AliAnalysisTaskSE *AddTaskFemtoNanoLD(bool fullBlastQA = false,
     AntiDeuteronCuts->SetFilterBit(256);
   }
   else if (suffix == "2") {
+    AntiDeuteronCuts->SetPID(AliPID::kDeuteron, 999.);
+  }
+  else if (suffix == "3") {
     AntiDeuteronCuts->SetFilterBit(256);
-    AntiDeuteronCuts->SetCutITSPID(1.4, -2., 1e30);
+    AntiDeuteronCuts->SetPID(AliPID::kDeuteron, 999.);
+    //AntiDeuteronCuts->SetCutITSPID(1.4, -2., 1e30);
+  }
+  else if (suffix == "4") {
+    AntiDeuteronCuts->SetFilterBit(256);
+    AntiDeuteronCuts->SetDCAVtxZ(5.);
+    AntiDeuteronCuts->SetDCAVtxXY(5.);
   }
 
   // Lambda Cuts


### PR DESCRIPTION
o Fix binning of mass squared hist for deuterons
o Change cuts for (anti-)deuterons
o FB 128/256, PID w/ w/o TOF, open DCAs