### PR TITLE
add vertex histograms for c deuteron

### DIFF
--- a/PWGHF/vertexingHF/AliAnalysisTaskSEXicTopKpi.cxx
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSEXicTopKpi.cxx
@@ -137,6 +137,19 @@ AliAnalysisTaskSEXicTopKpi::AliAnalysisTaskSEXicTopKpi():
   fDist23Signal(0x0),
   fDist23All(0x0),
   fDist23AllFilter(0x0),
+  fVtxResXPt(0x0),
+  fVtxResYPt(0x0),
+  fVtxResZPt(0x0),
+  fVtxResXYPt(0x0),
+  fVtxResXYZPt(0x0),
+  fPrimVtxResXPt(0x0),
+  fPrimVtxResYPt(0x0),
+  fPrimVtxResZPt(0x0),
+  fDecayLResXPt(0x0),
+  fDecayLResYPt(0x0),
+  fDecayLResZPt(0x0),
+  fDecayLResXYPt(0x0),
+  fDecayLResXYZPt(0x0),
   fnSigmaPIDtofProton(0x0),
   fnSigmaPIDtofPion(0x0),
   fnSigmaPIDtofKaon(0x0),
@@ -166,6 +179,7 @@ AliAnalysisTaskSEXicTopKpi::AliAnalysisTaskSEXicTopKpi():
   fSigmaCfromLcOnTheFly(kTRUE),
   fCheckOnlyTrackEfficiency(kFALSE),
   fIsCdeuteronAnalysis(kFALSE),
+  fIsKeepOnlyCdeuteronSignal(kFALSE),
   fNRotations(0),
   fMinAngleForRot(5*TMath::Pi()/6),
   fMaxAngleForRot(7*TMath::Pi()/6),
@@ -231,6 +245,19 @@ AliAnalysisTaskSEXicTopKpi::AliAnalysisTaskSEXicTopKpi(const char *name,AliRDHFC
   fDist23Signal(0x0),
   fDist23All(0x0),
   fDist23AllFilter(0x0),
+  fVtxResXPt(0x0),
+  fVtxResYPt(0x0),
+  fVtxResZPt(0x0),
+  fVtxResXYPt(0x0),
+  fVtxResXYZPt(0x0),
+  fPrimVtxResXPt(0x0),
+  fPrimVtxResYPt(0x0),
+  fPrimVtxResZPt(0x0),
+  fDecayLResXPt(0x0),
+  fDecayLResYPt(0x0),
+  fDecayLResZPt(0x0),
+  fDecayLResXYPt(0x0),
+  fDecayLResXYZPt(0x0),
   fnSigmaPIDtofProton(0x0),
   fnSigmaPIDtofPion(0x0),
   fnSigmaPIDtofKaon(0x0),
@@ -259,6 +286,7 @@ AliAnalysisTaskSEXicTopKpi::AliAnalysisTaskSEXicTopKpi(const char *name,AliRDHFC
   fSigmaCfromLcOnTheFly(kTRUE),
   fCheckOnlyTrackEfficiency(kFALSE),
   fIsCdeuteronAnalysis(kFALSE),
+  fIsKeepOnlyCdeuteronSignal(kFALSE),
   fNRotations(0),
   fMinAngleForRot(5*TMath::Pi()/6),
   fMaxAngleForRot(7*TMath::Pi()/6),
@@ -342,6 +370,17 @@ AliAnalysisTaskSEXicTopKpi::~AliAnalysisTaskSEXicTopKpi()
   if(fDist23Signal)delete fDist23Signal;
   if(fDist23All)delete fDist23All;
   if(fDist23AllFilter)delete fDist23AllFilter;
+  if(fVtxResXPt)delete fVtxResXPt;
+  if(fVtxResYPt)delete fVtxResYPt;
+  if(fVtxResZPt)delete fVtxResZPt;
+  if(fVtxResXYPt)delete fVtxResXYPt;
+  if(fPrimVtxResXPt)delete fPrimVtxResXPt;
+  if(fPrimVtxResYPt)delete fPrimVtxResYPt;
+  if(fPrimVtxResZPt)delete fPrimVtxResZPt;
+  if(fDecayLResXPt)delete fDecayLResXPt;
+  if(fDecayLResYPt)delete fDecayLResYPt;
+  if(fDecayLResZPt)delete fDecayLResZPt;
+  if(fDecayLResXYPt)delete fDecayLResXYPt;
   if(fOutput)delete fOutput;
   if(fVertexerTracks)delete fVertexerTracks;
   if(fnSigmaPIDtofProton)delete fnSigmaPIDtofProton;
@@ -645,7 +684,19 @@ void AliAnalysisTaskSEXicTopKpi::UserCreateOutputObjects()
   fDist12AllFilter=new TH1F("fDist12AllFilter","fDist12AllFilter",500,0.,1000.);
   fDist23All=new TH1F("fDist23All","fDist23All",500,0.,1000.);
   fDist23AllFilter=new TH1F("fDist23AllFilter","fDist23AllFilter",500,0.,1000.);
-
+  fVtxResXPt = new TH2F("fVtxResXPt","vertex resolution X vs p_{T}",1000,-0.1,0.1,200,0,20);
+  fVtxResYPt = new TH2F("fVtxResYPt","vertex resolution Y vs p_{T}",1000,-0.1,0.1,200,0,20);
+  fVtxResZPt = new TH2F("fVtxResZPt","vertex resolution Z vs p_{T}",1000,-0.1,0.1,200,0,20);
+  fVtxResXYPt = new TH2F("fVtxResXYPt","vertex resolution XY vs p_{T}",1000,-0.1,0.1,200,0,20);
+  fVtxResXYZPt = new TH2F("fVtxResXYZPt","vertex resolution XYZ vs p_{T}",1000,-0.1,0.1,200,0,20);
+  fPrimVtxResXPt = new TH2F("fPrimVtxResXPt","primary vertex resolution X vs p_{T}",1000,-0.1,0.1,200,0,20);
+  fPrimVtxResYPt = new TH2F("fPrimVtxResYPt","primary vertex resolution Y vs p_{T}",1000,-0.1,0.1,200,0,20);
+  fPrimVtxResZPt = new TH2F("fPrimVtxResZPt","primary vertex resolution Z vs p_{T}",1000,-0.1,0.1,200,0,20);
+  fDecayLResXPt = new TH2F("fDecayLResXPt","decay length resolution X vs p_{T}",1000,-0.1,0.1,200,0,20);
+  fDecayLResYPt = new TH2F("fDecayLResYPt","decay length resolution Y vs p_{T}",1000,-0.1,0.1,200,0,20);
+  fDecayLResZPt = new TH2F("fDecayLResZPt","decay length resolution Z vs p_{T}",1000,-0.1,0.1,200,0,20);
+  fDecayLResXYPt = new TH2F("fDecayLResXYPt","decay length resolution XY vs p_{T}",1000,-0.1,0.1,200,0,20);
+  fDecayLResXYZPt = new TH2F("fDecayLResXYZPt","decay length resolution XYZ vs p_{T}",1000,-0.1,0.1,200,0,20);
 
   fnSigmaPIDtofProton=new TH2F("fnSigmaPIDtofProton","fnSigmaPIDtofProton",100,0,20,80,-10,10);
   fnSigmaPIDtofPion=new TH2F("fnSigmaPIDtofPion","fnSigmaPIDtofPion",100,0,20,80,-10,10);
@@ -696,6 +747,19 @@ void AliAnalysisTaskSEXicTopKpi::UserCreateOutputObjects()
   fOutput->Add(fDist23Signal);
   fOutput->Add(fDist23All);
   fOutput->Add(fDist23AllFilter);
+  fOutput->Add(fVtxResXPt);
+  fOutput->Add(fVtxResYPt);
+  fOutput->Add(fVtxResZPt);
+  fOutput->Add(fVtxResXYPt);
+  fOutput->Add(fVtxResXYZPt);
+  fOutput->Add(fPrimVtxResXPt);
+  fOutput->Add(fPrimVtxResYPt);
+  fOutput->Add(fPrimVtxResZPt);
+  fOutput->Add(fDecayLResXPt);
+  fOutput->Add(fDecayLResYPt);
+  fOutput->Add(fDecayLResZPt);
+  fOutput->Add(fDecayLResXYPt);
+  fOutput->Add(fDecayLResXYZPt);
   fOutput->Add(fCosPointDistrAll);
   fOutput->Add(fCosPointDistrAllFilter);
   fOutput->Add(fCosPointDistrSignal);
@@ -921,8 +985,7 @@ void AliAnalysisTaskSEXicTopKpi::UserExec(Option_t */*option*/)
 
   fvHF=new AliAnalysisVertexingHF();
  
-
-  PrepareTracks(aod,fmcArray); // done always, also if only pre-filtered candidates are used: needed for SigmaC loop... or should work for a different solution
+  PrepareTracks(aod,fmcArray,mcHeader); // done always, also if only pre-filtered candidates are used: needed for SigmaC loop... or should work for a different solution
   if(fCheckOnlyTrackEfficiency){
     delete fvHF;
     PostData(1,fNentries);
@@ -1140,8 +1203,58 @@ void AliAnalysisTaskSEXicTopKpi::UserExec(Option_t */*option*/)
       Int_t pdgcode = part->GetPdgCode();
       if(TMath::Abs(pdgcode)==4122)       decay_channel = AliVertexingHFUtils::CheckLcpKpiDecay(fmcArray, part, arrayDauLabReco);
       else if(TMath::Abs(pdgcode)==4232)  decay_channel = CheckXicpKpiDecay(fmcArray, part, arrayDauLabReco);
+      if(TMath::Abs(pdgcode)==2010010020) { // c deuteron
+
+        // vertex information
+        Double_t secVtx[3] = {0};
+        Double_t secVtxMC[3] = {0};
+        secVtx[0] = io3Prong->GetSecVtxX();
+        secVtx[1] = io3Prong->GetSecVtxY();
+        secVtx[2] = io3Prong->GetSecVtxZ();
+
+        // get daughter for true vertex
+        Int_t daughLabel = ((AliAODTrack*)io3Prong->GetDaughter(1))->GetLabel();
+        if(daughLabel>=0){
+          AliAODMCParticle *daugh = (AliAODMCParticle*)fmcArray->At(daughLabel);
+          daugh->XvYvZv(secVtxMC);
+        }
+
+        fVtxResXPt->Fill(secVtx[0]-secVtxMC[0], io3Prong->Pt());
+        fVtxResYPt->Fill(secVtx[1]-secVtxMC[1], io3Prong->Pt());
+        fVtxResZPt->Fill(secVtx[2]-secVtxMC[2], io3Prong->Pt());
+        fVtxResXYPt->Fill(TMath::Sqrt(secVtx[0]*secVtx[0] + secVtx[1]*secVtx[1]) - TMath::Sqrt(secVtxMC[0]*secVtxMC[0] + secVtxMC[1]*secVtxMC[1]), io3Prong->Pt());
+        fVtxResXYZPt->Fill(TMath::Sqrt(secVtx[0]*secVtx[0] + secVtx[1]*secVtx[1] + secVtx[2]*secVtx[2]) - TMath::Sqrt(secVtxMC[0]*secVtxMC[0] + secVtxMC[1]*secVtxMC[1] + secVtxMC[2]*secVtxMC[2]), io3Prong->Pt());
+
+        // primary vertex
+        Double_t primVtx[3] = {0};
+        Double_t primVtxMC[3] = {0};
+        fprimVtx->GetXYZ(primVtx);
+
+        // get origin of MC particle for true primary vertex (?)
+        part->XvYvZv(primVtxMC);
+
+        fPrimVtxResXPt->Fill(primVtx[0]-primVtxMC[0], io3Prong->Pt());
+        fPrimVtxResYPt->Fill(primVtx[1]-primVtxMC[1], io3Prong->Pt());
+        fPrimVtxResZPt->Fill(primVtx[2]-primVtxMC[2], io3Prong->Pt());
+
+        fDecayLResXPt->Fill((secVtx[0]-primVtx[0]) - (secVtxMC[0]-primVtxMC[0]), io3Prong->Pt());
+        fDecayLResYPt->Fill((secVtx[1]-primVtx[1]) - (secVtxMC[1]-primVtxMC[1]), io3Prong->Pt());
+        fDecayLResZPt->Fill((secVtx[2]-primVtx[2]) - (secVtxMC[2]-primVtxMC[2]), io3Prong->Pt());
+        fDecayLResXYPt->Fill(TMath::Sqrt((secVtx[0]-primVtx[0])*(secVtx[0]-primVtx[0]) +
+              (secVtx[1]-primVtx[1])*(secVtx[1]-primVtx[1])) -
+            TMath::Sqrt((secVtxMC[0]-primVtxMC[0])*(secVtxMC[0]-primVtxMC[0]) + 
+              (secVtxMC[1]-primVtxMC[1])*(secVtxMC[1]-primVtxMC[1]))
+            , io3Prong->Pt());
+        fDecayLResXYZPt->Fill(TMath::Sqrt((secVtx[0]-primVtx[0])*(secVtx[0]-primVtx[0]) +
+              (secVtx[1]-primVtx[1])*(secVtx[1]-primVtx[1]) +
+              (secVtx[2]-primVtx[2])*(secVtx[2]-primVtx[2])) -
+            TMath::Sqrt((secVtxMC[0]-primVtxMC[0])*(secVtxMC[0]-primVtxMC[0]) + 
+              (secVtxMC[1]-primVtxMC[1])*(secVtxMC[1]-primVtxMC[1]) +
+              (secVtxMC[2]-primVtxMC[2])*(secVtxMC[2]-primVtxMC[2]))
+            , io3Prong->Pt());
+      }
     }
-	}
+  }
       
 	//if(fReadMC && isTrueLambdaCorXic==1){
 	// MAYBE WE'LL CAHNGE IT !!!     
@@ -2236,7 +2349,7 @@ void AliAnalysisTaskSEXicTopKpi::IsSelectedPID(AliAODTrack *track,Int_t &iSelPio
   
   if (status == AliPIDResponse::kDetPidOk){
     if(iSelProtonCuts>=0){
-      Double_t nsigma=fPidResponse->NumberOfSigmasTOF(track,fIsCdeuteronAnalysis?AliPID::kDeuteron:AliPID::kProton);
+      Double_t nsigma=fPidResponse->NumberOfSigmasTOF(track,(fIsCdeuteronAnalysis?(AliPID::kDeuteron):(AliPID::kProton)));
       if(fillHistos)fnSigmaPIDtofProton->Fill(trpt,nsigma);
       //      Printf("nsigma Proton TOF: %f",nsigma);
       if(-3.<=nsigma&&nsigma<=3)iSelProton++;
@@ -2268,7 +2381,7 @@ void AliAnalysisTaskSEXicTopKpi::IsSelectedPID(AliAODTrack *track,Int_t &iSelPio
   status = fPidResponse->CheckPIDStatus(AliPIDResponse::kTPC,track);
   if (status == AliPIDResponse::kDetPidOk){
     if(iSelProtonCuts>=0){
-      Double_t nsigma=fPidResponse->NumberOfSigmasTPC(track,fIsCdeuteronAnalysis?AliPID::kDeuteron:AliPID::kProton);
+      Double_t nsigma=fPidResponse->NumberOfSigmasTPC(track,(fIsCdeuteronAnalysis?(AliPID::kDeuteron):(AliPID::kProton)));
       if(fillHistos)fnSigmaPIDtpcProton->Fill(trpt,nsigma);
       //      Printf("nsigma Proton TPC: %f",nsigma);
       if(-3.<=nsigma&&nsigma<=3)iSelProton++;
@@ -2503,11 +2616,11 @@ void AliAnalysisTaskSEXicTopKpi::FillTree(AliAODRecoDecayHF3Prong *cand,Int_t ma
   status_TOF_2 = fPidResponse->CheckPIDStatus(AliPIDResponse::kTOF,(AliAODTrack*)cand->GetDaughter(2));
   if(status_TPC_0 == AliPIDResponse::kDetPidOk){
     nSigma_TPC_pion_0 = fPidResponse->NumberOfSigmasTPC((AliAODTrack*)cand->GetDaughter(0),AliPID::kPion);
-    nSigma_TPC_prot_0 = fPidResponse->NumberOfSigmasTPC((AliAODTrack*)cand->GetDaughter(0),AliPID::kProton);
+    nSigma_TPC_prot_0 = fPidResponse->NumberOfSigmasTPC((AliAODTrack*)cand->GetDaughter(0),(fIsCdeuteronAnalysis?(AliPID::kDeuteron):(AliPID::kProton)));
   }
   if(status_TOF_0 == AliPIDResponse::kDetPidOk){
     nSigma_TOF_pion_0 = fPidResponse->NumberOfSigmasTOF((AliAODTrack*)cand->GetDaughter(0),AliPID::kPion);
-    nSigma_TOF_prot_0 = fPidResponse->NumberOfSigmasTOF((AliAODTrack*)cand->GetDaughter(0),AliPID::kProton);
+    nSigma_TOF_prot_0 = fPidResponse->NumberOfSigmasTOF((AliAODTrack*)cand->GetDaughter(0),(fIsCdeuteronAnalysis?(AliPID::kDeuteron):(AliPID::kProton)));
   }
   if(status_TPC_1 == AliPIDResponse::kDetPidOk){
     nSigma_TPC_kaon_1 = fPidResponse->NumberOfSigmasTPC((AliAODTrack*)cand->GetDaughter(1),AliPID::kKaon);
@@ -2517,11 +2630,11 @@ void AliAnalysisTaskSEXicTopKpi::FillTree(AliAODRecoDecayHF3Prong *cand,Int_t ma
   }
   if(status_TPC_2 == AliPIDResponse::kDetPidOk){
     nSigma_TPC_pion_2 = fPidResponse->NumberOfSigmasTPC((AliAODTrack*)cand->GetDaughter(2),AliPID::kPion);
-    nSigma_TPC_prot_2 = fPidResponse->NumberOfSigmasTPC((AliAODTrack*)cand->GetDaughter(2),AliPID::kProton);
+    nSigma_TPC_prot_2 = fPidResponse->NumberOfSigmasTPC((AliAODTrack*)cand->GetDaughter(2),(fIsCdeuteronAnalysis?(AliPID::kDeuteron):(AliPID::kProton)));
   }
   if(status_TOF_2 == AliPIDResponse::kDetPidOk){
     nSigma_TOF_pion_2 = fPidResponse->NumberOfSigmasTOF((AliAODTrack*)cand->GetDaughter(2),AliPID::kPion);
-    nSigma_TOF_prot_2 = fPidResponse->NumberOfSigmasTOF((AliAODTrack*)cand->GetDaughter(2),AliPID::kProton);
+    nSigma_TOF_prot_2 = fPidResponse->NumberOfSigmasTOF((AliAODTrack*)cand->GetDaughter(2),(fIsCdeuteronAnalysis?(AliPID::kDeuteron):(AliPID::kProton)));
   }
   varPointer[23] = nSigma_TPC_prot_0;
   varPointer[24] = nSigma_TOF_prot_0;
@@ -2643,7 +2756,7 @@ Short_t AliAnalysisTaskSEXicTopKpi::SetMapCutsResponse(Int_t massHypo_filtering,
 }
 
 //________________________________________________________________________
-void AliAnalysisTaskSEXicTopKpi::PrepareTracks(AliAODEvent *aod,TClonesArray *mcArray){
+void AliAnalysisTaskSEXicTopKpi::PrepareTracks(AliAODEvent *aod,TClonesArray *mcArray, AliAODMCHeader *mcHeader){
 // SELECT TRACKS and flag them: could consider to include common tracks (dca) to reduce cpu time (call once propagatetodca)
   ftrackArraySel->Reset();
   ftrackArraySelSoftPi->Reset();
@@ -2660,6 +2773,16 @@ void AliAnalysisTaskSEXicTopKpi::PrepareTracks(AliAODEvent *aod,TClonesArray *mc
     Int_t iSelProtonCuts=-1,iSelKaonCuts=-1,iSelPionCuts=-1,iSelSoftPionCuts=-1;
     AliAODTrack *track = dynamic_cast<AliAODTrack*>(aod->GetTrack(itrack));
     if(!track) AliFatal("Not a standard AOD");
+    if(fIsCdeuteronAnalysis && fReadMC) {
+      Bool_t isTrackCD = AliVertexingHFUtils::IsTrackFromHadronDecay(2010010020, track, mcArray);
+      // remove track if only keeping signal, or if it is injected
+      if(!isTrackCD) { 
+        if(fIsKeepOnlyCdeuteronSignal) continue;
+        Bool_t isBkgTrackInjected = AliVertexingHFUtils::IsTrackInjected(track,mcHeader,mcArray);
+        if(isBkgTrackInjected) continue;
+      }
+    }
+
     //    Printf("selecting track");
     AliESDtrack *trackESD=SelectTrack(track,iSelProtonCuts,iSelKaonCuts,iSelPionCuts,iSelSoftPionCuts,fESDtrackCutsProton,fESDtrackCutsKaon,fESDtrackCutsPion,fESDtrackCutsSoftPion);
     

--- a/PWGHF/vertexingHF/AliAnalysisTaskSEXicTopKpi.h
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSEXicTopKpi.h
@@ -121,6 +121,7 @@ class AliAnalysisTaskSEXicTopKpi : public AliAnalysisTaskSE
   void SetOnTheFlyLcCandidatesForSigmaC(Bool_t onthefly){fSigmaCfromLcOnTheFly=onthefly;}
   void SetFillOnlyTrackSparse(Bool_t fillonlysparse){fCheckOnlyTrackEfficiency=fillonlysparse;}
   void SetIsCdeuteronAnalysis(Bool_t iscd){fIsCdeuteronAnalysis=iscd;}
+  void SetIsKeepOnlyCdeuteronSignal(Bool_t isSig){fIsKeepOnlyCdeuteronSignal=isSig;}
   void SetNSoftPionRotations(Int_t nrot){nrot < 0 ? Printf("Cannot set negative number of rotations, setting 0"), fNRotations=0 : fNRotations=nrot;}
   void SetMinAndMaxRotationAngles(Double_t minRot,Double_t maxRot){fMinAngleForRot=minRot;fMaxAngleForRot=maxRot;}
   void SetPDGcodeForFiducialYreco(Int_t pdgcode){fPdgFiducialYreco=pdgcode;}
@@ -186,7 +187,7 @@ class AliAnalysisTaskSEXicTopKpi : public AliAnalysisTaskSE
   void SigmaCloop(AliAODRecoDecayHF3Prong *io3Prong,AliAODEvent *aod,Int_t massHypothesis,Double_t mass1, Double_t mass2,Double_t *pointS,Int_t resp_onlyPID,Bool_t *arrayPIDselpKpi=0x0,Bool_t *arrayPIDselpiKpi=0x0,Int_t itrack1=-1,Int_t itrack2=-1,Int_t itrackThird=-1,AliAODMCParticle *pSigmaC=0x0,Int_t checkorigin=-1,Int_t decay_channel=0);
   void FillArrayVariableSparse(AliAODRecoDecayHF3Prong *io3Prong,AliAODEvent *aod,Double_t *point,Int_t massHypothesis);  
   Double_t Weight_fromLc_toXic(AliAODMCParticle* p, AliAODMCParticle* prong);
-  void PrepareTracks(AliAODEvent *aod,TClonesArray *mcArray=0x0);
+  void PrepareTracks(AliAODEvent *aod,TClonesArray *mcArray=0x0, AliAODMCHeader *mcHeader = 0x0);
   Int_t ConvertXicMCinfo(Int_t infoMC);
   AliAODMCParticle* MatchRecoCandtoMC(AliAODRecoDecayHF3Prong *io3Prong,Int_t &isTrueLambdaCorXic,Int_t &checkOrigin);
   AliAODMCParticle* MatchRecoCandtoMCAcc(AliAODRecoDecayHF3Prong *io3Prong,Int_t &isTrueLambdaCorXic,Int_t &checkOrigin);
@@ -249,6 +250,19 @@ class AliAnalysisTaskSEXicTopKpi : public AliAnalysisTaskSE
   TH1F* fDist23Signal; //!<! histo storing variable for debugging (pt integrted)
   TH1F* fDist23All; //!<! histo storing variable for debugging (pt integrted)
   TH1F *fDist23AllFilter;//!<! histo storing variable for debugging (pt integrted)
+  TH2F *fVtxResXPt; //!<! histo for vertex resolution in X vs pT
+  TH2F *fVtxResYPt; //!<! histo for vertex resolution in Y vs pT
+  TH2F *fVtxResZPt; //!<! histo for vertex resolution in Z vs pT
+  TH2F *fVtxResXYPt; //!<! histo for vertex resolution in XY vs pT
+  TH2F *fVtxResXYZPt; //!<! histo for vertex resolution in XYZ vs pT
+  TH2F *fPrimVtxResXPt; //!<! histo for primary vertex resolution in X vs pT
+  TH2F *fPrimVtxResYPt; //!<! histo for primary vertex resolution in Y vs pT
+  TH2F *fPrimVtxResZPt; //!<! histo for primary vertex resolution in Z vs pT
+  TH2F *fDecayLResXPt; //!<! histo for decay length resolution in X vs pT
+  TH2F *fDecayLResYPt; //!<! histo for decay length resolution in Y vs pT
+  TH2F *fDecayLResZPt; //!<! histo for decay length resolution in Z vs pT
+  TH2F *fDecayLResXYPt; //!<! histo for decay length resolution in XY vs pT
+  TH2F *fDecayLResXYZPt; //!<! histo for decay length resolution in XYZ vs pT
   TH2F *fnSigmaPIDtofProton; //!<! histo for monitoring PID performance
   TH2F *fnSigmaPIDtofPion; //!<! histo for monitoring PID performance
   TH2F *fnSigmaPIDtofKaon; //!<! histo for monitoring PID performance
@@ -328,6 +342,7 @@ class AliAnalysisTaskSEXicTopKpi : public AliAnalysisTaskSE
   Bool_t fSigmaCfromLcOnTheFly; /// switch to use on-the-fly Lc or filtered Lc from delta file
   Bool_t fCheckOnlyTrackEfficiency;// flag for filling only the single-track sparse and return
   Bool_t fIsCdeuteronAnalysis;// flag for doing the c deuteron analysis (inv mass)
+  Bool_t fIsKeepOnlyCdeuteronSignal;// flag for keeping only c deuteron signal
   Int_t fNRotations;    // number of rotations performed on soft pion, to study SigmaC background shape; 0 = no rotations, 1 -> single rotations by fMinAngleForRot, 2 -> fNRotations from fMinAngleForRot to fMaxAngleForRot
   Double_t fMinAngleForRot;//
   Double_t fMaxAngleForRot;//
@@ -345,7 +360,7 @@ class AliAnalysisTaskSEXicTopKpi : public AliAnalysisTaskSE
   Double_t fMinPtSoftPion;  // !
 
   /// \cond CLASSIMP
-  ClassDef(AliAnalysisTaskSEXicTopKpi,12); /// AliAnalysisTaskSE for Xic->pKpi
+  ClassDef(AliAnalysisTaskSEXicTopKpi,13); /// AliAnalysisTaskSE for Xic->pKpi
   /// \endcond
 };
 


### PR DESCRIPTION
- add vertex histograms and fill if running c-deuteron analysis
- add option, if running c-deuteron analysis, to only use tracks that come from signal (saves a lot of CPU time), and to remove injected particles