### PR TITLE
PWGGA/GammaConv: GammaIsoTree added cell based iso & GJ weights

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskGammaIsoTree.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaIsoTree.h
@@ -8,6 +8,7 @@
 #include <vector>
 #include "AliV0ReaderV1.h"
 #include "AliCaloPhotonCuts.h"
+#include "AliCalorimeterUtils.h"
 #include "AliConvEventCuts.h"
 #include "AliConversionPhotonCuts.h"
 #include "AliConversionMesonCuts.h"
@@ -39,10 +40,12 @@ typedef struct {
   Double_t rho;
 } mcEvtHeader;
 
+// currently not used, but can be if later simplification is needed
 typedef struct {
-  TVector3 p; // primary vertex 
-  Int_t nCells;
-  Double_t energy;
+  TLorentzVector p; 
+  Short_t clustertype;
+  Int_t nCells, nLM;
+  Double_t ToF;
   Double32_t m02,m20,disp;
   Int_t matchedTrackInd[20];
   Int_t nmbMatchedTracks;
@@ -50,7 +53,7 @@ typedef struct {
 } lightCluster;
 
 typedef struct {
-  Double32_t isoRawCharged,isoRawNeutral;
+  Double32_t isoRawCharged[2],isoRawNeutral[2], isoCell[2]; // storage for two isolation radii each
   Int_t isTagged; //0 : no 1:withOtherConv 2: withOtherCluster 3: both
 } isoInfo;
 
@@ -62,7 +65,8 @@ class AliAnalysisTaskGammaIsoTree : public AliAnalysisTaskSE{
     AliAnalysisTaskGammaIsoTree();
     AliAnalysisTaskGammaIsoTree(const char *name);
     virtual ~AliAnalysisTaskGammaIsoTree();
-
+    AliCalorimeterUtils * GetCaloUtils()     { if (!fCaloUtils) fCaloUtils = new AliCalorimeterUtils() ; 
+                                             return fCaloUtils     ; }
     virtual void   UserCreateOutputObjects  ();
     virtual Bool_t Notify                   ();
     void SetV0ReaderName(TString name){fV0ReaderName=name; return;}
@@ -78,6 +82,11 @@ class AliAnalysisTaskGammaIsoTree : public AliAnalysisTaskSE{
     void SetClusterCutsEMC                  ( AliCaloPhotonCuts* clusterCuts,
                                               Bool_t IsHeavyIon )                         {
                                                                                             fClusterCutsEMC=clusterCuts           ;
+                                                                                            fIsHeavyIon = IsHeavyIon            ;
+                                                                                          }
+    void SetClusterCutsBackgroundEMC             ( AliCaloPhotonCuts* clusterCuts,
+                                              Bool_t IsHeavyIon )                         {
+                                                                                           fClusterCutsBackgroundEMC=clusterCuts           ;
                                                                                            fIsHeavyIon = IsHeavyIon            ;
                                                                                           }
     void SetClusterCutsPHOS                  ( AliCaloPhotonCuts* clusterCuts,
@@ -103,11 +112,12 @@ class AliAnalysisTaskGammaIsoTree : public AliAnalysisTaskSE{
     }
 
     void SetEOverP(Double_t p0){ fMatchingEOverP = p0;}
+    void SetDoBackgroundTrackMatching(Bool_t p){ fDoBackgroundTrackMatching = p;}
 
     void SetDoTrackIso(Bool_t p0){ fDoTrackIsolation = p0;}
-    void SetTrackIsoR(Float_t r){ fTrackIsolationR = r;}
+    void SetTrackIsoR(Float_t r1, Float_t r2){ fTrackIsolationR[0] = r1; fTrackIsolationR[1] = r2;}
     void SetDoNeutralIso(Bool_t p0){ fDoNeutralIsolation = p0;}
-    void SetNeutralIsoR(Float_t r){ fNeutralIsolationR = r;}
+    void SetNeutralIsoR(Float_t r1, Float_t r2){ fNeutralIsolationR[0] = r1; fNeutralIsolationR[1] = r2;}
 
     void SetRhoOutName(TString s){fRhoOutName = s;}
     void SetBuffSize(Long64_t buff){fTreeBuffSize = buff;}
@@ -133,23 +143,7 @@ class AliAnalysisTaskGammaIsoTree : public AliAnalysisTaskSE{
     void SetSaveTracks(Bool_t b){
         fSavePHOSClusters = b;
     }
-  private:
-    ULong64_t GetUniqueEventID      ( AliVHeader *header);
-    void CountTracks                ();
-    void ResetBuffer();
-    void ProcessConversionPhotons();
-    void ProcessCaloPhotons();
-    Bool_t TrackIsSelectedAOD(AliAODTrack* lTrack);
-    void ProcessTracks();
-    void ProcessMCParticles();
-    Int_t ProcessTrackMatching(AliAODCaloCluster* clus, std::vector<AliAODTrack*> tracks);
-    Double32_t ProcessChargedIsolation(AliAODConversionPhoton* photon);
-    Double32_t ProcessChargedIsolation(AliAODCaloCluster* cluster);
-    Double32_t ProcessNeutralIsolation(AliAODConversionPhoton* photon);
-    Double32_t ProcessNeutralIsolation(AliAODCaloCluster* cluster);
-    Int_t ProcessTagging(AliAODConversionPhoton* photon);
-    Int_t ProcessTagging(AliAODCaloCluster* cluster);
-    void ReduceTrackInfo();
+
   protected:
     AliVEvent*                  fInputEvent;                //
     AliMCEvent*                 fMCEvent;                   //
@@ -163,14 +157,14 @@ class AliAnalysisTaskGammaIsoTree : public AliAnalysisTaskSE{
     TClonesArray*               fReaderGammas;     //!<! array with photon from fV0Reader                      //
     std::vector<AliAODConversionPhoton*> fConversionCandidates;  // stores conv candidates of event that fulfill cuts
     std::vector<AliAODCaloCluster*> fClusterEMCalCandidates;   // stores emcal clusters that fulfill cuts
-    std::vector<AliAODCaloCluster*> fClusterEMCalCandidatesNoCuts;  // vector containing all clusters , for internal use only (i.e. for iso)
+    std::vector<AliAODCaloCluster*> fClusterEMCalCandidatesBackground;  // vector containing clusters used for tagging and isolation, for internal use only
     std::vector<AliAODCaloCluster*> fClusterPHOSCandidates;  // stores phos clusters that fulfill cuts
     //std::vector<lightCluster> fClusterEMCalCandidates;  //
     //std::vector<lightCluster> fClusterPHOSCandidates;  //
     std::vector<AliAODTrack*>   fTracks;  //
     std::vector<AliAODMCParticle*>   fMCParticles;  // stores mc particles
     std::vector<Short_t>        fIDMatchedEMCTrack; // ID of up to 5 tracks per cluster, where index of vector corresponds to emc candidates index
-    std::vector<Short_t>        fIDMatchedEMCTrackNoCuts; // ID of up to 5 tracks per cluster, where index of vector corresponds to emc candidates index
+    std::vector<Short_t>        fIDMatchedEMCTrackBackground; // ID of up to 5 tracks per cluster, where index of vector corresponds to emc candidates index
     dEvtHeader                  fDataEvtHeader; // storage for general event properties
     mcEvtHeader                 fMCEvtHeader;   // storage for MC event properties
     std::vector<isoInfo>        fConvIsoInfo;   // storage for isolation info of conv photons, following same ordering as fConversionCandidates
@@ -181,9 +175,12 @@ class AliAnalysisTaskGammaIsoTree : public AliAnalysisTaskSE{
     // cuts and setting
     TString                     fCorrTaskSetting;
     AliConvEventCuts*           fEventCuts;                 // event cuts
-    AliCaloPhotonCuts*          fClusterCutsEMC;            // emc cluster cuts
+    AliCaloPhotonCuts*          fClusterCutsEMC;            // emc cluster cuts used for signal clusters (clusters that are stored to tree)
+    AliCaloPhotonCuts*          fClusterCutsBackgroundEMC;  // emc cluster cuts used for background clusters (used for tagging and isolation, not stored)
     AliCaloPhotonCuts*          fClusterCutsPHOS;           // phos cluster cuts
     AliConversionPhotonCuts*    fConvCuts;                  // Cuts used by the V0Reader
+
+    AliCalorimeterUtils*        fCaloUtils;
     
     // Track cuts
     Int_t                       fMinClsTPC;  // 
@@ -196,12 +193,13 @@ class AliAnalysisTaskGammaIsoTree : public AliAnalysisTaskSE{
     Double_t                    fMatchingParamsPhi[3];// [0] + (pt + [1])^[2]
     Double_t                    fMatchingParamsEta[3];//
     Double_t                    fMatchingEOverP; //
+    Bool_t                      fDoBackgroundTrackMatching; // should track matching be applied for background clusters (tagging and iso)
 
     Bool_t                      fDoTrackIsolation; //
-    Float_t                     fTrackIsolationR;  //
+    Float_t                     fTrackIsolationR[2];  //
 
     Bool_t                      fDoNeutralIsolation; //
-    Float_t                     fNeutralIsolationR; //
+    Float_t                     fNeutralIsolationR[2]; //
     
     Double_t                    fPi0TaggingWindow[2];    // inv mass window used for pi0 tagging
     Double_t                    fEtaTaggingWindow[2];    // inv mass window used for eta tagging
@@ -214,6 +212,7 @@ class AliAnalysisTaskGammaIsoTree : public AliAnalysisTaskSE{
     // histos
     TH1F*                       fHistoNEvents;   // 
     TH1F*                       fHistoNEventsWOWeight;   // 
+    TH1F*                       fHistoChargedIso;   // 
 
     TString                     fRhoOutName; // 
 
@@ -221,10 +220,29 @@ class AliAnalysisTaskGammaIsoTree : public AliAnalysisTaskSE{
     Long64_t                    fMemCountAOD;            //!<! accumulated tree size before AutoSave
 
   private:
-  // not implemented
+    ULong64_t GetUniqueEventID      ( AliVHeader *header);
+    void CountTracks                ();
+    void ResetBuffer();
+    void ProcessConversionPhotons();
+    void ProcessCaloPhotons();
+    Bool_t TrackIsSelectedAOD(AliAODTrack* lTrack);
+    void ProcessTracks();
+    void ProcessMCParticles();
+    Int_t ProcessTrackMatching(AliAODCaloCluster* clus, std::vector<AliAODTrack*> tracks);
+    void ProcessChargedIsolation(AliAODConversionPhoton* photon, Double32_t arrIso[]);
+    void ProcessChargedIsolation(AliAODCaloCluster* cluster, Double32_t arrIso[]);
+    void ProcessNeutralIsolation(AliAODConversionPhoton* photon, Double32_t arrIso[]);
+    void ProcessCellIsolation(AliAODConversionPhoton* photon, Double32_t arrIso[]);
+    void ProcessCellIsolation(AliAODCaloCluster* cluster, Double32_t arrIso[]);
+    void ProcessNeutralIsolation(AliAODCaloCluster* cluster, Double32_t arrIso[]);
+    Int_t ProcessTagging(AliAODConversionPhoton* photon);
+    Int_t ProcessTagging(AliAODCaloCluster* cluster);
+    void ReduceTrackInfo();
+    void RelabelAODPhotonCandidates(Bool_t mode);
+
     AliAnalysisTaskGammaIsoTree(const AliAnalysisTaskGammaIsoTree&); // Prevent copy-construction
-    AliAnalysisTaskGammaIsoTree& operator=(const AliAnalysisTaskGammaIsoTree&); // Prevent assignment
-    ClassDef(AliAnalysisTaskGammaIsoTree, 4);
+    AliAnalysisTaskGammaIsoTree& operator=(const AliAnalysisTaskGammaIsoTree&); // Prevent assignment  
+    ClassDef(AliAnalysisTaskGammaIsoTree, 5);
 };
 
 #endif

--- a/PWGGA/GammaConvBase/AliCaloPhotonCuts.cxx
+++ b/PWGGA/GammaConvBase/AliCaloPhotonCuts.cxx
@@ -6472,9 +6472,8 @@ void AliCaloPhotonCuts::ApplyNonLinearity(AliVCluster* cluster, Int_t isMC, AliV
         } else if( fCurrentMC == kPP8T12P2Pho ){
           if(fClusterType==1) energy /= FunctionNL_kSDM(energy, 0.969703*0.989*0.9969*0.9991, -3.80387, -0.200546);
 
-        } else if( fCurrentMC == kPP8T12P2JJ ){
+        } else if( fCurrentMC == kPP8T12P2JJ || fCurrentMC == kPP8T12P2GJGeant3 || fCurrentMC == kPP8T12P2GJGeant4 ){
           if(fClusterType==1) energy /= FunctionNL_kSDM(energy, 0.974859*0.987*0.996, -3.85842, -0.405277);
-
         // 2.76TeV LHC11a/LHC13g
         } else if( fCurrentMC==k12f1a || fCurrentMC==k12i3 || fCurrentMC==k15g2 ){
           if(fClusterType==1) energy /= FunctionNL_kSDM(energy, 0.984889*0.995*0.9970, -3.65456, -1.12744);
@@ -6598,7 +6597,7 @@ void AliCaloPhotonCuts::ApplyNonLinearity(AliVCluster* cluster, Int_t isMC, AliV
         } else if( fCurrentMC == kPP8T12P2Pho ){
           if(fClusterType==1) energy /= FunctionNL_kSDM(energy, 0.96105*0.999*0.9996, -3.62239, -0.556256);
 
-        } else if( fCurrentMC == kPP8T12P2JJ  ){
+        } else if( fCurrentMC == kPP8T12P2JJ || fCurrentMC == kPP8T12P2GJGeant3 || fCurrentMC == kPP8T12P2GJGeant4 ){
           if(fClusterType==1) energy /= FunctionNL_kSDM(energy, 0.960596*0.999*0.999, -3.48444, -0.766862);
 
         // 2.76TeV LHC11a/LHC13g
@@ -6710,7 +6709,7 @@ void AliCaloPhotonCuts::ApplyNonLinearity(AliVCluster* cluster, Int_t isMC, AliV
     case 15:
       if (fClusterType == 1 || fClusterType == 3){
         // 8TeV LHC12x
-        if ( fCurrentMC==k14e2b || fCurrentMC == kPP8T12P2Pyt8 || fCurrentMC == kPP8T12P2Pho  || fCurrentMC == k12pp8TeV || fCurrentMC == kPP8T12P2JJ ){
+        if ( fCurrentMC==k14e2b || fCurrentMC == kPP8T12P2Pyt8 || fCurrentMC == kPP8T12P2Pho  || fCurrentMC == k12pp8TeV || fCurrentMC == kPP8T12P2JJ || fCurrentMC == kPP8T12P2GJGeant3 || fCurrentMC == kPP8T12P2GJGeant4 ){
           energy *= FunctionNL_kPi0MC(energy, 1.0, 0.04979, 1.3, 0.0967998, 219.381, 63.1604, 1.011);
           if(isMC == 0) energy *= FunctionNL_kSDM(energy, 0.9846, -3.319, -2.033);
 
@@ -6730,7 +6729,7 @@ void AliCaloPhotonCuts::ApplyNonLinearity(AliVCluster* cluster, Int_t isMC, AliV
     case 16:
       if (fClusterType == 1 || fClusterType == 3){
         // 8TeV LHC12x
-        if ( fCurrentMC==k14e2b  || fCurrentMC == kPP8T12P2Pyt8 || fCurrentMC == kPP8T12P2Pho  || fCurrentMC == k12pp8TeV || fCurrentMC == kPP8T12P2JJ ){
+        if ( fCurrentMC==k14e2b  || fCurrentMC == kPP8T12P2Pyt8 || fCurrentMC == kPP8T12P2Pho  || fCurrentMC == k12pp8TeV || fCurrentMC == kPP8T12P2JJ || fCurrentMC == kPP8T12P2GJGeant3 || fCurrentMC == kPP8T12P2GJGeant4){
           energy *= FunctionNL_kPi0MC(energy, 1.0, 0.06539, 1.121, 0.0967998, 219.381, 63.1604, 1.011);
           if(isMC == 0) energy *= FunctionNL_kSDM(2.0*energy, 0.9676, -3.216, -0.6828);
 
@@ -6829,7 +6828,7 @@ void AliCaloPhotonCuts::ApplyNonLinearity(AliVCluster* cluster, Int_t isMC, AliV
           if(fClusterType==1) energy /= (FunctionNL_DPOW(energy, 1.0654169768, -0.0935785719, -0.1137883054, 1.1814766150, -0.1980098061, -0.0854569214) - 0.0138);
         } else if( fCurrentMC == kPP8T12P2Pho ){
           if(fClusterType==1) energy /= (FunctionNL_DPOW(energy, 1.0652493513, -0.0929276101, -0.1113762695, 1.1837801885, -0.1999914832, -0.0854569214) - 0.0145);
-        } else if( fCurrentMC == kPP8T12P2JJ ){
+        } else if( fCurrentMC == kPP8T12P2JJ || fCurrentMC == kPP8T12P2GJGeant3 || fCurrentMC == kPP8T12P2GJGeant4){
           if(fClusterType==1) energy /= (FunctionNL_DPOW(energy, 1.0489259285, -0.0759079646, -0.1239772934, 1.1835846739, -0.1998987993, -0.0854186691) - 0.014);
         // 7 TeV
         } else if( fCurrentMC == k14j4 ){ //v3
@@ -6939,7 +6938,7 @@ void AliCaloPhotonCuts::ApplyNonLinearity(AliVCluster* cluster, Int_t isMC, AliV
           if(fClusterType==1) energy /= (FunctionNL_DPOW(energy, 1.1389201636, -0.1999994717, -0.1622237979, 1.1603460704, -0.1999999989, -0.2194447313) - 0.0025);
         } else if( fCurrentMC == kPP8T12P2Pho ){
           if(fClusterType==1) energy /= (FunctionNL_DPOW(energy, 1.0105301622, -0.0732424689, -0.5000000000, 1.0689250170, -0.1082682369, -0.4388156470) - 0.001);
-        } else if( fCurrentMC == kPP8T12P2JJ ){
+        } else if( fCurrentMC == kPP8T12P2JJ || fCurrentMC == kPP8T12P2GJGeant3 || fCurrentMC == kPP8T12P2GJGeant4 ){
           if(fClusterType==1) energy /= (FunctionNL_DPOW(energy, 0.9922456908, -0.0551212559, -0.5000000000, 1.0513459039, -0.0894163252, -0.5000000000) + 0.002);
         // 7 TeV
         } else if( fCurrentMC == k14j4 ){ //v3
@@ -8207,6 +8206,8 @@ AliCaloPhotonCuts::MCSet AliCaloPhotonCuts::FindEnumForMCSet(TString namePeriod)
             namePeriod.CompareTo("LHC16c2_plus") == 0 ) return kPP8T12P2JJ;
   else if ( namePeriod.CompareTo("LHC17g5b") == 0 ) return kPP8T12P2GJLow;
   else if ( namePeriod.CompareTo("LHC17g5c") == 0 ) return kPP8T12P2GJHigh;
+  else if ( namePeriod.CompareTo("LHC17g5a1") == 0 ) return kPP8T12P2GJGeant3;
+  else if ( namePeriod.CompareTo("LHC17g5a2") == 0 ) return kPP8T12P2GJGeant4;
 
   // pPb 5 TeV 2013 MC pass 2
   else if(  namePeriod.Contains("LHC13b2_efix"))        return kPPb5T13P2DPMJet;

--- a/PWGGA/GammaConvBase/AliCaloPhotonCuts.h
+++ b/PWGGA/GammaConvBase/AliCaloPhotonCuts.h
@@ -131,6 +131,8 @@ class AliCaloPhotonCuts : public AliAnalysisCuts {
       kPP8T12P2JJ,
       kPP8T12P2GJLow,
       kPP8T12P2GJHigh,
+      kPP8T12P2GJGeant3,
+      kPP8T12P2GJGeant4,
       // pPb 5 TeV 2013
       kPPb5T13P2DPMJet,
       kPPb5T13P4JJ,

--- a/PWGGA/GammaConvBase/AliConvEventCuts.cxx
+++ b/PWGGA/GammaConvBase/AliConvEventCuts.cxx
@@ -3364,6 +3364,7 @@ Bool_t AliConvEventCuts::IsJetJetMCEventAccepted(AliMCEvent *mcEvent, Double_t& 
         fPeriodEnum != kLHC16c3a && fPeriodEnum != kLHC16c3b && fPeriodEnum != kLHC16c3c &&         // LHC13 pPb Jet Jet MC's
         fPeriodEnum != kLHC17g6a1 && fPeriodEnum != kLHC17g6a2 && fPeriodEnum != kLHC17g6a3 &&      // LHC13 pPb Jet Jet MC's
         fPeriodEnum != kLHC12P2JJ && fPeriodEnum != kLHC17g5b && fPeriodEnum != kLHC17g5c &&        // LHC12 JetJet MC
+        fPeriodEnum != kLHC17g5a1 && fPeriodEnum != kLHC17g5a2 &&                                    // LHC12 GammaJet MC
         fPeriodEnum != kLHC14k1a  &&  fPeriodEnum != kLHC14k1b                                      // LHC11 JetJet MC
      ){
 
@@ -3596,6 +3597,18 @@ Bool_t AliConvEventCuts::IsJetJetMCEventAccepted(AliMCEvent *mcEvent, Double_t& 
             weight = weightsBins[pthardbin-1];
             if(fUseAdditionalOutlierRejection && ((ptHard < ptHardBinRanges[pthardbin-1]) || (ptHard > ptHardBinRanges[pthardbin]))) eventAccepted= kFALSE;
           }
+        } else if ( fPeriodEnum == kLHC17g5a1 ||fPeriodEnum == kLHC17g5a2 ){
+          Double_t ptHardBinRanges[7]  = { 5,  11,  21, 36, 57,
+                                            84, 1000000};
+          Double_t weightsBins[6]      = {1.43277693e-04, 1.88432909e-05, 2.86381554e-06, 5.18655146e-07, 1.08660208e-07, 3.89688100e-08};
+            Int_t bin = 0;
+            while (!((ptHard< ptHardBinRanges[bin+1] && ptHard > ptHardBinRanges[bin]) || (ptHard == ptHardBinRanges[bin]) ) )bin++;
+            if (bin < 6) weight = weightsBins[bin];
+          if(fUseFilePathForPthard && (pthardbin > -1)){
+            weight = weightsBins[pthardbin-1];
+            if(fUseAdditionalOutlierRejection && ((ptHard < ptHardBinRanges[pthardbin-1]) || (ptHard > ptHardBinRanges[pthardbin]))) eventAccepted= kFALSE;
+          }
+                
         } else if ( fPeriodEnum == kLHC16c3a ){ // ALIROOT-5901
           Double_t ptHardBinRanges[6]   = {  7, 9, 12, 16, 21, 1000};
           Double_t weightsBins[5]       = {  6.731200e-03, 7.995602e-03, 6.778717e-03, 4.643571e-03, 6.014497e-03};
@@ -4163,6 +4176,20 @@ Bool_t AliConvEventCuts::IsJetJetMCEventAccepted(AliMCEvent *mcEvent, Double_t& 
               if(fUseAdditionalOutlierRejection && ((ptHard < ptHardBinRanges[pthardbin-1]) || (ptHard > ptHardBinRanges[pthardbin]))) eventAccepted= kFALSE;
             }
         }
+      
+      } else if ( fPeriodEnum == kLHC17g5a1 || fPeriodEnum == kLHC17g5a2 ){
+        Double_t ptHardBinRanges[7]  = { 5,  11,  21, 36, 57,
+                                            84, 1000000};
+        Double_t weightsBins[6]      = {1.43277693e-04, 1.88432909e-05, 2.86381554e-06, 5.18655146e-07, 1.08660208e-07, 3.89688100e-08};
+            Int_t bin = 0;
+            if(ptHard >= ptHardBinRanges[0]){
+              while (!((ptHard< ptHardBinRanges[bin+1] && ptHard > ptHardBinRanges[bin]) || (ptHard == ptHardBinRanges[bin]) ) )bin++;
+              if (bin < 6) weight = weightsBins[bin];
+              if(fUseFilePathForPthard && (pthardbin > -1)){
+                weight = weightsBins[pthardbin-1];
+                if(fUseAdditionalOutlierRejection && ((ptHard < ptHardBinRanges[pthardbin-1]) || (ptHard > ptHardBinRanges[pthardbin]))) eventAccepted= kFALSE;
+              }
+          }
       } else if ( fPeriodEnum == kLHC16c3a ){ //ALIROOT-5901
         Double_t ptHardBinRanges[6]   = {  7, 9, 12, 16, 21, 1000};
         Double_t weightsBins[5]       = {  6.73298726e-03, 8.00549934e-03, 6.77989565e-03, 4.64169953e-03, 6.01322269e-03};
@@ -4697,8 +4724,9 @@ void AliConvEventCuts::GetXSectionAndNTrials(AliMCEvent *mcEvent, Float_t &XSect
         fPeriodEnum != kLHC13b4_fix && fPeriodEnum != kLHC13b4_plus &&                              // LHC13 pPb Jet Jet MC's
         fPeriodEnum != kLHC19a4 &&                                                                  // LHC13 pPb Jet Jet MC's
         fPeriodEnum != kLHC16c3a && fPeriodEnum != kLHC16c3b && fPeriodEnum != kLHC16c3c &&         // LHC13 pPb Jet Jet MC's
-        fPeriodEnum != kLHC17g6a1 && fPeriodEnum != kLHC17g6a2 && fPeriodEnum != kLHC17g6a3 &&         // LHC13 pPb Jet Jet MC's
+        fPeriodEnum != kLHC17g6a1 && fPeriodEnum != kLHC17g6a2 && fPeriodEnum != kLHC17g6a3 &&      // LHC13 pPb Jet Jet MC's
         fPeriodEnum != kLHC12P2JJ  &&  fPeriodEnum != kLHC17g5b  &&  fPeriodEnum != kLHC17g5c  &&   // LHC12 JetJet MC
+        fPeriodEnum != kLHC17g5a1  &&  fPeriodEnum != kLHC17g5a2 &&                                 // LHC12 GammaJet MC
         fPeriodEnum != kLHC18b11a  &&                                                               // LHC18 GammaJet MC anchored to LHC15o
         fPeriodEnum != kLHC18b11b  &&                                                               // LHC18 GammaJet MC anchored to LHC15o
         fPeriodEnum != kLHC18b11c  &&                                                               // LHC18 GammaJet MC anchored to LHC15o
@@ -4816,6 +4844,7 @@ Float_t AliConvEventCuts::GetPtHard(AliMCEvent *mcEvent, AliVEvent* event){
         fPeriodEnum != kLHC16c3a && fPeriodEnum != kLHC16c3b && fPeriodEnum != kLHC16c3c &&         // LHC13 pPb Jet Jet MC's
         fPeriodEnum != kLHC17g6a1 && fPeriodEnum != kLHC17g6a2 && fPeriodEnum != kLHC17g6a3 &&      // LHC13 pPb Jet Jet MC's
         fPeriodEnum != kLHC12P2JJ  && fPeriodEnum != kLHC17g5b  && fPeriodEnum != kLHC17g5c  &&     // LHC12 JetJet MC
+        fPeriodEnum != kLHC17g5a1  && fPeriodEnum != kLHC17g5a2  &&     // LHC12 GammaJet MC
         fPeriodEnum != kLHC14k1a  &&  fPeriodEnum != kLHC14k1b                                      // LHC11 JetJet MC
     ) return -1;
 
@@ -7371,6 +7400,12 @@ void AliConvEventCuts::SetPeriodEnum (TString periodName){
     fEnergyEnum = k8TeV;
   } else if (periodName.CompareTo("LHC12P2JJ") == 0 || periodName.CompareTo("LHC16c2") == 0 || periodName.CompareTo("LHC16c2_plus") == 0){
     fPeriodEnum = kLHC12P2JJ;
+    fEnergyEnum = k8TeV;
+  } else if (periodName.CompareTo("LHC17g5a1") == 0){
+    fPeriodEnum = kLHC17g5a1;
+    fEnergyEnum = k8TeV;
+  } else if (periodName.CompareTo("LHC17g5a2") == 0){
+    fPeriodEnum = kLHC17g5a2;
     fEnergyEnum = k8TeV;
   } else if (periodName.CompareTo("LHC17g5b") == 0){
     fPeriodEnum = kLHC17g5b;

--- a/PWGGA/GammaConvBase/AliConvEventCuts.h
+++ b/PWGGA/GammaConvBase/AliConvEventCuts.h
@@ -142,6 +142,8 @@ class AliConvEventCuts : public AliAnalysisCuts {
         kLHC12P2JJ,       //!< anchored LHC12[a-h] pass 2 - JJ
         kLHC17g5b,        //!< anchored LHC12[a-h] pass 2 - dec gamma JJ
         kLHC17g5c,        //!< anchored LHC12[a-h] pass 2 - dec gamma JJ
+        kLHC17g5a1,        //!< anchored LHC12[a-h] pass 2 - GJ Geant3
+        kLHC17g5a2,        //!< anchored LHC12[a-h] pass 2 - GJ Geant3
 
         // 2013
         kLHC13bc,         //!< pPb 5.023TeV


### PR DESCRIPTION
- added cell experimental cell based isolation to GammaIsoTree
- added functionality to set cluster cuts separetly for signal clusters and background clusters (those use for isolation and taggin
- added functionality to calculate isolation for multiple radii on the fly
- added weighte for LHC17g5a1 GJ MC pp 8 TeV