### PR TITLE
Fix track extraction

### DIFF
--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskJetDynamicalGrooming.cxx
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskJetDynamicalGrooming.cxx
@@ -273,6 +273,11 @@ void JetSplittings::Print(Option_t* opt) const { Printf("%s", toString().c_str()
 /**
  * Jet constituents.
  */
+// Constant shift to be applied to storing the global index. This ensures that the value is
+// large enough that we're never going to overlap with the MCLabel. It also needs to be large
+// enough such that we'll never overlap with values from the index map. 2000000 allows for 20
+// collections, which should be more than enough.
+const int JetConstituents::fgkGlobalIndexOffset = 2000000;
 
 /**
  * Default constructor.
@@ -281,7 +286,7 @@ JetConstituents::JetConstituents():
   fPt{},
   fEta{},
   fPhi{},
-  fGlobalIndex{}
+  fID{}
 {
   // Nothing more to be done.
 }
@@ -293,7 +298,7 @@ JetConstituents::JetConstituents(const JetConstituents& other)
  : fPt{other.fPt},
   fEta{other.fEta},
   fPhi{other.fPhi},
-  fGlobalIndex{other.fGlobalIndex}
+  fID{other.fID}
 {
   // Nothing more to be done.
 }
@@ -313,21 +318,23 @@ bool JetConstituents::Clear()
   fPt.clear();
   fEta.clear();
   fPhi.clear();
-  fGlobalIndex.clear();
+  fID.clear();
   return true;
 }
 
-void JetConstituents::AddJetConstituent(const PWG::JETFW::AliEmcalParticleJetConstituent & part)
+void JetConstituents::AddJetConstituent(const AliVParticle * part, const int & id)
 {
-  fPt.emplace_back(part.Pt());
-  fEta.emplace_back(part.Eta());
-  fPhi.emplace_back(part.Phi());
-  fGlobalIndex.emplace_back(part.GetGlobalIndex());
+  fPt.emplace_back(part->Pt());
+  fEta.emplace_back(part->Eta());
+  fPhi.emplace_back(part->Phi());
+  // NOTE: We don't use the user_index() here because we need to use that for indexing the
+  //       constituents that are contained in each subjet.
+  fID.emplace_back(id);
 }
 
 std::tuple<float, float, float, int> JetConstituents::GetJetConstituent(int i) const
 {
-  return std::make_tuple(fPt.at(i), fEta.at(i), fPhi.at(i), fGlobalIndex.at(i));
+  return std::make_tuple(fPt.at(i), fEta.at(i), fPhi.at(i), fID.at(i));
 }
 
 /**
@@ -344,7 +351,7 @@ std::string JetConstituents::toString() const
   {
     tempSS << "#" << (i + 1) << ": pt = " << fPt.at(i)
         << ", eta = " << fEta.at(i) << ", phi = " << fPhi.at(i)
-        << ", global index = " << fGlobalIndex.at(i) << "\n";
+        << ", ID = " << fID.at(i) << "\n";
   }
   return tempSS.str();
 }
@@ -422,9 +429,9 @@ bool JetSubstructureSplittings::Clear()
  *
  * @param[in] part Constituent to be added.
  */
-void JetSubstructureSplittings::AddJetConstituent(const PWG::JETFW::AliEmcalParticleJetConstituent& part)
+void JetSubstructureSplittings::AddJetConstituent(const AliVParticle * part, const int & id)
 {
-  fJetConstituents.AddJetConstituent(part);
+  fJetConstituents.AddJetConstituent(part, id);
 }
 
 /**
@@ -1069,7 +1076,8 @@ Bool_t AliAnalysisTaskJetDynamicalGrooming::FillHistograms()
       fDataJetSplittings.SetJetPt(ptSubtracted);
 
       if (fCutDoubleCounts == kTRUE && fJetShapeType == kDetEmbPartPythia) {
-        if (jet1->MaxTrackPt() > jet3->MaxTrackPt()) {
+        // Cut if the leading hybrid track pt is greater than the leading detector level track pt.
+        if (jet1->MaxTrackPt() > jet2->MaxTrackPt()) {
           continue;
         }
       }
@@ -1122,19 +1130,28 @@ void AliAnalysisTaskJetDynamicalGrooming::IterativeParents(AliEmcalJet* jet,
   AliDebugStream(1) << "Beginning iteration through the splittings.\n";
   std::vector<fastjet::PseudoJet> inputVectors;
   fastjet::PseudoJet pseudoTrack;
-  unsigned int constituentIndex = 0;
-  for (auto part : jet->GetParticleConstituents()) {
-    if (isData == true && fDoTwoTrack == kTRUE && CheckClosePartner(jet, part))
+  for (int constituentIndex = 0; constituentIndex < jet->GetNumberOfTracks(); constituentIndex++) {
+    AliVParticle* part = jet->Track(constituentIndex);
+    if (!part) {
       continue;
-    pseudoTrack.reset(part.Px(), part.Py(), part.Pz(), part.E());
+    }
+    if (isData == true && fDoTwoTrack == kTRUE && CheckClosePartner(jet, part)) {
+      continue;
+    }
+    // Set the PseudoJet and add it to the inputs.
+    pseudoTrack.reset(part->Px(), part->Py(), part->Pz(), part->E());
+    // NOTE: This must be the constituent index to allow the subjets to properly determine which constituents are included
+    //       in each subjet.
     pseudoTrack.set_user_index(constituentIndex);
     inputVectors.push_back(pseudoTrack);
 
     // Also store the jet constituents in the output
-    jetSplittings.AddJetConstituent(part);
-
-    // Keep track of the number of constituents.
-    constituentIndex++;
+    // Ensure they are uniquely identified using the id. We don't use the global index (accessed via `TrackAt(int)`) because they
+    // won't be the same for the subtracted and unsubtracted constituents (they are different TClonesArrays). Instead, we label
+    // the part and det level with the MClabel (ie. for those which have it available), and for the data, we use the global
+    // index (offset sufficiently) so it won't overlap with other values.
+    int id = part->GetLabel() != -1 ? part->GetLabel() : (jet->TrackAt(constituentIndex) + SubstructureTree::JetConstituents::GetGlobalIndexOffset());
+    jetSplittings.AddJetConstituent(part , id);
   }
 
   try {
@@ -1237,9 +1254,13 @@ void AliAnalysisTaskJetDynamicalGrooming::CheckSubjetResolution(AliEmcalJet* jet
   std::vector<fastjet::PseudoJet> inputVectors;
   fastjet::PseudoJet pseudoTrack;
 
-  for (auto part : jet->GetParticleConstituents()) {
-    pseudoTrack.reset(part.Px(), part.Py(), part.Pz(), part.E());
-    pseudoTrack.set_user_index(part.GetGlobalIndex() + 100);
+  for (int constituentIndex = 0; constituentIndex < jet->GetNumberOfTracks(); constituentIndex++) {
+    AliVParticle* part = jet->Track(constituentIndex);
+    if (!part) {
+      continue;
+    }
+    pseudoTrack.reset(part->Px(), part->Py(), part->Pz(), part->E());
+    pseudoTrack.set_user_index(jet->TrackAt(constituentIndex) + 100);
     inputVectors.push_back(pseudoTrack);
   }
 
@@ -1250,9 +1271,13 @@ void AliAnalysisTaskJetDynamicalGrooming::CheckSubjetResolution(AliEmcalJet* jet
   std::vector<fastjet::PseudoJet> inputVectorsM;
   fastjet::PseudoJet pseudoTrackM;
 
-  for (auto part : jetM->GetParticleConstituents()) {
-    pseudoTrack.reset(part.Px(), part.Py(), part.Pz(), part.E());
-    pseudoTrack.set_user_index(part.GetGlobalIndex() + 100);
+  for (int constituentIndex = 0; constituentIndex < jetM->GetNumberOfTracks(); constituentIndex++) {
+    AliVParticle* part = jetM->Track(constituentIndex);
+    if (!part) {
+      continue;
+    }
+    pseudoTrack.reset(part->Px(), part->Py(), part->Pz(), part->E());
+    pseudoTrack.set_user_index(jetM->TrackAt(constituentIndex) + 100);
     inputVectorsM.push_back(pseudoTrack);
   }
 
@@ -1323,23 +1348,23 @@ void AliAnalysisTaskJetDynamicalGrooming::CheckSubjetResolution(AliEmcalJet* jet
  * @param[in] jet Jet whose constituents are to be checked.
  * @param[in] part1 Particle to check other particles in relation to.
  */
-bool AliAnalysisTaskJetDynamicalGrooming::CheckClosePartner(AliEmcalJet* jet, PWG::JETFW::AliEmcalParticleJetConstituent & part1)
+bool AliAnalysisTaskJetDynamicalGrooming::CheckClosePartner(const AliEmcalJet* jet, const AliVParticle * part1)
 {
-  auto jetConstituents = jet->GetParticleConstituents();
-  for (auto part2 : jetConstituents) {
+  for (unsigned int i = 0; i < jet->GetNumberOfTracks(); i++) {
+    AliVParticle * part2 = jet->Track(i);
     if (part2 == part1) {
       continue;
     }
-    Double_t phi1 = part1.Phi();
-    Double_t phi2 = part2.Phi();
-    Double_t chg1 = part1.GetParticle()->Charge();
-    Double_t chg2 = part2.GetParticle()->Charge();
-    Double_t ptv1 = part1.Pt();
-    Double_t ptv2 = part2.Pt();
-    Double_t deta = part2.Eta() - part1.Eta();
+    Double_t phi1 = part1->Phi();
+    Double_t phi2 = part2->Phi();
+    Double_t chg1 = part1->Charge();
+    Double_t chg2 = part2->Charge();
+    Double_t ptv1 = part1->Pt();
+    Double_t ptv2 = part2->Pt();
+    Double_t deta = part2->Eta() - part1->Eta();
     const Float_t kLimit = fPhiCutValue * 3;
 
-    if (TMath::Abs(part1.Eta() - part2.Eta()) < fEtaCutValue * 2.5 * 3) {
+    if (TMath::Abs(part1->Eta() - part2->Eta()) < fEtaCutValue * 2.5 * 3) {
       Float_t initdpsinner = (phi2 - TMath::ASin(0.075 * chg2 * fMagFieldPolarity * 0.8 / ptv2) -
                   (phi1 - TMath::ASin(0.075 * chg1 * fMagFieldPolarity * 0.8 / ptv1)));
 
@@ -1755,7 +1780,7 @@ void swap(PWGJE::EMCALJetTasks::SubstructureTree::JetConstituents& first,
   swap(first.fPt, second.fPt);
   swap(first.fEta, second.fEta);
   swap(first.fPhi, second.fPhi);
-  swap(first.fGlobalIndex, second.fGlobalIndex);
+  swap(first.fID, second.fID);
 }
 
 /**

--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskJetDynamicalGrooming.h
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskJetDynamicalGrooming.h
@@ -65,9 +65,17 @@ namespace PWGJE {
 namespace EMCALJetTasks {
 namespace SubstructureTree {
 
+/**
+ * @class Subjets
+ * @brief Subjets of a jet.
+ *
+ * Store the subjets as determined by declustering a jet.
+ *
+ * @author Raymond Ehlers <raymond.ehlers@cern.ch>, ORNL
+ * @date 9 Feb 2020
+ */
 class Subjets {
  public:
-  // TODO: Fully update and document!
   Subjets();
   // Additional constructors
   Subjets(const Subjets & other);
@@ -95,13 +103,22 @@ class Subjets {
  protected:
   std::vector<unsigned short> fSplittingNodeIndex;        ///<  Index of the parent splitting node.
   std::vector<bool> fPartOfIterativeSplitting;            ///<  True if the splitting is follow an iterative splitting.
-  std::vector<std::vector<unsigned short>> fConstituentIndices;        ///<  Constituent jet indices (ie. index by the stored jet constituents, not the global index).
+  std::vector<std::vector<unsigned short>> fConstituentIndices;        ///<  Constituent jet indices (ie. indexed by the stored jet constituents, not the global index).
 
   /// \cond CLASSIMP
   ClassDef(Subjets, 2) // Subjets from splittings.
   /// \endcond
 };
 
+/**
+ * @class JetSplittings
+ * @brief Properties of jet splittings.
+ *
+ * Store the properties of jet splittings determined by declustering a jet.
+ *
+ * @author Raymond Ehlers <raymond.ehlers@cern.ch>, ORNL
+ * @date 9 Feb 2020
+ */
 class JetSplittings {
  public:
   JetSplittings();
@@ -139,10 +156,18 @@ class JetSplittings {
   /// \endcond
 };
 
+/**
+ * @class JetConstituents
+ * @brief Jet constituents.
+ *
+ * Store the constituents associated with a jet.
+ *
+ * @author Raymond Ehlers <raymond.ehlers@cern.ch>, ORNL
+ * @date 9 Feb 2020
+ */
 class JetConstituents
 {
  public:
-  // TODO: Fully update and document!
   JetConstituents();
   // Additional constructors
   JetConstituents(const JetConstituents & other);
@@ -173,7 +198,7 @@ class JetConstituents
   std::vector<float> fPt;                 ///<  Jet constituent pt
   std::vector<float> fEta;                ///<  Jet constituent eta
   std::vector<float> fPhi;                ///<  Jet constituent phi
-  std::vector<int> fID;                   ///<  Jet constituent identifier. MClabel (via GetLabel()) or global index (with offset defined here).
+  std::vector<int> fID;                   ///<  Jet constituent identifier. MC label (via GetLabel()) or global index (with offset defined above).
 
   /// \cond CLASSIMP
   ClassDef(JetConstituents, 2) // Jet constituents.

--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskJetDynamicalGrooming.h
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskJetDynamicalGrooming.h
@@ -155,10 +155,11 @@ class JetConstituents
   bool Clear();
 
   // Getters and setters
-  void AddJetConstituent(const PWG::JETFW::AliEmcalParticleJetConstituent& part);
+  void AddJetConstituent(const AliVParticle* part, const int & id);
   #if !(defined(__CINT__) || defined(__MAKECINT__))
   std::tuple<float, float, float, int> GetJetConstituent(int i) const;
   #endif
+  static const int GetGlobalIndexOffset() { return fgkGlobalIndexOffset; }
 
   // Printing
   std::string toString() const;
@@ -167,13 +168,15 @@ class JetConstituents
   std::ostream & Print(std::ostream &in) const;
 
  protected:
+  static const int fgkGlobalIndexOffset;  ///<  Offset for GlobalIndex values in the ID to ensure it never conflicts with the label.
+
   std::vector<float> fPt;                 ///<  Jet constituent pt
   std::vector<float> fEta;                ///<  Jet constituent eta
   std::vector<float> fPhi;                ///<  Jet constituent phi
-  std::vector<unsigned int> fGlobalIndex; ///<  Jet constituent global index
+  std::vector<int> fID;                   ///<  Jet constituent identifier. MClabel (via GetLabel()) or global index (with offset defined here).
 
   /// \cond CLASSIMP
-  ClassDef(JetConstituents, 1) // Jet constituents.
+  ClassDef(JetConstituents, 2) // Jet constituents.
   /// \endcond
 };
 
@@ -202,7 +205,7 @@ class JetSubstructureSplittings {
 
   // Setters
   void SetJetPt(float pt) { fJetPt = pt; }
-  void AddJetConstituent(const PWG::JETFW::AliEmcalParticleJetConstituent& part);
+  void AddJetConstituent(const AliVParticle* part, const int & id);
   void AddSplitting(float kt, float deltaR, float z, short parentIndex);
   void AddSubjet(const unsigned short splittingNodeIndex, const bool partOfIterativeSplitting,
           const std::vector<unsigned short>& constituentIndices);
@@ -350,7 +353,7 @@ class AliAnalysisTaskJetDynamicalGrooming : public AliAnalysisTaskEmcalJet
   void IterativeParents(AliEmcalJet* jet, SubstructureTree::JetSubstructureSplittings& jetSplittings, bool isData);
   void ExtractJetSplittings(SubstructureTree::JetSubstructureSplittings & jetSplittings, fastjet::PseudoJet & inputJet, int splittingNodeIndex, bool followingIterativeSplitting);
   void CheckSubjetResolution(AliEmcalJet* fJet, AliEmcalJet* fJetM);
-  bool CheckClosePartner(AliEmcalJet* jet, PWG::JETFW::AliEmcalParticleJetConstituent & part1);
+  bool CheckClosePartner(const AliEmcalJet* jet, const AliVParticle * part1);
 
   // Basic configuration
   PWG::Tools::AliYAMLConfiguration fYAMLConfig; ///<  YAML configuration file.


### PR DESCRIPTION
The JetConstituent classes do not store subtracted constituents. So
instead we have to access them via `Track(int)`.