### PR TITLE
Fix copy/paste typo in starting point definition

### DIFF
--- a/PWGLF/NUCLEX/Utils/O2vertexer/DCAFitterN.h
+++ b/PWGLF/NUCLEX/Utils/O2vertexer/DCAFitterN.h
@@ -272,7 +272,7 @@ int DCAFitterN<N, Args...>::process(const Tr&... args)
     if (dst2 < mMaxDist2ToMergeSeeds) {
       mCrossings.nDCA = 1;
       mCrossings.xDCA[0] = 0.5 * (mCrossings.xDCA[0] + mCrossings.xDCA[1]);
-      mCrossings.xDCA[0] = 0.5 * (mCrossings.xDCA[0] + mCrossings.xDCA[1]);
+      mCrossings.yDCA[0] = 0.5 * (mCrossings.yDCA[0] + mCrossings.yDCA[1]);
     }
   }
   // check all crossings


### PR DESCRIPTION
By @galocco see AliceO2Group/AliceO2#3583