### PR TITLE
Additional options for outlier cut

### DIFF
--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetEnergyScale.h
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetEnergyScale.h
@@ -41,6 +41,10 @@ namespace EMCALJetTasks{
 
 class AliAnalysisTaskEmcalJetEnergyScale : public AliAnalysisTaskEmcalJet {
 public:
+  enum EJetTypeOutliers_t {
+    kOutlierPartJet,
+    kOutlierDetJet
+  };
   AliAnalysisTaskEmcalJetEnergyScale();
   AliAnalysisTaskEmcalJetEnergyScale(const char *name);
   virtual ~AliAnalysisTaskEmcalJetEnergyScale();
@@ -52,6 +56,8 @@ public:
   void SetFillHSparse(Bool_t doFill)             { fFillHSparse = doFill; }
   void SetEnergyScaleShift(Double_t scaleshift)  { fScaleShift = scaleshift; }
   void SetUseStandardOutlierRejection(bool doUse) { fUseStandardOutlierRejection = doUse; }
+  void SetDebugMaxJetOutliers(bool doDebug)      { fDebugMaxJetOutliers = doDebug; }
+  void SetJetTypeOutlierCut(EJetTypeOutliers_t jtype) { fJetTypeOutliers = jtype; }
 
   static AliAnalysisTaskEmcalJetEnergyScale *AddTaskJetEnergyScale(
     AliJetContainer::EJetType_t       jetType,
@@ -80,6 +86,8 @@ private:
   Bool_t                      fFillHSparse;                   ///< Fill THnSparses
   Double_t                    fScaleShift;                    ///< Shift of the jet energy scale (fixed)
   Bool_t                      fUseStandardOutlierRejection;   ///< Use standard outlier rejection
+  Bool_t                      fDebugMaxJetOutliers;           ///< Debug max jet determination for outlier rejection
+  EJetTypeOutliers_t          fJetTypeOutliers;               ///< Jet type used for outlier detection
   TRandom                     *fSampleSplitter;               //!<! Sample splitter
 
   AliAnalysisTaskEmcalJetEnergyScale(const AliAnalysisTaskEmcalJetEnergyScale &);

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetEnergySpectrum.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetEnergySpectrum.cxx
@@ -72,6 +72,7 @@ AliAnalysisTaskEmcalJetEnergySpectrum::AliAnalysisTaskEmcalJetEnergySpectrum():
   fUseSumw2(false),
   fUseMuonCalo(false),
   fUseStandardOutlierRejection(false),
+  fJetTypeOutliers(kOutlierPartJet),
   fScaleShift(0.),
   fCentralityEstimator("V0M"),
   fUserPtBinning()
@@ -97,6 +98,7 @@ AliAnalysisTaskEmcalJetEnergySpectrum::AliAnalysisTaskEmcalJetEnergySpectrum(EMC
   fUseSumw2(false),
   fUseMuonCalo(false),
   fUseStandardOutlierRejection(false),
+  fJetTypeOutliers(kOutlierPartJet),
   fScaleShift(0.),
   fCentralityEstimator("V0M"),
   fUserPtBinning()
@@ -184,11 +186,15 @@ Bool_t AliAnalysisTaskEmcalJetEnergySpectrum::CheckMCOutliers() {
   if(!(fIsPythia || fIsHerwig)) return true;    // Only relevant for pt-hard production
   if(fUseStandardOutlierRejection) return AliAnalysisTaskEmcal::CheckMCOutliers();
   AliDebugStream(1) << "Using custom MC outlier rejection" << std::endl;
-  auto partjets = GetJetContainer("partjets");
-  if(!partjets) return true;
+  AliJetContainer *outlierjets(nullptr);
+  switch(fJetTypeOutliers){
+    case kOutlierPartJet: outlierjets = GetJetContainer("partjets"); break;
+    case kOutlierDetJet: outlierjets = GetJetContainer(fNameJetContainer); break;
+  };
+  if(!outlierjets) return true;
 
   // Check whether there is at least one particle level jet with pt above n * event pt-hard
-  auto jetiter = partjets->accepted();
+  auto jetiter = outlierjets->accepted();
   auto max = std::max_element(jetiter.begin(), jetiter.end(), [](const AliEmcalJet *lhs, const AliEmcalJet *rhs ) { return lhs->Pt() < rhs->Pt(); });
   if(max != jetiter.end())  {
     // At least one jet found with pt > n * pt-hard

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetEnergySpectrum.h
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetEnergySpectrum.h
@@ -56,6 +56,10 @@ public:
     kTrgClusterOnlyCALOFAST,
     kTrgClusterN
   };
+  enum EJetTypeOutliers_t {
+    kOutlierPartJet,
+    kOutlierDetJet
+  };
   AliAnalysisTaskEmcalJetEnergySpectrum();
   AliAnalysisTaskEmcalJetEnergySpectrum(EMCAL_STRINGVIEW name);
   virtual ~AliAnalysisTaskEmcalJetEnergySpectrum();
@@ -79,6 +83,7 @@ public:
   void SetUseMuonCalo(Bool_t doUse)                { fUseMuonCalo = doUse; }
   void SetEnergyScaleShfit(Double_t scaleshift)    { fScaleShift = scaleshift; } 
   void SetUseStandardOutlierRejection(bool doUse)  { fUseStandardOutlierRejection = doUse; }
+  void SetJetTypeOutlierCut(EJetTypeOutliers_t jtype) { fJetTypeOutliers = jtype; }
 
 
   static AliAnalysisTaskEmcalJetEnergySpectrum *AddTaskJetEnergySpectrum(
@@ -120,6 +125,7 @@ private:
   Bool_t                        fUseSumw2;                      ///< Switch for sumw2 option in THnSparse (should not be used when a downscale weight is applied)
   Bool_t                        fUseMuonCalo;                   ///< Use events from the (muon)-calo-(fast) cluster
   Bool_t                        fUseStandardOutlierRejection;   ///< Use standard outlier rejection
+  EJetTypeOutliers_t            fJetTypeOutliers;               ///< Jet type used for outlier detection
   Double_t                      fScaleShift;                    ///< Artificial jet energy scale shift
   TString                       fCentralityEstimator;           ///< Centrality estimator
   TArrayD                       fUserPtBinning;                 ///< User-defined pt-binning

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalSoftDropResponse.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalSoftDropResponse.cxx
@@ -80,6 +80,7 @@ AliAnalysisTaskEmcalSoftDropResponse::AliAnalysisTaskEmcalSoftDropResponse() : A
                                                                                fUseChargedConstituents(true),
                                                                                fUseNeutralConstituents(true),
                                                                                fUseStandardOutlierRejection(false),
+                                                                               fJetTypeOutliers(kOutlierPartJet),
                                                                                fNameMCParticles("mcparticles"),
                                                                                fSampleSplitter(nullptr),
                                                                                fSampleTrimmer(nullptr),
@@ -114,6 +115,7 @@ AliAnalysisTaskEmcalSoftDropResponse::AliAnalysisTaskEmcalSoftDropResponse(const
                                                                                                fUseChargedConstituents(true),
                                                                                                fUseNeutralConstituents(true),
                                                                                                fUseStandardOutlierRejection(false),
+                                                                                               fJetTypeOutliers(kOutlierPartJet),
                                                                                                fNameMCParticles("mcparticles"),
                                                                                                fSampleSplitter(nullptr),
                                                                                                fSampleTrimmer(nullptr),
@@ -531,12 +533,24 @@ Bool_t AliAnalysisTaskEmcalSoftDropResponse::CheckMCOutliers()
   if(fUseStandardOutlierRejection) 
     return AliAnalysisTaskEmcal::CheckMCOutliers();
   AliDebugStream(1) << "Using custom MC outlier rejection" << std::endl;
-  auto partjets = GetJetContainer(fNamePartLevelJetContainer);
-  if (!partjets)
+  AliJetContainer *outlierjets(nullptr);
+  switch (fJetTypeOutliers)
+  {
+  case kOutlierPartJet:
+    outlierjets = GetJetContainer(fNamePartLevelJetContainer);
+    break;
+  case kOutlierDetJet:
+    outlierjets = GetJetContainer(fNameDetLevelJetContainer);
+    break;
+  
+  default:
+    break;
+  }
+  if (!outlierjets)
     return true;
 
   // Check whether there is at least one particle level jet with pt above n * event pt-hard
-  auto jetiter = partjets->accepted();
+  auto jetiter = outlierjets->accepted();
   auto max = std::max_element(jetiter.begin(), jetiter.end(), [](const AliEmcalJet *lhs, const AliEmcalJet *rhs) { return lhs->Pt() < rhs->Pt(); });
   if (max != jetiter.end())
   {

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalSoftDropResponse.h
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalSoftDropResponse.h
@@ -52,6 +52,10 @@ public:
     kKTAlgo = 1,
     kAKTAlgo = 2
   };
+  enum EJetTypeOutliers_t {
+    kOutlierPartJet,
+    kOutlierDetJet
+  };
 
   AliAnalysisTaskEmcalSoftDropResponse();
   AliAnalysisTaskEmcalSoftDropResponse(const char *name);
@@ -76,6 +80,7 @@ public:
   void SetNameUnSubLevelJetContainer(const char *name) { fNameUnSubLevelJetContainer = name; }
   void SetIsEmbeddedEvent(bool isEmbedded) {fIsEmbeddedEvent = isEmbedded; }
   void SetUseStandardOutlierRejection(bool doUse) { fUseStandardOutlierRejection = doUse; }
+  void SetJetTypeOutlierCut(EJetTypeOutliers_t jtype) { fJetTypeOutliers = jtype; }
 
   static AliAnalysisTaskEmcalSoftDropResponse *AddTaskEmcalSoftDropResponse(Double_t jetradius, AliJetContainer::EJetType_t jettype, AliJetContainer::ERecoScheme_t recombinationScheme, bool ifembed, const char *namepartcont, const char *trigger);
 
@@ -107,6 +112,7 @@ private:
   Bool_t                        fUseChargedConstituents;    ///< Use charged constituents for softdrop
   Bool_t                        fUseNeutralConstituents;    ///< Use neutral constituents for softdrop
   Bool_t                        fUseStandardOutlierRejection; ///< Use standard outlier rejection (from AliAnalysisTaskEmcal)
+  EJetTypeOutliers_t            fJetTypeOutliers;           ///< Jet type used for outlier detection
   TString                       fNameMCParticles;           ///< Name of the MC particle container
   TRandom                       *fSampleSplitter;           ///< Sample splitter
   TRandom                       *fSampleTrimmer;            ///< Sample trimmer


### PR DESCRIPTION
- Cross check whether std::max_element gives the same
  result as trivial iteration over the accepted jets
  by hand (debug mode - energy scale task only)
- Add switch performing the outlier cut either on
  part. level jets or det. level jets (all tasks running
  on MC), default: part. level jets