### PR TITLE
 PWGDQ EtaReconstruction Implemented methode to reconstruct etas from two gamma conversions

### DIFF
--- a/PWGDQ/dielectron/core/AliAnalysisTaskEtaReconstruction.cxx
+++ b/PWGDQ/dielectron/core/AliAnalysisTaskEtaReconstruction.cxx
@@ -71,7 +71,8 @@ AliAnalysisTaskEtaReconstruction::~AliAnalysisTaskEtaReconstruction(){
   delete fGeneratedSmearedPrimaryPairsList;
   delete fGeneratedSmearedSecondaryPairsList;
   delete fPairList;
-  delete fFourPairList;
+  delete fFourPairList_PrimSec;
+  delete fFourPairList_SecSec;
   delete fResolutionList;
 
   delete fOutputListSupportHistos;
@@ -83,7 +84,7 @@ AliAnalysisTaskEtaReconstruction::AliAnalysisTaskEtaReconstruction(): AliAnalysi
                                                                               , fdebug(false), run1analysis()
                                                                               , fResoFile(0x0), fResoFilename(""), fResoFilenameFromAlien(""), fArrResoPt(0x0), fArrResoEta(0x0), fArrResoPhi_Pos(0x0), fArrResoPhi_Neg(0x0)
                                                                               , fOutputList(0x0), fSingleElectronList(0x0), fGeneratedPrimaryList(0x0), fGeneratedSecondaryList(0x0), fGeneratedSmearedPrimaryList(0x0), fGeneratedSmearedSecondaryList(0x0), fRecPrimaryList(0x0), fRecSecondaryList(0x0)
-                                                                              , fGeneratedPrimaryPairsList(0x0), fGeneratedSecondaryPairsList(0x0), fGeneratedSmearedPrimaryPairsList(0x0), fGeneratedSmearedSecondaryPairsList(0x0), fPairList(0x0), fFourPairList(0x0), fGeneratedFourPairsList(0x0), fGeneratedSmearedFourPairsList(0x0), fResolutionList(0x0)
+                                                                              , fGeneratedPrimaryPairsList(0x0), fGeneratedSecondaryPairsList(0x0), fGeneratedSmearedPrimaryPairsList(0x0), fGeneratedSmearedSecondaryPairsList(0x0), fPairList(0x0), fFourPairList_PrimSec(0x0), fFourPairList_SecSec(0x0), fGeneratedFourPairsList(0x0), fGeneratedSmearedFourPairsList(0x0), fResolutionList(0x0)
                                                                               , fPGen_DeltaP(0x0), fPGen_PrecOverPGen(0x0), fPtGen_DeltaPt(0x0), fPtGen_DeltaPtOverPtGen(0x0), fPtGen_PtRecOverPtGen(0x0), fPtGen_DeltaPt_wGenSmeared(0x0), fPtGen_DeltaPtOverPtGen_wGenSmeared(0x0), fPtGen_PtRecOverPtGen_wGenSmeared(0x0)
                                                                               , fPGen_DeltaEta(0x0), fPtGen_DeltaEta(0x0), fPGen_DeltaTheta(0x0), fPGen_DeltaPhi_Ele(0x0), fPGen_DeltaPhi_Pos(0x0), fPtGen_DeltaPhi_Ele(0x0)
                                                                               , fPtGen_DeltaPhi_Pos(0x0), fThetaGen_DeltaTheta(0x0), fPhiGen_DeltaPhi(0x0)
@@ -93,7 +94,7 @@ AliAnalysisTaskEtaReconstruction::AliAnalysisTaskEtaReconstruction(): AliAnalysi
                                                                               , fPtMin(0.), fPtMax(0.), fEtaMin(-99.), fEtaMax(99.)
                                                                               , fPtMinGen(0.), fPtMaxGen(0.), fEtaMinGen(-99.), fEtaMaxGen(99.)
                                                                               , fLowerMassCutPrimaries(), fUpperMassCutPrimaries(), fMassCutSecondaries(), fUpperPrimSecPreFilterMass(), fLowerPrimSecPreFilterMass(), fUpperSecSecPreFilterMass(), fLowerSecSecPreFilterMass(), fV0OnFlyStatus()
-                                                                              , fSinglePrimaryLegMCSignal(), fSingleSecondaryLegMCSignal(), fPrimaryPairMCSignal(), fSecondaryPairMCSignal(), fFourPairMCSignal(), fPrimaryDielectronPairNotFromSameMother(), fSecondaryDielectronPairNotFromSameMother()
+                                                                              , fSinglePrimaryLegMCSignal(), fSingleSecondaryLegMCSignal(), fPrimaryPairMCSignal(), fSecondaryPairMCSignal(), fFourPairMCSignal_PrimSec(), fFourPairMCSignal_SecSec(), fPrimaryDielectronPairNotFromSameMother(), fSecondaryDielectronPairNotFromSameMother()
                                                                               , fGeneratorName(""), fGeneratorMCSignalName(""), fGeneratorULSSignalName(""), fGeneratorHashs(), fGeneratorMCSignalHashs(), fGeneratorULSSignalHashs(), fPIDResponse(0x0), fEvent(0x0), fMC(0x0), fTrack(0x0), isAOD(false), fSelectPhysics(false), fTriggerMask(0)
                                                                               , fTrackCuts_primary_PreFilter(), fTrackCuts_primary_standard(), fTrackCuts_secondary_PreFilter(), fTrackCuts_secondary_standard(), fPairCuts_primary(), fPairCuts_secondary_PreFilter(), fPairCuts_secondary_standard(), fUsedVars(0x0)
                                                                               , fSupportMCSignal(0), fSupportCutsetting(0)
@@ -101,7 +102,7 @@ AliAnalysisTaskEtaReconstruction::AliAnalysisTaskEtaReconstruction(): AliAnalysi
                                                                               , fMinCentrality(0.), fMaxCentrality(100), fCentralityFile(0x0), fCentralityFilename(""), fHistCentralityCorrection(0x0)
                                                                               , fOutputListSupportHistos(0x0), fTrackCutListVecPrim(), fTrackCutListVecSec(), fPairCutListVecSec(), fFourPairCutListVec()
                                                                               , fHistGenPrimaryPosPart(), fHistGenPrimaryNegPart(), fHistGenSecondaryPosPart(), fHistGenSecondaryNegPart(), fHistGenSmearedPrimaryPosPart(), fHistGenSmearedPrimaryNegPart(), fHistGenSmearedSecondaryPosPart(), fHistGenSmearedSecondaryNegPart(), fHistRecPrimaryPosPart(), fHistRecPrimaryNegPart(), fHistRecSecondaryPosPart(), fHistRecSecondaryNegPart()
-                                                                              , fHistGenPrimaryPair(), fHistGenSecondaryPair(), fHistGenSmearedPrimaryPair(), fHistGenSmearedSecondaryPair(), fHistRecPrimaryPair(), fHistRecSecondaryPair(), fHistGenFourPair(), fHistGenSmearedFourPair(), fHistRecFourPair(), fVecHistPrefilters()
+                                                                              , fHistGenPrimaryPair(), fHistGenSecondaryPair(), fHistGenSmearedPrimaryPair(), fHistGenSmearedSecondaryPair(), fHistRecPrimaryPair(), fHistRecSecondaryPair(), fHistGenFourPair(), fHistGenSmearedFourPair(), fHistRecFourPair_PrimSec(), fHistRecFourPair_SecSec(), fVecHistPrefilters()
                                                                               , fWriteLegsFromPair(false), fPtMinLegsFromPair(-99.), fPtMaxLegsFromPair(-99.), fEtaMinLegsFromPair(-99.), fEtaMaxLegsFromPair(-99.), fPhiMinLegsFromPair(-99.), fPhiMaxLegsFromPair(-99.), fOpAngleMinLegsFromPair(-99.), fOpAngleMaxLegsFromPair(-99.), fPtNBinsLegsFromPair(-99), fEtaNBinsLegsFromPair(-99), fPhiNBinsLegsFromPair(-99), fOpAngleNBinsLegsFromPair(-99), fTHnSparseGenSmearedLegsFromPrimaryPair(), fTHnSparseGenSmearedLegsFromSecondaryPair(), fTHnSparseRecLegsFromPrimaryPair(), fTHnSparseRecLegsFromSecondaryPair()
                                                                               , fDoPairing(false), fDoFourPairing(false), fUsePreFilter(false), fUseSecPreFilter(false), fDoMassCut(), fPhotonMass()
                                                                               , fGenNegPart_primary(), fGenPosPart_primary(), fGenNegPart_secondary(), fGenPosPart_secondary(), fGenSmearedNegPart_primary(), fGenSmearedPosPart_primary(), fGenSmearedNegPart_secondary(), fGenSmearedPosPart_secondary(), fRecNegPart_primary(), fRecPosPart_primary(), fRecNegPart_secondary(), fRecPosPart_secondary(), fGenPairVec_primary(), fGenPairVec_secondary(), fGenSmearedPairVec_primary(), fGenSmearedPairVec_secondary(), fRecPairVec_primary(), fRecPairVec_secondary(), fRecV0Pair(), fPreFilter_BadTracksLabel_primary()
@@ -119,7 +120,7 @@ AliAnalysisTaskEtaReconstruction::AliAnalysisTaskEtaReconstruction(const char * 
                                                                               , fdebug(false), run1analysis()
                                                                               , fResoFile(0x0), fResoFilename(""), fResoFilenameFromAlien(""), fArrResoPt(0x0), fArrResoEta(0x0), fArrResoPhi_Pos(0x0), fArrResoPhi_Neg(0x0)
                                                                               , fOutputList(0x0), fSingleElectronList(0x0), fGeneratedPrimaryList(0x0), fGeneratedSecondaryList(0x0), fGeneratedSmearedPrimaryList(0x0), fGeneratedSmearedSecondaryList(0x0), fRecPrimaryList(0x0), fRecSecondaryList(0x0)
-                                                                              , fGeneratedPrimaryPairsList(0x0), fGeneratedSecondaryPairsList(0x0), fGeneratedSmearedPrimaryPairsList(0x0), fGeneratedSmearedSecondaryPairsList(0x0), fPairList(0x0), fFourPairList(0x0), fGeneratedFourPairsList(0x0), fGeneratedSmearedFourPairsList(0x0), fResolutionList(0x0)
+                                                                              , fGeneratedPrimaryPairsList(0x0), fGeneratedSecondaryPairsList(0x0), fGeneratedSmearedPrimaryPairsList(0x0), fGeneratedSmearedSecondaryPairsList(0x0), fPairList(0x0), fFourPairList_PrimSec(0x0), fFourPairList_SecSec(0x0), fGeneratedFourPairsList(0x0), fGeneratedSmearedFourPairsList(0x0), fResolutionList(0x0)
                                                                               , fPGen_DeltaP(0x0), fPGen_PrecOverPGen(0x0), fPtGen_DeltaPt(0x0), fPtGen_DeltaPtOverPtGen(0x0), fPtGen_PtRecOverPtGen(0x0), fPtGen_DeltaPt_wGenSmeared(0x0), fPtGen_DeltaPtOverPtGen_wGenSmeared(0x0), fPtGen_PtRecOverPtGen_wGenSmeared(0x0)
                                                                               , fPGen_DeltaEta(0x0), fPtGen_DeltaEta(0x0), fPGen_DeltaTheta(0x0), fPGen_DeltaPhi_Ele(0x0), fPGen_DeltaPhi_Pos(0x0), fPtGen_DeltaPhi_Ele(0x0)
                                                                               , fPtGen_DeltaPhi_Pos(0x0), fThetaGen_DeltaTheta(0x0), fPhiGen_DeltaPhi(0x0)
@@ -129,7 +130,7 @@ AliAnalysisTaskEtaReconstruction::AliAnalysisTaskEtaReconstruction(const char * 
                                                                               , fPtMin(0.), fPtMax(0.), fEtaMin(-99.), fEtaMax(99.)
                                                                               , fPtMinGen(0.), fPtMaxGen(0.), fEtaMinGen(-99.), fEtaMaxGen(99.)
                                                                               , fLowerMassCutPrimaries(), fUpperMassCutPrimaries(), fMassCutSecondaries(), fUpperPrimSecPreFilterMass(), fLowerPrimSecPreFilterMass(), fUpperSecSecPreFilterMass(), fLowerSecSecPreFilterMass(), fV0OnFlyStatus()
-                                                                              , fSinglePrimaryLegMCSignal(), fSingleSecondaryLegMCSignal(), fPrimaryPairMCSignal(), fSecondaryPairMCSignal(), fFourPairMCSignal(), fPrimaryDielectronPairNotFromSameMother(), fSecondaryDielectronPairNotFromSameMother()
+                                                                              , fSinglePrimaryLegMCSignal(), fSingleSecondaryLegMCSignal(), fPrimaryPairMCSignal(), fSecondaryPairMCSignal(), fFourPairMCSignal_PrimSec(), fFourPairMCSignal_SecSec(), fPrimaryDielectronPairNotFromSameMother(), fSecondaryDielectronPairNotFromSameMother()
                                                                               , fGeneratorName(""), fGeneratorMCSignalName(""), fGeneratorULSSignalName(""), fGeneratorHashs(), fGeneratorMCSignalHashs(), fGeneratorULSSignalHashs(), fPIDResponse(0x0), fEvent(0x0), fMC(0x0), fTrack(0x0), isAOD(false), fSelectPhysics(false), fTriggerMask(0)
                                                                               , fTrackCuts_primary_PreFilter(), fTrackCuts_primary_standard(), fTrackCuts_secondary_PreFilter(), fTrackCuts_secondary_standard(), fPairCuts_primary(), fPairCuts_secondary_PreFilter(), fPairCuts_secondary_standard(), fUsedVars(0x0)
                                                                               , fSupportMCSignal(0), fSupportCutsetting(0)
@@ -137,7 +138,7 @@ AliAnalysisTaskEtaReconstruction::AliAnalysisTaskEtaReconstruction(const char * 
                                                                               , fMinCentrality(0.), fMaxCentrality(100), fCentralityFile(0x0), fCentralityFilename(""), fHistCentralityCorrection(0x0)
                                                                               , fOutputListSupportHistos(0x0), fTrackCutListVecPrim(), fTrackCutListVecSec(), fPairCutListVecSec(), fFourPairCutListVec()
                                                                               , fHistGenPrimaryPosPart(), fHistGenPrimaryNegPart(), fHistGenSecondaryPosPart(), fHistGenSecondaryNegPart(), fHistGenSmearedPrimaryPosPart(), fHistGenSmearedPrimaryNegPart(), fHistGenSmearedSecondaryPosPart(), fHistGenSmearedSecondaryNegPart(), fHistRecPrimaryPosPart(), fHistRecPrimaryNegPart(), fHistRecSecondaryPosPart(), fHistRecSecondaryNegPart()
-                                                                              , fHistGenPrimaryPair(), fHistGenSecondaryPair(), fHistGenSmearedPrimaryPair(), fHistGenSmearedSecondaryPair(), fHistRecPrimaryPair(), fHistRecSecondaryPair(), fHistGenFourPair(), fHistGenSmearedFourPair(), fHistRecFourPair(), fVecHistPrefilters()
+                                                                              , fHistGenPrimaryPair(), fHistGenSecondaryPair(), fHistGenSmearedPrimaryPair(), fHistGenSmearedSecondaryPair(), fHistRecPrimaryPair(), fHistRecSecondaryPair(), fHistGenFourPair(), fHistGenSmearedFourPair(), fHistRecFourPair_PrimSec(), fHistRecFourPair_SecSec(), fVecHistPrefilters()
                                                                               , fWriteLegsFromPair(false), fPtMinLegsFromPair(-99.), fPtMaxLegsFromPair(-99.), fEtaMinLegsFromPair(-99.), fEtaMaxLegsFromPair(-99.), fPhiMinLegsFromPair(-99.), fPhiMaxLegsFromPair(-99.), fOpAngleMinLegsFromPair(-99.), fOpAngleMaxLegsFromPair(-99.), fPtNBinsLegsFromPair(-99), fEtaNBinsLegsFromPair(-99), fPhiNBinsLegsFromPair(-99), fOpAngleNBinsLegsFromPair(-99), fTHnSparseGenSmearedLegsFromPrimaryPair(), fTHnSparseGenSmearedLegsFromSecondaryPair(), fTHnSparseRecLegsFromPrimaryPair(), fTHnSparseRecLegsFromSecondaryPair()
                                                                               , fDoPairing(false), fDoFourPairing(false), fUsePreFilter(false), fUseSecPreFilter(false), fDoMassCut(), fPhotonMass()
                                                                               , fGenNegPart_primary(), fGenPosPart_primary(), fGenNegPart_secondary(), fGenPosPart_secondary(), fGenSmearedNegPart_primary(), fGenSmearedPosPart_primary(), fGenSmearedNegPart_secondary(), fGenSmearedPosPart_secondary(), fRecNegPart_primary(), fRecPosPart_primary(), fRecNegPart_secondary(), fRecPosPart_secondary(), fGenPairVec_primary(), fGenPairVec_secondary(), fGenSmearedPairVec_primary(), fGenSmearedPairVec_secondary(), fRecPairVec_primary(), fRecPairVec_secondary(), fRecV0Pair(), fPreFilter_BadTracksLabel_primary()
@@ -704,33 +705,37 @@ void AliAnalysisTaskEtaReconstruction::UserCreateOutputObjects(){
       // ######################################################
                                                                                 // if(fdebug) std::cout << __LINE__ << " DEBUG_AnalysisTask: fDoFourPairing " << fDoFourPairing << std::endl;
       if (fDoFourPairing == true){
-        fFourPairList = new TList();
-        fFourPairList->SetName("4 el. Pairs");
-        fFourPairList->SetOwner();
+        fFourPairList_PrimSec = new TList();
+        fFourPairList_PrimSec->SetName("4Pairs_PrimSec");
+        fFourPairList_PrimSec->SetOwner();
+
+        fFourPairList_SecSec = new TList();
+        fFourPairList_SecSec->SetName("4Pairs_SecSec");
+        fFourPairList_SecSec->SetOwner();
                                                                                 // if(fdebug) std::cout << __LINE__ << " DEBUG_AnalysisTask: Line cout " << std::endl;
 
         fGeneratedFourPairsList = new TList();
         fGeneratedFourPairsList->SetName("Generated");
         fGeneratedFourPairsList->SetOwner();
-        for (unsigned int i = 0; i < fFourPairMCSignal.size(); /*i++*/ i+=2){
-          TH2D* th2_tmp = new TH2D(Form("Ngen_%s", fFourPairMCSignal.at(i).GetName()),";m_{eeee};p_{T,eeee}",fNmassBins,fMassBins.data(),fNpairptBins,fPairPtBins.data());
+        for (unsigned int i = 0; i < fFourPairMCSignal_PrimSec.size(); /*i++*/ i+=2){
+          TH2D* th2_tmp = new TH2D(Form("Ngen_%s", fFourPairMCSignal_PrimSec.at(i).GetName()),";m_{eeee};p_{T,eeee}",fNmassBins,fMassBins.data(),fNpairptBins,fPairPtBins.data());
           th2_tmp->Sumw2();
           fHistGenFourPair.push_back(th2_tmp);
           fGeneratedFourPairsList->Add(th2_tmp);
         }
-        fFourPairList->Add(fGeneratedFourPairsList);
+        fFourPairList_PrimSec->Add(fGeneratedFourPairsList);
 
         fGeneratedSmearedFourPairsList = new TList();
         fGeneratedSmearedFourPairsList->SetName("GeneratedSmeared");
         fGeneratedSmearedFourPairsList->SetOwner();
-        for (unsigned int i = 0; i < fFourPairMCSignal.size(); i+=2){
-         TH2D* th2_tmp = new TH2D(Form("Ngen_%s", fFourPairMCSignal.at(i).GetName()),";m_{eeee};p_{T,eeee}",fNmassBins,fMassBins.data(),fNpairptBins,fPairPtBins.data());
+        for (unsigned int i = 0; i < fFourPairMCSignal_PrimSec.size(); i+=2){
+         TH2D* th2_tmp = new TH2D(Form("Ngen_%s", fFourPairMCSignal_PrimSec.at(i).GetName()),";m_{eeee};p_{T,eeee}",fNmassBins,fMassBins.data(),fNpairptBins,fPairPtBins.data());
          th2_tmp->Sumw2();
          fHistGenSmearedFourPair.push_back(th2_tmp);
          fGeneratedSmearedFourPairsList->Add(th2_tmp);
         }
 
-        fFourPairList->Add(fGeneratedSmearedFourPairsList);
+        fFourPairList_PrimSec->Add(fGeneratedSmearedFourPairsList);
 
         // Generated reconstructed lists for every cutsetting one list and every MCsignal 1 histogram
         for (unsigned int list_i = 0; list_i < fTrackCuts_primary_standard.size(); ++list_i){
@@ -738,13 +743,13 @@ void AliAnalysisTaskEtaReconstruction::UserCreateOutputObjects(){
           list->SetName(fTrackCuts_primary_standard.at(list_i)->GetName());
           list->SetOwner();
 
-          for (unsigned int i = 0; i < fFourPairMCSignal.size(); i+=2){
-            TH2D* th2_tmp = new TH2D(Form("Nrec_%s", fFourPairMCSignal.at(i).GetName()),";m_{eeee};p_{T,eeee}",fNmassBins,fMassBins.data(),fNpairptBins,fPairPtBins.data());
+          for (unsigned int i = 0; i < fFourPairMCSignal_PrimSec.size(); i+=2){
+            TH2D* th2_tmp = new TH2D(Form("Nrec_%s", fFourPairMCSignal_PrimSec.at(i).GetName()),";m_{eeee};p_{T,eeee}",fNmassBins,fMassBins.data(),fNpairptBins,fPairPtBins.data());
             th2_tmp->Sumw2();
-            fHistRecFourPair.push_back(th2_tmp);
+            fHistRecFourPair_PrimSec.push_back(th2_tmp);
             list->Add(th2_tmp);
           }
-          fFourPairList->Add(list);
+          fFourPairList_PrimSec->Add(list);
         }
 
         TH2D* fHistBeforePrimSecPrefilter = new TH2D ("HistBeforePrimSecPrefilter",";m_{eeee};p_{T,eeee}",fNmassBins,fMassBins.data(),fNpairptBins,fPairPtBins.data());
@@ -759,10 +764,25 @@ void AliAnalysisTaskEtaReconstruction::UserCreateOutputObjects(){
         fVecHistPrefilters.push_back(fHistAfterPrimSecPrefilter);
         fVecHistPrefilters.push_back(fHistBeforeSecSecPrefilter);
         fVecHistPrefilters.push_back(fHistAfterSecSecPrefilter);
-        fFourPairList->Add(fHistBeforePrimSecPrefilter);
-        fFourPairList->Add(fHistAfterPrimSecPrefilter);
-        fFourPairList->Add(fHistBeforeSecSecPrefilter);
-        fFourPairList->Add(fHistAfterSecSecPrefilter);
+        fFourPairList_PrimSec->Add(fHistBeforePrimSecPrefilter);
+        fFourPairList_PrimSec->Add(fHistAfterPrimSecPrefilter);
+        fFourPairList_PrimSec->Add(fHistBeforeSecSecPrefilter);
+        fFourPairList_PrimSec->Add(fHistAfterSecSecPrefilter);
+
+
+        for (unsigned int list_i = 0; list_i < fTrackCuts_primary_standard.size(); ++list_i){
+          TList* list = new TList();
+          list->SetName(fTrackCuts_secondary_standard.at(list_i)->GetName());
+          list->SetOwner();
+
+          for (unsigned int i = 0; i < fFourPairMCSignal_SecSec.size(); i+=2){
+            TH2D* th2_tmp = new TH2D(Form("Nrec_%s", fFourPairMCSignal_SecSec.at(i).GetName()),";m_{eeee};p_{T,eeee}",fNmassBins,fMassBins.data(),fNpairptBins,fPairPtBins.data());
+            th2_tmp->Sumw2();
+            fHistRecFourPair_SecSec.push_back(th2_tmp);
+            list->Add(th2_tmp);
+          }
+          fFourPairList_SecSec->Add(list);
+        }
 
 
       } // end if fDoFourPairing
@@ -770,7 +790,8 @@ void AliAnalysisTaskEtaReconstruction::UserCreateOutputObjects(){
     fOutputList->Add(fSingleElectronList);
     fOutputList->Add(fResolutionList);
     if (fDoPairing)     fOutputList->Add(fPairList);
-    if (fDoFourPairing) fOutputList->Add(fFourPairList);
+    if (fDoFourPairing) fOutputList->Add(fFourPairList_PrimSec);
+    if (fDoFourPairing) fOutputList->Add(fFourPairList_SecSec);
 
     CreateSupportHistos();
     fOutputList->Add(fOutputListSupportHistos);
@@ -1427,6 +1448,7 @@ void AliAnalysisTaskEtaReconstruction::UserExec(Option_t* option){
                                                                                 // if(fdebug) std::cout << "Doing four pairing..." << std::endl;
     Bool_t SmearedPair  = kTRUE;
     Bool_t ReconstructedPair = kTRUE;
+    Bool_t PrimSecPairing = kTRUE;
     Bool_t PairPrimary = kTRUE;
     Bool_t TrackCuts = kTRUE;
 
@@ -1435,11 +1457,11 @@ void AliAnalysisTaskEtaReconstruction::UserExec(Option_t* option){
     // #     DoFourPairing of Gen & GenSmeared     #
     // #############################################
                                                                                 // if (fdebug) std::cout << "Do generated four pairing" << std::endl;
-    DoFourPairing(fGenPairVec_primary, fGenPairVec_secondary, !ReconstructedPair, !SmearedPair, centralityWeight);
+    DoFourPairing(fGenPairVec_primary, fGenPairVec_secondary, !ReconstructedPair, !SmearedPair, PrimSecPairing, centralityWeight);
                                                                                 // if(fdebug) std::cout << __LINE__ << " DEBUG_AnalysisTask: Line cout " << std::endl;
     if(fArrResoPt){
       // if (fdebug) std::cout << "Do generated smeared four pairing" << std::endl;
-      DoFourPairing(fGenSmearedPairVec_primary, fGenSmearedPairVec_secondary, !ReconstructedPair, SmearedPair, centralityWeight);
+      DoFourPairing(fGenSmearedPairVec_primary, fGenSmearedPairVec_secondary, !ReconstructedPair, SmearedPair, PrimSecPairing, centralityWeight);
     }
                                                                                 // if(fdebug) std::cout << __LINE__ << " DEBUG_AnalysisTask: Line cout " << std::endl;
 
@@ -1497,8 +1519,9 @@ void AliAnalysisTaskEtaReconstruction::UserExec(Option_t* option){
     // #      Do actual pairing       #
     // ################################
                                                                                 // if(fdebug) std::cout << __LINE__ << " Start Four Reconstructed Pairing " << std::endl;
-    DoFourPairing(fRecPairVec_primary, fRecV0Pair, ReconstructedPair, !SmearedPair, centralityWeight);
-    // DoFourPairing(fRecPairVec_primary, fRecPairVec_secondary, ReconstructedPair, !SmearedPair, centralityWeight);
+    DoFourPairing(fRecPairVec_primary, fRecV0Pair, ReconstructedPair, !SmearedPair, PrimSecPairing, centralityWeight);
+    // DoFourPairing(fRecPairVec_primary, fRecPairVec_secondary, ReconstructedPair, !SmearedPair, PrimSecPairing, centralityWeight);
+    DoFourPairing(fRecV0Pair, fRecV0Pair, ReconstructedPair, !SmearedPair, !PrimSecPairing, centralityWeight);
 
 										                                                            // if(fdebug) std::cout << __LINE__ << " DEBUG_AnalysisTask: Line cout " << std::endl;
                                                                                 // if(fdebug) std::cout << __LINE__ <<  "DEBUG_AnalysisTask: fGenNegPart_primary:   "  << fGenNegPart_primary.size()   << " fGenPosPart_primary:   " <<  fGenPosPart_primary.size()   << std::endl;
@@ -2219,8 +2242,6 @@ void AliAnalysisTaskEtaReconstruction::CreateSupportHistos()
     TH1D* hArmAlpha_sec = new TH1D("ArmAlpha","Armenteros-Podolanski alpha ;alpha;#tracks",200, -3., 3.); // kArmAlpha
     TH1D* hPairPt_sec = new TH1D("PairPt","Pt of pair ; Pt [GeV];#tracks",640, 0., 8.); // kArmAlpha
     TH2D* hArmAlpha_ArmPt_sec = new TH2D("Armenteros Podolanski Plot","Armenteros Podolanski Plot, secondary electrons ; ArmAlpha; ArmPt", 100, -1, 1, 320, 0, 0.1);//,AliDielectronVarManager::kEta,AliDielectronVarManager::kPhi);
-    // 4 pair variable histos
-    // TH1D* hFourPairOpeningAngle = new TH1D("Angle between primary and secondary pair", "Angle between primary and secondary pair ;rad ; #counts", 1000, 0. , 6.4);
 
     // pair support histos
     list_mcSig->AddAt(hCosPointingAngle_sec,0);
@@ -2233,8 +2254,7 @@ void AliAnalysisTaskEtaReconstruction::CreateSupportHistos()
     list_mcSig->AddAt(hArmAlpha_sec,7);
     list_mcSig->AddAt(hPairPt_sec,8);
     list_mcSig->AddAt(hArmAlpha_ArmPt_sec,9);
-    // 4 pair variable histos
-    // list_mcSig->AddAt(hFourPairOpeningAngle,37);
+
     listPairCuts->Add(list_mcSig);
     }
   fPairCutListVecSec.push_back(listPairCuts);
@@ -2246,9 +2266,9 @@ void AliAnalysisTaskEtaReconstruction::CreateSupportHistos()
     TList* listFourPair = new TList();
     listFourPair->SetName(Form("FourPairCuts: %s",fPairCuts_primary.at(list_i)->GetName()));
     listFourPair->SetOwner();
-    for (unsigned int i = 0; i < fFourPairMCSignal.size(); i+=2){
+    for (unsigned int i = 0; i < fFourPairMCSignal_PrimSec.size(); i+=2){
       TList* list_temp = new TList();
-      list_temp->SetName(Form("FourPairCuts: %s", fFourPairMCSignal.at(i).GetName()));
+      list_temp->SetName(Form("FourPairCuts: %s", fFourPairMCSignal_PrimSec.at(i).GetName()));
       list_temp->SetOwner();
 
     // 4 pair variable histos
@@ -3637,8 +3657,8 @@ void AliAnalysisTaskEtaReconstruction::DoFourPreFilter(std::vector<TwoPair>* fPa
 
                                                                                 // if(fdebug && (fPairVec_primary != fPairVec_secondary)) std::cout << __LINE__ << " DEBUG_AnalysisTask: PreFilter: erasing pair from primary and secondary vector. mass = " << mass << std::endl;
                                                                                 // if(fdebug && (fPairVec_primary == fPairVec_secondary)) std::cout << __LINE__ << " DEBUG_AnalysisTask: PreFilter: erasing V0's from secondary vector. mass = " << mass << std::endl;
-        fPairVec_primary->erase(fPairVec_primary->begin()+prim_i);
-        fPairVec_secondary->erase(fPairVec_secondary->begin()+sec_i);
+        fPairVec_primary  ->erase(fPairVec_primary  ->begin()+prim_i);
+        fPairVec_secondary->erase(fPairVec_secondary->begin()+sec_i );
         prim_i--;
         sec_i--;
         break;
@@ -3662,26 +3682,29 @@ void AliAnalysisTaskEtaReconstruction::DoFourPreFilter(std::vector<TwoPair>* fPa
 }
 
 
-void AliAnalysisTaskEtaReconstruction::DoFourPairing(std::vector<TwoPair> fPairVec_primary, std::vector<TwoPair> fPairVec_secondary, Bool_t CaseRec, Bool_t CaseSmearing, double centralityWeight){
+void AliAnalysisTaskEtaReconstruction::DoFourPairing(std::vector<TwoPair> fPairVec_primary, std::vector<TwoPair> fPairVec_secondary, Bool_t CaseRec, Bool_t CaseSmearing, Bool_t PrimSecPairing, double centralityWeight){
+// **** Note: The option of SecSecPairing, which is equivalanet to PrimSecPairing=kFALSE, is only available yet for CaseRec = kTRUE ****
+
                                                                                 // if(fdebug) std::cout << __LINE__ << " DEBUG_AnalysisTask: Line cout " << std::endl;
   								                                                              // if(fdebug) std::cout << __LINE__ << " DEBUG_AnalysisTask: fPairVec_primary = " << fPairVec_primary.size() << ", fPairVec_secondary = " << fPairVec_secondary.size() << ", CaseRec = " << CaseRec << ", CaseSmearing = " << CaseSmearing << std::endl;
                                                                                 // if(fdebug) std::cout << " fPairVec_primary: "    << fPairVec_primary.size()   << std::endl;
   								                                                              // if(fdebug) std::cout << " fPairVec_secondary: "  << fPairVec_secondary.size() << std::endl;
 
-  // TH1D* hFourPairOpeningAngle = new TH1D("Angle between primary and secondary pair", "Angle between primary and secondary pair ;rad ; #counts", 1000, 0. , 6.4);
-  // hFourPairOpeningAngle->Sumw2();
-
-
-
+  unsigned int sec_iStartValue = 0;
   // std::cout << "Bool fDoFourPairing is " << fDoFourPairing << std::endl;
   for (unsigned int prim_i = 0; prim_i < fPairVec_primary.size(); ++prim_i){
     // if (fPairVec_primary[prim_i].fMCTwoSignal_acc_prim[0] == false) continue;
-    // std::cout << "prim_i = " << prim_i << std::endl;
-    for (unsigned int sec_i = 0; sec_i < fPairVec_secondary.size(); ++sec_i){
+    if (PrimSecPairing == kFALSE) sec_iStartValue = prim_i+1;      // setting sec_i=prim_i+1 is avoiding pairing of same pair (V0)
+    for (unsigned int sec_i = sec_iStartValue; sec_i < fPairVec_secondary.size(); ++sec_i){
       // if (fPairVec_secondary[sec_i].fMCTwoSignal_acc_sec[0] == false) continue;
-      // std::cout << "sec_i = " << sec_i << std::endl;
 
-      std::vector<Bool_t> mcSignal_acc(fFourPairMCSignal.size()/2, kFALSE); // vector which stores if track is accepted by [i]-th mcsignal
+      Int_t fSize_mcSignal_acc = 0;
+      Int_t fSize_FourPairMCSignal = 0;
+      if (PrimSecPairing == kTRUE)  fSize_FourPairMCSignal = fFourPairMCSignal_PrimSec.size();
+      if (PrimSecPairing == kFALSE) fSize_FourPairMCSignal = fFourPairMCSignal_SecSec.size();
+
+      fSize_mcSignal_acc = fSize_FourPairMCSignal/2;
+      std::vector<Bool_t> mcSignal_acc(fSize_mcSignal_acc, kFALSE); // vector which stores if track is accepted by [i]-th mcsignal
 
 
       if (CaseRec == kFALSE) {
@@ -3695,8 +3718,8 @@ void AliAnalysisTaskEtaReconstruction::DoFourPairing(std::vector<TwoPair> fPairV
 
         // Apply MC signals
         // Check MCSignal based on particles (not fully implemented! Check AliDielectronMC & AliDielectronSignalMC)
-        for (unsigned int i = 0, j = 0 ; i < fFourPairMCSignal.size()/2 && j < fFourPairMCSignal.size(); ++i, j+=2){
-          mcSignal_acc[i] = AliDielectronMC::Instance()->IsMCTruth(track1, track2, track3, track4, &(fFourPairMCSignal[j]), &(fFourPairMCSignal[j+1]));
+        for (unsigned int i = 0, j = 0 ; i < fFourPairMCSignal_PrimSec.size()/2 && j < fFourPairMCSignal_PrimSec.size(); ++i, j+=2){
+          mcSignal_acc[i] = AliDielectronMC::Instance()->IsMCTruth(track1, track2, track3, track4, &(fFourPairMCSignal_PrimSec[j]), &(fFourPairMCSignal_PrimSec[j+1]));
         }
 
 
@@ -3704,15 +3727,30 @@ void AliAnalysisTaskEtaReconstruction::DoFourPairing(std::vector<TwoPair> fPairV
         if (CheckIfOneIsTrue(mcSignal_acc) == kFALSE) continue;
       }
 
+
       if (CaseRec == kTRUE) {
-        AliVParticle* track1 = fEvent->GetTrack(fPairVec_primary[prim_i].GetFirstDaughter());  // primary eletrons, neg, first Daughter
-        AliVParticle* track2 = fEvent->GetTrack(fPairVec_primary[prim_i].GetSecondDaughter());  // primary eletrons, pos, second Daughter
+        AliVParticle* track1;
+        AliVParticle* track2;
+        if (PrimSecPairing == kTRUE) {
+          track1 = fEvent->GetTrack(fPairVec_primary[prim_i].GetFirstDaughter());  // primary eletrons, neg, first Daughter
+          track2 = fEvent->GetTrack(fPairVec_primary[prim_i].GetSecondDaughter());  // primary eletrons, pos, second Daughter
+        }
+        else if (PrimSecPairing == kFALSE){
+          // GetV0 daughters
+          Int_t        iV0    = fPairVec_primary[prim_i].GetV0ID(); //  i-th V0 in the Event
+          AliAODv0*    fV0    = ((AliAODEvent*) fEvent)->GetV0(iV0); // select i-th V0 in the Event
+          track1 = (AliVParticle *) (fV0->GetSecondaryVtx()->GetDaughter(0));  // secondary electron, neg, first Daughter from V0
+          track2 = (AliVParticle *) (fV0->GetSecondaryVtx()->GetDaughter(1));  // secondary electron, pos, second Daughter from V0
+        }
 
         // GetV0 daughters
         Int_t        iV0    = fPairVec_secondary[sec_i].GetV0ID(); //  i-th V0 in the Event
         AliAODv0*    fV0    = ((AliAODEvent*) fEvent)->GetV0(iV0); // select i-th V0 in the Event
         AliAODTrack* track3 = (AliAODTrack *) (fV0->GetSecondaryVtx()->GetDaughter(0));  // secondary electron, neg, first Daughter from V0
         AliAODTrack* track4 = (AliAODTrack *) (fV0->GetSecondaryVtx()->GetDaughter(1));  // secondary electron, pos, second Daughter from V0
+
+
+        if(PrimSecPairing == kFALSE && (track1 == track2 || track1 == track3 || track1 == track4 || track2 == track3 || track2 == track4 || track3 == track4))  continue;
 
         // Check if electrons are from MCSignal Generator
               // if (!fGenPosPart_primary[prim_i].GetMCSignalPair() || !fGenNegPart_primary[prim_i].GetMCSignalPair() || !fGenNegPart_secondary[sec_i].GetMCSignalPair() || !fGenPosPart_secondary[sec_i].GetMCSignalPair()) continue;
@@ -3726,19 +3764,22 @@ void AliAnalysisTaskEtaReconstruction::DoFourPairing(std::vector<TwoPair> fPairV
         secondpair.SetKFUsage(false);
         firstpair.SetTracks(static_cast<AliVTrack*>(track1), 11, static_cast<AliVTrack*>(track2), -11);
         secondpair.SetTracks(static_cast<AliVTrack*>(track3), 11, static_cast<AliVTrack*>(track4), -11);
-        for (unsigned int i = 0, j = 0 ; i < fFourPairMCSignal.size()/2 && j < fFourPairMCSignal.size(); ++i, j+=2){
-          mcSignal_acc[i] = AliDielectronMC::Instance()->IsMCTruth(&firstpair, &secondpair, &(fFourPairMCSignal[j]), &(fFourPairMCSignal[j+1]));
+        for (unsigned int i = 0, j = 0 ; i < fFourPairMCSignal_PrimSec.size()/2 && j < fFourPairMCSignal_PrimSec.size(); ++i, j+=2){
+          if (PrimSecPairing == kTRUE)  mcSignal_acc[i] = AliDielectronMC::Instance()->IsMCTruth(&firstpair, &secondpair, &(fFourPairMCSignal_PrimSec[j]), &(fFourPairMCSignal_PrimSec[j+1]));
+          if (PrimSecPairing == kFALSE) mcSignal_acc[i] = AliDielectronMC::Instance()->IsMCTruth(&firstpair, &secondpair, &(fFourPairMCSignal_SecSec[j]) , &(fFourPairMCSignal_SecSec[j+1]));
         }
+
 
         // check if at least one mc signal is true
         if (CheckIfOneIsTrue(mcSignal_acc) == kFALSE) continue;
       }
+
+
       // Construct pair variables from LorentzVectors
       TLorentzVector Lvec1;
       TLorentzVector Lvec2;
       Lvec1.SetPtEtaPhiM(fPairVec_primary[prim_i].fPt , fPairVec_primary[prim_i].fEta , fPairVec_primary[prim_i].fPhi , fPairVec_primary[prim_i].fMass);
       Lvec2.SetPtEtaPhiM(fPairVec_secondary[sec_i].fPt, fPairVec_secondary[sec_i].fEta, fPairVec_secondary[sec_i].fPhi, fPairVec_secondary[sec_i].fMass);
-
 
       TLorentzVector LvecM = Lvec1 + Lvec2;
       double mass = LvecM.M();
@@ -3747,6 +3788,7 @@ void AliAnalysisTaskEtaReconstruction::DoFourPairing(std::vector<TwoPair> fPairV
 
 
       // if(fdebug) {
+      //   // Use to investigate Generated FourPair History
       //   if(mass<0.13){
       //     if (CaseRec == kFALSE && CaseSmearing == kFALSE) {
       //       AliVParticle* track1 = fMC->GetTrack(fPairVec_primary[prim_i].GetFirstDaughter());  // primary eletrons, neg, first Daughter
@@ -3796,24 +3838,63 @@ void AliAnalysisTaskEtaReconstruction::DoFourPairing(std::vector<TwoPair> fPairV
       //       std::cout << "   Recombine 4 particles to mother: mass = " << fLVMother.M() << std::endl;
       //     }
       //   }
+      //
+      //   // Use to investigate reconstructed FourPiar History
+      //   if (CaseRec == kTRUE && PrimSecPairing == kFALSE) {
+      //     if (0.1 < mass && mass < 0.2) {
+      //       Int_t        iFirstV0    = fPairVec_primary[prim_i].GetV0ID(); //  i-th V0 in the Event
+      //       Int_t        iSecondV0   = fPairVec_secondary[sec_i].GetV0ID(); //  i-th V0 in the Event
+      //       AliAODv0*    fFirstV0    = ((AliAODEvent*) fEvent)->GetV0(iFirstV0); // select i-th V0 in the Event
+      //       AliAODv0*    fSecondV0   = ((AliAODEvent*) fEvent)->GetV0(iSecondV0); // select i-th V0 in the Event
+      //       AliAODTrack* track1 = (AliAODTrack *) (fFirstV0->GetSecondaryVtx()->GetDaughter(0));  // secondary electron, neg, first Daughter from V0
+      //       AliAODTrack* track2 = (AliAODTrack *) (fFirstV0->GetSecondaryVtx()->GetDaughter(1));  // secondary electron, pos, second Daughter from V0
+      //       AliAODTrack* track3 = (AliAODTrack *) (fSecondV0->GetSecondaryVtx()->GetDaughter(0));  // secondary electron, neg, first Daughter from V0
+      //       AliAODTrack* track4 = (AliAODTrack *) (fSecondV0->GetSecondaryVtx()->GetDaughter(1));  // secondary electron, pos, second Daughter from V0
+      //
+      //       Int_t Track1Label = TMath::Abs(track1->GetLabel());     AliVParticle* daughter1 = fMC->GetTrack(Track1Label);     Int_t labelD1 = -1;   labelD1 = TMath::Abs(daughter1->GetLabel());     Int_t pdgD1 = daughter1->PdgCode();
+      //       Int_t Track2Label = TMath::Abs(track2->GetLabel());     AliVParticle* daughter2 = fMC->GetTrack(Track2Label);     Int_t labelD2 = -1;   labelD2 = TMath::Abs(daughter2->GetLabel());     Int_t pdgD2 = daughter2->PdgCode();
+      //       Int_t Track3Label = TMath::Abs(track3->GetLabel());     AliVParticle* daughter3 = fMC->GetTrack(Track3Label);     Int_t labelD3 = -1;   labelD3 = TMath::Abs(daughter3->GetLabel());     Int_t pdgD3 = daughter3->PdgCode();
+      //       Int_t Track4Label = TMath::Abs(track4->GetLabel());     AliVParticle* daughter4 = fMC->GetTrack(Track4Label);     Int_t labelD4 = -1;   labelD4 = TMath::Abs(daughter4->GetLabel());     Int_t pdgD4 = daughter4->PdgCode();
+      //       Int_t labelM1 = -1;   labelM1 = TMath::Abs(daughter1->GetMother());    AliVParticle* mother1 = fMC->GetTrack(labelM1);       Int_t pdgM1 = mother1->PdgCode();
+      //       Int_t labelM2 = -1;   labelM2 = TMath::Abs(daughter2->GetMother());    AliVParticle* mother2 = fMC->GetTrack(labelM2);       Int_t pdgM2 = mother2->PdgCode();
+      //       Int_t labelM3 = -1;   labelM3 = TMath::Abs(daughter3->GetMother());    AliVParticle* mother3 = fMC->GetTrack(labelM3);       Int_t pdgM3 = mother3->PdgCode();
+      //       Int_t labelM4 = -1;   labelM4 = TMath::Abs(daughter4->GetMother());    AliVParticle* mother4 = fMC->GetTrack(labelM4);       Int_t pdgM4 = mother4->PdgCode();
+      //
+      //       Int_t labelG1 = -1;   labelG1 = TMath::Abs(mother1->GetMother());   AliVParticle* grandmother1 = fMC->GetTrack(labelG1);     Int_t pdgG1 = grandmother1->PdgCode();       Int_t nDaughtersG1 =fMC->GetTrack(labelG1)->GetNDaughters();
+      //       Int_t labelG2 = -1;   labelG2 = TMath::Abs(mother2->GetMother());   AliVParticle* grandmother2 = fMC->GetTrack(labelG2);     Int_t pdgG2 = grandmother2->PdgCode();       Int_t nDaughtersG2 =fMC->GetTrack(labelG2)->GetNDaughters();
+      //       Int_t labelG3 = -1;   labelG3 = TMath::Abs(mother3->GetMother());   AliVParticle* grandmother3 = fMC->GetTrack(labelG3);     Int_t pdgG3 = grandmother3->PdgCode();       Int_t nDaughtersG3 =fMC->GetTrack(labelG3)->GetNDaughters();
+      //       Int_t labelG4 = -1;   labelG4 = TMath::Abs(mother4->GetMother());   AliVParticle* grandmother4 = fMC->GetTrack(labelG4);     Int_t pdgG4 = grandmother4->PdgCode();       Int_t nDaughtersG4 =fMC->GetTrack(labelG4)->GetNDaughters();
+      //
+      //       std::cout << "DEBUG_AnalysisTask: Line cout " << std::endl;
+      //       std::cout << "DEBUG_AnalysisTask: Mass = " << mass << ", pair_pT = " << pairpt << std::endl;
+      //       std::cout << "   List Labels of the four paring particles and their mother as well as grand mother" << std::endl;
+      //       std::cout << "    Label D1 = " << labelD1 << " pdgD1 = " << pdgD1 << std::endl;
+      //       std::cout << "    Label D2 = " << labelD2 << " pdgD1 = " << pdgD2 << std::endl;
+      //       std::cout << "    Label D3 = " << labelD3 << " pdgD1 = " << pdgD3 << std::endl;
+      //       std::cout << "    Label D4 = " << labelD4 << " pdgD1 = " << pdgD4 << std::endl;
+      //       std::cout << "    -----------" << std::endl;
+      //       std::cout << "    Label M1 = " << labelM1 << " pdgM1 = " << pdgM1 << " Mass of particle " << mother1->M() << std::endl;
+      //       std::cout << "    Label M2 = " << labelM2 << " pdgM1 = " << pdgM2 << " Mass of particle " << mother2->M() << std::endl;
+      //       std::cout << "    Label M3 = " << labelM3 << " pdgM1 = " << pdgM3 << " Mass of particle " << mother3->M() << std::endl;
+      //       std::cout << "    Label M4 = " << labelM4 << " pdgM1 = " << pdgM4 << " Mass of particle " << mother4->M() << std::endl;
+      //       std::cout << "    -----------" << std::endl;
+      //       std::cout << "    Label G1 = " << labelG1 << " pdgG1 = " << pdgG1 << " nDaughtersG1 = " << nDaughtersG1 << " Mass of particle " << grandmother1->M() << std::endl;
+      //       std::cout << "    Label G2 = " << labelG2 << " pdgG1 = " << pdgG2 << " nDaughtersG2 = " << nDaughtersG2 << " Mass of particle " << grandmother2->M() << std::endl;
+      //       std::cout << "    Label G3 = " << labelG3 << " pdgG1 = " << pdgG3 << " nDaughtersG3 = " << nDaughtersG3 << " Mass of particle " << grandmother3->M() << std::endl;
+      //       std::cout << "    Label G4 = " << labelG4 << " pdgG1 = " << pdgG4 << " nDaughtersG4 = " << nDaughtersG4 << " Mass of particle " << grandmother4->M() << std::endl;
+      //       std::cout << "    -----------" << std::endl;
+      //       TLorentzVector fLVPart1; TLorentzVector fLVPart2; TLorentzVector fLVPart3; TLorentzVector fLVPart4; TLorentzVector fLVMother;
+      //       fLVPart1.SetPtEtaPhiM(daughter1->Pt(), daughter1->Eta(), daughter1->Phi(), daughter1->M());
+      //       fLVPart2.SetPtEtaPhiM(daughter2->Pt(), daughter2->Eta(), daughter2->Phi(), daughter2->M());
+      //       fLVPart3.SetPtEtaPhiM(daughter3->Pt(), daughter3->Eta(), daughter3->Phi(), daughter3->M());
+      //       fLVPart4.SetPtEtaPhiM(daughter4->Pt(), daughter4->Eta(), daughter4->Phi(), daughter4->M());
+      //       fLVMother = fLVPart1+fLVPart2+fLVPart3+fLVPart4;
+      //       std::cout << "   Recombine 4 particles to mother: mass = " << fLVMother.M() << std::endl;
+      //     }
+      //   }
       // }
 
 
-
-      if (CaseRec == kTRUE) {
-        double  pairAngle = Lvec1.Angle(Lvec2.Vect());
-        for (unsigned int i = 0; i < fPairVec_secondary[sec_i].isReconstructed_secondary.size(); ++i){
-          if (fPairVec_secondary[sec_i].isReconstructed_secondary[i] == kTRUE && fPairVec_primary[prim_i].isReconstructed_primary[i] == kTRUE){
-            for (unsigned int j = 0; j < mcSignal_acc.size(); ++j){
-              if (mcSignal_acc[j] == kTRUE){
-                (dynamic_cast<TH1D *>(((TList*)((TList*)fFourPairCutListVec.at(i))->At(j))->At(0)))->Fill(pairAngle);
-              }
-            }
-          }
-        }
-      //   hFourPairOpeningAngle->Fill(pairAngle);
-      //   fOutputListSupportHistos->Add(hFourPairOpeningAngle);
-      }
 
       if (CaseRec == kFALSE) {
         if (CaseSmearing == kFALSE) {
@@ -3833,16 +3914,44 @@ void AliAnalysisTaskEtaReconstruction::DoFourPairing(std::vector<TwoPair> fPairV
       }
                                                                                 // if(fdebug) std::cout << __LINE__ << " DEBUG_AnalysisTask: 4Pair with mass = " << mass << std::endl;
       if (CaseRec == kTRUE) {
-        for (unsigned int i = 0; i < mcSignal_acc.size(); ++i){
-          if (mcSignal_acc[i] == kTRUE){
-            for (unsigned int j = 0; j < fPairVec_primary[prim_i].fFirstPartIsReconstructed.size(); ++j){
-              if (fPairVec_primary[prim_i].fFirstPartIsReconstructed[j] == kTRUE && fPairVec_primary[prim_i].fSecondPartIsReconstructed[j] == kTRUE && fPairVec_secondary[sec_i].isReconstructed_secondary[j] == kTRUE ){
-                fHistRecFourPair.at(j * mcSignal_acc.size() + i)->Fill(mass, pairpt, weight * centralityWeight);
+        if (PrimSecPairing == kTRUE) {
+          // Filling Four pair Support Histogram, with Angle between Primary and Secondary Pair
+          double  pairAngle = Lvec1.Angle(Lvec2.Vect());
+          for (unsigned int i = 0; i < fPairVec_secondary[sec_i].isReconstructed_secondary.size(); ++i){
+            if (fPairVec_secondary[sec_i].isReconstructed_secondary[i] == kTRUE && fPairVec_primary[prim_i].isReconstructed_primary[i] == kTRUE){
+              for (unsigned int j = 0; j < mcSignal_acc.size(); ++j){
+                if (mcSignal_acc[j] == kTRUE){
+                  (dynamic_cast<TH1D *>(((TList*)((TList*)fFourPairCutListVec.at(i))->At(j))->At(0)))->Fill(pairAngle);
+                }
               }
             }
-          } // is selected by MCSignal
-        } // end of loop over all MCsignals
+          }
+          // Fill 4 el. Pair Histograms according to MC-Signals
+          for (unsigned int i = 0; i < mcSignal_acc.size(); ++i){
+            if (mcSignal_acc[i] == kTRUE){
+              for (unsigned int j = 0; j < fPairVec_primary[prim_i].fFirstPartIsReconstructed.size(); ++j){
+                if (fPairVec_primary[prim_i].fFirstPartIsReconstructed[j] == kTRUE && fPairVec_primary[prim_i].fSecondPartIsReconstructed[j] == kTRUE && fPairVec_secondary[sec_i].isReconstructed_secondary[j] == kTRUE ){
+                  fHistRecFourPair_PrimSec.at(j * mcSignal_acc.size() + i)->Fill(mass, pairpt, weight * centralityWeight);
+                }
+              }
+            } // is selected by MCSignal
+          } // end of loop over all MCsignals
+        } // end of if PrimSecPairing = true
+
+        if (PrimSecPairing == kFALSE) {
+          // Fill 4 el. Pair Histograms according to MC-Signals
+          for (unsigned int i = 0; i < mcSignal_acc.size(); ++i){
+            if (mcSignal_acc[i] == kTRUE){
+              for (unsigned int j = 0; j < fPairVec_primary[prim_i].isReconstructed_secondary.size(); ++j){
+                if (fPairVec_primary[prim_i].isReconstructed_secondary[j] == kTRUE  && fPairVec_secondary[sec_i].isReconstructed_secondary[j] == kTRUE ){
+                  fHistRecFourPair_SecSec.at(j * mcSignal_acc.size() + i)->Fill(mass, pairpt, weight * centralityWeight);
+                }
+              }
+            } // is selected by MCSignal
+          } // end of loop over all MCsignals
+        }
       }
+
     } // end of loop sec_i
   } // end of loop prim_i
 }

--- a/PWGDQ/dielectron/core/AliAnalysisTaskEtaReconstruction.cxx
+++ b/PWGDQ/dielectron/core/AliAnalysisTaskEtaReconstruction.cxx
@@ -755,10 +755,10 @@ void AliAnalysisTaskEtaReconstruction::UserCreateOutputObjects(){
         fHistBeforeSecSecPrefilter->Sumw2();
         fHistAfterPrimSecPrefilter->Sumw2();
         fHistAfterSecSecPrefilter->Sumw2();
-        fVecHistPrefilters.push_back(fHistBeforeSecSecPrefilter);
         fVecHistPrefilters.push_back(fHistBeforePrimSecPrefilter);
-        fVecHistPrefilters.push_back(fHistAfterSecSecPrefilter);
         fVecHistPrefilters.push_back(fHistAfterPrimSecPrefilter);
+        fVecHistPrefilters.push_back(fHistBeforeSecSecPrefilter);
+        fVecHistPrefilters.push_back(fHistAfterSecSecPrefilter);
         fFourPairList->Add(fHistBeforePrimSecPrefilter);
         fFourPairList->Add(fHistAfterPrimSecPrefilter);
         fFourPairList->Add(fHistBeforeSecSecPrefilter);

--- a/PWGDQ/dielectron/core/AliAnalysisTaskEtaReconstruction.cxx
+++ b/PWGDQ/dielectron/core/AliAnalysisTaskEtaReconstruction.cxx
@@ -84,7 +84,7 @@ AliAnalysisTaskEtaReconstruction::AliAnalysisTaskEtaReconstruction(): AliAnalysi
                                                                               , fdebug(false), run1analysis()
                                                                               , fResoFile(0x0), fResoFilename(""), fResoFilenameFromAlien(""), fArrResoPt(0x0), fArrResoEta(0x0), fArrResoPhi_Pos(0x0), fArrResoPhi_Neg(0x0)
                                                                               , fOutputList(0x0), fSingleElectronList(0x0), fGeneratedPrimaryList(0x0), fGeneratedSecondaryList(0x0), fGeneratedSmearedPrimaryList(0x0), fGeneratedSmearedSecondaryList(0x0), fRecPrimaryList(0x0), fRecSecondaryList(0x0)
-                                                                              , fGeneratedPrimaryPairsList(0x0), fGeneratedSecondaryPairsList(0x0), fGeneratedSmearedPrimaryPairsList(0x0), fGeneratedSmearedSecondaryPairsList(0x0), fPairList(0x0), fFourPairList_PrimSec(0x0), fFourPairList_SecSec(0x0), fGeneratedFourPairsList(0x0), fGeneratedSmearedFourPairsList(0x0), fResolutionList(0x0)
+                                                                              , fGeneratedPrimaryPairsList(0x0), fGeneratedSecondaryPairsList(0x0), fGeneratedSmearedPrimaryPairsList(0x0), fGeneratedSmearedSecondaryPairsList(0x0), fPairList(0x0), fFourPairList_PrimSec(0x0), fFourPairList_SecSec(0x0), fGeneratedFourPairsList_PrimSec(0x0), fGeneratedFourPairsList_SecSec(0x0), fGeneratedSmearedFourPairsList_PrimSec(0x0), fGeneratedSmearedFourPairsList_SecSec(0x0), fResolutionList(0x0)
                                                                               , fPGen_DeltaP(0x0), fPGen_PrecOverPGen(0x0), fPtGen_DeltaPt(0x0), fPtGen_DeltaPtOverPtGen(0x0), fPtGen_PtRecOverPtGen(0x0), fPtGen_DeltaPt_wGenSmeared(0x0), fPtGen_DeltaPtOverPtGen_wGenSmeared(0x0), fPtGen_PtRecOverPtGen_wGenSmeared(0x0)
                                                                               , fPGen_DeltaEta(0x0), fPtGen_DeltaEta(0x0), fPGen_DeltaTheta(0x0), fPGen_DeltaPhi_Ele(0x0), fPGen_DeltaPhi_Pos(0x0), fPtGen_DeltaPhi_Ele(0x0)
                                                                               , fPtGen_DeltaPhi_Pos(0x0), fThetaGen_DeltaTheta(0x0), fPhiGen_DeltaPhi(0x0)
@@ -102,7 +102,7 @@ AliAnalysisTaskEtaReconstruction::AliAnalysisTaskEtaReconstruction(): AliAnalysi
                                                                               , fMinCentrality(0.), fMaxCentrality(100), fCentralityFile(0x0), fCentralityFilename(""), fHistCentralityCorrection(0x0)
                                                                               , fOutputListSupportHistos(0x0), fTrackCutListVecPrim(), fTrackCutListVecSec(), fPairCutListVecSec(), fFourPairCutListVec()
                                                                               , fHistGenPrimaryPosPart(), fHistGenPrimaryNegPart(), fHistGenSecondaryPosPart(), fHistGenSecondaryNegPart(), fHistGenSmearedPrimaryPosPart(), fHistGenSmearedPrimaryNegPart(), fHistGenSmearedSecondaryPosPart(), fHistGenSmearedSecondaryNegPart(), fHistRecPrimaryPosPart(), fHistRecPrimaryNegPart(), fHistRecSecondaryPosPart(), fHistRecSecondaryNegPart()
-                                                                              , fHistGenPrimaryPair(), fHistGenSecondaryPair(), fHistGenSmearedPrimaryPair(), fHistGenSmearedSecondaryPair(), fHistRecPrimaryPair(), fHistRecSecondaryPair(), fHistGenFourPair(), fHistGenSmearedFourPair(), fHistRecFourPair_PrimSec(), fHistRecFourPair_SecSec(), fVecHistPrefilters()
+                                                                              , fHistGenPrimaryPair(), fHistGenSecondaryPair(), fHistGenSmearedPrimaryPair(), fHistGenSmearedSecondaryPair(), fHistRecPrimaryPair(), fHistRecSecondaryPair(), fHistGenFourPair_PrimSec(), fHistGenFourPair_SecSec(), fHistGenSmearedFourPair_PrimSec(), fHistGenSmearedFourPair_SecSec(), fHistRecFourPair_PrimSec(), fHistRecFourPair_SecSec(), fVecHistPrefilters()
                                                                               , fWriteLegsFromPair(false), fPtMinLegsFromPair(-99.), fPtMaxLegsFromPair(-99.), fEtaMinLegsFromPair(-99.), fEtaMaxLegsFromPair(-99.), fPhiMinLegsFromPair(-99.), fPhiMaxLegsFromPair(-99.), fOpAngleMinLegsFromPair(-99.), fOpAngleMaxLegsFromPair(-99.), fPtNBinsLegsFromPair(-99), fEtaNBinsLegsFromPair(-99), fPhiNBinsLegsFromPair(-99), fOpAngleNBinsLegsFromPair(-99), fTHnSparseGenSmearedLegsFromPrimaryPair(), fTHnSparseGenSmearedLegsFromSecondaryPair(), fTHnSparseRecLegsFromPrimaryPair(), fTHnSparseRecLegsFromSecondaryPair()
                                                                               , fDoPairing(false), fDoFourPairing(false), fUsePreFilter(false), fUseSecPreFilter(false), fDoMassCut(), fPhotonMass()
                                                                               , fGenNegPart_primary(), fGenPosPart_primary(), fGenNegPart_secondary(), fGenPosPart_secondary(), fGenSmearedNegPart_primary(), fGenSmearedPosPart_primary(), fGenSmearedNegPart_secondary(), fGenSmearedPosPart_secondary(), fRecNegPart_primary(), fRecPosPart_primary(), fRecNegPart_secondary(), fRecPosPart_secondary(), fGenPairVec_primary(), fGenPairVec_secondary(), fGenSmearedPairVec_primary(), fGenSmearedPairVec_secondary(), fRecPairVec_primary(), fRecPairVec_secondary(), fRecV0Pair(), fPreFilter_BadTracksLabel_primary()
@@ -120,7 +120,7 @@ AliAnalysisTaskEtaReconstruction::AliAnalysisTaskEtaReconstruction(const char * 
                                                                               , fdebug(false), run1analysis()
                                                                               , fResoFile(0x0), fResoFilename(""), fResoFilenameFromAlien(""), fArrResoPt(0x0), fArrResoEta(0x0), fArrResoPhi_Pos(0x0), fArrResoPhi_Neg(0x0)
                                                                               , fOutputList(0x0), fSingleElectronList(0x0), fGeneratedPrimaryList(0x0), fGeneratedSecondaryList(0x0), fGeneratedSmearedPrimaryList(0x0), fGeneratedSmearedSecondaryList(0x0), fRecPrimaryList(0x0), fRecSecondaryList(0x0)
-                                                                              , fGeneratedPrimaryPairsList(0x0), fGeneratedSecondaryPairsList(0x0), fGeneratedSmearedPrimaryPairsList(0x0), fGeneratedSmearedSecondaryPairsList(0x0), fPairList(0x0), fFourPairList_PrimSec(0x0), fFourPairList_SecSec(0x0), fGeneratedFourPairsList(0x0), fGeneratedSmearedFourPairsList(0x0), fResolutionList(0x0)
+                                                                              , fGeneratedPrimaryPairsList(0x0), fGeneratedSecondaryPairsList(0x0), fGeneratedSmearedPrimaryPairsList(0x0), fGeneratedSmearedSecondaryPairsList(0x0), fPairList(0x0), fFourPairList_PrimSec(0x0), fFourPairList_SecSec(0x0), fGeneratedFourPairsList_PrimSec(0x0), fGeneratedFourPairsList_SecSec(0x0), fGeneratedSmearedFourPairsList_PrimSec(0x0), fGeneratedSmearedFourPairsList_SecSec(0x0), fResolutionList(0x0)
                                                                               , fPGen_DeltaP(0x0), fPGen_PrecOverPGen(0x0), fPtGen_DeltaPt(0x0), fPtGen_DeltaPtOverPtGen(0x0), fPtGen_PtRecOverPtGen(0x0), fPtGen_DeltaPt_wGenSmeared(0x0), fPtGen_DeltaPtOverPtGen_wGenSmeared(0x0), fPtGen_PtRecOverPtGen_wGenSmeared(0x0)
                                                                               , fPGen_DeltaEta(0x0), fPtGen_DeltaEta(0x0), fPGen_DeltaTheta(0x0), fPGen_DeltaPhi_Ele(0x0), fPGen_DeltaPhi_Pos(0x0), fPtGen_DeltaPhi_Ele(0x0)
                                                                               , fPtGen_DeltaPhi_Pos(0x0), fThetaGen_DeltaTheta(0x0), fPhiGen_DeltaPhi(0x0)
@@ -138,7 +138,7 @@ AliAnalysisTaskEtaReconstruction::AliAnalysisTaskEtaReconstruction(const char * 
                                                                               , fMinCentrality(0.), fMaxCentrality(100), fCentralityFile(0x0), fCentralityFilename(""), fHistCentralityCorrection(0x0)
                                                                               , fOutputListSupportHistos(0x0), fTrackCutListVecPrim(), fTrackCutListVecSec(), fPairCutListVecSec(), fFourPairCutListVec()
                                                                               , fHistGenPrimaryPosPart(), fHistGenPrimaryNegPart(), fHistGenSecondaryPosPart(), fHistGenSecondaryNegPart(), fHistGenSmearedPrimaryPosPart(), fHistGenSmearedPrimaryNegPart(), fHistGenSmearedSecondaryPosPart(), fHistGenSmearedSecondaryNegPart(), fHistRecPrimaryPosPart(), fHistRecPrimaryNegPart(), fHistRecSecondaryPosPart(), fHistRecSecondaryNegPart()
-                                                                              , fHistGenPrimaryPair(), fHistGenSecondaryPair(), fHistGenSmearedPrimaryPair(), fHistGenSmearedSecondaryPair(), fHistRecPrimaryPair(), fHistRecSecondaryPair(), fHistGenFourPair(), fHistGenSmearedFourPair(), fHistRecFourPair_PrimSec(), fHistRecFourPair_SecSec(), fVecHistPrefilters()
+                                                                              , fHistGenPrimaryPair(), fHistGenSecondaryPair(), fHistGenSmearedPrimaryPair(), fHistGenSmearedSecondaryPair(), fHistRecPrimaryPair(), fHistRecSecondaryPair(), fHistGenFourPair_PrimSec(), fHistGenFourPair_SecSec(), fHistGenSmearedFourPair_PrimSec(), fHistGenSmearedFourPair_SecSec(), fHistRecFourPair_PrimSec(), fHistRecFourPair_SecSec(), fVecHistPrefilters()
                                                                               , fWriteLegsFromPair(false), fPtMinLegsFromPair(-99.), fPtMaxLegsFromPair(-99.), fEtaMinLegsFromPair(-99.), fEtaMaxLegsFromPair(-99.), fPhiMinLegsFromPair(-99.), fPhiMaxLegsFromPair(-99.), fOpAngleMinLegsFromPair(-99.), fOpAngleMaxLegsFromPair(-99.), fPtNBinsLegsFromPair(-99), fEtaNBinsLegsFromPair(-99), fPhiNBinsLegsFromPair(-99), fOpAngleNBinsLegsFromPair(-99), fTHnSparseGenSmearedLegsFromPrimaryPair(), fTHnSparseGenSmearedLegsFromSecondaryPair(), fTHnSparseRecLegsFromPrimaryPair(), fTHnSparseRecLegsFromSecondaryPair()
                                                                               , fDoPairing(false), fDoFourPairing(false), fUsePreFilter(false), fUseSecPreFilter(false), fDoMassCut(), fPhotonMass()
                                                                               , fGenNegPart_primary(), fGenPosPart_primary(), fGenNegPart_secondary(), fGenPosPart_secondary(), fGenSmearedNegPart_primary(), fGenSmearedPosPart_primary(), fGenSmearedNegPart_secondary(), fGenSmearedPosPart_secondary(), fRecNegPart_primary(), fRecPosPart_primary(), fRecNegPart_secondary(), fRecPosPart_secondary(), fGenPairVec_primary(), fGenPairVec_secondary(), fGenSmearedPairVec_primary(), fGenSmearedPairVec_secondary(), fRecPairVec_primary(), fRecPairVec_secondary(), fRecV0Pair(), fPreFilter_BadTracksLabel_primary()
@@ -708,34 +708,30 @@ void AliAnalysisTaskEtaReconstruction::UserCreateOutputObjects(){
         fFourPairList_PrimSec = new TList();
         fFourPairList_PrimSec->SetName("4Pairs_PrimSec");
         fFourPairList_PrimSec->SetOwner();
-
-        fFourPairList_SecSec = new TList();
-        fFourPairList_SecSec->SetName("4Pairs_SecSec");
-        fFourPairList_SecSec->SetOwner();
                                                                                 // if(fdebug) std::cout << __LINE__ << " DEBUG_AnalysisTask: Line cout " << std::endl;
 
-        fGeneratedFourPairsList = new TList();
-        fGeneratedFourPairsList->SetName("Generated");
-        fGeneratedFourPairsList->SetOwner();
+        fGeneratedFourPairsList_PrimSec = new TList();
+        fGeneratedFourPairsList_PrimSec->SetName("Generated");
+        fGeneratedFourPairsList_PrimSec->SetOwner();
         for (unsigned int i = 0; i < fFourPairMCSignal_PrimSec.size(); /*i++*/ i+=2){
           TH2D* th2_tmp = new TH2D(Form("Ngen_%s", fFourPairMCSignal_PrimSec.at(i).GetName()),";m_{eeee};p_{T,eeee}",fNmassBins,fMassBins.data(),fNpairptBins,fPairPtBins.data());
           th2_tmp->Sumw2();
-          fHistGenFourPair.push_back(th2_tmp);
-          fGeneratedFourPairsList->Add(th2_tmp);
+          fHistGenFourPair_PrimSec.push_back(th2_tmp);
+          fGeneratedFourPairsList_PrimSec->Add(th2_tmp);
         }
-        fFourPairList_PrimSec->Add(fGeneratedFourPairsList);
+        fFourPairList_PrimSec->Add(fGeneratedFourPairsList_PrimSec);
 
-        fGeneratedSmearedFourPairsList = new TList();
-        fGeneratedSmearedFourPairsList->SetName("GeneratedSmeared");
-        fGeneratedSmearedFourPairsList->SetOwner();
+        fGeneratedSmearedFourPairsList_PrimSec = new TList();
+        fGeneratedSmearedFourPairsList_PrimSec->SetName("GeneratedSmeared");
+        fGeneratedSmearedFourPairsList_PrimSec->SetOwner();
         for (unsigned int i = 0; i < fFourPairMCSignal_PrimSec.size(); i+=2){
          TH2D* th2_tmp = new TH2D(Form("Ngen_%s", fFourPairMCSignal_PrimSec.at(i).GetName()),";m_{eeee};p_{T,eeee}",fNmassBins,fMassBins.data(),fNpairptBins,fPairPtBins.data());
          th2_tmp->Sumw2();
-         fHistGenSmearedFourPair.push_back(th2_tmp);
-         fGeneratedSmearedFourPairsList->Add(th2_tmp);
+         fHistGenSmearedFourPair_PrimSec.push_back(th2_tmp);
+         fGeneratedSmearedFourPairsList_PrimSec->Add(th2_tmp);
         }
 
-        fFourPairList_PrimSec->Add(fGeneratedSmearedFourPairsList);
+        fFourPairList_PrimSec->Add(fGeneratedSmearedFourPairsList_PrimSec);
 
         // Generated reconstructed lists for every cutsetting one list and every MCsignal 1 histogram
         for (unsigned int list_i = 0; list_i < fTrackCuts_primary_standard.size(); ++list_i){
@@ -769,6 +765,33 @@ void AliAnalysisTaskEtaReconstruction::UserCreateOutputObjects(){
         fFourPairList_PrimSec->Add(fHistBeforeSecSecPrefilter);
         fFourPairList_PrimSec->Add(fHistAfterSecSecPrefilter);
 
+
+
+        fFourPairList_SecSec = new TList();
+        fFourPairList_SecSec->SetName("4Pairs_SecSec");
+        fFourPairList_SecSec->SetOwner();
+
+        fGeneratedFourPairsList_SecSec = new TList();
+        fGeneratedFourPairsList_SecSec->SetName("Generated");
+        fGeneratedFourPairsList_SecSec->SetOwner();
+        for (unsigned int i = 0; i < fFourPairMCSignal_SecSec.size(); /*i++*/ i+=2){
+          TH2D* th2_tmp = new TH2D(Form("Ngen_%s", fFourPairMCSignal_SecSec.at(i).GetName()),";m_{eeee};p_{T,eeee}",fNmassBins,fMassBins.data(),fNpairptBins,fPairPtBins.data());
+          th2_tmp->Sumw2();
+          fHistGenFourPair_SecSec.push_back(th2_tmp);
+          fGeneratedFourPairsList_SecSec->Add(th2_tmp);
+        }
+        fFourPairList_SecSec->Add(fGeneratedFourPairsList_SecSec);
+
+        fGeneratedSmearedFourPairsList_SecSec = new TList();
+        fGeneratedSmearedFourPairsList_SecSec->SetName("GeneratedSmeared");
+        fGeneratedSmearedFourPairsList_SecSec->SetOwner();
+        for (unsigned int i = 0; i < fFourPairMCSignal_SecSec.size(); i+=2){
+         TH2D* th2_tmp = new TH2D(Form("Ngen_%s", fFourPairMCSignal_SecSec.at(i).GetName()),";m_{eeee};p_{T,eeee}",fNmassBins,fMassBins.data(),fNpairptBins,fPairPtBins.data());
+         th2_tmp->Sumw2();
+         fHistGenSmearedFourPair_SecSec.push_back(th2_tmp);
+         fGeneratedSmearedFourPairsList_SecSec->Add(th2_tmp);
+        }
+        fFourPairList_SecSec->Add(fGeneratedSmearedFourPairsList_SecSec);
 
         for (unsigned int list_i = 0; list_i < fTrackCuts_primary_standard.size(); ++list_i){
           TList* list = new TList();
@@ -1458,10 +1481,12 @@ void AliAnalysisTaskEtaReconstruction::UserExec(Option_t* option){
     // #############################################
                                                                                 // if (fdebug) std::cout << "Do generated four pairing" << std::endl;
     DoFourPairing(fGenPairVec_primary, fGenPairVec_secondary, !ReconstructedPair, !SmearedPair, PrimSecPairing, centralityWeight);
+    DoFourPairing(fGenPairVec_secondary, fGenPairVec_secondary, !ReconstructedPair, !SmearedPair, !PrimSecPairing, centralityWeight);
                                                                                 // if(fdebug) std::cout << __LINE__ << " DEBUG_AnalysisTask: Line cout " << std::endl;
     if(fArrResoPt){
       // if (fdebug) std::cout << "Do generated smeared four pairing" << std::endl;
       DoFourPairing(fGenSmearedPairVec_primary, fGenSmearedPairVec_secondary, !ReconstructedPair, SmearedPair, PrimSecPairing, centralityWeight);
+      DoFourPairing(fGenSmearedPairVec_secondary, fGenSmearedPairVec_secondary, !ReconstructedPair, SmearedPair, !PrimSecPairing, centralityWeight);
     }
                                                                                 // if(fdebug) std::cout << __LINE__ << " DEBUG_AnalysisTask: Line cout " << std::endl;
 
@@ -3699,7 +3724,7 @@ void AliAnalysisTaskEtaReconstruction::DoFourPairing(std::vector<TwoPair> fPairV
       // if (fPairVec_secondary[sec_i].fMCTwoSignal_acc_sec[0] == false) continue;
 
       Int_t fSize_mcSignal_acc = 0;
-      Int_t fSize_FourPairMCSignal = 0;
+      unsigned int fSize_FourPairMCSignal = 0;
       if (PrimSecPairing == kTRUE)  fSize_FourPairMCSignal = fFourPairMCSignal_PrimSec.size();
       if (PrimSecPairing == kFALSE) fSize_FourPairMCSignal = fFourPairMCSignal_SecSec.size();
 
@@ -3718,11 +3743,10 @@ void AliAnalysisTaskEtaReconstruction::DoFourPairing(std::vector<TwoPair> fPairV
 
         // Apply MC signals
         // Check MCSignal based on particles (not fully implemented! Check AliDielectronMC & AliDielectronSignalMC)
-        for (unsigned int i = 0, j = 0 ; i < fFourPairMCSignal_PrimSec.size()/2 && j < fFourPairMCSignal_PrimSec.size(); ++i, j+=2){
-          mcSignal_acc[i] = AliDielectronMC::Instance()->IsMCTruth(track1, track2, track3, track4, &(fFourPairMCSignal_PrimSec[j]), &(fFourPairMCSignal_PrimSec[j+1]));
+        for (unsigned int i = 0, j = 0 ; i < fSize_FourPairMCSignal/2 && j < fSize_FourPairMCSignal; ++i, j+=2){
+          if (PrimSecPairing == kTRUE)  mcSignal_acc[i] = AliDielectronMC::Instance()->IsMCTruth(track1, track2, track3, track4, &(fFourPairMCSignal_PrimSec[j]), &(fFourPairMCSignal_PrimSec[j+1]));
+          if (PrimSecPairing == kFALSE) mcSignal_acc[i] = AliDielectronMC::Instance()->IsMCTruth(track1, track2, track3, track4, &(fFourPairMCSignal_SecSec[j]) , &(fFourPairMCSignal_SecSec[j+1]));
         }
-
-
         // check if at least one mc signal is true
         if (CheckIfOneIsTrue(mcSignal_acc) == kFALSE) continue;
       }
@@ -3764,7 +3788,7 @@ void AliAnalysisTaskEtaReconstruction::DoFourPairing(std::vector<TwoPair> fPairV
         secondpair.SetKFUsage(false);
         firstpair.SetTracks(static_cast<AliVTrack*>(track1), 11, static_cast<AliVTrack*>(track2), -11);
         secondpair.SetTracks(static_cast<AliVTrack*>(track3), 11, static_cast<AliVTrack*>(track4), -11);
-        for (unsigned int i = 0, j = 0 ; i < fFourPairMCSignal_PrimSec.size()/2 && j < fFourPairMCSignal_PrimSec.size(); ++i, j+=2){
+        for (unsigned int i = 0, j = 0 ; i < fSize_FourPairMCSignal/2 && j < fSize_FourPairMCSignal; ++i, j+=2){
           if (PrimSecPairing == kTRUE)  mcSignal_acc[i] = AliDielectronMC::Instance()->IsMCTruth(&firstpair, &secondpair, &(fFourPairMCSignal_PrimSec[j]), &(fFourPairMCSignal_PrimSec[j+1]));
           if (PrimSecPairing == kFALSE) mcSignal_acc[i] = AliDielectronMC::Instance()->IsMCTruth(&firstpair, &secondpair, &(fFourPairMCSignal_SecSec[j]) , &(fFourPairMCSignal_SecSec[j+1]));
         }
@@ -3900,14 +3924,16 @@ void AliAnalysisTaskEtaReconstruction::DoFourPairing(std::vector<TwoPair> fPairV
         if (CaseSmearing == kFALSE) {
           for (unsigned int i = 0; i < mcSignal_acc.size(); ++i){
             if (mcSignal_acc[i] == kTRUE){
-              fHistGenFourPair.at(i)->Fill(mass, pairpt, weight * centralityWeight);
+              if (PrimSecPairing == kTRUE) fHistGenFourPair_PrimSec.at(i)->Fill(mass, pairpt, weight * centralityWeight);
+              else if (PrimSecPairing == kFALSE) fHistGenFourPair_SecSec.at(i)->Fill(mass, pairpt, weight * centralityWeight);
             }
           } // end of loop over all MCsignals
         }
         if (CaseSmearing == kTRUE) {
           for (unsigned int i = 0; i < mcSignal_acc.size(); ++i){
             if (mcSignal_acc[i] == kTRUE){
-              fHistGenSmearedFourPair.at(i)->Fill(mass, pairpt, weight * centralityWeight);
+              if (PrimSecPairing == kTRUE) fHistGenSmearedFourPair_PrimSec.at(i)->Fill(mass, pairpt, weight * centralityWeight);
+              else if (PrimSecPairing == kFALSE) fHistGenSmearedFourPair_SecSec.at(i)->Fill(mass, pairpt, weight * centralityWeight);
             }
           } // end of loop over all MCsignals
         }

--- a/PWGDQ/dielectron/core/AliAnalysisTaskEtaReconstruction.h
+++ b/PWGDQ/dielectron/core/AliAnalysisTaskEtaReconstruction.h
@@ -69,7 +69,8 @@ public:
    void   AddSingleSecondaryLegMCSignal(AliDielectronSignalMC signal1)       {fSingleSecondaryLegMCSignal.push_back(signal1);}
    void   AddPrimaryPairMCSignal(AliDielectronSignalMC signal1)              {fPrimaryPairMCSignal.push_back(signal1);}
    void   AddSecondaryPairMCSignal(AliDielectronSignalMC signal1)            {fSecondaryPairMCSignal.push_back(signal1);}
-   void   AddFourPairMCSignal(AliDielectronSignalMC signal1)                 {fFourPairMCSignal.push_back(signal1);}
+   void   AddFourPairMCSignal_PrimSec(AliDielectronSignalMC signal1)                 {fFourPairMCSignal_PrimSec.push_back(signal1);}
+   void   AddFourPairMCSignal_SecSec(AliDielectronSignalMC signal1)                  {fFourPairMCSignal_SecSec.push_back(signal1);}
    void   AddMCSignalsWherePrimaryDielectronPairNotFromSameMother(std::vector<bool> vec)   {fPrimaryDielectronPairNotFromSameMother = vec;}
    void   AddMCSignalsWhereSecondaryDielectronPairNotFromSameMother(std::vector<bool> vec) {fSecondaryDielectronPairNotFromSameMother = vec;}
 
@@ -276,7 +277,7 @@ private:
   void   DoGenAndGenSmearTwoPairing(std::vector<Particle>* vec_negParticle, std::vector<Particle>* vec_posParticle, Bool_t PartPrimary, Bool_t SmearedPair, double centralityWeight);
   void   DoRecTwoPairing(std::vector<Particle> fRecNegPart, std::vector<Particle> fRecPosPart, std::vector<AliDielectronSignalMC> fPairMCSignal, Bool_t PartPrimary, double centralityWeight);
   void   DoRecTwoPairingV0(std::vector<AliDielectronSignalMC> fPairMCSignal);
-  void   DoFourPairing(std::vector<TwoPair> fPairVec_primary, std::vector<TwoPair> fPairVec_secondary, Bool_t ReconstructedPair, Bool_t SmearedPair, double centralityWeight);
+  void   DoFourPairing(std::vector<TwoPair> fPairVec_primary, std::vector<TwoPair> fPairVec_secondary, Bool_t ReconstructedPair, Bool_t SmearedPair, Bool_t PrimSecPairing, double centralityWeight);
   void   DoFourPreFilter(std::vector<TwoPair>* fPairVec_primary, std::vector<TwoPair>* fPairVec_secondary);
   void   ApplyStandardCutsAndFillHists(std::vector<TwoPair>* fPairVec, std::vector<AliAnalysisFilter*> fTrackCuts, Bool_t TrackCuts, Bool_t PairPrimary, double centralityWeight);
 
@@ -317,7 +318,8 @@ private:
   TList* fGeneratedSmearedPrimaryPairsList;
   TList* fGeneratedSmearedSecondaryPairsList;
   TList* fPairList;
-  TList* fFourPairList;
+  TList* fFourPairList_PrimSec;
+  TList* fFourPairList_SecSec;
   TList* fGeneratedFourPairsList;
   TList* fGeneratedSmearedFourPairsList;
   TList* fResolutionList;
@@ -378,7 +380,8 @@ private:
   std::vector<AliDielectronSignalMC> fSingleSecondaryLegMCSignal;
   std::vector<AliDielectronSignalMC> fPrimaryPairMCSignal;
   std::vector<AliDielectronSignalMC> fSecondaryPairMCSignal;
-  std::vector<AliDielectronSignalMC> fFourPairMCSignal;
+  std::vector<AliDielectronSignalMC> fFourPairMCSignal_PrimSec;
+  std::vector<AliDielectronSignalMC> fFourPairMCSignal_SecSec;
   std::vector<bool> fPrimaryDielectronPairNotFromSameMother; // this is used to get electrons from charmed mesons in a environment where GEANT is doing the decay of D mesons, like in LHC18b5a
   std::vector<bool> fSecondaryDielectronPairNotFromSameMother; // this is used to get electrons from charmed mesons in a environment where GEANT is doing the decay of D mesons, like in LHC18b5a
 
@@ -449,7 +452,8 @@ private:
   std::vector<TH2D*> fHistRecSecondaryPair;
   std::vector<TH2D*> fHistGenFourPair;
   std::vector<TH2D*> fHistGenSmearedFourPair;
-  std::vector<TH2D*> fHistRecFourPair;
+  std::vector<TH2D*> fHistRecFourPair_PrimSec;
+  std::vector<TH2D*> fHistRecFourPair_SecSec;
 
   std::vector<TH2D*> fVecHistPrefilters;
 

--- a/PWGDQ/dielectron/core/AliAnalysisTaskEtaReconstruction.h
+++ b/PWGDQ/dielectron/core/AliAnalysisTaskEtaReconstruction.h
@@ -320,8 +320,10 @@ private:
   TList* fPairList;
   TList* fFourPairList_PrimSec;
   TList* fFourPairList_SecSec;
-  TList* fGeneratedFourPairsList;
-  TList* fGeneratedSmearedFourPairsList;
+  TList* fGeneratedFourPairsList_PrimSec;
+  TList* fGeneratedFourPairsList_SecSec;
+  TList* fGeneratedSmearedFourPairsList_PrimSec;
+  TList* fGeneratedSmearedFourPairsList_SecSec;
   TList* fResolutionList;
 
   TH2D* fPGen_DeltaP;
@@ -450,8 +452,10 @@ private:
   std::vector<TH2D*> fHistGenSmearedSecondaryPair;
   std::vector<TH2D*> fHistRecPrimaryPair;
   std::vector<TH2D*> fHistRecSecondaryPair;
-  std::vector<TH2D*> fHistGenFourPair;
-  std::vector<TH2D*> fHistGenSmearedFourPair;
+  std::vector<TH2D*> fHistGenFourPair_PrimSec;
+  std::vector<TH2D*> fHistGenFourPair_SecSec;
+  std::vector<TH2D*> fHistGenSmearedFourPair_PrimSec;
+  std::vector<TH2D*> fHistGenSmearedFourPair_SecSec;
   std::vector<TH2D*> fHistRecFourPair_PrimSec;
   std::vector<TH2D*> fHistRecFourPair_SecSec;
 

--- a/PWGDQ/dielectron/macrosLMEE/AddTask_feisenhut_EtaReconstruction.C
+++ b/PWGDQ/dielectron/macrosLMEE/AddTask_feisenhut_EtaReconstruction.C
@@ -175,7 +175,8 @@ AliAnalysisTaskEtaReconstruction* AddTask_feisenhut_EtaReconstruction(TString na
   AddSingleSecondaryLegMCSignal(task);
   AddPrimaryPairMCSignal(task);
   AddSecondaryPairMCSignal(task);
-  AddFourPairMCSignal(task);
+  AddFourPairMCSignal_PrimSec(task);
+  AddFourPairMCSignal_SecSec(task);
   std::vector<bool> PrimaryDielectronsPairNotFromSameMother = AddSinglePrimaryLegMCSignal(task);
   std::vector<bool> SecondaryDielectronsPairNotFromSameMother = AddSingleSecondaryLegMCSignal(task);
   task->AddMCSignalsWherePrimaryDielectronPairNotFromSameMother(PrimaryDielectronsPairNotFromSameMother);

--- a/PWGDQ/dielectron/macrosLMEE/Config_feisenhut_EtaReconstruction.C
+++ b/PWGDQ/dielectron/macrosLMEE/Config_feisenhut_EtaReconstruction.C
@@ -90,7 +90,7 @@ bool DoPairing         = true;
 bool DoFourPairing     = true;
 bool UsePreFilter      = true;
 bool UseSecPreFilter   = true;
-bool DoMassCut         = true;
+bool DoMassCut         = false;
 bool V0OnFlyStatus     = true; // true stands for OnFlyStatus:aktive ; false means deaktivated
 // bool DoULSLS   = true;
 

--- a/PWGDQ/dielectron/macrosLMEE/Config_feisenhut_EtaReconstruction.C
+++ b/PWGDQ/dielectron/macrosLMEE/Config_feisenhut_EtaReconstruction.C
@@ -90,7 +90,7 @@ bool DoPairing         = true;
 bool DoFourPairing     = true;
 bool UsePreFilter      = true;
 bool UseSecPreFilter   = true;
-bool DoMassCut         = false;
+bool DoMassCut         = true;
 bool V0OnFlyStatus     = true; // true stands for OnFlyStatus:aktive ; false means deaktivated
 // bool DoULSLS   = true;
 
@@ -1161,10 +1161,9 @@ task->AddSecondaryPairMCSignal(elePair_random_secondary);
 task->AddSecondaryPairMCSignal(elePair_NotSameMother_secondary);
 }
 
-void AddFourPairMCSignal(AliAnalysisTaskEtaReconstruction* task){
-  //#########################################
-  //########### Unlike Signe Signals ########
-  //#########################################
+
+
+void AddFourPairMCSignal_PrimSec(AliAnalysisTaskEtaReconstruction* task){
   // AliDielectronSignalMC for 4 particles
   // Seperate it into 2 pair MCSignals
   //
@@ -1420,33 +1419,88 @@ void AddFourPairMCSignal(AliAnalysisTaskEtaReconstruction* task){
 
 
 //________________________________________________________
-    task->AddFourPairMCSignal(FourElePair1_FinalState);
-    task->AddFourPairMCSignal(FourElePair2_Secondary_from_Photon);
+    task->AddFourPairMCSignal_PrimSec(FourElePair1_FinalState);
+    task->AddFourPairMCSignal_PrimSec(FourElePair2_Secondary_from_Photon);
 
-    task->AddFourPairMCSignal(FourElePair1_FinalState_Dalitz);
-    task->AddFourPairMCSignal(FourElePair2_Secondary_from_Photon_Dalitz);
+    task->AddFourPairMCSignal_PrimSec(FourElePair1_FinalState_Dalitz);
+    task->AddFourPairMCSignal_PrimSec(FourElePair2_Secondary_from_Photon_Dalitz);
 
-    task->AddFourPairMCSignal(FourElePair1_FromPion);
-    task->AddFourPairMCSignal(FourElePair2_FromPion);
+    task->AddFourPairMCSignal_PrimSec(FourElePair1_FromPion);
+    task->AddFourPairMCSignal_PrimSec(FourElePair2_FromPion);
 
-    task->AddFourPairMCSignal(FourElePair1_FromPion_Dalitz);
-    task->AddFourPairMCSignal(FourElePair2_FromPion_Dalitz);
+    task->AddFourPairMCSignal_PrimSec(FourElePair1_FromPion_Dalitz);
+    task->AddFourPairMCSignal_PrimSec(FourElePair2_FromPion_Dalitz);
 
-    task->AddFourPairMCSignal(FourElePair1_FromEta);
-    task->AddFourPairMCSignal(FourElePair2_FromEta);
+    task->AddFourPairMCSignal_PrimSec(FourElePair1_FromEta);
+    task->AddFourPairMCSignal_PrimSec(FourElePair2_FromEta);
 
-    task->AddFourPairMCSignal(FourElePair1_FromEta_Dalitz);
-    task->AddFourPairMCSignal(FourElePair2_FromEta_Dalitz);
+    task->AddFourPairMCSignal_PrimSec(FourElePair1_FromEta_Dalitz);
+    task->AddFourPairMCSignal_PrimSec(FourElePair2_FromEta_Dalitz);
 
-    task->AddFourPairMCSignal(FourElePair1_MissMatchPionEta_Dalitz);
-    task->AddFourPairMCSignal(FourElePair2_MissMatchPionEta_Dalitz);
+    task->AddFourPairMCSignal_PrimSec(FourElePair1_MissMatchPionEta_Dalitz);
+    task->AddFourPairMCSignal_PrimSec(FourElePair2_MissMatchPionEta_Dalitz);
 
-    task->AddFourPairMCSignal(FourElePair1_MissMatchEtaPion_Dalitz);
-    task->AddFourPairMCSignal(FourElePair2_MissMatchEtaPion_Dalitz);
+    task->AddFourPairMCSignal_PrimSec(FourElePair1_MissMatchEtaPion_Dalitz);
+    task->AddFourPairMCSignal_PrimSec(FourElePair2_MissMatchEtaPion_Dalitz);
 
-    task->AddFourPairMCSignal(FourElePair1_FinalState_UndefinedMother);
-    task->AddFourPairMCSignal(FourElePair2_Secondary_from_UndefinedMother);
+    task->AddFourPairMCSignal_PrimSec(FourElePair1_FinalState_UndefinedMother);
+    task->AddFourPairMCSignal_PrimSec(FourElePair2_Secondary_from_UndefinedMother);
 
-    if(UseMCDataSig) task->AddFourPairMCSignal(FourAnyPartPair1_FinalState_UndefinedMother);
-    if(UseMCDataSig) task->AddFourPairMCSignal(FourAnyPartPair2_Secondary_UndefinedMother);
+    if(UseMCDataSig) task->AddFourPairMCSignal_PrimSec(FourAnyPartPair1_FinalState_UndefinedMother);
+    if(UseMCDataSig) task->AddFourPairMCSignal_PrimSec(FourAnyPartPair2_Secondary_UndefinedMother);
+}
+
+
+
+
+void AddFourPairMCSignal_SecSec(AliAnalysisTaskEtaReconstruction* task){
+  // AliDielectronSignalMC for 4 particles
+  // Seperate it into 2 pair MCSignals
+  //
+  //________________________________________________________
+      // First Pair
+        AliDielectronSignalMC FourElePair1_Secondary_from_Photon("FourElePair1_Secondary_from_Photon","FourElePair1_Secondary_from_Photon");
+        FourElePair1_Secondary_from_Photon.SetLegPDGs(11,-11);
+        FourElePair1_Secondary_from_Photon.SetCheckBothChargesLegs(kTRUE,kTRUE);
+        FourElePair1_Secondary_from_Photon.SetLegSources(AliDielectronSignalMC::kSecondary, AliDielectronSignalMC::kSecondary);
+        // mother
+        FourElePair1_Secondary_from_Photon.SetMothersRelation(AliDielectronSignalMC::kSame);
+        FourElePair1_Secondary_from_Photon.SetMotherPDGs(22, 22); //
+
+
+      // Second Pair
+        AliDielectronSignalMC FourElePair2_Secondary_from_Photon("FourElePair2_Secondary_from_Photon","FourElePair2_Secondary_from_Photon");
+        FourElePair2_Secondary_from_Photon.SetLegPDGs(11,-11);
+        FourElePair2_Secondary_from_Photon.SetCheckBothChargesLegs(kTRUE,kTRUE);
+        FourElePair2_Secondary_from_Photon.SetLegSources(AliDielectronSignalMC::kSecondary, AliDielectronSignalMC::kSecondary);
+        // mother
+        FourElePair2_Secondary_from_Photon.SetMothersRelation(AliDielectronSignalMC::kSame);
+        FourElePair2_Secondary_from_Photon.SetMotherPDGs(22, 22); //
+
+  //________________________________________________________
+      // First Pair
+        AliDielectronSignalMC FourAnyPartPair1_Secondary_UndefinedMother("FourAnyPartPair1_Secondary_UndefinedMother","FourAnyPartPair1_Secondary_UndefinedMother");
+        FourAnyPartPair1_Secondary_UndefinedMother.SetLegPDGs(0,0);
+        FourAnyPartPair1_Secondary_UndefinedMother.SetCheckBothChargesLegs(kTRUE,kTRUE);
+        FourAnyPartPair1_Secondary_UndefinedMother.SetLegSources(AliDielectronSignalMC::kSecondary, AliDielectronSignalMC::kSecondary);
+        // mother
+        FourAnyPartPair1_Secondary_UndefinedMother.SetMothersRelation(AliDielectronSignalMC::kUndefined);
+
+
+      // Second Pair
+        AliDielectronSignalMC FourAnyPartPair2_Secondary_UndefinedMother("FourAnyPartPair2_Secondary_UndefinedMother","FourAnyPartPair2_Secondary_UndefinedMother");
+        FourAnyPartPair2_Secondary_UndefinedMother.SetLegPDGs(0,0);
+        FourAnyPartPair2_Secondary_UndefinedMother.SetCheckBothChargesLegs(kTRUE,kTRUE);
+        FourAnyPartPair2_Secondary_UndefinedMother.SetLegSources(AliDielectronSignalMC::kSecondary, AliDielectronSignalMC::kSecondary);
+        // mother
+        FourAnyPartPair2_Secondary_UndefinedMother.SetMothersRelation(AliDielectronSignalMC::kUndefined);
+
+
+
+//________________________________________________________
+    task->AddFourPairMCSignal_SecSec(FourElePair1_Secondary_from_Photon);
+    task->AddFourPairMCSignal_SecSec(FourElePair2_Secondary_from_Photon);
+
+    if(UseMCDataSig) task->AddFourPairMCSignal_SecSec(FourAnyPartPair1_Secondary_UndefinedMother);
+    if(UseMCDataSig) task->AddFourPairMCSignal_SecSec(FourAnyPartPair2_Secondary_UndefinedMother);
 }

--- a/PWGDQ/dielectron/macrosLMEE/Config_feisenhut_EtaReconstruction.C
+++ b/PWGDQ/dielectron/macrosLMEE/Config_feisenhut_EtaReconstruction.C
@@ -84,7 +84,7 @@ Bool_t SetITSCorrection = kFALSE;
 Bool_t SetTOFCorrection = kFALSE;
 
 
-bool debug = false;
+bool debug = true;
 
 bool DoPairing         = true;
 bool DoFourPairing     = true;
@@ -1178,15 +1178,15 @@ void AddFourPairMCSignal_PrimSec(AliAnalysisTaskEtaReconstruction* task){
 
 
       // Second Pair
-        AliDielectronSignalMC FourElePair2_Secondary_from_Photon("FourElePair2_Secondary_from_Photon","FourElePair2_Secondary_from_Photon");
-        FourElePair2_Secondary_from_Photon.SetLegPDGs(11,-11);
-        FourElePair2_Secondary_from_Photon.SetCheckBothChargesLegs(kTRUE,kTRUE);
-        FourElePair2_Secondary_from_Photon.SetLegSources(AliDielectronSignalMC::kSecondary, AliDielectronSignalMC::kSecondary);
-        // FourElePair2_Secondary_from_Photon.SetLegSources(AliDielectronSignalMC::kFinalState, AliDielectronSignalMC::kFinalState);
-        // FourElePair2_Secondary_from_Photon.SetLegSources(AliDielectronSignalMC::kSecondaryFromMaterial, AliDielectronSignalMC::kSecondaryFromMaterial);
+        AliDielectronSignalMC FourElePair2_Secondary_samePhoton("FourElePair2_Secondary_samePhoton","FourElePair2_Secondary_samePhoton");
+        FourElePair2_Secondary_samePhoton.SetLegPDGs(11,-11);
+        FourElePair2_Secondary_samePhoton.SetCheckBothChargesLegs(kTRUE,kTRUE);
+        FourElePair2_Secondary_samePhoton.SetLegSources(AliDielectronSignalMC::kSecondary, AliDielectronSignalMC::kSecondary);
+        // FourElePair2_Secondary_samePhoton.SetLegSources(AliDielectronSignalMC::kFinalState, AliDielectronSignalMC::kFinalState);
+        // FourElePair2_Secondary_samePhoton.SetLegSources(AliDielectronSignalMC::kSecondaryFromMaterial, AliDielectronSignalMC::kSecondaryFromMaterial);
         // mother
-        FourElePair2_Secondary_from_Photon.SetMothersRelation(AliDielectronSignalMC::kSame);
-        FourElePair2_Secondary_from_Photon.SetMotherPDGs(22, 22); //
+        FourElePair2_Secondary_samePhoton.SetMothersRelation(AliDielectronSignalMC::kSame);
+        FourElePair2_Secondary_samePhoton.SetMotherPDGs(22, 22); //
 
 
   //________________________________________________________
@@ -1201,180 +1201,180 @@ void AddFourPairMCSignal_PrimSec(AliAnalysisTaskEtaReconstruction* task){
         FourElePair1_FinalState_Dalitz.SetCheckMotherGrandmotherDiffPairRelation(kTRUE,kTRUE); // is assuming that both pairs using: SetMothersRelation(AliDielectronSignalMC::kSame)
 
       // Second Pair
-        AliDielectronSignalMC FourElePair2_Secondary_from_Photon_Dalitz("FourElePair2_Secondary_from_Photon_Dalitz","FourElePair2_Secondary_from_Photon_Dalitz");
-        FourElePair2_Secondary_from_Photon_Dalitz.SetLegPDGs(11,-11);
-        FourElePair2_Secondary_from_Photon_Dalitz.SetCheckBothChargesLegs(kTRUE,kTRUE);
-        FourElePair2_Secondary_from_Photon_Dalitz.SetLegSources(AliDielectronSignalMC::kSecondary, AliDielectronSignalMC::kSecondary);
-        // FourElePair2_Secondary_from_Photon_Dalitz.SetLegSources(AliDielectronSignalMC::kFinalState, AliDielectronSignalMC::kFinalState);
-        // FourElePair2_Secondary_from_Photon_Dalitz.SetLegSources(AliDielectronSignalMC::kSecondaryFromMaterial, AliDielectronSignalMC::kSecondaryFromMaterial);
+        AliDielectronSignalMC FourElePair2_Secondary_samePhoton_Dalitz("FourElePair2_Secondary_samePhoton_Dalitz","FourElePair2_Secondary_samePhoton_Dalitz");
+        FourElePair2_Secondary_samePhoton_Dalitz.SetLegPDGs(11,-11);
+        FourElePair2_Secondary_samePhoton_Dalitz.SetCheckBothChargesLegs(kTRUE,kTRUE);
+        FourElePair2_Secondary_samePhoton_Dalitz.SetLegSources(AliDielectronSignalMC::kSecondary, AliDielectronSignalMC::kSecondary);
+        // FourElePair2_Secondary_samePhoton_Dalitz.SetLegSources(AliDielectronSignalMC::kFinalState, AliDielectronSignalMC::kFinalState);
+        // FourElePair2_Secondary_samePhoton_Dalitz.SetLegSources(AliDielectronSignalMC::kSecondaryFromMaterial, AliDielectronSignalMC::kSecondaryFromMaterial);
         // mother
-        FourElePair2_Secondary_from_Photon_Dalitz.SetMothersRelation(AliDielectronSignalMC::kSame);
-        FourElePair2_Secondary_from_Photon_Dalitz.SetMotherPDGs(22, 22); //
+        FourElePair2_Secondary_samePhoton_Dalitz.SetMothersRelation(AliDielectronSignalMC::kSame);
+        FourElePair2_Secondary_samePhoton_Dalitz.SetMotherPDGs(22, 22); //
 
         // check if mother of first pair is grand mother of second pair or vice versa
-        FourElePair2_Secondary_from_Photon_Dalitz.SetCheckMotherGrandmotherDiffPairRelation(kTRUE,kTRUE); // is assuming that both pairs using: SetMothersRelation(AliDielectronSignalMC::kSame)
+        FourElePair2_Secondary_samePhoton_Dalitz.SetCheckMotherGrandmotherDiffPairRelation(kTRUE,kTRUE); // is assuming that both pairs using: SetMothersRelation(AliDielectronSignalMC::kSame)
 
   //________________________________________________________
       // First Pair
-        AliDielectronSignalMC FourElePair1_FromPion("FourElePair1_FromPion","FourElePair1_FromPion");
-        FourElePair1_FromPion.SetLegPDGs(11,-11);
-        FourElePair1_FromPion.SetCheckBothChargesLegs(kTRUE,kTRUE);
-        FourElePair1_FromPion.SetLegSources(AliDielectronSignalMC::kFinalState, AliDielectronSignalMC::kFinalState);
+        AliDielectronSignalMC FourElePair1_samePion("FourElePair1_samePion","FourElePair1_samePion");
+        FourElePair1_samePion.SetLegPDGs(11,-11);
+        FourElePair1_samePion.SetCheckBothChargesLegs(kTRUE,kTRUE);
+        FourElePair1_samePion.SetLegSources(AliDielectronSignalMC::kFinalState, AliDielectronSignalMC::kFinalState);
         //mother
-        FourElePair1_FromPion.SetMothersRelation(AliDielectronSignalMC::kSame);
-        FourElePair1_FromPion.SetMotherPDGs(111, 111); //
+        FourElePair1_samePion.SetMothersRelation(AliDielectronSignalMC::kSame);
+        FourElePair1_samePion.SetMotherPDGs(111, 111); //
 
       // Second Pair
-        AliDielectronSignalMC FourElePair2_FromPion("FourElePair2_FromPion","FourElePair2_FromPion");
-        FourElePair2_FromPion.SetLegPDGs(11,-11);
-        FourElePair2_FromPion.SetCheckBothChargesLegs(kTRUE,kTRUE);
-        FourElePair2_FromPion.SetLegSources(AliDielectronSignalMC::kSecondary, AliDielectronSignalMC::kSecondary);
-        // FourElePair2_FromPion.SetLegSources(AliDielectronSignalMC::kFinalState, AliDielectronSignalMC::kFinalState);
-        // FourElePair2_FromPion.SetLegSources(AliDielectronSignalMC::kSecondaryFromMaterial, AliDielectronSignalMC::kSecondaryFromMaterial);
+        AliDielectronSignalMC FourElePair2_samePion("FourElePair2_samePion","FourElePair2_samePion");
+        FourElePair2_samePion.SetLegPDGs(11,-11);
+        FourElePair2_samePion.SetCheckBothChargesLegs(kTRUE,kTRUE);
+        FourElePair2_samePion.SetLegSources(AliDielectronSignalMC::kSecondary, AliDielectronSignalMC::kSecondary);
+        // FourElePair2_samePion.SetLegSources(AliDielectronSignalMC::kFinalState, AliDielectronSignalMC::kFinalState);
+        // FourElePair2_samePion.SetLegSources(AliDielectronSignalMC::kSecondaryFromMaterial, AliDielectronSignalMC::kSecondaryFromMaterial);
         // mother
-        FourElePair2_FromPion.SetMothersRelation(AliDielectronSignalMC::kSame);
-        FourElePair2_FromPion.SetMotherPDGs(22, 22); //
+        FourElePair2_samePion.SetMothersRelation(AliDielectronSignalMC::kSame);
+        FourElePair2_samePion.SetMotherPDGs(22, 22); //
         // grand-mother
-        // FourElePair2_FromPion.SetGrandMothersRelation(AliDielectronSignalMC::kSame);
-        FourElePair2_FromPion.SetGrandMotherPDGs(111, 111); //
+        // FourElePair2_samePion.SetGrandMothersRelation(AliDielectronSignalMC::kSame);
+        FourElePair2_samePion.SetGrandMotherPDGs(111, 111); //
 
   //________________________________________________________
       // First Pair
-        AliDielectronSignalMC FourElePair1_FromPion_Dalitz("FourElePair1_FromPion_Dalitz","FourElePair1_FromPion_Dalitz");
-        FourElePair1_FromPion_Dalitz.SetLegPDGs(11,-11);
-        FourElePair1_FromPion_Dalitz.SetCheckBothChargesLegs(kTRUE,kTRUE);
-        FourElePair1_FromPion_Dalitz.SetLegSources(AliDielectronSignalMC::kFinalState, AliDielectronSignalMC::kFinalState);
+        AliDielectronSignalMC FourElePair1_samePion_Dalitz("FourElePair1_samePion_Dalitz","FourElePair1_samePion_Dalitz");
+        FourElePair1_samePion_Dalitz.SetLegPDGs(11,-11);
+        FourElePair1_samePion_Dalitz.SetCheckBothChargesLegs(kTRUE,kTRUE);
+        FourElePair1_samePion_Dalitz.SetLegSources(AliDielectronSignalMC::kFinalState, AliDielectronSignalMC::kFinalState);
         //mother
-        FourElePair1_FromPion_Dalitz.SetMothersRelation(AliDielectronSignalMC::kSame);
-        FourElePair1_FromPion_Dalitz.SetMotherPDGs(111, 111); //
+        FourElePair1_samePion_Dalitz.SetMothersRelation(AliDielectronSignalMC::kSame);
+        FourElePair1_samePion_Dalitz.SetMotherPDGs(111, 111); //
         // check if mother of first pair is grand mother of second pair or vice versa
-        FourElePair1_FromPion_Dalitz.SetCheckMotherGrandmotherDiffPairRelation(kTRUE,kTRUE); // is assuming that both pairs using: SetMothersRelation(AliDielectronSignalMC::kSame)
+        FourElePair1_samePion_Dalitz.SetCheckMotherGrandmotherDiffPairRelation(kTRUE,kTRUE); // is assuming that both pairs using: SetMothersRelation(AliDielectronSignalMC::kSame)
 
       // Second Pair
-        AliDielectronSignalMC FourElePair2_FromPion_Dalitz("FourElePair2_FromPion_Dalitz","FourElePair2_FromPion_Dalitz");
-        FourElePair2_FromPion_Dalitz.SetLegPDGs(11,-11);
-        FourElePair2_FromPion_Dalitz.SetCheckBothChargesLegs(kTRUE,kTRUE);
-        FourElePair2_FromPion_Dalitz.SetLegSources(AliDielectronSignalMC::kSecondary, AliDielectronSignalMC::kSecondary);
-        // FourElePair2_FromPion_Dalitz.SetLegSources(AliDielectronSignalMC::kFinalState, AliDielectronSignalMC::kFinalState);
-        // FourElePair2_FromPion_Dalitz.SetLegSources(AliDielectronSignalMC::kSecondaryFromMaterial, AliDielectronSignalMC::kSecondaryFromMaterial);
+        AliDielectronSignalMC FourElePair2_samePion_Dalitz("FourElePair2_samePion_Dalitz","FourElePair2_samePion_Dalitz");
+        FourElePair2_samePion_Dalitz.SetLegPDGs(11,-11);
+        FourElePair2_samePion_Dalitz.SetCheckBothChargesLegs(kTRUE,kTRUE);
+        FourElePair2_samePion_Dalitz.SetLegSources(AliDielectronSignalMC::kSecondary, AliDielectronSignalMC::kSecondary);
+        // FourElePair2_samePion_Dalitz.SetLegSources(AliDielectronSignalMC::kFinalState, AliDielectronSignalMC::kFinalState);
+        // FourElePair2_samePion_Dalitz.SetLegSources(AliDielectronSignalMC::kSecondaryFromMaterial, AliDielectronSignalMC::kSecondaryFromMaterial);
         // mother
-        FourElePair2_FromPion_Dalitz.SetMothersRelation(AliDielectronSignalMC::kSame);
-        FourElePair2_FromPion_Dalitz.SetMotherPDGs(22, 22); //
+        FourElePair2_samePion_Dalitz.SetMothersRelation(AliDielectronSignalMC::kSame);
+        FourElePair2_samePion_Dalitz.SetMotherPDGs(22, 22); //
         // grand-mother
-        // FourElePair2_FromPion_Dalitz.SetGrandMothersRelation(AliDielectronSignalMC::kSame);
-        FourElePair2_FromPion_Dalitz.SetGrandMotherPDGs(111, 111); //
+        // FourElePair2_samePion_Dalitz.SetGrandMothersRelation(AliDielectronSignalMC::kSame);
+        FourElePair2_samePion_Dalitz.SetGrandMotherPDGs(111, 111); //
         // check if mother of first pair is grand mother of second pair or vice versa
-        FourElePair2_FromPion_Dalitz.SetCheckMotherGrandmotherDiffPairRelation(kTRUE,kTRUE); // is assuming that both pairs using: SetMothersRelation(AliDielectronSignalMC::kSame)
+        FourElePair2_samePion_Dalitz.SetCheckMotherGrandmotherDiffPairRelation(kTRUE,kTRUE); // is assuming that both pairs using: SetMothersRelation(AliDielectronSignalMC::kSame)
 
   //________________________________________________________
       // First Pair
-        AliDielectronSignalMC FourElePair1_FromEta("FourElePair1_FromEta","FourElePair1_FromEta");
-        FourElePair1_FromEta.SetLegPDGs(11,-11);
-        FourElePair1_FromEta.SetCheckBothChargesLegs(kTRUE,kTRUE);
-        FourElePair1_FromEta.SetLegSources(AliDielectronSignalMC::kFinalState, AliDielectronSignalMC::kFinalState);
+        AliDielectronSignalMC FourElePair1_sameEta("FourElePair1_sameEta","FourElePair1_sameEta");
+        FourElePair1_sameEta.SetLegPDGs(11,-11);
+        FourElePair1_sameEta.SetCheckBothChargesLegs(kTRUE,kTRUE);
+        FourElePair1_sameEta.SetLegSources(AliDielectronSignalMC::kFinalState, AliDielectronSignalMC::kFinalState);
         //mother
-        FourElePair1_FromEta.SetMothersRelation(AliDielectronSignalMC::kSame);
-        FourElePair1_FromEta.SetMotherPDGs(221, 221); //
+        FourElePair1_sameEta.SetMothersRelation(AliDielectronSignalMC::kSame);
+        FourElePair1_sameEta.SetMotherPDGs(221, 221); //
 
       // Second Pair
-        AliDielectronSignalMC FourElePair2_FromEta("FourElePair2_FromEta","FourElePair2_FromEta");
-        FourElePair2_FromEta.SetLegPDGs(11,-11);
-        FourElePair2_FromEta.SetCheckBothChargesLegs(kTRUE,kTRUE);
-        FourElePair2_FromEta.SetLegSources(AliDielectronSignalMC::kSecondary, AliDielectronSignalMC::kSecondary);
-        // FourElePair2_FromEta.SetLegSources(AliDielectronSignalMC::kFinalState, AliDielectronSignalMC::kFinalState);
-        // FourElePair2_FromEta.SetLegSources(AliDielectronSignalMC::kSecondaryFromMaterial, AliDielectronSignalMC::kSecondaryFromMaterial);
+        AliDielectronSignalMC FourElePair2_sameEta("FourElePair2_sameEta","FourElePair2_sameEta");
+        FourElePair2_sameEta.SetLegPDGs(11,-11);
+        FourElePair2_sameEta.SetCheckBothChargesLegs(kTRUE,kTRUE);
+        FourElePair2_sameEta.SetLegSources(AliDielectronSignalMC::kSecondary, AliDielectronSignalMC::kSecondary);
+        // FourElePair2_sameEta.SetLegSources(AliDielectronSignalMC::kFinalState, AliDielectronSignalMC::kFinalState);
+        // FourElePair2_sameEta.SetLegSources(AliDielectronSignalMC::kSecondaryFromMaterial, AliDielectronSignalMC::kSecondaryFromMaterial);
         // mother
-        FourElePair2_FromEta.SetMothersRelation(AliDielectronSignalMC::kSame);
-        FourElePair2_FromEta.SetMotherPDGs(22, 22); //
+        FourElePair2_sameEta.SetMothersRelation(AliDielectronSignalMC::kSame);
+        FourElePair2_sameEta.SetMotherPDGs(22, 22); //
         // grand-mother
-        // FourElePair2_FromEta.SetGrandMothersRelation(AliDielectronSignalMC::kSame);
-        FourElePair2_FromEta.SetGrandMotherPDGs(221, 221); //
+        // FourElePair2_sameEta.SetGrandMothersRelation(AliDielectronSignalMC::kSame);
+        FourElePair2_sameEta.SetGrandMotherPDGs(221, 221); //
 
   //________________________________________________________
       // First Pair
-        AliDielectronSignalMC FourElePair1_FromEta_Dalitz("FourElePair1_FromEta_Dalitz","FourElePair1_FromEta_Dalitz");
-        FourElePair1_FromEta_Dalitz.SetLegPDGs(11,-11);
-        FourElePair1_FromEta_Dalitz.SetCheckBothChargesLegs(kTRUE,kTRUE);
-        FourElePair1_FromEta_Dalitz.SetLegSources(AliDielectronSignalMC::kFinalState, AliDielectronSignalMC::kFinalState);
+        AliDielectronSignalMC FourElePair1_sameEta_Dalitz("FourElePair1_sameEta_Dalitz","FourElePair1_sameEta_Dalitz");
+        FourElePair1_sameEta_Dalitz.SetLegPDGs(11,-11);
+        FourElePair1_sameEta_Dalitz.SetCheckBothChargesLegs(kTRUE,kTRUE);
+        FourElePair1_sameEta_Dalitz.SetLegSources(AliDielectronSignalMC::kFinalState, AliDielectronSignalMC::kFinalState);
         //mother
-        FourElePair1_FromEta_Dalitz.SetMothersRelation(AliDielectronSignalMC::kSame);
-        FourElePair1_FromEta_Dalitz.SetMotherPDGs(221, 221); //
+        FourElePair1_sameEta_Dalitz.SetMothersRelation(AliDielectronSignalMC::kSame);
+        FourElePair1_sameEta_Dalitz.SetMotherPDGs(221, 221); //
         // check if mother of first pair is grand mother of second pair or vice versa
-        FourElePair1_FromEta_Dalitz.SetCheckMotherGrandmotherDiffPairRelation(kTRUE,kTRUE); // is assuming that both pairs using: SetMothersRelation(AliDielectronSignalMC::kSame)
+        FourElePair1_sameEta_Dalitz.SetCheckMotherGrandmotherDiffPairRelation(kTRUE,kTRUE); // is assuming that both pairs using: SetMothersRelation(AliDielectronSignalMC::kSame)
 
       // Second Pair
-        AliDielectronSignalMC FourElePair2_FromEta_Dalitz("FourElePair2_FromEta_Dalitz","FourElePair2_FromEta_Dalitz");
-        FourElePair2_FromEta_Dalitz.SetLegPDGs(11,-11);
-        FourElePair2_FromEta_Dalitz.SetCheckBothChargesLegs(kTRUE,kTRUE);
-        FourElePair2_FromEta_Dalitz.SetLegSources(AliDielectronSignalMC::kSecondary, AliDielectronSignalMC::kSecondary);
-        // FourElePair2_FromEta_Dalitz.SetLegSources(AliDielectronSignalMC::kFinalState, AliDielectronSignalMC::kFinalState);
-        // FourElePair2_FromEta_Dalitz.SetLegSources(AliDielectronSignalMC::kSecondaryFromMaterial, AliDielectronSignalMC::kSecondaryFromMaterial);
+        AliDielectronSignalMC FourElePair2_sameEta_Dalitz("FourElePair2_sameEta_Dalitz","FourElePair2_sameEta_Dalitz");
+        FourElePair2_sameEta_Dalitz.SetLegPDGs(11,-11);
+        FourElePair2_sameEta_Dalitz.SetCheckBothChargesLegs(kTRUE,kTRUE);
+        FourElePair2_sameEta_Dalitz.SetLegSources(AliDielectronSignalMC::kSecondary, AliDielectronSignalMC::kSecondary);
+        // FourElePair2_sameEta_Dalitz.SetLegSources(AliDielectronSignalMC::kFinalState, AliDielectronSignalMC::kFinalState);
+        // FourElePair2_sameEta_Dalitz.SetLegSources(AliDielectronSignalMC::kSecondaryFromMaterial, AliDielectronSignalMC::kSecondaryFromMaterial);
         // mother
-        FourElePair2_FromEta_Dalitz.SetMothersRelation(AliDielectronSignalMC::kSame);
-        FourElePair2_FromEta_Dalitz.SetMotherPDGs(22, 22); //
+        FourElePair2_sameEta_Dalitz.SetMothersRelation(AliDielectronSignalMC::kSame);
+        FourElePair2_sameEta_Dalitz.SetMotherPDGs(22, 22); //
         // grand-mother
-        // FourElePair2_FromEta_Dalitz.SetGrandMothersRelation(AliDielectronSignalMC::kSame);
-        FourElePair2_FromEta_Dalitz.SetGrandMotherPDGs(221, 221); //
+        // FourElePair2_sameEta_Dalitz.SetGrandMothersRelation(AliDielectronSignalMC::kSame);
+        FourElePair2_sameEta_Dalitz.SetGrandMotherPDGs(221, 221); //
         // check if mother of first pair is grand mother of second pair or vice versa
-        FourElePair2_FromEta_Dalitz.SetCheckMotherGrandmotherDiffPairRelation(kTRUE,kTRUE); // is assuming that both pairs using: SetMothersRelation(AliDielectronSignalMC::kSame)
-
-
-  //________________________________________________________
-      // First Pair
-        AliDielectronSignalMC FourElePair1_MissMatchPionEta_Dalitz("FourElePair1_MissMatchPionEta_Dalitz","FourElePair1_MissMatchPionEta_Dalitz");
-        FourElePair1_MissMatchPionEta_Dalitz.SetLegPDGs(11,-11);
-        FourElePair1_MissMatchPionEta_Dalitz.SetCheckBothChargesLegs(kTRUE,kTRUE);
-        FourElePair1_MissMatchPionEta_Dalitz.SetLegSources(AliDielectronSignalMC::kFinalState, AliDielectronSignalMC::kFinalState);
-        //mother
-        FourElePair1_MissMatchPionEta_Dalitz.SetMothersRelation(AliDielectronSignalMC::kSame);
-        FourElePair1_MissMatchPionEta_Dalitz.SetMotherPDGs(111, 111); //
-        // check if mother of first pair is grand mother of second pair or vice versa
-        // FourElePair1_MissMatchPionEta_Dalitz.SetCheckMotherGrandmotherDiffPairRelation(kTRUE,kTRUE); // is assuming that both pairs using: SetMothersRelation(AliDielectronSignalMC::kSame)
-
-      // Second Pair
-        AliDielectronSignalMC FourElePair2_MissMatchPionEta_Dalitz("FourElePair2_MissMatchPionEta_Dalitz","FourElePair2_MissMatchPionEta_Dalitz");
-        FourElePair2_MissMatchPionEta_Dalitz.SetLegPDGs(11,-11);
-        FourElePair2_MissMatchPionEta_Dalitz.SetCheckBothChargesLegs(kTRUE,kTRUE);
-        FourElePair2_MissMatchPionEta_Dalitz.SetLegSources(AliDielectronSignalMC::kSecondary, AliDielectronSignalMC::kSecondary);
-        // FourElePair2_MissMatchPionEta_Dalitz.SetLegSources(AliDielectronSignalMC::kFinalState, AliDielectronSignalMC::kFinalState);
-        // FourElePair2_MissMatchPionEta_Dalitz.SetLegSources(AliDielectronSignalMC::kSecondaryFromMaterial, AliDielectronSignalMC::kSecondaryFromMaterial);
-        // mother
-        FourElePair2_MissMatchPionEta_Dalitz.SetMothersRelation(AliDielectronSignalMC::kSame);
-        FourElePair2_MissMatchPionEta_Dalitz.SetMotherPDGs(22, 22); //
-        // grand-mother
-        // FourElePair2_MissMatchPionEta_Dalitz.SetGrandMothersRelation(AliDielectronSignalMC::kSame);
-        FourElePair2_MissMatchPionEta_Dalitz.SetGrandMotherPDGs(221, 221); //
-        // check if mother of first pair is grand mother of second pair or vice versa
-        // FourElePair2_MissMatchPionEta_Dalitz.SetCheckMotherGrandmotherDiffPairRelation(kTRUE,kTRUE); // is assuming that both pairs using: SetMothersRelation(AliDielectronSignalMC::kSame)
+        FourElePair2_sameEta_Dalitz.SetCheckMotherGrandmotherDiffPairRelation(kTRUE,kTRUE); // is assuming that both pairs using: SetMothersRelation(AliDielectronSignalMC::kSame)
 
 
   //________________________________________________________
       // First Pair
-        AliDielectronSignalMC FourElePair1_MissMatchEtaPion_Dalitz("FourElePair1_MissMatchEtaPion_Dalitz","FourElePair1_MissMatchEtaPion_Dalitz");
-        FourElePair1_MissMatchEtaPion_Dalitz.SetLegPDGs(11,-11);
-        FourElePair1_MissMatchEtaPion_Dalitz.SetCheckBothChargesLegs(kTRUE,kTRUE);
-        FourElePair1_MissMatchEtaPion_Dalitz.SetLegSources(AliDielectronSignalMC::kFinalState, AliDielectronSignalMC::kFinalState);
+        AliDielectronSignalMC FourElePair1_MissMatchPionEta("FourElePair1_MissMatchPionEta","FourElePair1_MissMatchPionEta");
+        FourElePair1_MissMatchPionEta.SetLegPDGs(11,-11);
+        FourElePair1_MissMatchPionEta.SetCheckBothChargesLegs(kTRUE,kTRUE);
+        FourElePair1_MissMatchPionEta.SetLegSources(AliDielectronSignalMC::kFinalState, AliDielectronSignalMC::kFinalState);
         //mother
-        FourElePair1_MissMatchEtaPion_Dalitz.SetMothersRelation(AliDielectronSignalMC::kSame);
-        FourElePair1_MissMatchEtaPion_Dalitz.SetMotherPDGs(221, 221); //
+        FourElePair1_MissMatchPionEta.SetMothersRelation(AliDielectronSignalMC::kSame);
+        FourElePair1_MissMatchPionEta.SetMotherPDGs(111, 111); //
         // check if mother of first pair is grand mother of second pair or vice versa
-        // FourElePair1_MissMatchEtaPion_Dalitz.SetCheckMotherGrandmotherDiffPairRelation(kTRUE,kTRUE); // is assuming that both pairs using: SetMothersRelation(AliDielectronSignalMC::kSame)
+        // FourElePair1_MissMatchPionEta.SetCheckMotherGrandmotherDiffPairRelation(kTRUE,kTRUE); // is assuming that both pairs using: SetMothersRelation(AliDielectronSignalMC::kSame)
 
       // Second Pair
-        AliDielectronSignalMC FourElePair2_MissMatchEtaPion_Dalitz("FourElePair2_MissMatchEtaPion_Dalitz","FourElePair2_MissMatchEtaPion_Dalitz");
-        FourElePair2_MissMatchEtaPion_Dalitz.SetLegPDGs(11,-11);
-        FourElePair2_MissMatchEtaPion_Dalitz.SetCheckBothChargesLegs(kTRUE,kTRUE);
-        FourElePair2_MissMatchEtaPion_Dalitz.SetLegSources(AliDielectronSignalMC::kSecondary, AliDielectronSignalMC::kSecondary);
-        // FourElePair2_MissMatchEtaPion_Dalitz.SetLegSources(AliDielectronSignalMC::kFinalState, AliDielectronSignalMC::kFinalState);
-        // FourElePair2_MissMatchEtaPion_Dalitz.SetLegSources(AliDielectronSignalMC::kSecondaryFromMaterial, AliDielectronSignalMC::kSecondaryFromMaterial);
+        AliDielectronSignalMC FourElePair2_MissMatchPionEta("FourElePair2_MissMatchPionEta","FourElePair2_MissMatchPionEta");
+        FourElePair2_MissMatchPionEta.SetLegPDGs(11,-11);
+        FourElePair2_MissMatchPionEta.SetCheckBothChargesLegs(kTRUE,kTRUE);
+        FourElePair2_MissMatchPionEta.SetLegSources(AliDielectronSignalMC::kSecondary, AliDielectronSignalMC::kSecondary);
+        // FourElePair2_MissMatchPionEta.SetLegSources(AliDielectronSignalMC::kFinalState, AliDielectronSignalMC::kFinalState);
+        // FourElePair2_MissMatchPionEta.SetLegSources(AliDielectronSignalMC::kSecondaryFromMaterial, AliDielectronSignalMC::kSecondaryFromMaterial);
         // mother
-        FourElePair2_MissMatchEtaPion_Dalitz.SetMothersRelation(AliDielectronSignalMC::kSame);
-        FourElePair2_MissMatchEtaPion_Dalitz.SetMotherPDGs(22, 22); //
+        FourElePair2_MissMatchPionEta.SetMothersRelation(AliDielectronSignalMC::kSame);
+        FourElePair2_MissMatchPionEta.SetMotherPDGs(22, 22); //
         // grand-mother
-        // FourElePair2_MissMatchEtaPion_Dalitz.SetGrandMothersRelation(AliDielectronSignalMC::kSame);
-        FourElePair2_MissMatchEtaPion_Dalitz.SetGrandMotherPDGs(111, 111); //
+        // FourElePair2_MissMatchPionEta.SetGrandMothersRelation(AliDielectronSignalMC::kSame);
+        FourElePair2_MissMatchPionEta.SetGrandMotherPDGs(221, 221); //
         // check if mother of first pair is grand mother of second pair or vice versa
-        // FourElePair2_MissMatchEtaPion_Dalitz.SetCheckMotherGrandmotherDiffPairRelation(kTRUE,kTRUE); // is assuming that both pairs using: SetMothersRelation(AliDielectronSignalMC::kSame)
+        // FourElePair2_MissMatchPionEta.SetCheckMotherGrandmotherDiffPairRelation(kTRUE,kTRUE); // is assuming that both pairs using: SetMothersRelation(AliDielectronSignalMC::kSame)
+
+
+  //________________________________________________________
+      // First Pair
+        AliDielectronSignalMC FourElePair1_MissMatchEtaPion("FourElePair1_MissMatchEtaPion","FourElePair1_MissMatchEtaPion");
+        FourElePair1_MissMatchEtaPion.SetLegPDGs(11,-11);
+        FourElePair1_MissMatchEtaPion.SetCheckBothChargesLegs(kTRUE,kTRUE);
+        FourElePair1_MissMatchEtaPion.SetLegSources(AliDielectronSignalMC::kFinalState, AliDielectronSignalMC::kFinalState);
+        //mother
+        FourElePair1_MissMatchEtaPion.SetMothersRelation(AliDielectronSignalMC::kSame);
+        FourElePair1_MissMatchEtaPion.SetMotherPDGs(221, 221); //
+        // check if mother of first pair is grand mother of second pair or vice versa
+        // FourElePair1_MissMatchEtaPion.SetCheckMotherGrandmotherDiffPairRelation(kTRUE,kTRUE); // is assuming that both pairs using: SetMothersRelation(AliDielectronSignalMC::kSame)
+
+      // Second Pair
+        AliDielectronSignalMC FourElePair2_MissMatchEtaPion("FourElePair2_MissMatchEtaPion","FourElePair2_MissMatchEtaPion");
+        FourElePair2_MissMatchEtaPion.SetLegPDGs(11,-11);
+        FourElePair2_MissMatchEtaPion.SetCheckBothChargesLegs(kTRUE,kTRUE);
+        FourElePair2_MissMatchEtaPion.SetLegSources(AliDielectronSignalMC::kSecondary, AliDielectronSignalMC::kSecondary);
+        // FourElePair2_MissMatchEtaPion.SetLegSources(AliDielectronSignalMC::kFinalState, AliDielectronSignalMC::kFinalState);
+        // FourElePair2_MissMatchEtaPion.SetLegSources(AliDielectronSignalMC::kSecondaryFromMaterial, AliDielectronSignalMC::kSecondaryFromMaterial);
+        // mother
+        FourElePair2_MissMatchEtaPion.SetMothersRelation(AliDielectronSignalMC::kSame);
+        FourElePair2_MissMatchEtaPion.SetMotherPDGs(22, 22); //
+        // grand-mother
+        // FourElePair2_MissMatchEtaPion.SetGrandMothersRelation(AliDielectronSignalMC::kSame);
+        FourElePair2_MissMatchEtaPion.SetGrandMotherPDGs(111, 111); //
+        // check if mother of first pair is grand mother of second pair or vice versa
+        // FourElePair2_MissMatchEtaPion.SetCheckMotherGrandmotherDiffPairRelation(kTRUE,kTRUE); // is assuming that both pairs using: SetMothersRelation(AliDielectronSignalMC::kSame)
 
 
   //________________________________________________________
@@ -1388,15 +1388,15 @@ void AddFourPairMCSignal_PrimSec(AliAnalysisTaskEtaReconstruction* task){
 
 
       // Second Pair
-        AliDielectronSignalMC FourElePair2_Secondary_from_UndefinedMother("FourElePair2_Secondary_from_UndefinedMother","FourElePair2_Secondary_from_UndefinedMother");
-        FourElePair2_Secondary_from_UndefinedMother.SetLegPDGs(11,-11);
-        FourElePair2_Secondary_from_UndefinedMother.SetCheckBothChargesLegs(kTRUE,kTRUE);
-        FourElePair2_Secondary_from_UndefinedMother.SetLegSources(AliDielectronSignalMC::kSecondary, AliDielectronSignalMC::kSecondary);
-        // FourElePair2_Secondary_from_UndefinedMother.SetLegSources(AliDielectronSignalMC::kFinalState, AliDielectronSignalMC::kFinalState);
-        // FourElePair2_Secondary_from_UndefinedMother.SetLegSources(AliDielectronSignalMC::kSecondaryFromMaterial, AliDielectronSignalMC::kSecondaryFromMaterial);
+        AliDielectronSignalMC FourElePair2_Secondary_UndefinedMother("FourElePair2_Secondary_UndefinedMother","FourElePair2_Secondary_UndefinedMother");
+        FourElePair2_Secondary_UndefinedMother.SetLegPDGs(11,-11);
+        FourElePair2_Secondary_UndefinedMother.SetCheckBothChargesLegs(kTRUE,kTRUE);
+        FourElePair2_Secondary_UndefinedMother.SetLegSources(AliDielectronSignalMC::kSecondary, AliDielectronSignalMC::kSecondary);
+        // FourElePair2_Secondary_UndefinedMother.SetLegSources(AliDielectronSignalMC::kFinalState, AliDielectronSignalMC::kFinalState);
+        // FourElePair2_Secondary_UndefinedMother.SetLegSources(AliDielectronSignalMC::kSecondaryFromMaterial, AliDielectronSignalMC::kSecondaryFromMaterial);
         // mother
-        FourElePair2_Secondary_from_UndefinedMother.SetMothersRelation(AliDielectronSignalMC::kUndefined);
-        // FourElePair2_Secondary_from_UndefinedMother.SetMotherPDGs(22, 22); //
+        FourElePair2_Secondary_UndefinedMother.SetMothersRelation(AliDielectronSignalMC::kUndefined);
+        // FourElePair2_Secondary_UndefinedMother.SetMotherPDGs(22, 22); //
 
 
   //________________________________________________________
@@ -1420,31 +1420,31 @@ void AddFourPairMCSignal_PrimSec(AliAnalysisTaskEtaReconstruction* task){
 
 //________________________________________________________
     task->AddFourPairMCSignal_PrimSec(FourElePair1_FinalState);
-    task->AddFourPairMCSignal_PrimSec(FourElePair2_Secondary_from_Photon);
+    task->AddFourPairMCSignal_PrimSec(FourElePair2_Secondary_samePhoton);
 
     task->AddFourPairMCSignal_PrimSec(FourElePair1_FinalState_Dalitz);
-    task->AddFourPairMCSignal_PrimSec(FourElePair2_Secondary_from_Photon_Dalitz);
+    task->AddFourPairMCSignal_PrimSec(FourElePair2_Secondary_samePhoton_Dalitz);
 
-    task->AddFourPairMCSignal_PrimSec(FourElePair1_FromPion);
-    task->AddFourPairMCSignal_PrimSec(FourElePair2_FromPion);
+    task->AddFourPairMCSignal_PrimSec(FourElePair1_samePion);
+    task->AddFourPairMCSignal_PrimSec(FourElePair2_samePion);
 
-    task->AddFourPairMCSignal_PrimSec(FourElePair1_FromPion_Dalitz);
-    task->AddFourPairMCSignal_PrimSec(FourElePair2_FromPion_Dalitz);
+    task->AddFourPairMCSignal_PrimSec(FourElePair1_samePion_Dalitz);
+    task->AddFourPairMCSignal_PrimSec(FourElePair2_samePion_Dalitz);
 
-    task->AddFourPairMCSignal_PrimSec(FourElePair1_FromEta);
-    task->AddFourPairMCSignal_PrimSec(FourElePair2_FromEta);
+    task->AddFourPairMCSignal_PrimSec(FourElePair1_sameEta);
+    task->AddFourPairMCSignal_PrimSec(FourElePair2_sameEta);
 
-    task->AddFourPairMCSignal_PrimSec(FourElePair1_FromEta_Dalitz);
-    task->AddFourPairMCSignal_PrimSec(FourElePair2_FromEta_Dalitz);
+    task->AddFourPairMCSignal_PrimSec(FourElePair1_sameEta_Dalitz);
+    task->AddFourPairMCSignal_PrimSec(FourElePair2_sameEta_Dalitz);
 
-    task->AddFourPairMCSignal_PrimSec(FourElePair1_MissMatchPionEta_Dalitz);
-    task->AddFourPairMCSignal_PrimSec(FourElePair2_MissMatchPionEta_Dalitz);
+    task->AddFourPairMCSignal_PrimSec(FourElePair1_MissMatchPionEta);
+    task->AddFourPairMCSignal_PrimSec(FourElePair2_MissMatchPionEta);
 
-    task->AddFourPairMCSignal_PrimSec(FourElePair1_MissMatchEtaPion_Dalitz);
-    task->AddFourPairMCSignal_PrimSec(FourElePair2_MissMatchEtaPion_Dalitz);
+    task->AddFourPairMCSignal_PrimSec(FourElePair1_MissMatchEtaPion);
+    task->AddFourPairMCSignal_PrimSec(FourElePair2_MissMatchEtaPion);
 
     task->AddFourPairMCSignal_PrimSec(FourElePair1_FinalState_UndefinedMother);
-    task->AddFourPairMCSignal_PrimSec(FourElePair2_Secondary_from_UndefinedMother);
+    task->AddFourPairMCSignal_PrimSec(FourElePair2_Secondary_UndefinedMother);
 
     if(UseMCDataSig) task->AddFourPairMCSignal_PrimSec(FourAnyPartPair1_FinalState_UndefinedMother);
     if(UseMCDataSig) task->AddFourPairMCSignal_PrimSec(FourAnyPartPair2_Secondary_UndefinedMother);
@@ -1459,23 +1459,50 @@ void AddFourPairMCSignal_SecSec(AliAnalysisTaskEtaReconstruction* task){
   //
   //________________________________________________________
       // First Pair
-        AliDielectronSignalMC FourElePair1_Secondary_from_Photon("FourElePair1_Secondary_from_Photon","FourElePair1_Secondary_from_Photon");
-        FourElePair1_Secondary_from_Photon.SetLegPDGs(11,-11);
-        FourElePair1_Secondary_from_Photon.SetCheckBothChargesLegs(kTRUE,kTRUE);
-        FourElePair1_Secondary_from_Photon.SetLegSources(AliDielectronSignalMC::kSecondary, AliDielectronSignalMC::kSecondary);
+        AliDielectronSignalMC FourElePair1_Secondary_samePhoton("FourElePair1_Secondary_samePhoton","FourElePair1_Secondary_samePhoton");
+        FourElePair1_Secondary_samePhoton.SetLegPDGs(11,-11);
+        FourElePair1_Secondary_samePhoton.SetCheckBothChargesLegs(kTRUE,kTRUE);
+        FourElePair1_Secondary_samePhoton.SetLegSources(AliDielectronSignalMC::kSecondary, AliDielectronSignalMC::kSecondary);
         // mother
-        FourElePair1_Secondary_from_Photon.SetMothersRelation(AliDielectronSignalMC::kSame);
-        FourElePair1_Secondary_from_Photon.SetMotherPDGs(22, 22); //
+        FourElePair1_Secondary_samePhoton.SetMothersRelation(AliDielectronSignalMC::kSame);
+        FourElePair1_Secondary_samePhoton.SetMotherPDGs(22, 22); //
 
 
       // Second Pair
-        AliDielectronSignalMC FourElePair2_Secondary_from_Photon("FourElePair2_Secondary_from_Photon","FourElePair2_Secondary_from_Photon");
-        FourElePair2_Secondary_from_Photon.SetLegPDGs(11,-11);
-        FourElePair2_Secondary_from_Photon.SetCheckBothChargesLegs(kTRUE,kTRUE);
-        FourElePair2_Secondary_from_Photon.SetLegSources(AliDielectronSignalMC::kSecondary, AliDielectronSignalMC::kSecondary);
+        AliDielectronSignalMC FourElePair2_Secondary_samePhoton("FourElePair2_Secondary_samePhoton","FourElePair2_Secondary_samePhoton");
+        FourElePair2_Secondary_samePhoton.SetLegPDGs(11,-11);
+        FourElePair2_Secondary_samePhoton.SetCheckBothChargesLegs(kTRUE,kTRUE);
+        FourElePair2_Secondary_samePhoton.SetLegSources(AliDielectronSignalMC::kSecondary, AliDielectronSignalMC::kSecondary);
         // mother
-        FourElePair2_Secondary_from_Photon.SetMothersRelation(AliDielectronSignalMC::kSame);
-        FourElePair2_Secondary_from_Photon.SetMotherPDGs(22, 22); //
+        FourElePair2_Secondary_samePhoton.SetMothersRelation(AliDielectronSignalMC::kSame);
+        FourElePair2_Secondary_samePhoton.SetMotherPDGs(22, 22); //
+
+
+  //________________________________________________________
+      // First Pair
+        AliDielectronSignalMC FourElePair1_Secondary_samePhoton_sameEta("FourElePair1_Secondary_samePhoton_sameEta","FourElePair1_Secondary_samePhoton_sameEta");
+        FourElePair1_Secondary_samePhoton_sameEta.SetLegPDGs(11,-11);
+        FourElePair1_Secondary_samePhoton_sameEta.SetCheckBothChargesLegs(kTRUE,kTRUE);
+        FourElePair1_Secondary_samePhoton_sameEta.SetLegSources(AliDielectronSignalMC::kSecondary, AliDielectronSignalMC::kSecondary);
+        // mother
+        FourElePair1_Secondary_samePhoton_sameEta.SetMothersRelation(AliDielectronSignalMC::kSame);
+        FourElePair1_Secondary_samePhoton_sameEta.SetMotherPDGs(22, 22); //
+        // grand mother
+        FourElePair1_Secondary_samePhoton_sameEta.SetGrandMothersRelation(AliDielectronSignalMC::kSame);
+        FourElePair1_Secondary_samePhoton_sameEta.SetGrandMotherPDGs(221, 221); //
+
+
+      // Second Pair
+        AliDielectronSignalMC FourElePair2_Secondary_samePhoton_sameEta("FourElePair2_Secondary_samePhoton_sameEta","FourElePair2_Secondary_samePhoton_sameEta");
+        FourElePair2_Secondary_samePhoton_sameEta.SetLegPDGs(11,-11);
+        FourElePair2_Secondary_samePhoton_sameEta.SetCheckBothChargesLegs(kTRUE,kTRUE);
+        FourElePair2_Secondary_samePhoton_sameEta.SetLegSources(AliDielectronSignalMC::kSecondary, AliDielectronSignalMC::kSecondary);
+        // mother
+        FourElePair2_Secondary_samePhoton_sameEta.SetMothersRelation(AliDielectronSignalMC::kSame);
+        FourElePair2_Secondary_samePhoton_sameEta.SetMotherPDGs(22, 22); //
+        // grand mother
+        FourElePair2_Secondary_samePhoton_sameEta.SetGrandMothersRelation(AliDielectronSignalMC::kSame);
+        FourElePair2_Secondary_samePhoton_sameEta.SetGrandMotherPDGs(221, 221); //
 
   //________________________________________________________
       // First Pair
@@ -1495,12 +1522,30 @@ void AddFourPairMCSignal_SecSec(AliAnalysisTaskEtaReconstruction* task){
         // mother
         FourAnyPartPair2_Secondary_UndefinedMother.SetMothersRelation(AliDielectronSignalMC::kUndefined);
 
+        //
+        // //________________________________________________________
+        //     // First Pair
+        //       AliDielectronSignalMC FourPairMCSignalTest1("FourPairMCSignalTest1","FourPairMCSignalTest1");
+        //       FourPairMCSignalTest1.SetLegSources(AliDielectronSignalMC::kSecondary, AliDielectronSignalMC::kSecondary);
+        //       FourPairMCSignalTest1.SetMothersRelation(AliDielectronSignalMC::kSame);
+        //     // Second Pair
+        //       AliDielectronSignalMC FourPairMCSignalTest2("FourPairMCSignalTest2","FourPairMCSignalTest2");
+        //       FourPairMCSignalTest2.SetLegSources(AliDielectronSignalMC::kSecondary, AliDielectronSignalMC::kSecondary);
+        //       FourPairMCSignalTest2.SetMothersRelation(AliDielectronSignalMC::kSame);
 
 
-//________________________________________________________
-    task->AddFourPairMCSignal_SecSec(FourElePair1_Secondary_from_Photon);
-    task->AddFourPairMCSignal_SecSec(FourElePair2_Secondary_from_Photon);
+// ________________________________________________________
+    task->AddFourPairMCSignal_SecSec(FourElePair1_Secondary_samePhoton);
+    task->AddFourPairMCSignal_SecSec(FourElePair2_Secondary_samePhoton);
+
+    task->AddFourPairMCSignal_SecSec(FourElePair1_Secondary_samePhoton_sameEta);
+    task->AddFourPairMCSignal_SecSec(FourElePair2_Secondary_samePhoton_sameEta);
+
 
     if(UseMCDataSig) task->AddFourPairMCSignal_SecSec(FourAnyPartPair1_Secondary_UndefinedMother);
     if(UseMCDataSig) task->AddFourPairMCSignal_SecSec(FourAnyPartPair2_Secondary_UndefinedMother);
+
+    // task->AddFourPairMCSignal_SecSec(FourPairMCSignalTest1);
+    // task->AddFourPairMCSignal_SecSec(FourPairMCSignalTest2);
+
 }


### PR DESCRIPTION
In the new commit an additional method is implemented in order to measure and reconstruct two photo conversions from an decayed eta meson.