### PR TITLE
PWGHF: Add unc. efficiency to total systematic

### DIFF
--- a/PWGHF/vertexingHF/AliHFPtSpectrum.cxx
+++ b/PWGHF/vertexingHF/AliHFPtSpectrum.cxx
@@ -1678,19 +1678,31 @@ void AliHFPtSpectrum::ComputeSystUncertainties(Bool_t combineFeedDown) {
   Double_t errylcomb=0., erryhcomb=0;
   for(Int_t i=0; i<nentries; i++) {
     fgSigmaCorr->GetPoint(i,x,y);
+    Int_t ibin = fhDirectEffpt->FindBin(x);
+    Double_t errEff = fhDirectEffpt->GetBinError(ibin)/fhDirectEffpt->GetBinContent(ibin);
     if (fFeedDownOption!=0 && combineFeedDown) {
 //      errylcomb = systematics->GetTotalSystErr(x,erryl) * y ;
 //        erryhcomb = systematics->GetTotalSystErr(x,erryh) * y ;
       errx = grErrFeeddown->GetErrorXlow(i) ;
       erryl = grErrFeeddown->GetErrorYlow(i);
       erryh = grErrFeeddown->GetErrorYhigh(i);
-      errylcomb = fSystematics->GetTotalSystErr(x,erryl) * y ;
-      erryhcomb = fSystematics->GetTotalSystErr(x,erryh) * y ;
+      errylcomb = fSystematics->GetTotalSystErr(x,erryl) * fSystematics->GetTotalSystErr(x,erryl);
+      erryhcomb = fSystematics->GetTotalSystErr(x,erryh) * fSystematics->GetTotalSystErr(x,erryh);
+      //Adding relative stat. unc. efficiency
+      errylcomb += errEff*errEff;
+      erryhcomb += errEff*errEff;
+      errylcomb = TMath::Sqrt(errylcomb) * y ;
+      erryhcomb = TMath::Sqrt(erryhcomb) * y ;
     } else {
 //      errylcomb = systematics->GetTotalSystErr(x) * y ;
 //        erryhcomb = systematics->GetTotalSystErr(x) * y ;
-      errylcomb = fSystematics->GetTotalSystErr(x) * y ;
-      erryhcomb = fSystematics->GetTotalSystErr(x) * y ;
+      errylcomb = fSystematics->GetTotalSystErr(x) * fSystematics->GetTotalSystErr(x);
+      erryhcomb = fSystematics->GetTotalSystErr(x) * fSystematics->GetTotalSystErr(x);
+      //Adding relative stat. unc. efficiency
+      errylcomb += errEff*errEff;
+      erryhcomb += errEff*errEff;
+      errylcomb = TMath::Sqrt(errylcomb) * y ;
+      erryhcomb = TMath::Sqrt(erryhcomb) * y ;
     }
     fgSigmaCorr->SetPointError(i,errx,errx,errylcomb,erryhcomb);
     //


### PR DESCRIPTION
Adding the relative statistical uncertainty of the prompt efficiency to the total systematic TGraph (gSigmaCorr). For most D meson analyses minor contribution (~1%), but can go up to ~5% for Lc in a D2H MC or in special HM MCs.

Now pp is also consistent with PbPb, where it is done here: https://github.com/alisw/AliPhysics/blob/66cc83e/PWGHF/vertexingHF/macros/ComputeDmesonYield.C#L996-L1007