### PR TITLE
PWGPP-592- OCDB dump and diff working also with the OCDB snapshot

### DIFF
--- a/PWGPP/CalibMacros/AliOCDBtoolkit.sh
+++ b/PWGPP/CalibMacros/AliOCDBtoolkit.sh
@@ -202,6 +202,9 @@ dumpObject(){
             dumpObject  alien:///alice/cern.ch/user/p/pwg_pp/JIRA/ALIROOT-8240/TPC/Calib/RecoParam/Run0_999999999_v0_s2.root    "object" "MI"  Run0_999999999_v0_s2.mi
             dumpObject  alien:///alice/cern.ch/user/p/pwg_pp/JIRA/ALIROOT-8240/TPC/Calib/RecoParam/Run0_999999999_v0_s2.root    "object" "POCDB"  Run0_999999999_v0_s2.pocdb
             dumpObject  alien:///alice/cern.ch/user/p/pwg_pp/JIRA/ALIROOT-8240/TPC/Calib/RecoParam/Run0_999999999_v0_s2.root    "object" "POCDB"  Run0_999999999_v0_s2.pocdb
+            dumpObject alien:///alice/sim/2020/LHC120c1/OCDB/297479/iontail1.0crosstalk0.0/OCDBsim.root "TPC*Calib*RecoParam" "XML" iontail1.0crosstalk0.0.xml
+            dumpObject alien:///alice/sim/2020/LHC120c1/OCDB/297479/iontail0.8crosstalk0.2/OCDBsim.root "TPC*Calib*RecoParam" "XML" iontail0.8crosstalk0.2.xml
+
 HELP_USAGE
     [[ $# -ne 4 ]] && return
     alilog_info "dumpObject BEGIN $1 $2 $3 $4"

--- a/PWGPP/CalibMacros/AliOCDBtoolkit.sh
+++ b/PWGPP/CalibMacros/AliOCDBtoolkit.sh
@@ -231,11 +231,21 @@ HELP_USAGE
     fi;
 
     tmpscript=$(mktemp)
-    cat > ${tmpscript} <<HEREDOC
+
+    if [ $fobject == "object" ] ; then
+        cat > ${tmpscript} <<HEREDOC
         {
             AliOCDBtoolkit::DumpOCDBFile("${inFile}","${outFile}",1,"${ftype}");
         }
 HEREDOC
+    else
+        cat > ${tmpscript} <<HEREDOC
+        {
+            AliOCDBtoolkit::DumpOCDBFile("${inFile}","${fobject}","${outFile}",0,"${ftype}");
+        }
+HEREDOC
+    fi
+
     root.exe -l -q -b ${tmpscript}
     sleep 60 && rm ${tmpscript} &
     alilog_success "dumpObject ${inFile} ${fobject} ${ftype} ${outFile}"

--- a/PWGPP/CalibMacros/AliOCDBtoolkit.sh
+++ b/PWGPP/CalibMacros/AliOCDBtoolkit.sh
@@ -204,6 +204,8 @@ dumpObject(){
             dumpObject  alien:///alice/cern.ch/user/p/pwg_pp/JIRA/ALIROOT-8240/TPC/Calib/RecoParam/Run0_999999999_v0_s2.root    "object" "POCDB"  Run0_999999999_v0_s2.pocdb
             dumpObject alien:///alice/sim/2020/LHC120c1/OCDB/297479/iontail1.0crosstalk0.0/OCDBsim.root "TPC*Calib*RecoParam" "XML" iontail1.0crosstalk0.0.xml
             dumpObject alien:///alice/sim/2020/LHC120c1/OCDB/297479/iontail0.8crosstalk0.2/OCDBsim.root "TPC*Calib*RecoParam" "XML" iontail0.8crosstalk0.2.xml
+            dumpObject alien:///alice/sim/2020/LHC120c1/OCDB/297479/iontail1.0crosstalk0.0/OCDBsim.root "TPC*Calib*GainFactorDedx" "pocdb all" iontail1.0crosstalk0.0.GainFactorDedx.print
+            dumpObject alien:///alice/data/2018/LHC18r/000297479/pass3/OCDB.root  "TPC*Calib*GainFactorDedx" "pocdb all" LHC18r.pass3.GainFactorDedx.print
 
 HELP_USAGE
     [[ $# -ne 4 ]] && return


### PR DESCRIPTION
For details see:
https://alice.its.cern.ch/jira/browse/PWGPP-592?focusedCommentId=248872&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-248872

## Example usage 1 - RecoParam diff 
```

recoParamDiff(){
    #Singularity> alien_find    /alice/sim/2020/LHC120c1/OCDB/297479/ OCDBsim.root
    # /alice/sim/2020/LHC120c1/OCDB/297479/iontail0.6crosstalk0.4/OCDBsim.root
    # /alice/sim/2020/LHC120c1/OCDB/297479/iontail0.8crosstalk0.2/OCDBsim.root
    # /alice/sim/2020/LHC120c1/OCDB/297479/iontail1.0crosstalk0.0/OCDBsim.root
    # /alice/sim/2020/LHC120c1/OCDB/297479/noiontail/OCDBsim.root
    # ls /alice/sim/2020/LHC120c1/OCDB/297479/OCDBsim.root
    source $AliPhysics_SRC/PWGPP/CalibMacros/AliOCDBtoolkit.sh
    dumpObject alien:///alice/sim/2020/LHC120c1/OCDB/297479/iontail1.0crosstalk0.0/OCDBsim.root "TPC*Calib*RecoParam" "XML" iontail1.0crosstalk0.0.xml
    dumpObject alien:///alice/sim/2020/LHC120c1/OCDB/297479/iontail0.8crosstalk0.2/OCDBsim.root "TPC*Calib*RecoParam" "XML" iontail0.8crosstalk0.2.xml
    diff --suppress-common-lines -y iontail1.0crosstalk0.0.xml  iontail0.8crosstalk0.2.xml
}
```
```
  <XmlKey name="AliCDBEntry" cycle="4" created="2020-05-31 11 |   <XmlKey name="AliCDBEntry" cycle="4" created="2020-05-31 11
        <fIonTailCorrection v="1.000000e+00"/>                |         <fIonTailCorrection v="8.000000e-01"/>
        <fCrosstalkCorrection v="0.000000e+00"/>              |         <fCrosstalkCorrection v="2.000000e-01"/>
  <XmlKey name="AliCDBEntry" cycle="3" created="2020-05-31 11 |   <XmlKey name="AliCDBEntry" cycle="3" created="2020-05-31 11
        <fIonTailCorrection v="1.000000e+00"/>                |         <fIonTailCorrection v="8.000000e-01"/>
        <fCrosstalkCorrection v="0.000000e+00"/>              |         <fCrosstalkCorrection v="2.000000e-01"/>
  <XmlKey name="AliCDBEntry" cycle="2" created="2020-05-31 11 |   <XmlKey name="AliCDBEntry" cycle="2" created="2020-05-31 11
        <fIonTailCorrection v="1.000000e+00"/>                |         <fIonTailCorrection v="8.000000e-01"/>
        <fCrosstalkCorrection v="0.000000e+00"/>              |         <fCrosstalkCorrection v="2.000000e-01"/>
  <XmlKey name="AliCDBEntry" cycle="1" created="2020-05-31 11 |   <XmlKey name="AliCDBEntry" cycle="1" created="2020-05-31 11
        <fIonTailCorrection v="1.000000e+00"/>                |         <fIonTailCorrection v="8.000000e-01"/>
        <fCrosstalkCorrection v="0.000000e+00"/>              |         <fCrosstalkCorrection v="2.000000e-01"/>

```



## Example usage 2 - Gain map aggregated diff  
```
gainDiff(){
    #compare gain map
    dumpObject alien:///alice/sim/2020/LHC120c1/OCDB/297479/iontail1.0crosstalk0.0/OCDBsim.root "TPC*Calib*GainFactorDedx" "pocdb all" iontail1.0crosstalk0.0.GainFactorDedx.print
    dumpObject alien:///alice/data/2018/LHC18r/000297479/pass3/OCDB.root  "TPC*Calib*GainFactorDedx" "pocdb all" LHC18r.pass3.GainFactorDedx.print
    diff --suppress-common-lines -y  iontail1.0crosstalk0.0.GainFactorDedx.print  LHC18r.pass3.GainFactorDedx.print
}

```
|       |Mean|  Median| RMS|
|--|--|--|--|
|ALL    |0.995423|      1.005181|       0.108049|
|ROC0|  0.977966|       0.999320|       0.107378|
|ROC1|  1.019171|       1.031983|       0.110654|
|ROC2|  1.014116|       1.022614|       0.087557|
|ROC3|  1.017703|       1.028242|       0.092070|
|ROC4|  0.990138|       0.993318|       0.096501|
|ROC5|  1.014701|       1.029409|       0.102698|
|ROC6|  0.978627|       0.982655|       0.098689|
|ROC7|  1.019368|       1.031555|       0.139829|
|ROC8|  1.017898|       1.031424|       0.085238|
|ROC9|  0.986449|       0.997007|       0.084243|
|ROC10| 1.001107|       1.017617|       0.091301|
|ROC11| 0.984506|       0.997770|       0.089258|
|ROC12| 0.991279|       1.000333|       0.101088|
|ROC13| 0.988853|       1.011793|       0.136668|
|ROC14| 0.996716|       1.005496|       0.103941|
|ROC15| 1.004975|       1.018177|       0.075384|
|ROC16| 1.007258|       1.014013|       0.092688|