### PR TITLE
Add option to cut on the number of non-0 FastORs

### DIFF
--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalPatchesRef.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalPatchesRef.cxx
@@ -59,23 +59,31 @@ namespace EMCalTriggerPtAnalysis {
 AliAnalysisTaskEmcalPatchesRef::AliAnalysisTaskEmcalPatchesRef() :
     AliAnalysisTaskEmcalTriggerBase(),
     fCentralityRange(-999., 999.),
+    fCellTimeRange(-1., 1.),
+    fOfflineTriggerData(),
+    fMinNumberFastors(0),
     fEnableSumw2(false),
     fUseRecalcPatches(false),
     fRequestCentrality(false),
     fEventCentrality(0)
 {
   SetCaloTriggerPatchInfoName("EmcalTriggers");
+  SetNeedEmcalGeom(true);
 }
 
 AliAnalysisTaskEmcalPatchesRef::AliAnalysisTaskEmcalPatchesRef(const char *name):
     AliAnalysisTaskEmcalTriggerBase(name),
     fCentralityRange(-999., 999.),
+    fCellTimeRange(-1., 1.),
+    fOfflineTriggerData(),
+    fMinNumberFastors(0),
     fEnableSumw2(false),
     fUseRecalcPatches(false),
     fRequestCentrality(false),
     fEventCentrality(0)
 {
   SetCaloTriggerPatchInfoName("EmcalTriggers");
+  SetNeedEmcalGeom(true);
 }
 
 void AliAnalysisTaskEmcalPatchesRef::CreateUserHistos(){
@@ -102,6 +110,10 @@ void AliAnalysisTaskEmcalPatchesRef::CreateUserHistos(){
       }
     }
   }
+
+  // creating trigger data grid
+  fOfflineTriggerData.Allocate(48, 104);
+
   AliDebugStream(1) << "Histograms done" << std::endl;
 }
 
@@ -130,6 +142,7 @@ bool AliAnalysisTaskEmcalPatchesRef::IsUserEventSelected(){
 
 bool AliAnalysisTaskEmcalPatchesRef::Run(){
   AliDebugStream(1) << GetName() << ": Start function" << std::endl;
+  FillDataGrid();
 
   AliDebugStream(1) << GetName() << ": Number of trigger patches " << fTriggerPatchInfo->GetEntries() << std::endl;
 
@@ -138,6 +151,7 @@ bool AliAnalysisTaskEmcalPatchesRef::Run(){
   for(auto patchIter : *fTriggerPatchInfo){
     AliEMCALTriggerPatchInfo *patch = static_cast<AliEMCALTriggerPatchInfo *>(patchIter);
     if(!patch->IsOfflineSimple()) continue;
+    if(GetNumberOfFastORs(patch) < fMinNumberFastors) continue;
 
     bool isDCAL         = patch->IsDCalPHOS(),
         isSingleShower  = SelectSingleShowerPatch(patch),
@@ -244,6 +258,31 @@ bool AliAnalysisTaskEmcalPatchesRef::SelectJetPatch(const AliEMCALTriggerPatchIn
   }
 }
 
+void AliAnalysisTaskEmcalPatchesRef::FillDataGrid(){
+  fOfflineTriggerData.Reset();
+  Short_t cellID;
+  Double_t cellamplitude, celltime, efrac;
+  Int_t mclabel, fastorID, row, col;
+  for(int icell = 0; icell < fCaloCells->GetNumberOfCells(); icell++) {
+    fCaloCells->GetCell(icell, cellID, cellamplitude, celltime, mclabel, efrac);
+    if(!fCellTimeRange.IsInRange(celltime)) continue;
+    if(cellamplitude > 0.) {
+      fGeom->GetFastORIndexFromCellIndex(cellID, fastorID);
+      fGeom->GetPositionInEMCALFromAbsFastORIndex(fastorID, col, row);
+      fOfflineTriggerData(col, row) += cellamplitude;
+    } 
+  }
+}
+
+Int_t AliAnalysisTaskEmcalPatchesRef::GetNumberOfFastORs(const AliEMCALTriggerPatchInfo *patch) const {
+  Int_t nfastor = 0;
+  for(int icol = patch->GetColStart(); icol < patch->GetColStart() + patch->GetPatchSize(); icol++) {
+    for(int irow = patch->GetRowStart(); irow < patch->GetRowStart() + patch->GetPatchSize(); irow++) {
+      if(fOfflineTriggerData(icol, irow) > 0) nfastor++;
+    }
+  }
+  return nfastor;
+}
 AliAnalysisTaskEmcalPatchesRef::EnergyBinning::EnergyBinning():
     TCustomBinning()
 {

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalPatchesRef.h
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalPatchesRef.h
@@ -30,6 +30,7 @@
 #include <string>
 #include <vector>
 #include "AliAnalysisTaskEmcalTriggerBase.h"
+#include "AliEMCALTriggerDataGrid.h"
 #include "AliCutValueRange.h"
 #include <TCustomBinning.h>
 #include <TString.h>
@@ -88,6 +89,19 @@ public:
    * @param[in] max Max. value of the centrality interval
    */
   void SetCentralityRange(double min, double max) { fCentralityRange.SetLimits(min,max); fRequestCentrality = true; }
+
+  /**
+   * @brief Set time range for cell amplitudes for filling the offline trigger data grid
+   * @param min Min. cell time
+   * @param max Max. cell time
+   */
+  void SetCellTimeRange(double min, double max) { fCellTimeRange.SetLimits(min, max); }
+
+  /**
+   * @brief Set minimum number of FastORs used to accept the patch
+   * @param min Min. number of FastORs
+   */
+  void SetMinNumberOfFastorsPatch(int min) { fMinNumberFastors = min; }
 
   /**
    * @brief Switch for recalc patches
@@ -190,7 +204,26 @@ protected:
    */
   void FillPatchHistograms(TString triggerclass, TString patchname, double energy, double transverseenergy, double smearedenergy, double eta, double phi, int col, int row);
 
+  /**
+   * @brief Fill trigger data grid
+   * 
+   * Fill offline FEE grid in FastOR dimenision in order to 
+   * provide access single FastOR energies included in the
+   * patch
+   */
+  void FillDataGrid();
+
+  /**
+   * @brief Get the number of non-0 FastORs contributing to the trigger patch
+   * @param patch Trigger patch to analyse
+   * @return Number of non-0 FastORs
+   */
+  Int_t GetNumberOfFastORs(const AliEMCALTriggerPatchInfo *patch) const;
+
   AliCutValueRange<double>            fCentralityRange;           ///< Range of accepted event centralities
+  AliCutValueRange<double>            fCellTimeRange;             ///< Range of accepted cell time (for data grid)
+  AliEMCALTriggerDataGrid<double>     fOfflineTriggerData;        ///< Trigger energy data grid       
+  Double_t                            fMinNumberFastors;          ///< Min. number of non-0 fastors contributing to the patch
   Bool_t                              fEnableSumw2;               ///< Enable sumw2 during histogram creation
   Bool_t                              fUseRecalcPatches;          ///< Switch between offline (FEE) and recalc (L1) patches
   Bool_t                              fRequestCentrality;         ///< Switch for request of centrality selection


### PR DESCRIPTION
Internally using a data grid with the fake FastOR
data filled for all cells with a cell time cut.
Number of contributing FastORs calculated from
looping over the data grid within the patch ranges.