### PR TITLE
Added AD timing and muon UPC triggers

### DIFF
--- a/RUN3/AliAnalysisTaskAO2Dconverter.cxx
+++ b/RUN3/AliAnalysisTaskAO2Dconverter.cxx
@@ -531,6 +531,8 @@ void AliAnalysisTaskAO2Dconverter::UserExec(Option_t *)
   UInt_t mMuonCl = 0xFFFFFFFF; // Position and charge
   UInt_t mMuonClErr = 0xFFFFFFFF;
 
+  UInt_t mADTime = 0xFFFFFFFF;
+  
   // No compression for ZDC and Run2 VZERO for the moment
 
   if (fTruncate) {
@@ -565,6 +567,8 @@ void AliAnalysisTaskAO2Dconverter::UserExec(Option_t *)
 
     mMuonCl = 0xFFFFFF00; // 15 bits
     mMuonClErr = 0xFFFF0000; // 7 bits
+    
+    mADTime = 0xFFFFF000; // 11 bits
   }
   
   // Initialisation
@@ -1131,8 +1135,8 @@ void AliAnalysisTaskAO2Dconverter::UserExec(Option_t *)
   // AD (FDD)
   AliESDAD* esdad = fESD->GetADData();
   fdd.fBCsID = eventID;
-  fdd.fTimeA = esdad->GetADATime();
-  fdd.fTimeC = esdad->GetADCTime();
+  fdd.fTimeA = AliMathBase::TruncateFloatFraction(esdad->GetADATime(),mADTime);
+  fdd.fTimeC = AliMathBase::TruncateFloatFraction(esdad->GetADCTime(),mADTime);
   FillTree(kFDD);
   if (fTreeStatus[kFDD]) eventextra.fNentries[kFDD] = 1;
   

--- a/RUN3/AliAnalysisTaskAO2Dconverter.h
+++ b/RUN3/AliAnalysisTaskAO2Dconverter.h
@@ -49,6 +49,7 @@ public:
     kMuonCls,
     kZdc,
     kRun2V0,
+    kFDD,
     kV0s,
     kCascades,
     kTOF,
@@ -393,6 +394,17 @@ private:
     ULong64_t fBBFlag = 0ul;         ///  BB Flags from Online V0 Electronics
     ULong64_t fBGFlag = 0ul;         ///  BG Flags from Online V0 Electronics
   } vzero;                     //! structure to keep VZERO information
+
+  struct {
+    /// FDD (AD)  
+
+    Int_t fBCsID = 0u;              /// Index to BC table
+
+    Float_t fAmplitude[8] = {0.f};  ///  adc for each channel (not filled)
+    Float_t fTimeA = 0.f;           ///  average A-side time
+    Float_t fTimeC = 0.f;           ///  average C-side time
+    uint8_t fBCSignal = 0;          ///  trigger info (not filled)
+  } fdd;                            //! structure to keep FDD (AD) information
 
   struct {
     /// V0s (Ks, Lambda)


### PR DESCRIPTION
* AD (FDD) table with ADA and ADC timing
* Bypass of vertex cuts for muon UPC triggers with at least one muon track
* Selected trigger classes with index>50 added in bits 50-58 of fTriggerMask 
