### PR TITLE
Fixing pythia header info for 2016 MC data analysis

### DIFF
--- a/PWGDQ/dielectron/LMEE/AliAnalysisTaskeeCor.h
+++ b/PWGDQ/dielectron/LMEE/AliAnalysisTaskeeCor.h
@@ -22,6 +22,7 @@ public:
     virtual void   UserExec(Option_t *option);
     virtual void   Terminate(Option_t *);
 
+    void SetPyHeader(Int_t h){ fPyHeader = h;}
     void SetTrackCuts(AliESDtrackCuts* const cuts){ fTrackCuts = cuts;}
     void SetMinPtCut(Double_t ptMin){ fPtMinCut = ptMin;}
     void SetEleTPCcuts(Double_t TPCmin, Double_t TPCmax){ fTPCmin = TPCmin; fTPCmax = TPCmax;}
@@ -92,7 +93,7 @@ private:
 
 	Bool_t 		IsCharmedEle(Int_t label);
 	Bool_t 		IsBeautyEle(Int_t label);
-	void	 	  GetRecalibrationPID(Double_t mom, Double_t eta, Double_t *meanTPC, Double_t *widthTPC, Double_t *meanTOF, Double_t *widthTOF);
+	void	 	GetRecalibrationPID(Double_t mom, Double_t eta, Double_t *meanTPC, Double_t *widthTPC, Double_t *meanTOF, Double_t *widthTOF);
 	Double_t	GetPtSmr(Double_t pt);
 	Double_t	GetEtaSmr(Double_t pt);
 	Double_t	GetPhiSmr(Double_t pt, Double_t q);
@@ -322,6 +323,7 @@ private:
 
     AliPIDResponse *fPIDResponse;   //! PID response object
     // persistent members are streamed (copied/stored)
+    Int_t			fPyHeader;
     AliESDtrackCuts *fTrackCuts; // Track cuts
     Double_t		fPtMinCut; //Gen Track cut
     Bool_t			fRecabPID;//

--- a/PWGDQ/dielectron/macrosLMEE/AddTask_hdegenhardt_eeCorMC.C
+++ b/PWGDQ/dielectron/macrosLMEE/AddTask_hdegenhardt_eeCorMC.C
@@ -1,5 +1,5 @@
 
-AliAnalysisTask* AddTask_hdegenhardt_eeCorMC(
+AliAnalysisTask* AddTask_hdegenhardt_eeCorrMC(
 			char *name = 			"Output"
 			,char *period = 		"17"
 			,Bool_t recabPID = 		kTRUE
@@ -22,12 +22,12 @@ AliAnalysisTask* AddTask_hdegenhardt_eeCorMC(
 		AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
 
 		if (!mgr) {
-			::Error("AliAnalysisTaskeeCorr", "No analysis manager to connect to.");
+			::Error("AliAnalysisTaskeeCor", "No analysis manager to connect to.");
 			return NULL;
 		}
 
 		if (!mgr->GetInputEventHandler()) {
-			::Error("AliAnalysisTaskeeCorr", "This task requires an input event handler");
+			::Error("AliAnalysisTaskeeCor", "This task requires an input event handler");
 			return NULL;
 		}
 		
@@ -124,7 +124,9 @@ AliAnalysisTask* AddTask_hdegenhardt_eeCorMC(
 		tasklmee->SetProtTPCrej(-4.+TOFv,4.-TPCv);
 		tasklmee->SetKaonTPCrej(-4.+TOFv,4.-TPCv);
 
-		//------------------- NON - DEPENDENT OF THE CONFIG ------------------------
+		//------------------- INDEPENDENT OF THE CONFIG --------------------
+		if (period[1] == '6') tasklmee->SetPyHeader(1); //Set position of the header to find information about CC/BB production
+		else tasklmee->SetPyHeader(0);
 
 		//----- PID Recalibration ------------------------------------------
 		tasklmee->SetRecabPID(recabPID);

--- a/PWGDQ/dielectron/macrosLMEE/AddTask_hdegenhardt_eeCorMC.C
+++ b/PWGDQ/dielectron/macrosLMEE/AddTask_hdegenhardt_eeCorMC.C
@@ -1,5 +1,5 @@
 
-AliAnalysisTask* AddTask_hdegenhardt_eeCorrMC(
+AliAnalysisTask* AddTask_hdegenhardt_eeCorMC(
 			char *name = 			"Output"
 			,char *period = 		"17"
 			,Bool_t recabPID = 		kTRUE


### PR DESCRIPTION
Before:
AliGenEventHeader* gh=(AliGenEventHeader*)l->At(0); //works fine for 2017&2018
Now:
AliGenEventHeader* gh=(AliGenEventHeader*)l->At(fPyHeader); //2016: At(1), 2017&2018: At(0)