### PR TITLE
Add option for energy scale multiplicator

### DIFF
--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerKernel.cxx
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerKernel.cxx
@@ -67,6 +67,7 @@ AliEmcalTriggerMakerKernel::AliEmcalTriggerMakerKernel():
   fSmearModelSigma(nullptr),
   fSmearThreshold(0.1),
   fScaleShift(0.),
+  fScaleMult(1.),
   fDoBackgroundSubtraction(false),
   fGeometry(nullptr),
   fPatchAmplitudes(nullptr),
@@ -428,8 +429,10 @@ void AliEmcalTriggerMakerKernel::ReadCellData(AliVCaloCells *cells){
     Double_t amp = cells->GetAmplitude(iCell),
              celltime = cells->GetTime(iCell);
     if(celltime < fCellTimeLimits[0] || celltime > fCellTimeLimits[1]) continue;
+    amp *= fScaleMult;
     if(amp < fMinCellAmplitude) continue;
     if(fScaleShift) amp += fScaleShift;
+     
     amp = TMath::Max(amp, 0.);      // never go negative in energy
     // get position
     Int_t absId=-1;

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerKernel.h
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerKernel.h
@@ -415,6 +415,12 @@ public:
   void SetScaleShift(Double_t scaleshift) { fScaleShift = scaleshift; }
 
   /**
+   * @brief Simulate EMCAL scale mismatch by constant multiplication factor
+   * @param scalemult Scale multiplication factor
+   */
+  void SetScaleMult(Double_t scalemult) { fScaleMult = scalemult; }
+
+  /**
    * Check whether the trigger maker has been specially configured. Status has to
    * be set in the functions ConfigureForXX.
    * @return True if the trigger maker kernel is configured, false otherwise
@@ -531,6 +537,7 @@ protected:
   TF1                                       *fSmearModelSigma;            ///< Smearing parameterization for the width
   Double_t                                  fSmearThreshold;              ///< Smear threshold: Only cell energies above threshold are smeared
   Double_t                                  fScaleShift;                  ///< Scale shift simulation
+  Double_t                                  fScaleMult;                   ///< Constant EMCAL energy scale multiplicator
   Bool_t                                    fDoBackgroundSubtraction;     ///< Swtich for background subtraction (only online ADC)
 
   const AliEMCALGeometry                    *fGeometry;                   //!<! Underlying EMCAL geometry


### PR DESCRIPTION
Simulation of the energy-independent EMCAL
energy scale mismatch between data and MC
using constant mulitplicator applied to
the FEE amplitude when converting to FastOR
energy.