### PR TITLE
Fix ML model choice in prediction

### DIFF
--- a/ML/AliMLResponse.cxx
+++ b/ML/AliMLResponse.cxx
@@ -141,9 +141,13 @@ void AliMLResponse::MLResponseInit() {
 
 //_______________________________________________________________________________
 int AliMLResponse::FindBin(double binvar) {
-  vector<float>::iterator low;
-  low = std::lower_bound(fBins.begin(), fBins.end(), binvar);
-  return low - fBinsBegin;
+  vector<float>::iterator low = std::lower_bound(fBins.begin(), fBins.end(), binvar);
+  int bin = low - fBinsBegin;
+  if (bin == 0 || bin >= fNBins) {
+    AliWarning("Binned variable outside range, no model available!");
+    return -1;
+  }
+  return bin;
 }
 
 //_______________________________________________________________________________
@@ -161,10 +165,8 @@ double AliMLResponse::Predict(double binvar, map<string, double> varmap) {
   }
 
   int bin = FindBin(binvar);
-  if (bin == 0 || bin >= fNBins) {
-    AliWarning("Binned variable outside range, no model available!");
+  if (bin < 0)
     return -999.;
-  }
 
   return fModels.at(bin - 1).GetModel()->Predict(&features[0], fNVariables, fRaw);
 }
@@ -177,10 +179,8 @@ double AliMLResponse::Predict(double binvar, vector<double> variables) {
   }
 
   int bin = FindBin(binvar);
-  if (bin == 0 || bin >= fNBins) {
-    AliWarning("Binned variable outside range, no model available!");
+  if (bin < 0)
     return -999.;
-  }
 
   return fModels.at(bin - 1).GetModel()->Predict(&variables[0], fNVariables, fRaw);
 }

--- a/ML/AliMLResponse.cxx
+++ b/ML/AliMLResponse.cxx
@@ -114,7 +114,7 @@ void AliMLResponse::CompileModels(std::string configLocalPath) {
 
   fVariableNames = nodeList["VAR_NAMES"].as<vector<string>>();
   fBins          = nodeList["BINS"].as<vector<float>>();
-  fNBins         = nodeList["N_MODELS"].as<int>();
+  fNBins         = fBins.size();
   fNVariables    = nodeList["NUM_VAR"].as<int>();
   fRaw           = nodeList["RAW_SCORE"].as<bool>();
 
@@ -143,7 +143,7 @@ void AliMLResponse::MLResponseInit() {
 int AliMLResponse::FindBin(double binvar) {
   vector<float>::iterator low = std::lower_bound(fBins.begin(), fBins.end(), binvar);
   int bin = low - fBinsBegin;
-  if (bin == 0 || bin >= fNBins) {
+  if (bin == 0 || bin == fNBins) {
     AliWarning("Binned variable outside range, no model available!");
     return -1;
   }

--- a/ML/AliMLResponse.cxx
+++ b/ML/AliMLResponse.cxx
@@ -161,12 +161,12 @@ double AliMLResponse::Predict(double binvar, map<string, double> varmap) {
   }
 
   int bin = FindBin(binvar);
-  if (bin == 0 || bin == fNBins) {
+  if (bin == 0 || bin >= fNBins) {
     AliWarning("Binned variable outside range, no model available!");
     return -999.;
   }
 
-  return fModels[bin - 1].GetModel()->Predict(&features[0], fNVariables, fRaw);
+  return fModels.at(bin - 1).GetModel()->Predict(&features[0], fNVariables, fRaw);
 }
 
 //_______________________________________________________________________________
@@ -177,12 +177,12 @@ double AliMLResponse::Predict(double binvar, vector<double> variables) {
   }
 
   int bin = FindBin(binvar);
-  if (bin == 0 || bin == fNBins) {
+  if (bin == 0 || bin >= fNBins) {
     AliWarning("Binned variable outside range, no model available!");
     return -999.;
   }
 
-  return fModels[bin - 1].GetModel()->Predict(&variables[0], fNVariables, fRaw);
+  return fModels.at(bin - 1).GetModel()->Predict(&variables[0], fNVariables, fRaw);
 }
 
 //_______________________________________________________________________________

--- a/ML/AliMLResponse.h
+++ b/ML/AliMLResponse.h
@@ -21,7 +21,6 @@
 
 #include "TNamed.h"
 
-#include "AliLog.h"
 #include "AliMLModelHandler.h"
 
 namespace YAML {
@@ -84,20 +83,16 @@ protected:
 
 template <typename F> bool AliMLResponse::IsSelected(double binvar, std::map<std::string, double> varmap, F &score) {
   int bin = FindBin(binvar);
-  if (bin == 0 || bin >= fNBins) {
-    AliWarning("Binned variable outside range, no model available!");
+  if (bin < 0)
     return false;
-  }
   score = Predict(binvar, varmap);
   return score >= fModels.at(bin - 1).GetScoreCut();
 }
 
 template <typename F> bool AliMLResponse::IsSelected(double binvar, std::vector<double> variables, F &score) {
   int bin = FindBin(binvar);
-  if (bin == 0 || bin >= fNBins) {
-    AliWarning("Binned variable outside range, no model available!");
+  if (bin < 0)
     return false;
-  }
   score = Predict(binvar, variables);
   return score >= fModels.at(bin - 1).GetScoreCut();
 }

--- a/ML/AliMLResponse.h
+++ b/ML/AliMLResponse.h
@@ -77,7 +77,7 @@ protected:
   bool fRaw;    /// set to true to use raw score instead of probability
 
   /// \cond CLASSIMP
-  ClassDef(AliMLResponse, 3);    ///
+  ClassDef(AliMLResponse, 2);    ///
   /// \endcond
 };
 

--- a/ML/AliMLResponse.h
+++ b/ML/AliMLResponse.h
@@ -21,6 +21,7 @@
 
 #include "TNamed.h"
 
+#include "AliLog.h"
 #include "AliMLModelHandler.h"
 
 namespace YAML {
@@ -77,20 +78,28 @@ protected:
   bool fRaw;    /// set to true to use raw score instead of probability
 
   /// \cond CLASSIMP
-  ClassDef(AliMLResponse, 2);    ///
+  ClassDef(AliMLResponse, 3);    ///
   /// \endcond
 };
 
 template <typename F> bool AliMLResponse::IsSelected(double binvar, std::map<std::string, double> varmap, F &score) {
   int bin = FindBin(binvar);
-  score   = Predict(binvar, varmap);
-  return score >= fModels[bin - 1].GetScoreCut();
+  if (bin == 0 || bin >= fNBins) {
+    AliWarning("Binned variable outside range, no model available!");
+    return false;
+  }
+  score = Predict(binvar, varmap);
+  return score >= fModels.at(bin - 1).GetScoreCut();
 }
 
 template <typename F> bool AliMLResponse::IsSelected(double binvar, std::vector<double> variables, F &score) {
   int bin = FindBin(binvar);
-  score   = Predict(binvar, variables);
-  return score >= fModels[bin - 1].GetScoreCut();
+  if (bin == 0 || bin >= fNBins) {
+    AliWarning("Binned variable outside range, no model available!");
+    return false;
+  }
+  score = Predict(binvar, variables);
+  return score >= fModels.at(bin - 1).GetScoreCut();
 }
 
 #endif


### PR DESCRIPTION
This should fix the issue spotted by @lvermunt where there are crashes for candidates with pT above the last value defined in the config file. Moreover, the candidates falling in the last defined bin were rejected.

@pfecchio @mpuccio @fgrosa Please double check.