### PR TITLE
Avoid double counting of subjet constituents for matching

### DIFF
--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskJetHardestKt.cxx
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskJetHardestKt.cxx
@@ -905,6 +905,9 @@ double AliAnalysisTaskJetHardestKt::SubjetSharedMomentum(const std::vector<fastj
         }
       }
       sumPt += generatorLikeConstituent.pt();
+      // We've mached once - no need to match again.
+      // Otherwise, the run the risk of summing a generator-like constituent pt twice.
+      break;
     }
   }
 


### PR DESCRIPTION
Without this change, a constituent could be counted twice during subjet
distance matching, which could cause the pt fraction to be greater than
1 (beyond just float rounding)