### PR TITLE
AliAnalysisTaskHFJetIPQA: expand definition of track probability

### DIFF
--- a/PWGJE/FlavourJetTasks/AliAnalysisTaskHFJetIPQA.h
+++ b/PWGJE/FlavourJetTasks/AliAnalysisTaskHFJetIPQA.h
@@ -127,7 +127,8 @@ public:
     enum TCTagType{
         TCNo,
         TCIPSigPtDep,
-        TCIPFixedPt
+        TCIPFixedPt,
+        TCIPSigPtDepVarNTemps
     };
 
     enum ProbTagType{
@@ -294,6 +295,10 @@ public:
     Bool_t IsParton(int pdg);
     Bool_t IsParticleInCone(const AliVParticle* part, const AliEmcalJet* jet, Double_t dRMax);
 
+    void GetLowUpperBinNo(int &iLowerBin, int &iUpperBin, double min, double max, TString type, Int_t iN);
+
+    void PrintAllTreeVars();
+
     //____________________________
     //Cuts
     void SetESDCuts (AliESDtrackCuts  *cuts =NULL){fESDTrackCut =  new AliESDtrackCuts(*cuts);}
@@ -332,6 +337,7 @@ public:
     AliExternalTrackParam GetExternalParamFromJet(const AliEmcalJet *jet, const AliAODEvent *event);
     Bool_t GetImpactParameterWrtToJet(const AliAODTrack *track, const AliAODEvent *event, const AliEmcalJet *jet, Double_t *dca, Double_t *cov, Double_t *XYZatDCA, Double_t &jetsign, int jetflavour);
     int DetermineUnsuitableVtxTracks(int *skipped, AliAODEvent * const aod, AliVTrack * const track);
+    void DetermineIPVars(std::vector<AliAnalysisTaskHFJetIPQA::SJetIpPati> sImpParXY, std::vector<AliAnalysisTaskHFJetIPQA::SJetIpPati> sImpParXYSig, vector<Float_t> &ipvalsig, vector<Float_t> &ipval, Int_t& HasGoodIPTracks);
     //______________________________
     //Corrections
     double DoUESubtraction(AliJetContainer* &jetcongen, AliJetContainer* &jetconrec, AliEmcalJet* &jetrec, double jetpt);
@@ -377,7 +383,7 @@ public:
     void setfNoJetConstituents(Int_t value){fNoJetConstituents=value;}
     void setfNThresholds(Int_t value){fNThresholds=value; printf("Setting threshold value=%i\n",fNThresholds);}
     void setfUserSignificance(Bool_t value){fUseSignificance=value;}
-    void SetTagSettings(int iTagSetting);
+    void SetTagSettings(int iTagSetting, int ntracktypes=-1);
     void SetfUnfoldPseudoDataFrac(int frac){fUnfoldPseudeDataFrac=frac;}
     void setfResponseMode(bool value){fResponseMode=value;}
     void setTaskName(const char* name){sTaskName=Form("%s",name);}
@@ -397,20 +403,20 @@ public:
           Triple,
     };
 
-    void DoTCTagging(double jetpt, bool* hasIPs, double* ipval, bool **kTagDec);
+    void DoTCTagging(Float_t jetpt, Int_t nGoodIPTracks, const vector<Float_t>& ipval, Bool_t **kTagDec);
     void DoProbTagging(double probval, double jetpt, bool** kTagDec);
     void SetTCThresholds(TObjArray** &threshs);
     void SetProbThresholds(TObjArray** &threshs);
     void ReadProbvsIPLookup(TObjArray *&oLookup);
-    void ReadThresholdHists(TString PathToThresholds, TString taskname, int nTCThresh, int iTagSetting);
+    void ReadThresholdHists(TString PathToThresholds, TString taskname, int nTCThresh, int iTagSetting, int ntracktypesprob);
     void setTagLevel(int taglevel){kTagLevel=taglevel;}
     void setTCThresholdPtFixed(double value){fTCThresholdPtFixed=value;};
 
     //________________________________
     //Probability Tagging
-    double GetTrackProbability(double jetpt, bool* hasIPs, double* ipval);
+    Float_t GetTrackProbability(Float_t jetpt, Int_t nGoodIPTracks, const vector<Float_t>& ipval);
     void setDoLundPlane(Bool_t dolundplane){fDoLundPlane=dolundplane;}
-    double IntegrateIP(int iJetPtBin, int iIPBin, int iN);
+    Float_t IntegrateIP(Float_t jetpt, Float_t IP, Int_t iN);
 
     void useTreeForCorrelations(Bool_t value){fUseTreeForCorrelations = value;}
     //virtual Bool_t IsEventSelected();
@@ -438,13 +444,13 @@ private:
     Int_t nTracks;
     Int_t fNEvent;
     bool bMatched;
-    Float_t fTrackIPs[100];
-    Float_t fTrackIPSigs[100];
-    Float_t fTrackProb[100];
-    Float_t fTrackChi2OverNDF[100];
-    Float_t fTrackPt[100];
-    Int_t iTrackITSHits[100];
-    Int_t bTrackIsV0[100];
+    Float_t fTrackIPs[40];
+    Float_t fTrackIPSigs[40];
+    Float_t fTrackProb[40];
+    Float_t fTrackChi2OverNDF[40];
+    Float_t fTrackPt[40];
+    Int_t iTrackITSHits[40];
+    Int_t bTrackIsV0[40];
     Bool_t bFull[30];
     Bool_t bSingle1st[30];
     Bool_t bSingle2nd[30];
@@ -654,7 +660,7 @@ private:
         }
     }
 
-    Bool_t GetMixDCA(int n , double &v){
+   /* Bool_t GetMixDCA(int n , double &v){
         if(n==1){
                 if (!fIsMixSignalReady_n1 || fIsSameEvent_n1) return kFALSE;
                 v= fn1_mix;
@@ -671,9 +677,9 @@ private:
                 fIsMixSignalReady_n3 = kFALSE;
             }
     return kTRUE;
-    }
+    }*/
 
-   ClassDef(AliAnalysisTaskHFJetIPQA, 60)
+   ClassDef(AliAnalysisTaskHFJetIPQA, 61)
 };
 
 #endif

--- a/PWGJE/FlavourJetTasks/macros/AddTaskHFJetIPQA.C
+++ b/PWGJE/FlavourJetTasks/macros/AddTaskHFJetIPQA.C
@@ -30,13 +30,8 @@ AliAnalysisTaskHFJetIPQA* AddTaskHFJetIPQA(
                                            const char *nrhoMC               = "RhoMC",
                                            int nTCThresh                      =1,
                                            int iTagSetting              =0,
-                                           TString PathToWeights = 	"alien:///alice/cern.ch/user/k/kgarner/Weights_18_07_18.root",
+                                           int nTrackTypesProb =-1,
                                            TString PathToThresholds = "alien:///alice/cern.ch/user/k/kgarner/ThresholdHists_LHC16JJ_new.root",
-                                          // TString PathToRunwiseCorrectionParameters = "alien:///alice/cern.ch/user/l/lfeldkam/MeanSigmaImpParFactors.root",
-                                          // TString PathToJetProbabilityInput = "/home/katha/Uni/PhD/PhD/LinusCode/Anwendung/data/Binned_ResFct_XYSignificance_pp7TeV.root",
-                                           TString PathToFlukaFactor="alien:///alice/cern.ch/user/k/kgarner/FlukaFactors_18_07_18.root",
-                                           Bool_t GenerateMeanSigmaCorrectionTable=kTRUE,
-                                           Int_t nITSReq=6,
                                            Bool_t useCorrelationTree=kFALSE,
                                            const char* suffix = ""
                                            )
@@ -81,22 +76,6 @@ AliAnalysisTaskHFJetIPQA* AddTaskHFJetIPQA(
         return 0x0;
     }
 
-
-    TFile* fileMCoverDataWeights;
-    if(isMC){
-        if(PathToWeights.EqualTo("") ) {
-        } else {
-            fileMCoverDataWeights=TFile::Open(PathToWeights.Data());
-            if(!fileMCoverDataWeights ||(fileMCoverDataWeights&& !fileMCoverDataWeights->IsOpen())){
-                Printf("%s :: File with modified weights not found",taskname);
-                return 0x0;
-            }
-        }
-    }
-
-    
-    Printf("%s :: File %s successfully loaded, setting up correction factors.",taskname,PathToWeights.Data());
-
     TString name(taskname),combinedName;
     combinedName.Form("%s%s", name.Data(),suffix);
     AliAnalysisTaskHFJetIPQA* jetTask = new AliAnalysisTaskHFJetIPQA(combinedName);
@@ -104,52 +83,7 @@ AliAnalysisTaskHFJetIPQA* AddTaskHFJetIPQA(
     jetTask->SetJetRadius(jetradius);
     jetTask->setTaskName(taskname);
 
-    /*if(isMC && fileMCoverDataWeights){
-        TH1F * h[20] = {0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0};
-        const char * nampart[20] = {"pi0","eta","etap","rho","phi","omega","k0s","lambda","pi","kaon","proton","D0","Dp","Dsp","Ds","lambdac","bplus","b0","lambdab","bsp"};
-        for(int i = 0;i<20;++i){
-            h[i]=(TH1F*)fileMCoverDataWeights->Get(Form("%s/%s",system,nampart[i]));
-        }
-        Printf("%s :: Reading MC correction factors completed.",taskname);
-        for (int i = 0 ; i<20;++i) if(h[i]==0) return 0x0;
-        jetTask->SetUseMonteCarloWeighingLinus(h[0],h[1],h[2],h[3],h[4],h[5],h[6],h[7],h[8],h[9],h[10],h[11],h[12],h[13],h[14],h[15],h[16],h[17],h[18],h[19]);
-        Printf("%s :: Weights written to analysis task.",taskname);
-        if(fileMCoverDataWeights) fileMCoverDataWeights->Close();
-    }*/
-
-
-
-    // Load and setup Fluka correction factors from file
-    //==============================================================================
-    TFile* fileFlukaCorrection;
-    if(isMC){
-        if( PathToFlukaFactor.EqualTo("") ) {
-        } else {
-            fileFlukaCorrection=TFile::Open(PathToFlukaFactor.Data());
-            if(!fileFlukaCorrection ||(fileFlukaCorrection&& !fileFlukaCorrection->IsOpen())){
-                printf("%s :: File with original weights not found",taskname);
-                return 0x0;
-            }
-        }
-    }
-
-
-    Printf("%s :: File %s successfully loaded, setting up background correction factors.",taskname,PathToFlukaFactor.Data());
-
-    /*if(isMC && fileFlukaCorrection){
-        TGraph *g[4] = {0x0,0x0,0x0,0x0};
-        const char * nampart[4] = {"fGraphOmega","fGraphXi","fK0Star","fPhi"};
-        for(int i = 0;i<4;++i){
-            g[i]=(TGraph*)fileFlukaCorrection->Get(Form("%s/%s",system,nampart[i]));
-        }
-        Printf("%s :: Reading  Fluka factors completed.",taskname);
-        for (int i = 0 ; i<4;++i) if(g[i]==0) return 0x0;
-        jetTask->SetFlukaFactor(g[0],g[1],g[2],g[3]);
-        Printf("%s :: Weights written to analysis task.",taskname);
-        if(fileFlukaCorrection) fileFlukaCorrection->Close();
-    }*/
-
-    jetTask->ReadThresholdHists(PathToThresholds, taskname, nTCThresh, iTagSetting);
+    jetTask->ReadThresholdHists(PathToThresholds, taskname, nTCThresh, iTagSetting, nTrackTypesProb);
 
 
     // Setup input containers


### PR DESCRIPTION
Track Probability:
- widen definition of track probability to all tracks within jet
- introduce cut on maximum IP
- introduce handling of boundary effects
- enable reading of more than 3 IP templates

Basic Code:
- tidy up
- add print of all tree variables
- decrease array size in output tree
- rearrange initialisation of loop variables 