### PR TITLE
Added MEMassQA histograms, which follow the logic of the MassQA (Inv …

### DIFF
--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCorrHists.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCorrHists.cxx
@@ -42,6 +42,9 @@ AliFemtoDreamCorrHists::AliFemtoDreamCorrHists()
       fMassQADistPart1(nullptr),
       fMassQADistPart2(nullptr),
       fPairInvMassQAD(nullptr),
+      fMEMassQADistPart1(nullptr),
+      fMEMassQADistPart2(nullptr),
+      fPairInvMEMassQAD(nullptr),
       fPairCounterSE(nullptr),
       fMixedEventDist(nullptr),
       fMixedEventMultDist(nullptr),
@@ -129,6 +132,9 @@ AliFemtoDreamCorrHists::AliFemtoDreamCorrHists(
       fMassQADistPart1(hists.fMassQADistPart1),
       fMassQADistPart2(hists.fMassQADistPart2),
       fPairInvMassQAD(hists.fPairInvMassQAD),
+      fMEMassQADistPart1(hists.fMEMassQADistPart1),
+      fMEMassQADistPart2(hists.fMEMassQADistPart2),
+      fPairInvMEMassQAD(hists.fPairInvMEMassQAD),      
       fPairCounterSE(hists.fPairCounterSE),
       fMixedEventDist(hists.fMixedEventDist),
       fMixedEventMultDist(hists.fMixedEventMultDist),
@@ -216,6 +222,9 @@ AliFemtoDreamCorrHists::AliFemtoDreamCorrHists(AliFemtoDreamCollConfig *conf,
       fMassQADistPart1(nullptr),
       fMassQADistPart2(nullptr),
       fPairInvMassQAD(nullptr),
+      fMEMassQADistPart1(nullptr),
+      fMEMassQADistPart2(nullptr),
+      fPairInvMEMassQAD(nullptr),      
       fPairCounterSE(nullptr),
       fMixedEventDist(nullptr),
       fMixedEventMultDist(nullptr),
@@ -484,10 +493,18 @@ AliFemtoDreamCorrHists::AliFemtoDreamCorrHists(AliFemtoDreamCollConfig *conf,
     fMassQADistPart1 = new TH2F*[nHists];
     fMassQADistPart2 = new TH2F*[nHists];
     fPairInvMassQAD = new TH1F*[nHists];
+    
+    fMEMassQADistPart1 = new TH2F*[nHists];
+    fMEMassQADistPart2 = new TH2F*[nHists];
+    fPairInvMEMassQAD = new TH1F*[nHists];    
   } else {
     fMassQADistPart1 = nullptr;
     fMassQADistPart2 = nullptr;
     fPairInvMassQAD = nullptr;
+    
+    fMEMassQADistPart1 = nullptr;
+    fMEMassQADistPart2 = nullptr;
+    fPairInvMEMassQAD = nullptr;
   }
 
   if (fdPhidEtaPlots) {
@@ -1035,6 +1052,45 @@ AliFemtoDreamCorrHists::AliFemtoDreamCorrHists(AliFemtoDreamCollConfig *conf,
               "#it{k}* (GeV/#it{c})");
           fPairQA[Counter]->Add(fPairInvMassQAD[Counter]);
 
+		  //MIXED EVENTS
+          TString MEMassQANamePart1 = TString::Format("MEMassQA_Particle%d_1", iPar1);
+          TString MEMassQANamePart2 = TString::Format("MEMassQA_Particle%d_2", iPar2);
+          TString MEMassQANamePart3 = TString::Format("InvMEMassQA_Particle%d_Particle%d",
+                                         iPar1, iPar2);  //???????
+
+          fMEMassQADistPart1[Counter] = new TH2F(MEMassQANamePart1.Data(),
+                                               MEMassQANamePart1.Data(), 512,
+                                               massPart1 - 0.04,
+                                               massPart1 + 0.04, *itNBins,
+                                               *itKMin, *itKMax);
+          fMEMassQADistPart1[Counter]->GetXaxis()->SetTitle(
+              TString::Format("M_{Particle %d} (GeV/#it{c}^{2})", iPar1));
+          fMEMassQADistPart1[Counter]->GetYaxis()->SetTitle(
+              "#it{k}* (GeV/#it{c})");
+          fPairQA[Counter]->Add(fMEMassQADistPart1[Counter]);
+
+          fMEMassQADistPart2[Counter] = new TH2F(MEMassQANamePart2.Data(),
+                                               MEMassQANamePart2.Data(), 512,
+                                               massPart2 - 0.04,
+                                               massPart2 + 0.04, *itNBins,
+                                               *itKMin, *itKMax);
+          fMEMassQADistPart2[Counter]->GetXaxis()->SetTitle(
+              TString::Format("M_{Particle %d} (GeV/#it{c}^{2})", iPar2));
+          fMEMassQADistPart2[Counter]->GetYaxis()->SetTitle(
+              "#it{k}* (GeV/#it{c})");
+          fPairQA[Counter]->Add(fMEMassQADistPart2[Counter]);
+
+          fPairInvMEMassQAD[Counter] = new TH1F(MEMassQANamePart3.Data(),
+                                              MEMassQANamePart3.Data(), 100,
+                                              massPart1 + massPart2,
+                                              4 * (massPart1 + massPart2));
+          fPairInvMEMassQAD[Counter]->GetXaxis()->SetTitle(
+              TString::Format("InvMass_{Particle %d_1}_{Particle %d_2} (GeV/#it{c}^{2})",
+                   iPar1, iPar2));
+          fPairInvMEMassQAD[Counter]->GetYaxis()->SetTitle(
+              "#it{k}* (GeV/#it{c})");
+          fPairQA[Counter]->Add(fPairInvMEMassQAD[Counter]);
+
         }
 
         if (fillHists && fMomentumResolution) {
@@ -1257,6 +1313,9 @@ AliFemtoDreamCorrHists &AliFemtoDreamCorrHists::operator=(
     this->fMassQADistPart1 = hists.fMassQADistPart1;
     this->fMassQADistPart2 = hists.fMassQADistPart2;
     this->fPairInvMassQAD = hists.fPairInvMassQAD;
+    this->fMEMassQADistPart1 = hists.fMEMassQADistPart1;
+    this->fMEMassQADistPart2 = hists.fMEMassQADistPart2;
+    this->fPairInvMEMassQAD = hists.fPairInvMEMassQAD;
     this->fPairCounterSE = hists.fPairCounterSE;
     this->fMixedEventDist = hists.fMixedEventDist;
     this->fMixedEventMultDist = hists.fMixedEventMultDist;
@@ -1332,7 +1391,16 @@ AliFemtoDreamCorrHists::~AliFemtoDreamCorrHists() {
   if (fPairInvMassQAD) {
     delete[] fPairInvMassQAD;
   }
-
+  if (fMEMassQADistPart1) {
+    delete[] fMEMassQADistPart1;
+  }
+  if (fMEMassQADistPart2) {
+    delete[] fMEMassQADistPart2;
+  }
+  if (fPairInvMEMassQAD) {
+    delete[] fPairInvMEMassQAD;
+  }
+  
   if (fSameEventkTandMultDist) {
     delete[] fSameEventkTandMultDist;
     delete fSameEventkTandMultDist;

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCorrHists.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCorrHists.h
@@ -165,7 +165,15 @@ class AliFemtoDreamCorrHists {
       }
     }
   }
-
+  void FillMEMassQADist(int i, float kstar, float invMass1, float invMass2) {
+    if (!fMinimalBooking) {
+      if (fMEMassQADistPart1[i] && fMEMassQADistPart2[i]) {
+        fMEMassQADistPart1[i]->Fill(invMass1, kstar);
+        fMEMassQADistPart2[i]->Fill(invMass2, kstar);
+      }
+    }
+  }
+  
   void FillPairInvMassQAD(int i, AliFemtoDreamBasePart &part1,
                           AliFemtoDreamBasePart &part2) {
     if (!fMinimalBooking) {
@@ -180,6 +188,23 @@ class AliFemtoDreamCorrHists {
         TLorentzVector trackSum = trackPos + trackNeg;
 
         fPairInvMassQAD[i]->Fill(trackSum.M());
+      }
+    }
+  }
+  void FillPairInvMEMassQAD(int i, AliFemtoDreamBasePart &part1,
+                          AliFemtoDreamBasePart &part2) {
+    if (!fMinimalBooking) {
+      if (fPairInvMEMassQAD[i]) {
+        TVector3 momPart1 = part1.GetMomentum();
+        TVector3 momPart2 = part2.GetMomentum();
+        TLorentzVector trackPos, trackNeg;
+        trackPos.SetXYZM(momPart1.Px(), momPart1.Py(), momPart1.Pz(),
+                         part1.GetInvMass());
+        trackNeg.SetXYZM(momPart2.Px(), momPart2.Py(), momPart2.Pz(),
+                         part2.GetInvMass());
+        TLorentzVector trackSum = trackPos + trackNeg;
+
+        fPairInvMEMassQAD[i]->Fill(trackSum.M());
       }
     }
   }
@@ -355,6 +380,9 @@ class AliFemtoDreamCorrHists {
   TH2F **fMassQADistPart1;
   TH2F **fMassQADistPart2;
   TH1F **fPairInvMassQAD;
+  TH2F **fMEMassQADistPart1;
+  TH2F **fMEMassQADistPart2;
+  TH1F **fPairInvMEMassQAD;
   TH2F **fPairCounterSE;
   TH1F **fMixedEventDist;
   TH2F **fMixedEventMultDist;

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamHigherPairMath.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamHigherPairMath.cxx
@@ -217,6 +217,14 @@ void AliFemtoDreamHigherPairMath::MassQA(int iHC, float RelK,
     fHists->FillPairInvMassQAD(iHC, part1, part2);
   }
 }
+void AliFemtoDreamHigherPairMath::MEMassQA(int iHC, float RelK,
+                                         AliFemtoDreamBasePart &part1,
+                                         AliFemtoDreamBasePart &part2) {
+  if (fWhichPairs.at(iHC) && fHists->GetDoMassQA()) {
+    fHists->FillMEMassQADist(iHC, RelK, part1.GetInvMass(), part2.GetInvMass());
+    fHists->FillPairInvMEMassQAD(iHC, part1, part2);
+  }
+}
 
 float AliFemtoDreamHigherPairMath::FillMixedEvent(
     int iHC, int Mult, float cent, AliFemtoDreamBasePart &part1, int PDGPart1,

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamHigherPairMath.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamHigherPairMath.h
@@ -40,6 +40,8 @@ class AliFemtoDreamHigherPairMath {
                       int PDGPart1, AliFemtoDreamBasePart& part2, int PDGPart2);
   void MassQA(int iHC, float RelK, AliFemtoDreamBasePart &part1,
               AliFemtoDreamBasePart &part2);
+  void MEMassQA(int iHC, float RelK, AliFemtoDreamBasePart &part1,
+              AliFemtoDreamBasePart &part2);
   void SEMomentumResolution(int iHC, AliFemtoDreamBasePart* part1, int PDGPart1,
                             AliFemtoDreamBasePart* part2, int PDGPart2,
                             float RelativeK);

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamZVtxMultContainer.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamZVtxMultContainer.cxx
@@ -162,7 +162,8 @@ void AliFemtoDreamZVtxMultContainer::PairParticlesME(
                 HistCounter, iMult, cent, *itPart1, *itPDGPar1,
                 *itPart2, *itPDGPar2,
                 AliFemtoDreamCollConfig::kNone);
-
+			
+			HigherMath->MEMassQA(HistCounter, RelativeK, *itPart1, *itPart2);
             HigherMath->MEDetaDPhiPlots(HistCounter, *itPart1, *itPDGPar1,
                                         *itPart2, *itPDGPar2, RelativeK, false);
             HigherMath->MEMomentumResolution(HistCounter, &(*itPart1),


### PR DESCRIPTION
…mass vs k*), applied to the ME. N.B. There is one instance of MassQA in AliFemtoDreamControlSample.cxx, which I did not understood and did not implement for MEMassQA.

I think this "ControlSample" is irrelevant for most used cases, as it applies to the rotated phi, correct? Please confirm that no further work is needed in that file. Thanks! 

Successful local test