### PR TITLE
PWGHF: Add PreSelect function for pKpi

### DIFF
--- a/PWGHF/vertexingHF/AliRDHFCutsLctopKpi.h
+++ b/PWGHF/vertexingHF/AliRDHFCutsLctopKpi.h
@@ -93,13 +93,21 @@ class AliRDHFCutsLctopKpi : public AliRDHFCuts
   virtual Int_t IsSelected(TObject* obj,Int_t selectionLevel,AliAODEvent *aod);
   using AliRDHFCuts::IsSelectedPID;
   virtual Int_t IsSelectedPID(AliAODRecoDecayHF* obj);
+  Int_t IsSelectedPID(Double_t Pt, TObjArray aodtracks);
   Int_t IsSelectedCombinedPID(AliAODRecoDecayHF* obj);
+  Int_t IsSelectedCombinedPID(Double_t Pt, TObjArray aodtracks);
   Int_t IsSelectedCombinedPIDSoft(AliAODRecoDecayHF* obj);
+  Int_t IsSelectedCombinedPIDSoft(Double_t Pt, TObjArray aodtracks);
   Int_t IsSelectedCombinedPIDpPb(AliAODRecoDecayHF* obj);
+  Int_t IsSelectedCombinedPIDpPb(Double_t Pt, TObjArray aodtracks);
   Int_t IsSelectedCombinedPIDpPb2(AliAODRecoDecayHF* obj);
+  Int_t IsSelectedCombinedPIDpPb2(Double_t Pt, TObjArray aodtracks);
   Int_t IsSelectedPIDStrong(AliAODRecoDecayHF* obj);
+  Int_t IsSelectedPIDStrong(Double_t Pt, TObjArray aodtracks);
   Int_t IsSelectedNSigmaPbPb(AliAODRecoDecayHF* obj);
+  Int_t IsSelectedNSigmaPbPb(Double_t Pt, TObjArray aodtracks);
   Int_t IsSelectedCombinedPIDProb(AliAODRecoDecayHF* obj);
+  Int_t IsSelectedCombinedPIDProb(Double_t Pt, TObjArray aodtracks);
   Int_t CombinePIDCuts (Int_t returnvalue, Int_t returnvaluePID) const;
 
   virtual Bool_t IsInFiducialAcceptance(Double_t pt,Double_t y) const;
@@ -120,6 +128,8 @@ class AliRDHFCutsLctopKpi : public AliRDHFCuts
     return fMaxDistanceSecPrimVertex;
   }
   Double_t ComputeInvMass3tracks(AliAODTrack* track1, AliAODTrack* track2, AliAODTrack* track3, Int_t pdg1, Int_t pdg2, Int_t pdg3);
+
+  virtual Int_t PreSelect(TObjArray aodtracks);
   Bool_t PreSelectMass(TObjArray aodTracks);
     
   AliKFParticle* ReconstructKF(AliAODRecoDecayHF3Prong *d,Int_t *pdgs,Double_t field,Bool_t constraint) const;


### PR DESCRIPTION
To be used in productions where there are many candidates to be refilled (PbPb `18 or HF ITSUpgrade productions). So far I only added a pT, PID, and (when requested) a Lc invariant mass selection. More cuts, that don't need the secondary vertex, can still be added of course

PR includes also a minor fix for the Bayes PID strategies, to reject tracks that don't have TPC and TOF PID info. In rare cases these tracks could end up being selected by a loose PID strategy