### PR TITLE
add option to include bayesian PID in tree

### DIFF
--- a/PWGHF/treeHF/AliHFTreeHandler.h
+++ b/PWGHF/treeHF/AliHFTreeHandler.h
@@ -60,7 +60,9 @@ class AliHFTreeHandler : public TObject
       kNsigmaCombPIDfloatandint, //--> to test
       kRawPID,
       kRawAndNsigmaPID,
-      kNsigmaDetAndCombPID
+      kNsigmaDetAndCombPID,
+      kBayesianPID,
+      kBayesianAndNsigmaPID
     };
 
     enum piddet {
@@ -119,6 +121,7 @@ class AliHFTreeHandler : public TObject
     void SetOptPID(int PIDopt) {fPidOpt=PIDopt;}
     void SetOptSingleTrackVars(int opt) {fSingleTrackOpt=opt;}
     void SetFillOnlySignal(bool fillopt=true) {fFillOnlySignal=fillopt;}
+    void SetUpCombinedPid(); 
 
     void SetCandidateType(bool issignal, bool isbkg, bool isprompt, bool isFD, bool isreflected);
     void SetIsSelectedStd(bool isselected, bool isselectedTopo, bool isselectedPID, bool isselectedTracks) {
@@ -202,6 +205,7 @@ class AliHFTreeHandler : public TObject
     void GetNsigmaTPCMeanSigmaData(float &mean, float &sigma, AliPID::EParticleType species, float pTPC, float eta);
 
     TTree* fTreeVar; /// tree with variables
+    AliPIDCombined* fPidCombined; /// bayesian PID object
     unsigned int fNProngs; /// number of prongs
     unsigned int fNCandidates; /// number of candidates in one fill (event)
     int fCandType; ///flag for candidate type (bit map above)
@@ -236,6 +240,7 @@ class AliHFTreeHandler : public TObject
     float fPIDNsigmaVector[knMaxProngs][knMaxDet4Pid+1][knMaxHypo4Pid]; ///PID nsigma variables
     int fPIDNsigmaIntVector[knMaxProngs][knMaxDet4Pid+1][knMaxHypo4Pid]; ///PID nsigma variables (integers)
     float fPIDrawVector[knMaxProngs][knMaxDet4Pid]; ///raw PID variables
+    float fPIDprobBayesVector[knMaxProngs][knMaxHypo4Pid]; ///bayesian PID variables
     int fPidOpt; ///option for PID variables
     int fSingleTrackOpt; ///option for single-track variables
     bool fFillOnlySignal; ///flag to enable only signal filling


### PR DESCRIPTION
add two additional PID options for the tree 
1. Include Bayesian PID variables
2. Include Bayesian and Nsigma variables

Currently the implementation includes default priors, and combines information from the TPC and TOF to calculate the Bayesian probabilities for each track to be a proton, kaon or pion.