### PR TITLE
PWGHF: Typo fix in CombinedSoft PID strategy

### DIFF
--- a/PWGHF/vertexingHF/AliRDHFCutsLctopKpi.cxx
+++ b/PWGHF/vertexingHF/AliRDHFCutsLctopKpi.cxx
@@ -1291,7 +1291,7 @@ Int_t AliRDHFCutsLctopKpi::IsSelectedCombinedPIDSoft(Double_t Pt, TObjArray aodt
   }
   AliAODTrack *trackaod2=(AliAODTrack*)aodtracks.At(2);
   if(fPidObjpion->MakeRawPid(trackaod2,2)>=1)ispi2=kTRUE;
-  AliAODTrack *trackaod0=(AliAODTrack*)aodtracks.At(2); //bug? Should be 0?
+  AliAODTrack *trackaod0=(AliAODTrack*)aodtracks.At(0);
   if(fPidObjpion->MakeRawPid(trackaod0,2)>=1)ispi0=kTRUE;
   
   if(TMath::MaxElement(AliPID::kSPECIES,prob1) == prob1[AliPID::kKaon]){


### PR DESCRIPTION
Spotted this typo/bug in previous PR where I added the PreSelect function, but forgot to actually fix it