### PR TITLE
PWGPP-538 - set event properties and correction mask (enum) in NSigma

### DIFF
--- a/PWGPP/AliAnalysisTaskFilteredTree.cxx
+++ b/PWGPP/AliAnalysisTaskFilteredTree.cxx
@@ -3169,7 +3169,7 @@ Int_t   AliAnalysisTaskFilteredTree::GetNearestTrack(const AliExternalTrackParam
 }
 
 
-void  AliAnalysisTaskFilteredTree::SetDefaultAliasesV0(TTree *tree){
+void  AliAnalysisTaskFilteredTree::SetDefaultAliasesV0(TTree *tree) {
   //
   // SetAliases and Metadata for the V0 trees
   //
@@ -3178,74 +3178,97 @@ void  AliAnalysisTaskFilteredTree::SetDefaultAliasesV0(TTree *tree){
   Double_t massK0 = pdg->GetParticle("K0")->Mass();
   Double_t massPion = pdg->GetParticle("pi+")->Mass();
   Double_t massProton = pdg->GetParticle("proton")->Mass();
-  const Double_t livetimeK0=2.684341668932;  // livetime in cm (surpisely missing info in PDG - see root forum)
-  const Double_t livetimeLambda=7.8875395;  // livetime in cm (missing info in PDG - see root forum)
+  const Double_t livetimeK0 = 2.684341668932;  // livetime in cm (surpisely missing info in PDG - see root forum)
+  const Double_t livetimeLambda = 7.8875395;  // livetime in cm (missing info in PDG - see root forum)
   //
-  tree->SetAlias("massPion",Form("(%f+0)",massPion));
-  tree->SetAlias("massProton",Form("(%f+0)",massProton));
-  tree->SetAlias("massK0",Form("(%f+0)",massK0));
-  tree->SetAlias("massLambda",Form("(%f+0)",massLambda));
+  tree->SetAlias("massPion", Form("(%f+0)", massPion));
+  tree->SetAlias("massProton", Form("(%f+0)", massProton));
+  tree->SetAlias("massK0", Form("(%f+0)", massK0));
+  tree->SetAlias("massLambda", Form("(%f+0)", massLambda));
   //
-  tree->SetAlias("livetimeK0",TString::Format("%f",livetimeK0));
-  tree->SetAlias("livetimeLambda",TString::Format("%f",livetimeLambda));
-  tree->SetAlias("livetimeLikeK0",TString::Format("exp(-v0.fRr/(sqrt((v0.P()/%f)^2+1)*%f))",massK0, livetimeK0)); // 
-  tree->SetAlias("livetimeLikeLambda",TString::Format("exp(-v0.fRr/(sqrt((v0.P()/%f)^2+1)*%f))",massLambda,livetimeLambda)); // 
-  tree->SetAlias("livetimeLikeGamma","v0.fRr/80"); // 
-  tree->SetAlias("livetimeLikeBkg","v0.fRr/80"); //   
+  tree->SetAlias("livetimeK0", TString::Format("%f", livetimeK0));
+  tree->SetAlias("livetimeLambda", TString::Format("%f", livetimeLambda));
+  tree->SetAlias("livetimeLikeK0", TString::Format("exp(-v0.fRr/(sqrt((v0.P()/%f)^2+1)*%f))", massK0, livetimeK0)); //
+  tree->SetAlias("livetimeLikeLambda", TString::Format("exp(-v0.fRr/(sqrt((v0.P()/%f)^2+1)*%f))", massLambda, livetimeLambda)); //
+  tree->SetAlias("livetimeLikeGamma", "v0.fRr/80"); //
+  tree->SetAlias("livetimeLikeBkg", "v0.fRr/80"); //
   // delta of mass
-  tree->SetAlias("K0Delta","(v0.GetEffMass(2,2)-massK0)");
-  tree->SetAlias("LDelta","(v0.GetEffMass(4,2)-massLambda)");
-  tree->SetAlias("ALDelta","(v0.GetEffMass(2,4)-massLambda)");
-  tree->SetAlias("EDelta","(v0.GetEffMass(0,0))");
+  tree->SetAlias("K0Delta", "(v0.GetEffMass(2,2)-massK0)");
+  tree->SetAlias("LDelta", "(v0.GetEffMass(4,2)-massLambda)");
+  tree->SetAlias("ALDelta", "(v0.GetEffMass(2,4)-massLambda)");
+  tree->SetAlias("EDelta", "(v0.GetEffMass(0,0))");
   // pull of the mass
-  tree->SetAlias("K0Pull","(v0.GetEffMass(2,2)-massK0)/v0.GetKFInfo(2,2,1)");
-  tree->SetAlias("LPull","(v0.GetEffMass(4,2)-massLambda)/v0.GetKFInfo(4,2,1)");
-  tree->SetAlias("ALPull","(v0.GetEffMass(2,4)-massLambda)/v0.GetKFInfo(2,4,1)");
-  tree->SetAlias("EPull","EDelta/v0.GetKFInfo(0,0,1)");
+  tree->SetAlias("K0Pull", "(v0.GetEffMass(2,2)-massK0)/v0.GetKFInfo(2,2,1)");
+  tree->SetAlias("LPull", "(v0.GetEffMass(4,2)-massLambda)/v0.GetKFInfo(4,2,1)");
+  tree->SetAlias("ALPull", "(v0.GetEffMass(2,4)-massLambda)/v0.GetKFInfo(2,4,1)");
+  tree->SetAlias("EPull", "EDelta/v0.GetKFInfo(0,0,1)");
   // effective pull of the mass - (empirical values from fits)
-  tree->SetAlias("K0PullEff","K0Delta/sqrt((3.63321e-03)**2+(5.68795e-04*v0.Pt())**2)");
-  tree->SetAlias("LPullEff","LDelta/sqrt((1.5e-03)**2+(1.8e-04*v0.Pt())**2)");
-  tree->SetAlias("ALPullEff","ALDelta/sqrt((1.5e-03)**2+(1.8e-04*v0.Pt())**2)");
-  tree->SetAlias("EPullEff","v0.GetEffMass(0,0)/sqrt((5e-03)**2+(1.e-04*v0.Pt())**2)");
+  tree->SetAlias("K0PullEff", "K0Delta/sqrt((3.63321e-03)**2+(5.68795e-04*v0.Pt())**2)");
+  tree->SetAlias("LPullEff", "LDelta/sqrt((1.5e-03)**2+(1.8e-04*v0.Pt())**2)");
+  tree->SetAlias("ALPullEff", "ALDelta/sqrt((1.5e-03)**2+(1.8e-04*v0.Pt())**2)");
+  tree->SetAlias("EPullEff", "v0.GetEffMass(0,0)/sqrt((5e-03)**2+(1.e-04*v0.Pt())**2)");
   // 
-  tree->SetAlias("dEdx0DProton","AliMathBase::BetheBlochAleph(track0.fIp.P()/massProton)");
-  tree->SetAlias("dEdx1DProton","AliMathBase::BetheBlochAleph(track1.fIp.P()/massProton)");
-  tree->SetAlias("dEdx0DPion","AliMathBase::BetheBlochAleph(track0.fIp.P()/massPion)");
-  tree->SetAlias("dEdx1DPion","AliMathBase::BetheBlochAleph(track1.fIp.P()/massPion)");
+  tree->SetAlias("dEdx0DProton", "AliMathBase::BetheBlochAleph(track0.fIp.P()/massProton)");
+  tree->SetAlias("dEdx1DProton", "AliMathBase::BetheBlochAleph(track1.fIp.P()/massProton)");
+  tree->SetAlias("dEdx0DPion", "AliMathBase::BetheBlochAleph(track0.fIp.P()/massPion)");
+  tree->SetAlias("dEdx1DPion", "AliMathBase::BetheBlochAleph(track1.fIp.P()/massPion)");
   // V0 - cuts - for PID 
-  tree->SetAlias("cutDist","sqrt((track0.fIp.fP[0]-track1.fIp.fP[0])**2+(track0.fIp.fP[1]-track1.fIp.fP[1])**2)>3");
-  tree->SetAlias("cutLong","track0.GetTPCClusterInfo(3,1,0)-5*abs(track0.fP[4])>130&&track1.GetTPCClusterInfo(3,1,0)>130-5*abs(track0.fP[4])");
-  tree->SetAlias("cutPID","track0.fTPCsignal>0&&track1.fTPCsignal>0");
-  tree->SetAlias("cutResol","sqrt(track0.fC[14]/track0.fP[4])<0.15&&sqrt(track1.fC[14]/track1.fP[4])<0.15");
-  tree->SetAlias("cutV0","cutPID&&cutLong&&cutResol"); 
+  tree->SetAlias("cutDist", "sqrt((track0.fIp.fP[0]-track1.fIp.fP[0])**2+(track0.fIp.fP[1]-track1.fIp.fP[1])**2)>3");
+  tree->SetAlias("cutLong", "track0.GetTPCClusterInfo(3,1,0)-5*abs(track0.fP[4])>130&&track1.GetTPCClusterInfo(3,1,0)>130-5*abs(track0.fP[4])");
+  tree->SetAlias("cutPID", "track0.fTPCsignal>0&&track1.fTPCsignal>0");
+  tree->SetAlias("cutResol", "sqrt(track0.fC[14]/track0.fP[4])<0.15&&sqrt(track1.fC[14]/track1.fP[4])<0.15");
+  tree->SetAlias("cutV0", "cutPID&&cutLong&&cutResol");
   //  
-  tree->SetAlias("K0PullBkg","min(min(abs(LPull),abs(ALPull)),abs(EPull))+0");
-  tree->SetAlias("LambdaPullBkg","min(min(abs(K0Pull),abs(ALPull)),abs(EPull)+0)");
-  tree->SetAlias("ALambdaPullBkg","min(min(abs(K0Pull),abs(LPull)),abs(EPull)+0)");
-  tree->SetAlias("EPullBkg","min(min(abs(K0Pull),abs(LPull)),abs(ALPull)+0)");
+  tree->SetAlias("K0PullBkg", "min(min(abs(LPull),abs(ALPull)),abs(EPull))+0");
+  tree->SetAlias("LambdaPullBkg", "min(min(abs(K0Pull),abs(ALPull)),abs(EPull)+0)");
+  tree->SetAlias("ALambdaPullBkg", "min(min(abs(K0Pull),abs(LPull)),abs(EPull)+0)");
+  tree->SetAlias("EPullBkg", "min(min(abs(K0Pull),abs(LPull)),abs(ALPull)+0)");
   //
-  tree->SetAlias("K0Selected",      "abs(K0Pull)<3. &&abs(K0PullEff)<3.  && abs(LPull)>3  && abs(ALPull)>3 &&v0.PtArmV0()>0.11"); 
-  tree->SetAlias("LambdaSelected",  "abs(LPull)<3.  &&abs(LPullEff)<3.   && abs(K0Pull)>3 && abs(EPull)>3  && abs(EDelta)>0.05");  
+  tree->SetAlias("K0Selected", "abs(K0Pull)<3. &&abs(K0PullEff)<3.  && abs(LPull)>3  && abs(ALPull)>3 &&v0.PtArmV0()>0.11");
+  tree->SetAlias("LambdaSelected", "abs(LPull)<3.  &&abs(LPullEff)<3.   && abs(K0Pull)>3 && abs(EPull)>3  && abs(EDelta)>0.05");
   tree->SetAlias("ALambdaSelected", "abs(ALPull)<3. &&abs(ALPullEff)<3   && abs(K0Pull)>3 && abs(EPull)>3  &&abs(EDelta)>0.05");
   tree->SetAlias("GammaSelected", "abs(EPull)<3     && abs(K0Pull)>3 && abs(LPull)>3 && abs(ALPull)>3");
 
-  tree->SetAlias("K0Like0","exp(-K0Pull^2)*livetimeLikeK0");
-  tree->SetAlias("LLike0","exp(-LPull^2)*livetimeLikeLambda");
-  tree->SetAlias("ALLike0","exp(-ALPull^2)*livetimeLikeLambda");
-  tree->SetAlias("ELike0","exp(-abs(EPull)*0.2)*livetimeLikeGamma");
-  tree->SetAlias("BkgLike","0.000005*ntracks");  // backround coeefecint  to be fitted - depends on other cuts 
+  tree->SetAlias("K0Like0", "exp(-K0Pull^2)*livetimeLikeK0");
+  tree->SetAlias("LLike0", "exp(-LPull^2)*livetimeLikeLambda");
+  tree->SetAlias("ALLike0", "exp(-ALPull^2)*livetimeLikeLambda");
+  tree->SetAlias("ELike0", "exp(-abs(EPull)*0.2)*livetimeLikeGamma");
+  tree->SetAlias("BkgLike", "0.000005*ntracks");  // backround coeefecint  to be fitted - depends on other cuts
   //
-  tree->SetAlias("V0Like","exp(-acos(v0.fPointAngle)*v0.fRr/0.36)*exp(-sqrt(kf.GetChi2())/0.5)");
-  tree->SetAlias("ELike","(V0Like*ELike0)/(V0Like*(K0Like0+LLike0+ALLike0+ELike0)+BkgLike)");
-  tree->SetAlias("K0Like","K0Like0/(K0Like0+LLike0+ALLike0+ELike0+BkgLike)");
-  tree->SetAlias("LLike","LLike0/(K0Like0+LLike0+ALLike0+ELike0+BkgLike)");
-  tree->SetAlias("ALLike","ALLike0/(K0Like0+LLike0+ALLike0+ELike0+BkgLike)");
+  tree->SetAlias("V0Like", "exp(-acos(v0.fPointAngle)*v0.fRr/0.36)*exp(-sqrt(kf.GetChi2())/0.5)");
+  tree->SetAlias("ELike", "(V0Like*ELike0)/(V0Like*(K0Like0+LLike0+ALLike0+ELike0)+BkgLike)");
+  tree->SetAlias("K0Like", "K0Like0/(K0Like0+LLike0+ALLike0+ELike0+BkgLike)");
+  tree->SetAlias("LLike", "LLike0/(K0Like0+LLike0+ALLike0+ELike0+BkgLike)");
+  tree->SetAlias("ALLike", "ALLike0/(K0Like0+LLike0+ALLike0+ELike0+BkgLike)");
   //
-  tree->SetAlias("K0PIDPull","(abs(track0.fTPCsignal/dEdx0DPion-50)+abs(track1.fTPCsignal/dEdx1DPion-50))/5.");
-  tree->SetAlias("mpt","1/v0.Pt()");                 // 
-  tree->SetAlias("tglV0","v0.Pz()/v0.Pt()");                 // 
-  tree->SetAlias("alphaV0","atan2(v0.Py(),v0.Px()+0)");
-  tree->SetAlias("dalphaV0","alphaV0-((int(36+9*(alphaV0/pi))-36)*pi/9.)");
+  tree->SetAlias("K0PIDPull", "(abs(track0.fTPCsignal/dEdx0DPion-50)+abs(track1.fTPCsignal/dEdx1DPion-50))/5.");
+  tree->SetAlias("mpt", "1/v0.Pt()");                 //
+  tree->SetAlias("tglV0", "v0.Pz()/v0.Pt()");                 //
+  tree->SetAlias("alphaV0", "atan2(v0.Py(),v0.Px()+0)");
+  tree->SetAlias("dalphaV0", "alphaV0-((int(36+9*(alphaV0/pi))-36)*pi/9.)");
+}
+
+void  AliAnalysisTaskFilteredTree::SetDefaultAliasesV0PID(TTree *treeV0, Int_t pidHash){
+  //
+   //
+  treeV0->SetAlias("track0tpcNsigmaElectron",Form("AliPIDtools::NumberOfSigmas(%d,1, 0,0+0)",pidHash));
+  treeV0->SetAlias("track0tpcNsigmaPion",Form("AliPIDtools::NumberOfSigmas(%d,1, 2,0+0)",pidHash));
+  treeV0->SetAlias("track0tpcNsigmaKaon",Form("AliPIDtools::NumberOfSigmas(%d,1, 3,0+0)",pidHash));
+  treeV0->SetAlias("track0tpcNsigmaProton",Form("AliPIDtools::NumberOfSigmas(%d,1, 4,0+0)",pidHash));
+  treeV0->SetAlias("track1tpcNsigmaElectron",Form("AliPIDtools::NumberOfSigmas(%d,1, 0,1+0)",pidHash));
+  treeV0->SetAlias("track1tpcNsigmaPion",Form("AliPIDtools::NumberOfSigmas(%d,1, 2,1+0)",pidHash));
+  treeV0->SetAlias("track1tpcNsigmaKaon",Form("AliPIDtools::NumberOfSigmas(%d,1, 3,1+0)",pidHash));
+  treeV0->SetAlias("track1tpcNsigmaProton",Form("AliPIDtools::NumberOfSigmas(%d,1, 4,1+0)",pidHash));
+  //
+  treeV0->SetAlias("track0ExpectedTPCSignalV0_el",Form("AliPIDtools::GetExpectedTPCSignalV0(%d,0,0x1, 0,1+0)",pidHash));
+  treeV0->SetAlias("track0ExpectedTPCSignalV0_pi",Form("AliPIDtools::GetExpectedTPCSignalV0(%d,2,0x1, 0,1+0)",pidHash));
+  treeV0->SetAlias("track0ExpectedTPCSignalV0_ka",Form("AliPIDtools::GetExpectedTPCSignalV0(%d,3,0x1, 0,1+0)",pidHash));
+  treeV0->SetAlias("track0ExpectedTPCSignalV0_pro",Form("AliPIDtools::GetExpectedTPCSignalV0(%d,4,0x1, 0,1+0)",pidHash));
+
+  treeV0->SetAlias("track1ExpectedTPCSignalV0_el",Form("AliPIDtools::GetExpectedTPCSignalV0(%d,0,0x1, 1,1+0)",pidHash));
+  treeV0->SetAlias("track1ExpectedTPCSignalV0_pi",Form("AliPIDtools::GetExpectedTPCSignalV0(%d,2,0x1, 1,1+0)",pidHash));
+  treeV0->SetAlias("track1ExpectedTPCSignalV0_ka",Form("AliPIDtools::GetExpectedTPCSignalV0(%d,3,0x1, 1,1+0)",pidHash));
+  treeV0->SetAlias("track1ExpectedTPCSignalV0_pro",Form("AliPIDtools::GetExpectedTPCSignalV0(%d,4,0x1, 1,1+0)",pidHash));
 
 }
 

--- a/PWGPP/AliAnalysisTaskFilteredTree.h
+++ b/PWGPP/AliAnalysisTaskFilteredTree.h
@@ -134,7 +134,8 @@ class AliAnalysisTaskFilteredTree : public AliAnalysisTaskSE {
   void FillHistograms(AliESDtrack* const ptrack, AliExternalTrackParam* const ptpcInnerC, Double_t centralityF, Double_t chi2TPCInnerC);
   Int_t   GetNearestTrack(const AliExternalTrackParam * trackMatch, Int_t indexSkip, AliESDEvent*event, Int_t trackType, Int_t paramType,  AliExternalTrackParam & paramNearest);
   static void SetDefaultAliasesV0(TTree *treeV0);
-  static void SetDefaultAliasesHighPt(TTree *treeV0);
+  static void  SetDefaultAliasesV0PID(TTree *treeV0, Int_t pidHash);
+  static void SetDefaultAliasesHighPt(TTree *tree);
   static void SetDefaultAliasesEvents(TTree *treeEvent);
   Int_t GetMCInfoTrack(Int_t label,   std::map<std::string,float> &trackInfoF, std::map<std::string,TObject*> &trackInfoO);  //TODO- test before enabling
   Int_t GetMCInfoKink(Int_t label,    std::map<std::string,float> &kinkInfoF, std::map<std::string,TObject*> &kinkInfoO);  // TODO

--- a/PWGPP/AliPIDtools.cxx
+++ b/PWGPP/AliPIDtools.cxx
@@ -144,7 +144,7 @@ Bool_t AliPIDtools::SetFilteredTreeV0(TTree * filteredTreeV0){
 /// \param corrMask             - corr mask
 ///                                 0x1 - eta correction
 ///                                 0x2 - multiplicity correction
-///                                 0x4 - pile-up correction
+///                                 0x4 - pile-up correction kPileUp
 ///                                 0x8  - return pileup correction
 /// \param returnType            0
 ///                                 0 - expected signal
@@ -158,7 +158,7 @@ Double_t AliPIDtools::GetExpectedTPCSignal(Int_t hash, Int_t particleType, Int_t
   TVectorF   **pptpcVertexInfo=0;
   TVectorF   **ppitsClustersPerLayer=0;
   Float_t primMult=0;
-  Bool_t corrPileUp=corrMask&0x4;
+  Bool_t corrPileUp=corrMask&kPileUpCorr;
   if (fFilteredTree){  // data from filtered trees
     Int_t entry = fFilteredTree->GetReadEntry();
     static  TBranch * branch = NULL;
@@ -194,11 +194,11 @@ Double_t AliPIDtools::GetExpectedTPCSignal(Int_t hash, Int_t particleType, Int_t
   if (pptrack==0) return 0;
   if (corrMask==0x8) return tpcPID->GetPileupCorrectionValue(*pptrack);
   if (returnType==0) {
-    dEdx = tpcPID->GetExpectedSignal(*pptrack, (AliPID::EParticleType) particleType, AliTPCPIDResponse::kdEdxDefault, corrMask & 0x1, corrMask & 0x2, corrMask & 0x4);
+    dEdx = tpcPID->GetExpectedSignal(*pptrack, (AliPID::EParticleType) particleType, AliTPCPIDResponse::kdEdxDefault, corrMask & kEtaCorr, corrMask & kMultCorr, corrMask & kPileUpCorr);
     return dEdx;
   }
   if (returnType==1) {
-    dEdx = tpcPID->GetCorrectedTrackdEdx(*pptrack, (AliPID::EParticleType) particleType, corrMask & 0x1, corrMask & 0x2, corrMask & 0x4, AliTPCPIDResponse::kdEdxDefault);
+    dEdx = tpcPID->GetCorrectedTrackdEdx(*pptrack, (AliPID::EParticleType) particleType, corrMask & kEtaCorr, corrMask & kMultCorr, corrMask & kPileUpCorr, AliTPCPIDResponse::kdEdxDefault);
     return dEdx;
   }
   return 0;
@@ -207,7 +207,7 @@ Double_t AliPIDtools::GetExpectedTPCSignal(Int_t hash, Int_t particleType, Int_t
 /// GetExpected TPC signal for current V0 track
 /// \param hash                 - PID hash
 /// \param particleType         - assumed particle type
-/// \param corrMask             - corr mask
+/// \param corrMask             - corr mask (see TPCCorrFlag)
 ///                                 0x1 - eta correction
 ///                                 0x2 - multiplicity correction
 ///                                 0x4 - pile-up correction
@@ -221,7 +221,7 @@ Double_t AliPIDtools::GetExpectedTPCSignalV0(Int_t hash, Int_t particleType, Int
   AliESDtrack **pptrack=0;
   TVectorF   **pptpcVertexInfo=0;
   TVectorF   **ppitsClustersPerLayer=0;
-  Bool_t corrPileUp=corrMask&0x4;
+  Bool_t corrPileUp=corrMask&kPileUpCorr;
   if (fFilteredTreeV0){  // data from filtered trees
     Int_t entry = fFilteredTreeV0->GetReadEntry();
     static TBranch * branch0, *branch1 = NULL;
@@ -256,11 +256,11 @@ Double_t AliPIDtools::GetExpectedTPCSignalV0(Int_t hash, Int_t particleType, Int
   if (corrMask==0x8) return tpcPID->GetPileupCorrectionValue(*pptrack);
 
   if (returnType==0) {
-    dEdx = tpcPID->GetExpectedSignal(*pptrack, (AliPID::EParticleType) particleType, AliTPCPIDResponse::kdEdxDefault, corrMask & 0x1, corrMask & 0x2, corrMask & 0x4);
+    dEdx = tpcPID->GetExpectedSignal(*pptrack, (AliPID::EParticleType) particleType, AliTPCPIDResponse::kdEdxDefault, corrMask & kEtaCorr, corrMask & kMultCorr, corrMask & kPileUpCorr);
     return dEdx;
   }
   if (returnType==1) {
-    dEdx = tpcPID->GetCorrectedTrackdEdx(*pptrack, (AliPID::EParticleType) particleType, corrMask & 0x1, corrMask & 0x2, corrMask & 0x4, AliTPCPIDResponse::kdEdxDefault);
+    dEdx = tpcPID->GetCorrectedTrackdEdx(*pptrack, (AliPID::EParticleType) particleType, corrMask & kEtaCorr, corrMask & kMultCorr, corrMask & kPileUpCorr, AliTPCPIDResponse::kdEdxDefault);
     return dEdx;
   }
   return 0;
@@ -317,6 +317,84 @@ AliESDtrack* AliPIDtools::GetCurrentTrackV0(Int_t index) {
   return 0;
 }
 
+/// Set TPCPIDResponse event information
+/// \param pidHash      - pidhash  index of the response
+/// \param corrPileUp   - switch -
+/// \return
+Bool_t       AliPIDtools::SetTPCEventInfo(Int_t pidHash,Int_t corrMaskTPC){
+  if (fFilteredTree==NULL) return kFALSE;
+  AliTPCPIDResponse *tpcPID=pidTPC[pidHash];
+  if (tpcPID == NULL) return kFALSE;
+  TVectorF   **pptpcVertexInfo=0;
+  TVectorF   **ppitsClustersPerLayer=0;
+  Int_t entry = fFilteredTree->GetReadEntry();
+  static TBranch *branchVertex=0;
+  static TBranch *branchITS=0;
+  static Int_t treeNumber=-1;
+  static TLeaf * leafPrim=0;
+  static TLeaf * leaftpcClusterMult=0;
+  static TLeaf * leaftpcTrackBeforeClean=0;
+  fFilteredTree->GetEntry(entry);   // load full tree - branch GetEntry is loading only for fit file in TChain  //TODO fix
+  if (treeNumber!=fFilteredTree->GetTreeNumber()) {
+    if (fFilteredTree->GetFriend("E")) {
+      branchVertex = fFilteredTreeV0->GetFriend("E")->GetBranch("tpcVertexInfoESD.");
+      branchITS = fFilteredTreeV0->GetFriend("E")->GetBranch("itsClustersPerLayer.");
+      leafPrim = fFilteredTreeV0->GetFriend("E")->GetLeaf("primMult");
+      leaftpcClusterMult = fFilteredTreeV0->GetFriend("E")->GetLeaf("tpcClusterMult");
+      leaftpcTrackBeforeClean = fFilteredTreeV0->GetFriend("E")->GetLeaf("tpcTrackBeforeClean");
+    }
+    treeNumber = fFilteredTreeV0->GetTreeNumber();
+  }
+  if ((corrMaskTPC&kPileUpCorr)&& branchVertex!=NULL) {
+    pptpcVertexInfo = (branchVertex != NULL) ? (TVectorF **) (branchVertex->GetAddress()) : NULL;
+    ppitsClustersPerLayer = (branchITS != NULL) ? (TVectorF **) (branchITS->GetAddress()) : NULL;
+    SetPileUpProperties(**pptpcVertexInfo, **ppitsClustersPerLayer, leafPrim->GetValue(), tpcPID);
+  }
+  tpcPID->SetCurrentEventMultiplicity(leaftpcTrackBeforeClean->GetValue());
+  return kTRUE;
+}
+
+
+/// Set TPCPIDResponse event information
+/// \param pidHash      - pidhash  index of the response
+/// \param corrPileUp   - switch -
+/// \return
+Bool_t       AliPIDtools::SetTPCEventInfoV0(Int_t pidHash,Int_t corrMaskTPC){
+  if (fFilteredTreeV0==NULL) return kFALSE;
+  AliTPCPIDResponse *tpcPID=pidTPC[pidHash];
+  if (tpcPID == NULL) return kFALSE;
+  TVectorF   **pptpcVertexInfo=0;
+  TVectorF   **ppitsClustersPerLayer=0;
+  Int_t entry = fFilteredTree->GetReadEntry();
+  static TBranch *branchVertex=0;
+  static TBranch *branchITS=0;
+  static Int_t treeNumber=-1;
+  static TLeaf * leafPrim=0;
+  static TLeaf * leaftpcClusterMult=0;
+  static TLeaf * leaftpcTrackBeforeClean=0;
+  fFilteredTreeV0->GetEntry(entry);   // load full tree - branch GetEntry is loading only for fit file in TChain  //TODO fix
+  if (treeNumber!=fFilteredTreeV0->GetTreeNumber()) {
+    if (fFilteredTreeV0->GetFriend("E")) {
+      branchVertex = fFilteredTreeV0->GetFriend("E")->GetBranch("tpcVertexInfoESD.");
+      branchITS = fFilteredTreeV0->GetFriend("E")->GetBranch("itsClustersPerLayer.");
+      leafPrim = fFilteredTreeV0->GetFriend("E")->GetLeaf("primMult");
+      leaftpcClusterMult = fFilteredTreeV0->GetFriend("E")->GetLeaf("tpcClusterMult");
+      leaftpcTrackBeforeClean = fFilteredTreeV0->GetFriend("E")->GetLeaf("tpcTrackBeforeClean");
+    }
+    treeNumber = fFilteredTreeV0->GetTreeNumber();
+  }
+  if ((corrMaskTPC&kPileUpCorr)&& branchVertex!=NULL) {
+    pptpcVertexInfo = (branchVertex != NULL) ? (TVectorF **) (branchVertex->GetAddress()) : NULL;
+    ppitsClustersPerLayer = (branchITS != NULL) ? (TVectorF **) (branchITS->GetAddress()) : NULL;
+    SetPileUpProperties(**pptpcVertexInfo, **ppitsClustersPerLayer, leafPrim->GetValue(), tpcPID);
+  }
+  tpcPID->SetCurrentEventMultiplicity(leaftpcTrackBeforeClean->GetValue());
+  return kTRUE;
+}
+
+
+
+
 /// GetITSPID for given particle and valu type
 /// TODO - interface other PID options
 /// \param hash              - hash value of PID
@@ -358,16 +436,36 @@ Double_t AliPIDtools::GetTOFPID(Int_t hash, Int_t particleType, Int_t valueType,
   return 0;
 }
 
-///
-/// \param hash
-/// \param detCode
-/// \param particleType
-/// \param source
+/// Return PIDnsigma
+/// \param hash           - hash value of PID correction
+/// \param detCode        - detector code (0-ITS, 1-TPC, 2-TRD, 3-TOF
+/// \param particleType   -
+/// \param source         -
+/// \param corrMask       - correction bitMask - TPCCorrFlag
 /// \return
-Float_t AliPIDtools::NumberOfSigmas(Int_t hash, Int_t detCode, Int_t particleType, Int_t source){
+Float_t AliPIDtools::NumberOfSigmas(Int_t hash, Int_t detCode, Int_t particleType, Int_t source, Int_t corrMask){
   if (pidAll[hash]==NULL) return 0;
+  AliPIDResponse pid = pidAll[hash];
+  //
+  Int_t maskBackup=0;                     // make backup of PID state
+  if (pid.UseTPCEtaCorrection()) maskBackup+=kEtaCorr;
+  if (pid.UseTPCMultiplicityCorrection()) maskBackup+=kMultCorr;
+  if (pid.UseTPCPileupCorrection()) maskBackup+=kPileUpCorr;
+  //
+  if (corrMask<0) corrMask=maskBackup;
   AliESDtrack *track=NULL;
-  if (source<0)track=GetCurrentTrack();
-  if (source>=0)track=GetCurrentTrackV0(source%2);
-  return pidAll[hash]->NumberOfSigmas((AliPIDResponse::EDetector) detCode, track, (AliPID::EParticleType)particleType);
+  if (source<0){
+    track=GetCurrentTrack();
+    SetTPCEventInfo(hash,corrMask);
+  }
+  if (source>=0){
+    track=GetCurrentTrackV0(source%2);
+    SetTPCEventInfoV0(hash,corrMask);
+  }
+  Double_t value=pidAll[hash]->NumberOfSigmas((AliPIDResponse::EDetector) detCode, track, (AliPID::EParticleType)particleType);
+  // restore flags
+  pid.SetUseTPCEtaCorrection(kEtaCorr&maskBackup);
+  pid.SetUseTPCMultiplicityCorrection(maskBackup&kMultCorr);
+  pid.SetUseTPCPileupCorrection(maskBackup&kPileUpCorr);
+  return value;
 }

--- a/PWGPP/AliPIDtools.h
+++ b/PWGPP/AliPIDtools.h
@@ -32,6 +32,7 @@ class AliTOFPIDResponse;
 
 
 class AliPIDtools {
+  enum TPCCorrFlag { kEtaCorr=0x1, kMultCorr=0x2, kPileUpCorr=0x4 };
 public:
   static Int_t GetHash(Int_t run, Int_t passNumber, TString recoPass, Bool_t isMC);
   static Int_t LoadPID(Int_t run, Int_t passNumber, TString recoPass, Bool_t isMC);
@@ -50,11 +51,14 @@ public:
   // TTree interface
   static AliESDtrack* GetCurrentTrack();
   static AliESDtrack* GetCurrentTrackV0(Int_t index);
+  static Bool_t       SetTPCEventInfo(Int_t hash,  Int_t corrMask);
+  static Bool_t       SetTPCEventInfoV0(Int_t hash, Int_t corrMask);
+  //
   static Double_t GetExpectedTPCSignal(Int_t hash, Int_t particleType, Int_t corrMask, Int_t returnType);
   static Double_t GetExpectedTPCSignalV0(Int_t hash, Int_t particleType, Int_t corrMask, Int_t index, Int_t returnType);
   static Double_t GetITSPID(Int_t hash, Int_t particleType, Int_t valueType, Float_t resol=0);
   static Double_t GetTOFPID(Int_t hash, Int_t particleType, Int_t valueType, Float_t resol=0);
-  static Float_t NumberOfSigmas(Int_t hash, Int_t detCode, Int_t particleType, Int_t source=-1);
+  static Float_t NumberOfSigmas(Int_t hash, Int_t detCode, Int_t particleType, Int_t source=-1, Int_t corrMask=-1);
   //
   //
   static std::map<Int_t, AliTPCPIDResponse *> pidTPC;     /// we should use better hash map

--- a/PWGPP/AliPIDtools.h
+++ b/PWGPP/AliPIDtools.h
@@ -32,7 +32,7 @@ class AliTOFPIDResponse;
 
 
 class AliPIDtools {
-  enum TPCCorrFlag { kEtaCorr=0x1, kMultCorr=0x2, kPileUpCorr=0x4 };
+  enum  { kEtaCorr=0x1, kMultCorr=0x2, kPileUpCorr=0x4 };
 public:
   static Int_t GetHash(Int_t run, Int_t passNumber, TString recoPass, Bool_t isMC);
   static Int_t LoadPID(Int_t run, Int_t passNumber, TString recoPass, Bool_t isMC);

--- a/PWGPP/TPC/macros/performanceFiltered.C
+++ b/PWGPP/TPC/macros/performanceFiltered.C
@@ -267,7 +267,7 @@ TObjArray * FillPerformanceHistogram(Int_t maxEntries){
   chain->SetEstimate(chain->GetEntries());
   TString timeRange=TString::Format( "%d,%.0f,%.0f",timeBins,timeStart, timeEnd);
   //
-  TString defaultCut="esdTrack.GetTPCClusterInfo(3,1)>60&&esdTrack.IsOn(0x1)>0";
+  TString defaultCut="esdTrack.GetTPCClusterInfo(3,1)>60&&esdTrack.IsOn(0x1)>0&&selectionPtMask>0";
   TString defaultCutMatch="esdTrack.GetTPCClusterInfo(3,1)>60";
   const Int_t nQAHisto=23;
   const char * qaHistos[nQAHisto]={"nclITS","nclTPC","nclTRD",		\


### PR DESCRIPTION
PWGPP-538 - set event properties and correction mask (enum) in NSigma
PWGPP-538 - update doc
PWGPP-538 - reset PID correction mask
PWGPP-538 - set /reset switches
PWGPP-312 - use only selectionPTMask tracks
PWGPP-538 - set default aliases for PID AliAnalysisTaskFilteredTree::SetDefaultAliasesV0PID