### PR TITLE
PWGPP-538 - Exception handling - adding test/checks of track and event GID

### DIFF
--- a/PWGPP/AliPIDtools.h
+++ b/PWGPP/AliPIDtools.h
@@ -59,6 +59,7 @@ public:
   static Double_t GetITSPID(Int_t hash, Int_t particleType, Int_t valueType, Float_t resol=0);
   static Double_t GetTOFPID(Int_t hash, Int_t particleType, Int_t valueType, Float_t resol=0);
   static Float_t NumberOfSigmas(Int_t hash, Int_t detCode, Int_t particleType, Int_t source=-1, Int_t corrMask=-1);
+  static Float_t GetSignalDelta(Int_t hash, Int_t detCode, Int_t particleType, Int_t source=-1, Int_t corrMask=-1);
   //
   //
   static std::map<Int_t, AliTPCPIDResponse *> pidTPC;     /// we should use better hash map


### PR DESCRIPTION
## PWGPP-538 - add Float_t AliPIDtools::GetSignalDelta(Int_t hash, Int_t detCode, Int_t particleType, Int_t source, Int_t corrMask){

````
/// \param hash           - hash value of PID correction
/// \param detCode        - detector code (0-ITS, 1-TPC, 2-TRD, 3-TOF)  AliPIDResponse::enum EDetector
/// \param particleType   - see enum
/// \param source         - track index
/// \param corrMask       - correction bitMask - AliPIDTools:: enum TPCCorrFlag
/// \return
Float_t AliPIDtools::GetSignalDelta(Int_t hash, Int_t detCode, Int_t particleType, Int_t source, Int_t corrMask){
````

## PWGPP-538 - Exception handling - adding test/checks of track and event GID

* in case of the tree and event tree not properly initialized - print meassage
* automatically set trees in case of change of input  trees
