### PR TITLE
add pt-dependent Lb fragmentation

### DIFF
--- a/PWGHF/vertexingHF/macros/ComputeBtoDdecay.C
+++ b/PWGHF/vertexingHF/macros/ComputeBtoDdecay.C
@@ -41,6 +41,10 @@
 ///   opt4ff = set of fragmentation fractions f(b->B) to be used
 ///                  0 --> ppbar fractions from PDG
 ///                  1 --> Z decay fractions from PDG
+///                  2 --> pT-dependent fractions from LHCb - cent hypothesis
+///                  3 --> pT-dependent fractions from LHCb - min hypothesis
+///                  4 --> pT-dependent fractions from LHCb - max hypothesis
+///                  5 --> pT-dependent fractions from LHCb - min hypothesis + Lb energy scaling to 5 TeV
 ///   optForNorm = treatment of rapidity cut and normalization of xsec
 ///                  0 --> no cut on y(D) and normalisation ot xsec of B in |y|<0.5
 ///                  1 --> generate B in |yB|<1, cut on |yD|<0.5, count B in |yB|<0.5 for normalisation to xsec
@@ -65,6 +69,11 @@ void ComputeBtoDdecay(Int_t nGener=10000000,
   Int_t pdgArrB[nBeautyHadSpecies]={511,521,531,5122};
   TString bhadrname[nBeautyHadSpecies]={"B0","Bplus","Bs","Lb"};
   Double_t fracB[4]={0.401,0.401,0.105,0.093};
+  TF1 *fracU[15];
+  TF1 *fracBs[15];
+  TF1 *fracLb[15];
+  TF1 *enScal;
+
   if(opt4ff==0){
     // ppbar fractions
     fracB[0]=0.340;
@@ -78,7 +87,82 @@ void ComputeBtoDdecay(Int_t nGener=10000000,
     fracB[2]=0.088;
     fracB[3]=0.088;    
   }
-  
+  else if(opt4ff>=2){
+    // pt-dependent fractions - evaluate when b hadron pt is calculated in the gen. loop
+    // parameters for pT-dependence from LHCb beauty fraction measurement from https://arxiv.org/pdf/1902.06794.pdf
+    fracB[0]=0.;
+    fracB[1]=0.;
+    fracB[2]=0.;
+    fracB[3]=0.;    
+
+    // FF uncertainty defined as the envelope of the variations of the fit parameters in LHCb paper
+    // ipar=0 : central
+    // 1 <= ipar <= 7 : upper uncertainties 
+    // 8 <= ipar <= 14 : lower uncertainties 
+    for(Int_t ipar=0;ipar<15;ipar++){
+
+      fracU[ipar] = new TF1("fracU","1 /  (2 * (([0] * ([1] + [2] * (x - [3])))  + ([4] * ([5] + exp([6] + [7] * x))) + 1) ) ",0,50 );
+      fracLb[ipar] = new TF1("fracLb","([4] * ([5] + exp([6] + [7] * x))) /  (([0] * ([1] + [2] * (x - [3])))  + ([4] * ([5] + exp([6] + [7] * x))) + 1)  ",0,50 );
+      fracBs[ipar] = new TF1("fracBs","([0] * ([1] + [2] * (x - [3]))) /  (([0] * [1] + [2] * (x - [3]))  + ([4] * ([5] + exp([6] + [7] * x))) + 1)  ",0,50 );
+
+      Double_t parLbA = 1;
+      Double_t parLbp1 = 0.0793;
+      Double_t parLbp2 = -1.022;
+      Double_t parLbp3 = -0.107;
+      Double_t parBsA = 1;
+      Double_t parBsp1 = 0.119;
+      Double_t parBsp2 = -0.00091;
+      Double_t parBsAvePt = 10.1;
+
+      // positive
+      if(ipar==1) parLbA += 0.061;
+      if(ipar==2) parLbp1 += 0.0141;
+      if(ipar==3) parLbp2 += 0.0047;
+      if(ipar==4) parLbp3 += 0.002;
+      if(ipar==5) parBsA += 0.043;
+      if(ipar==6) parBsp1 += 0.001;
+      if(ipar==7) parBsp2 += 0.00025;
+      // negative errors
+      if(ipar==8) parLbA -= 0.061;
+      if(ipar==9) parLbp1 -= 0.0141;
+      if(ipar==10) parLbp2 -= 0.0047;
+      if(ipar==11) parLbp3 -= 0.002;
+      if(ipar==12) parBsA -= 0.043;
+      if(ipar==13) parBsp1 -= 0.001;
+      if(ipar==14) parBsp2 -= 0.00025;
+
+      fracU[ipar]->SetParameter(0,parBsA);
+      fracU[ipar]->SetParameter(1,parBsp1);
+      fracU[ipar]->SetParameter(2,parBsp2);
+      fracU[ipar]->SetParameter(3,parBsAvePt);
+      fracU[ipar]->SetParameter(4,parLbA);
+      fracU[ipar]->SetParameter(5,parLbp1);
+      fracU[ipar]->SetParameter(6,parLbp2);
+      fracU[ipar]->SetParameter(7,parLbp3);
+      fracBs[ipar]->SetParameter(0,parBsA);
+      fracBs[ipar]->SetParameter(1,parBsp1);
+      fracBs[ipar]->SetParameter(2,parBsp2);
+      fracBs[ipar]->SetParameter(3,parBsAvePt);
+      fracBs[ipar]->SetParameter(4,parLbA);
+      fracBs[ipar]->SetParameter(5,parLbp1);
+      fracBs[ipar]->SetParameter(6,parLbp2);
+      fracBs[ipar]->SetParameter(7,parLbp3);
+      fracLb[ipar]->SetParameter(0,parBsA);
+      fracLb[ipar]->SetParameter(1,parBsp1);
+      fracLb[ipar]->SetParameter(2,parBsp2);
+      fracLb[ipar]->SetParameter(3,parBsAvePt);
+      fracLb[ipar]->SetParameter(4,parLbA);
+      fracLb[ipar]->SetParameter(5,parLbp1);
+      fracLb[ipar]->SetParameter(6,parLbp2);
+      fracLb[ipar]->SetParameter(7,parLbp3);
+
+    }
+    if(opt4ff==5) {
+      enScal = new TF1("enScal","[0]",0,50);
+      enScal->SetParameter(0,0.796357); // average difference between 13 TeV/7 TeV Lb/B ratio, + 50%
+    }
+  }
+
   const Int_t nCharmHadSpecies=5;
   Int_t pdgArrC[nCharmHadSpecies]={421,411,431,4122,413};
   TString chadrname[nCharmHadSpecies]={"D0","Dplus","Ds","Lc","Dstar"};
@@ -172,6 +256,9 @@ void ComputeBtoDdecay(Int_t nGener=10000000,
       hDptVsBpt[ib*nCharmHadSpecies+ic] = new TH2F(Form("h%sptVs%spt",chadrname[ic].Data(),bhadrname[ib].Data()),Form(" ; p_{T}(%s) ; p_{T}(%s)",bhadrname[ib].Data(),chadrname[ic].Data()),200,0.,100.,200.,0.,100.);
     }
   }
+  TH1D *hUfrac = new TH1D("hUfrac","hUfrac",250,0,50);
+  TH1D *hBsfrac = new TH1D("hBsfrac","hBsfrac",250,0,50);
+  TH1D *hLbfrac = new TH1D("hLbfrac","hLbfrac",250,0,50);
 
   TTree* fTreeDecays = 0x0;
   Int_t pdgB = -9999;
@@ -202,7 +289,7 @@ void ComputeBtoDdecay(Int_t nGener=10000000,
   TLorentzVector* vec=new TLorentzVector();
 
   Double_t countB=0;
-  
+
   for(Int_t itry=0; itry<nGener; itry++){
     if(itry%10000==0) printf("Particle %d\n",itry);
 
@@ -212,6 +299,58 @@ void ComputeBtoDdecay(Int_t nGener=10000000,
     TH2F* hptDptofill=0x0;
     TH2F* hptDstofill=0x0;
     TH2F* hptLctofill=0x0;
+    ptB=hBptDistr->GetRandom();
+    if(opt4ff>=2){
+      if(opt4ff==2){
+        fracB[0] = fracU[0]->Eval(ptB>5?ptB:5);  
+        fracB[1] = fracU[0]->Eval(ptB>5?ptB:5);  
+        fracB[2] = fracBs[0]->Eval(ptB>5?ptB:5); 
+        fracB[3] = fracLb[0]->Eval(ptB>5?ptB:5); 
+      }
+      else{ 
+        fracB[0] = opt4ff==4?0:1;
+        fracB[1] = opt4ff==4?0:1;
+        fracB[2] = opt4ff==4?0:1;
+        fracB[3] = opt4ff==4?0:1;
+        for(Int_t ipar=1;ipar<15;ipar++){
+          if(opt4ff==3){ // minimum
+            Double_t fracLbtry = fracLb[ipar]->Eval(ptB>5?ptB:5);
+            if(fracLbtry<fracB[3]){
+              fracB[0] = fracU[ipar]->Eval(ptB>5?ptB:5);
+              fracB[1] = fracU[ipar]->Eval(ptB>5?ptB:5);
+              fracB[2] = fracBs[ipar]->Eval(ptB>5?ptB:5);
+              fracB[3] = fracLb[ipar]->Eval(ptB>5?ptB:5);
+            }
+          }
+          else if(opt4ff==4){ // maximum
+            Double_t fracLbtry = fracLb[ipar]->Eval(ptB);
+            if(fracLbtry>fracB[3]){
+              fracB[0] = fracU[ipar]->Eval(ptB);
+              fracB[1] = fracU[ipar]->Eval(ptB);
+              fracB[2] = fracBs[ipar]->Eval(ptB);
+              fracB[3] = fracLb[ipar]->Eval(ptB);
+            }
+          }
+          else if(opt4ff==5){ // minimum, with additional energy uncertainty
+            Double_t fracLbtry = fracLb[ipar]->Eval(ptB>5?ptB:5);
+            Double_t scaleLb; 
+            if(opt4ff==5) {
+              scaleLb = enScal->Eval(ptB);
+            }
+            if(fracLbtry<fracB[3]){
+              Double_t diffLb = fracLb[ipar]->Eval(ptB>5?ptB:5) * (1. -  scaleLb);
+              fracB[0] = fracU[ipar]->Eval(ptB>5?ptB:5) ;
+              fracB[1] = fracU[ipar]->Eval(ptB>5?ptB:5) ;
+              fracB[2] = fracBs[ipar]->Eval(ptB>5?ptB:5) + diffLb;
+              fracB[3] = fracLb[ipar]->Eval(ptB>5?ptB:5) * scaleLb;
+            }
+          }
+        }
+      }
+      hUfrac->SetBinContent(hUfrac->FindBin(ptB),fracB[0]);
+      hBsfrac->SetBinContent(hBsfrac->FindBin(ptB),fracB[2]);
+      hLbfrac->SetBinContent(hLbfrac->FindBin(ptB),fracB[3]);
+    }
     if(value<fracB[0]){ 
       pdgB=pdgArrB[0];
       iBhad=0;
@@ -228,7 +367,6 @@ void ComputeBtoDdecay(Int_t nGener=10000000,
     hBhadDau[iBhad]->Fill(-1);
     
     Double_t mass=db->GetParticle(pdgB)->Mass();
-    ptB=hBptDistr->GetRandom();
     Double_t phiB=gener->Rndm()*2*TMath::Pi();
     yB=gener->Rndm()*2.-1.; // flat in -1<y<1
     Double_t px=ptB*TMath::Cos(phiB);
@@ -384,6 +522,8 @@ void ComputeBtoDdecay(Int_t nGener=10000000,
     legf->AddEntry(hfpromptD[ic],chadrname[ic].Data(),"L")->SetTextColor(cols[ic]);
   }
   legf->Draw();
+
+
   
   TString outfilnam="DfromB_FONLL";
   if(fonllCase==1) outfilnam.Append("max");
@@ -392,6 +532,10 @@ void ComputeBtoDdecay(Int_t nGener=10000000,
   outfilnam.Append(Form("Pythia%d",pythiaver));
   if(opt4ff==0) outfilnam.Append("_FFppbar");
   else if(opt4ff==1) outfilnam.Append("_FFee");
+  else if(opt4ff==2) outfilnam.Append("_FFptDepcent");
+  else if(opt4ff==3) outfilnam.Append("_FFptDepmin");
+  else if(opt4ff==4) outfilnam.Append("_FFptDepmax");
+  else if(opt4ff==5) outfilnam.Append("_FFptDepminEnScaleConst");
   else outfilnam.Append("_FFold");
   if(optForNorm==1) outfilnam.Append("_yDcut");
   outfilnam.Append(".root");
@@ -415,6 +559,11 @@ void ComputeBtoDdecay(Int_t nGener=10000000,
     }
   }
   if(fTreeDecays) fTreeDecays->Write();
+  if(opt4ff>=2) {
+    hUfrac->Write();
+    hBsfrac->Write();
+    hLbfrac->Write();
+  }
   outfil->Close();
 }
 


### PR DESCRIPTION
- pt dependent fragmentation fractions from LHCb measurement  - https://arxiv.org/pdf/1902.06794.pdf
- Uses fits defined in this paper to parameterise fragmentation fraction as a function of the beauty hadron pT, plus flat FF for pT<5
- minimum and maximum FF uncertainties are from the envelope of parameter variations
- includes option for 5 TeV for additional uncertainty taking into account possible difference in FF between 13 TeV and 5 TeV measurements

See D2H presentation for details: https://indico.cern.ch/event/922573/contributions/3925508/attachments/2066201/3467564/Fragmentation_Spectra_D2H.pdf 