### PR TITLE
PWGPP-545 - AliPIDtools::ComputePIDProbability with user defined  fake 

### DIFF
--- a/PWGPP/AliPIDtools.h
+++ b/PWGPP/AliPIDtools.h
@@ -58,8 +58,10 @@ public:
   static Double_t GetExpectedTPCSignalV0(Int_t hash, Int_t particleType, Int_t corrMask, Int_t index, Int_t returnType);
   static Double_t GetITSPID(Int_t hash, Int_t particleType, Int_t valueType, Float_t resol=0);
   static Double_t GetTOFPID(Int_t hash, Int_t particleType, Int_t valueType, Float_t resol=0);
+  //
   static Float_t NumberOfSigmas(Int_t hash, Int_t detCode, Int_t particleType, Int_t source=-1, Int_t corrMask=-1);
   static Float_t GetSignalDelta(Int_t hash, Int_t detCode, Int_t particleType, Int_t source=-1, Int_t corrMask=-1);
+  static Float_t ComputePIDProbability(Int_t hash, Int_t detCode, Int_t particleType, Int_t source=-1, Int_t corrMask=-1,Int_t norm=1, Float_t fakeProb=0.01);
   //
   //
   static std::map<Int_t, AliTPCPIDResponse *> pidTPC;     /// we should use better hash map


### PR DESCRIPTION
## PWGPP-545 - AliPIDtools::ComputePIDProbability with external user defined  fake probability
```
/// Return Compute probability
/// \param hash           - hash value of PID correction
/// \param detCode        - detector code (0-ITS, 1-TPC, 2-TRD, 3-TOF)  AliPIDResponse::enum EDetector
/// \param particleType   - see enum
/// \param source         - track index
/// \param corrMask       - correction bitMask - AliPIDTools:: enum TPCCorrFlag
/// \param norm           - include normalization to all species
/// \param fakeProb       -  user defined fake probability (normaly scales with mult*(1+1/pt))  - detector dependent
/// \return
Float_t AliPIDtools::ComputePIDProbability(Int_t hash, Int_t detCode, Int_t particleType, Int_t source, Int_t corrMask,Int_t norm,Float_t fakeProb){
````