### PR TITLE
PWGPP-545, ATO-465 - adding TOF track length to streamer also for V0s

### DIFF
--- a/PWGPP/AliAnalysisTaskFilteredTree.cxx
+++ b/PWGPP/AliAnalysisTaskFilteredTree.cxx
@@ -2130,19 +2130,20 @@ void AliAnalysisTaskFilteredTree::ProcessV0(AliESDEvent *const esdEvent, AliMCEv
       if(!fFillTree) return;
       if(!fTreeSRedirector) return;
       
-      TVectorD tofClInfo0(5);                        // starting at 2014 - TOF infdo not part of the AliESDtrack
-      TVectorD tofClInfo1(5);                        // starting at 2014 - TOF infdo not part of the AliESDtrack
+      TVectorD tofClInfo0(6);                        // starting at 2014 - TOF infdo not part of the AliESDtrack
+      TVectorD tofClInfo1(6);                        // starting at 2014 - TOF infdo not part of the AliESDtrack
       tofClInfo0[0]=track0->GetTOFsignal();
       tofClInfo0[1]=track0->GetTOFsignalToT();
       tofClInfo0[2]=track0->GetTOFsignalRaw();
       tofClInfo0[3]=track0->GetTOFsignalDz();
       tofClInfo0[4]=track0->GetTOFsignalDx();
+      tofClInfo0[5]=track0->GetIntegratedLength();
       tofClInfo1[0]=track1->GetTOFsignal();
       tofClInfo1[1]=track1->GetTOFsignalToT();
       tofClInfo1[2]=track1->GetTOFsignalRaw();
       tofClInfo1[3]=track1->GetTOFsignalDz();
       tofClInfo1[4]=track1->GetTOFsignalDx();
- 
+      tofClInfo1[5]=track1->GetIntegratedLength();
       //get the nSigma information; NB particle number ID in the vectors follow the convention in AliPID
       const Int_t nSpecies=AliPID::kSPECIES;
       TVectorD tpcNsigma0(nSpecies); 

--- a/PWGPP/AliPIDtools.cxx
+++ b/PWGPP/AliPIDtools.cxx
@@ -649,10 +649,13 @@ Float_t AliPIDtools::ComputePIDProbability(Int_t hash, Int_t detCode, Int_t part
   else{ //special treatment for TOF
     TVectorD *tofSigma=(source==-1) ? GetTOFInfo(1):GetTOFInfoV0(source,1);
     TVectorD *tofInfo=(source==-1) ? GetTOFInfo(0):GetTOFInfoV0(source,0);
-    status=(*tofInfo)[5]>0;    // time assigned to TOF cluster
+    status=kFALSE;                    // time assigned to TOF cluster
     if (tofSigma) for (Int_t i=0; i<tofSigma->GetNrows();i++){
       Float_t nsigma=(*tofSigma)[i];
-      if (TMath::Abs(nsigma)<kMaxSigma)   prob[i]=TMath::Exp(-0.5*nsigma*nsigma);
+      if (TMath::Abs(nsigma)<kMaxSigma)   {
+        prob[i]=TMath::Exp(-0.5*nsigma*nsigma);
+        status=kTRUE;      // assing status if measurement
+      }
     }
   }
   Double_t value = (status==kTRUE) ? prob[particleType%AliPID::kSPECIESC]:0;

--- a/PWGPP/AliPIDtools.cxx
+++ b/PWGPP/AliPIDtools.cxx
@@ -798,12 +798,12 @@ Bool_t AliPIDtools::RegisterPIDAliases(Int_t pidHash, TString fakeRate, Int_t su
     fFilteredTreeV0->SetAlias(Form("probCN13_0_%d%s",iPID,sSufix.Data()),Form("AliPIDtools::ComputePIDProbabilityCombined(%d,10,%d,0,3+0,0,%s)",pidHash,iPID,fakeRate.Data()));
     fFilteredTreeV0->SetAlias(Form("probC13_0_%d%s", iPID,sSufix.Data()),Form("AliPIDtools::ComputePIDProbabilityCombined(%d,10,%d,0,3+0,1,%s)",pidHash,iPID,fakeRate.Data()));
     //
-    fFilteredTreeV0->SetAlias(Form("probCN01_1_%d%s",iPID,sSufix.Data()),Form("AliPIDtools::ComputePIDProbabilityCombined(%d,3,%d,0,3+0,0,%s)",pidHash,iPID,fakeRate.Data()));
-    fFilteredTreeV0->SetAlias(Form("probC01_1_%d%s", iPID,sSufix.Data()),Form("AliPIDtools::ComputePIDProbabilityCombined(%d,3,%d,0,3+0,1,%s)",pidHash,iPID,fakeRate.Data()));
-    fFilteredTreeV0->SetAlias(Form("probCN03_1_%d%s",iPID,sSufix.Data()),Form("AliPIDtools::ComputePIDProbabilityCombined(%d,9,%d,0,3+0,0,%s)",pidHash,iPID,fakeRate.Data()));
-    fFilteredTreeV0->SetAlias(Form("probC03_1_%d%s", iPID,sSufix.Data()),Form("AliPIDtools::ComputePIDProbabilityCombined(%d,9,%d,0,3+0,1,%s)",pidHash,iPID,fakeRate.Data()));
-    fFilteredTreeV0->SetAlias(Form("probCN13_1_%d%s",iPID,sSufix.Data()),Form("AliPIDtools::ComputePIDProbabilityCombined(%d,10,%d,0,3+0,0,%s)",pidHash,iPID,fakeRate.Data()));
-    fFilteredTreeV0->SetAlias(Form("probC13_1_%d%s", iPID,sSufix.Data()),Form("AliPIDtools::ComputePIDProbabilityCombined(%d,10,%d,0,3+0,1,%s)",pidHash,iPID,fakeRate.Data()));
+    fFilteredTreeV0->SetAlias(Form("probCN01_1_%d%s",iPID,sSufix.Data()),Form("AliPIDtools::ComputePIDProbabilityCombined(%d,3,%d,1,3+0,0,%s)",pidHash,iPID,fakeRate.Data()));
+    fFilteredTreeV0->SetAlias(Form("probC01_1_%d%s", iPID,sSufix.Data()),Form("AliPIDtools::ComputePIDProbabilityCombined(%d,3,%d,1,3+0,1,%s)",pidHash,iPID,fakeRate.Data()));
+    fFilteredTreeV0->SetAlias(Form("probCN03_1_%d%s",iPID,sSufix.Data()),Form("AliPIDtools::ComputePIDProbabilityCombined(%d,9,%d,1,3+0,0,%s)",pidHash,iPID,fakeRate.Data()));
+    fFilteredTreeV0->SetAlias(Form("probC03_1_%d%s", iPID,sSufix.Data()),Form("AliPIDtools::ComputePIDProbabilityCombined(%d,9,%d,1,3+0,1,%s)",pidHash,iPID,fakeRate.Data()));
+    fFilteredTreeV0->SetAlias(Form("probCN13_1_%d%s",iPID,sSufix.Data()),Form("AliPIDtools::ComputePIDProbabilityCombined(%d,10,%d,1,3+0,0,%s)",pidHash,iPID,fakeRate.Data()));
+    fFilteredTreeV0->SetAlias(Form("probC13_1_%d%s", iPID,sSufix.Data()),Form("AliPIDtools::ComputePIDProbabilityCombined(%d,10,%d,1,3+0,1,%s)",pidHash,iPID,fakeRate.Data()));
   }
   return kTRUE;
 }


### PR DESCRIPTION
###  PWGPP-545, ATO-465 - adding TOF track length to streamer also for V0s
* possibility to calibrate TOF  and for ML
* before it was implemented only for the track trees

### PWGPP-545 - use TOF nSigma to assign TOF PID status - related to problem above
* or TOF we have to use NSigma stored in tree - can not used esdTrack
* previous  algorithm working only for the track tree not for V0 tree
  * by mistake trackLength not intilized in V0s - fixed in  trackLegth fix above