### PR TITLE
Add noise simulation to the trigger maker

### DIFF
--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerKernel.h
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerKernel.h
@@ -391,6 +391,19 @@ public:
   void SetL0TriggerAlgorithm(Int_t rowmin, Int_t rowmax, UInt_t bitmask, Int_t patchSize, Int_t subregionSize);
 
   /**
+   * @brief Specify constant noise to be added to FastOR signal generated from smeared FEE data
+   * @param noise Constant noise term (pedestal) in GeV
+   */
+  void SetConstNoiseFEESmear(double noise) { fConstNoiseFEESmear = noise; fAddConstantNoiseFEESmear = true; }
+
+  /**
+   * @brief Specify parameter for gaussian noise to be added to FastOR signal generated from smeared FEE data
+   * @param mean Mean of the gauss parameterization in GeV
+   * @param sigma Sigma of the gauss parameterization in GeV
+   */
+  void SetGaussianNoiseFEESmear(double mean, double sigma) { fMeanNoiseFEESmear = mean; fSigmaNoiseFEESmear = sigma; fAddGaussianNoiseFEESmear = true; }
+
+  /**
    * @brief Set energy-dependent models for gaussian energy smearing
    * @param[in] mean Parameterization of the mean
    * @param[in] width Parameterization of the width
@@ -538,6 +551,11 @@ protected:
   Double_t                                  fSmearThreshold;              ///< Smear threshold: Only cell energies above threshold are smeared
   Double_t                                  fScaleShift;                  ///< Scale shift simulation
   Double_t                                  fScaleMult;                   ///< Constant EMCAL energy scale multiplicator
+  Double_t                                  fConstNoiseFEESmear;          ///< Constant noise at smeared FEE level
+  Double_t                                  fMeanNoiseFEESmear;           ///< Mean for gaussian noise model applied to smeared FEE
+  Double_t                                  fSigmaNoiseFEESmear;          ///< Sigma for gaussian noise model applied to smeared FEE
+  Bool_t                                    fAddConstantNoiseFEESmear;    ///< Switch adding constnat noise to smeared FEE data
+  Bool_t                                    fAddGaussianNoiseFEESmear;    ///< Switch adding noise to smeared FEE data using a gaussian model
   Bool_t                                    fDoBackgroundSubtraction;     ///< Swtich for background subtraction (only online ADC)
 
   const AliEMCALGeometry                    *fGeometry;                   //!<! Underlying EMCAL geometry

--- a/PWG/EMCAL/READMEtrgfw.txt
+++ b/PWG/EMCAL/READMEtrgfw.txt
@@ -126,6 +126,20 @@ channel map on fastor level should be used, not the one on cell level. As tender
 cells, the offline bad cell map will be applied. Therefor the trigger maker should run before the tender / correction
 task in case of simulations.
 
+# Simulation of noise
+
+The trigger maker supports generating noise when calculating FastOR signals from 
+smeared FEE signals. Noise is simulated for each FastOR (run2 - except PHOS hole)
+and every event, either as constant value or via a gaussian model. In order to switch
+on noise simulation one needs to call
+
+~~~.{cxx}
+// for constant noise
+triggermaker->SetConstNoiseFEESmear(0.005);   // Add 5 MeV noise to each FastOR
+// for gaussian noise
+triggermaker->SetGaussianNoiseFEESmear(0.005, 0.001); // Add noise simulated as gaussian noise with mean 5 MeV and sigma 1 MeV
+~~~
+
 # Selection of trigger patches by the user
 
 Trigger patches are attached to the input event as new list object of type TClonesArray. The list object


### PR DESCRIPTION

Noise is simulated FastOR-by-FastOR and event-by-event,
applied only to fastOR signal calculated from smeared FEE
singal. Two models are available:
- constant noise
- gaussian noise