### PR TITLE
PWGPP-545, ATO-465, PWGPP-312 - adding dSectorM and AlphaM histograms (position at middle of IROC)

### DIFF
--- a/PWGPP/AliAnalysisTaskFilteredTree.cxx
+++ b/PWGPP/AliAnalysisTaskFilteredTree.cxx
@@ -89,6 +89,7 @@
 #include "TStatToolkit.h"
 #include "AliESDtools.h"
 #include "TVectorF.h"
+#include "AliTPCROC.h"
 using namespace std;
 
 ClassImp(AliAnalysisTaskFilteredTree)
@@ -3174,6 +3175,13 @@ void  AliAnalysisTaskFilteredTree::SetDefaultAliasesV0(TTree *tree) {
   //
   // SetAliases and Metadata for the V0 trees
   //
+  tree->Draw("Bz","1","goff",1);Double_t bz=tree->GetV1()[0];
+  Float_t irocMiddle = (AliTPCROC::Instance()->GetPadRowRadii(0,62)+ AliTPCROC::Instance()->GetPadRowRadii(0,0))*0.5;
+  tree->SetAlias("dSector0M",Form("track0.fIp.GetParameterAtRadius(%f,%f+0,13)",irocMiddle,bz));
+  tree->SetAlias("alpha0M",Form("track0.fIp.GetParameterAtRadius(%f,%f+0,7)",irocMiddle,bz));
+  tree->SetAlias("dSector1M",Form("track1.fIp.GetParameterAtRadius(%f,%f+0,13)",irocMiddle,bz));
+  tree->SetAlias("alpha1M",Form("track1.fIp.GetParameterAtRadius(%f,%f+0,7)",irocMiddle,bz));
+
   TDatabasePDG *pdg = TDatabasePDG::Instance();
   Double_t massLambda = pdg->GetParticle("Lambda0")->Mass();
   Double_t massK0 = pdg->GetParticle("K0")->Mass();
@@ -3285,6 +3293,11 @@ void  AliAnalysisTaskFilteredTree::SetDefaultAliasesHighPt(TTree *tree){
   //
   // set shortcut aliases for some variables
   //
+  tree->Draw("Bz","1","goff",1);Double_t bz=tree->GetV1()[0];
+  Float_t irocMiddle = (AliTPCROC::Instance()->GetPadRowRadii(0,62)+ AliTPCROC::Instance()->GetPadRowRadii(0,0))*0.5;
+  tree->SetAlias("dSectorM",Form("esdTrack.fIp.GetParameterAtRadius(%f,%f+0,13)",irocMiddle,bz));
+  tree->SetAlias("alphaM",Form("esdTrack.fIp.GetParameterAtRadius(%f,%f+0,7)",irocMiddle,bz));
+
   tree->SetAlias("phiInner","atan2(esdTrack.fIp.Py(),esdTrack.fIp.Px()+0)");
   tree->SetAlias("secInner","9*(atan2(esdTrack.fIp.Py(),esdTrack.fIp.Px()+0)/pi)+18*(esdTrack.fIp.Py()<0)");
   tree->SetAlias("tgl","esdTrack.fP[3]");

--- a/PWGPP/AliAnalysisTaskFilteredTree.cxx
+++ b/PWGPP/AliAnalysisTaskFilteredTree.cxx
@@ -3209,10 +3209,10 @@ void  AliAnalysisTaskFilteredTree::SetDefaultAliasesV0(TTree *tree) {
   tree->SetAlias("ALPullEff", "ALDelta/sqrt((1.5e-03)**2+(1.8e-04*v0.Pt())**2)");
   tree->SetAlias("EPullEff", "v0.GetEffMass(0,0)/sqrt((5e-03)**2+(1.e-04*v0.Pt())**2)");
   // 
-  tree->SetAlias("dEdx0DProton", "AliMathBase::BetheBlochAleph(track0.fIp.P()/massProton)");
-  tree->SetAlias("dEdx1DProton", "AliMathBase::BetheBlochAleph(track1.fIp.P()/massProton)");
-  tree->SetAlias("dEdx0DPion", "AliMathBase::BetheBlochAleph(track0.fIp.P()/massPion)");
-  tree->SetAlias("dEdx1DPion", "AliMathBase::BetheBlochAleph(track1.fIp.P()/massPion)");
+  tree->SetAlias("dEdx0DProton", "AliExternalTrackParam::BetheBlochAleph(track0.fIp.P()/massProton)");
+  tree->SetAlias("dEdx1DProton", "AliExternalTrackParam::BetheBlochAleph(track1.fIp.P()/massProton)");
+  tree->SetAlias("dEdx0DPion", "AliExternalTrackParam::BetheBlochAleph(track0.fIp.P()/massPion)");
+  tree->SetAlias("dEdx1DPion", "AliExternalTrackParam::BetheBlochAleph(track1.fIp.P()/massPion)");
   // V0 - cuts - for PID 
   tree->SetAlias("cutDist", "sqrt((track0.fIp.fP[0]-track1.fIp.fP[0])**2+(track0.fIp.fP[1]-track1.fIp.fP[1])**2)>3");
   tree->SetAlias("cutLong", "track0.GetTPCClusterInfo(3,1,0)-5*abs(track0.fP[4])>130&&track1.GetTPCClusterInfo(3,1,0)>130-5*abs(track0.fP[4])");

--- a/PWGPP/AliPIDtools.cxx
+++ b/PWGPP/AliPIDtools.cxx
@@ -652,7 +652,7 @@ Float_t AliPIDtools::ComputePIDProbability(Int_t hash, Int_t detCode, Int_t part
     status=kFALSE;                    // time assigned to TOF cluster
     if (tofSigma) for (Int_t i=0; i<tofSigma->GetNrows();i++){
       Float_t nsigma=(*tofSigma)[i];
-      if (TMath::Abs(nsigma)<kMaxSigma)   {
+      if (TMath::Abs((*tofSigma)[0])<kMaxSigma)   {
         prob[i]=TMath::Exp(-0.5*nsigma*nsigma);
         status=kTRUE;      // assing status if measurement
       }
@@ -701,7 +701,7 @@ Float_t AliPIDtools::ComputePIDProbabilityCombined(Int_t hash, Int_t detMask, In
       }
     }
   }
-  if (nDetectors==0) return 0;
+  if (nDetectors==0) return 0.2; // return default value 1/5 standard species
 
   if (norm&0x2){
     for (Int_t i=0; i<AliPID::kSPECIESC; i++) {
@@ -711,7 +711,7 @@ Float_t AliPIDtools::ComputePIDProbabilityCombined(Int_t hash, Int_t detMask, In
   if (norm&0x1){
     Float_t sum=0;
     for (Int_t i=0; i<AliPID::kSPECIESC; i++) { sum+=pidVector[i];}
-    sum+=fakeProb;
+    sum+=fakeProb*AliPID::kSPECIESC;
     for (Int_t i=0; i<AliPID::kSPECIESC; i++) { pidVector[i]/=sum;}
   }
   return pidVector[particleType];

--- a/PWGPP/AliPIDtools.h
+++ b/PWGPP/AliPIDtools.h
@@ -66,6 +66,7 @@ public:
   static Float_t GetSignalDelta(Int_t hash, Int_t detCode, Int_t particleType, Int_t source=-1, Int_t corrMask=-1);
   static Float_t ComputePIDProbability(Int_t hash, Int_t detCode, Int_t particleType, Int_t source=-1, Int_t corrMask=-1,Int_t norm=1, Float_t fakeProb=0.01, Float_t* pidVector=0);
   static Float_t ComputePIDProbabilityCombined(Int_t hash, Int_t detMask, Int_t particleType, Int_t source=-1, Int_t corrMask=-1,Int_t norm=1, Float_t fakeProb=0.01);
+  static Float_t ComputePIDProbabilityCombinedMask(Int_t hash, Int_t detMask, Int_t particleMask, Int_t source=-1, Int_t corrMask=-1,Int_t norm=1, Float_t fakeProb=0.01);
   //
   static Bool_t    RegisterPIDAliases(Int_t pidHash, TString fakeRate="0.1", Int_t suffix=-1);
   //

--- a/PWGPP/TPC/macros/performanceFiltered.C
+++ b/PWGPP/TPC/macros/performanceFiltered.C
@@ -143,7 +143,7 @@ void SetMetadata(){
   //
   tree->Draw("Bz","1","goff",1);
   bz=tree->GetV1()[0];
-  tree->SetAlias("dSector",Form("esdTrack.fIp.GetParameterAtRadius(125,%f+0,13)",bz));
+  chain->SetAlias("bz",Form("%f",bz));
   //
   chain->SetAlias("logTracks5","log(1+ntracks/5.)");
   chain->SetAlias("esdTrackPt","esdTrack.Pt()");
@@ -271,8 +271,8 @@ TObjArray * FillPerformanceHistogram(Int_t maxEntries){
   chain->SetEstimate(chain->GetEntries());
   TString timeRange=TString::Format( "%d,%.0f,%.0f",timeBins,timeStart, timeEnd);
   //
-  TString defaultCut="esdTrack.GetTPCClusterInfo(3,1)>60&&esdTrack.IsOn(0x1)>0&&selectionPtMask>0";
-  TString defaultCutMatch="esdTrack.GetTPCClusterInfo(3,1)>60";
+  TString defaultCut="(esdTrack.GetTPCClusterInfo(3,1)>60)&&esdTrack.IsOn(0x1)>0&&selectionPtMask>0";
+  TString defaultCutMatch="(esdTrack.GetTPCClusterInfo(3,1)>110-abs(qPt)*10)&&selectionPtMask>0&&normChi2TPC<4";
   const Int_t nQAHisto=23;
   const char * qaHistos[nQAHisto]={"nclITS","nclTPC","nclTRD",		\
 				    "normChi2ITS","normChi2TPC","normChi2TRD", \
@@ -326,9 +326,11 @@ TObjArray * FillPerformanceHistogram(Int_t maxEntries){
 			       qaHistos[iPar],qaHistos[iPar],hisBins[iPar],hisMin[iPar],hisMax[iPar]);
     hisString+=TString::Format("%s:qPt:tgl:dalphaQ:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut>>qahis%s_v_qPt_tgl_dalphaQ(%d,%f,%f,48,-3,3,10,-1,1,50,-0.18,0.18);", \
 			       qaHistos[iPar],qaHistos[iPar],hisBins[iPar],hisMin[iPar],hisMax[iPar]);
-    hisString+=TString::Format("%s:qPt:tgl:dSector:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut>>qahis%s_v_qPt_tgl_dSector(%d,%f,%f,48,-3,3,10,-1,1,50,0,1);", \
+    hisString+=TString::Format("%s:qPt:tgl:dSectorM:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut>>qahis%s_v_qPt_tgl_dSectorM(%d,%f,%f,48,-3,3,10,-1,1,50,0,1);", \
 			       qaHistos[iPar],qaHistos[iPar],hisBins[iPar],hisMin[iPar],hisMax[iPar]);
     hisString+=TString::Format("%s:qPt:tgl:alphaV:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut>>qahis%s_v_qPt_tgl_alphaV(%d,%f,%f,48,-3,3,10,-1,1,90,-3.145,3.145);",\
+			       qaHistos[iPar],qaHistos[iPar],hisBins[iPar],hisMin[iPar],hisMax[iPar]);
+     hisString+=TString::Format("%s:qPt:tgl:alphaM:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut>>qahis%s_v_qPt_tgl_alphaM(%d,%f,%f,48,-3,3,10,-1,1,90,-3.145,3.145);",\
 			       qaHistos[iPar],qaHistos[iPar],hisBins[iPar],hisMin[iPar],hisMax[iPar]);
   }
   // Matching efficiency histograms for primary +-4 sigma tracks
@@ -343,9 +345,13 @@ TObjArray * FillPerformanceHistogram(Int_t maxEntries){
 			       matchHistos[iPar],matchHistos[iPar]);
     hisMatch+=TString::Format("%s:qPt:tgl:dalphaQ:#TPCOn&&TOFOn&&IsPrim4&&IsPrim4TPC>>matchhis%s_v_qPt_tgl_dalphaQ(2,-0.5,1.5,48,-3,3,10,-1,1,50,-0.18,0.18);", \
 			       matchHistos[iPar],matchHistos[iPar]);
-    hisMatch+=TString::Format("%s:qPt:tgl:dSector:#TPCOn&&TOFOn&&IsPrim4&&IsPrim4TPC>>matchhis%s_v_qPt_tgl_dSector(2,-0.5,1.5,48,-3,3,10,-1,1,50,-0.0,1);", \
+    hisMatch+=TString::Format("%s:qPt:tgl:dSectorM:#TPCOn&&TOFOn&&IsPrim4&&IsPrim4TPC>>matchhis%s_v_qPt_tgl_dSectorM(2,-0.5,1.5,48,-3,3,10,-1,1,50,-0.0,1);", \
 			       matchHistos[iPar],matchHistos[iPar]);
     hisMatch+=TString::Format("%s:qPt:tgl:alphaV:#TPCOn&&TOFOn&&IsPrim4&&IsPrim4TPC>>matchhis%s_v_qPt_tgl_alphaV(2,-0.5,1.5,48,-3,3,10,-1,1,90,-3.145,3.145);", \
+			       matchHistos[iPar],matchHistos[iPar]);
+    hisMatch+=TString::Format("%s:qPt:tgl:alphaM:#TPCOn&&TOFOn&&IsPrim4&&IsPrim4TPC>>matchhis%s_v_qPt_tgl_alphaM(2,-0.5,1.5,48,-3,3,10,-1,1,90,-3.145,3.145);", \
+			       matchHistos[iPar],matchHistos[iPar]);
+    hisMatch+=TString::Format("%s:qPt:tgl:logTracks5:#TPCOn&&TOFOn&&IsPrim4&&IsPrim4TPC>>matchhis%s_v_qPt_tgl_logTracks5(2,-0.5,1.5,48,-3,3,10,-1,1,10,0,10);", \
 			       matchHistos[iPar],matchHistos[iPar]);
     }
   
@@ -407,6 +413,16 @@ TObjArray * FillPerformanceHistogram(Int_t maxEntries){
     hisString+=TString::Format("covarP%d:qPt:tgl:alphaV:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut&&TRDOn>>hisCovarP%d_TRDv_qPt_tgl_alphaV(100,%f,%f,48,-3,3,10,-1,1,90,-3.145,3.145);",iPar,iPar, fnull,range[iPar]);
     hisString+=TString::Format("covarP%dITS:qPt:tgl:alphaV:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut>>hisCovarP%dITS_Allv_qPt_tgl_alphaV(100,%f,%f,48,-3,3,10,-1,1,90,-3.145,3.145);",iPar,iPar, fnull,rangeCITS[iPar]);
     hisString+=TString::Format("covarP%dITS:qPt:tgl:alphaV:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut&&TRDOn>>hisCovarP%dITS_TRDv_qPt_tgl_alphaV(100,%f,%f,48,-3,3,10,-1,1,90,-3.145,3.145);",iPar,iPar, fnull,rangeCITS[iPar]);
+    //
+    hisString+=TString::Format("deltaP%d:qPt:tgl:alphaM:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut>>hisDeltaP%d_Allv_qPt_tgl_alphaM(100,%f,%f,48,-3,3,10,-1,1,90,-3.145,3.145);",iPar,iPar, -range[iPar],range[iPar]);
+    hisString+=TString::Format("deltaP%d:qPt:tgl:alphaM:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut&&TRDOn>>hisDeltaP%d_TRDv_qPt_tgl_alphaM(100,%f,%f,48,-3,3,10,-1,1,90,-3.145,3.145);",iPar,iPar, -range[iPar],range[iPar]);
+    hisString+=TString::Format("pullP%d:qPt:tgl:alphaM:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut>>hisPullP%d_Allv_qPt_tgl_alphaM(100,%f,%f,48,-3,3,10,-1,1,90,-3.145,3.145);",iPar,iPar, -rangeP[iPar],rangeP[iPar]);
+    hisString+=TString::Format("pullP%d:qPt:tgl:alphaM:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut&&TRDOn>>hisPullP%d_TRDv_qPt_tgl_alphaM(100,%f,%f,48,-3,3,10,-1,1,90,-3.145,3.145);",iPar,iPar, -rangeP[iPar],rangeP[iPar]);
+    hisString+=TString::Format("covarP%d:qPt:tgl:alphaM:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut>>hisCovarP%d_Allv_qPt_tgl_alphaM(100,%f,%f,48,-3,3,10,-1,1,90,-3.145,3.145);",iPar,iPar, fnull,range[iPar]);
+    hisString+=TString::Format("covarP%d:qPt:tgl:alphaM:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut&&TRDOn>>hisCovarP%d_TRDv_qPt_tgl_alphaM(100,%f,%f,48,-3,3,10,-1,1,90,-3.145,3.145);",iPar,iPar, fnull,range[iPar]);
+    hisString+=TString::Format("covarP%dITS:qPt:tgl:alphaM:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut>>hisCovarP%dITS_Allv_qPt_tgl_alphaM(100,%f,%f,48,-3,3,10,-1,1,90,-3.145,3.145);",iPar,iPar, fnull,rangeCITS[iPar]);
+    hisString+=TString::Format("covarP%dITS:qPt:tgl:alphaM:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut&&TRDOn>>hisCovarP%dITS_TRDv_qPt_tgl_alphaM(100,%f,%f,48,-3,3,10,-1,1,90,-3.145,3.145);",iPar,iPar, fnull,rangeCITS[iPar]);
+
     // Edge Effect histogramming
     hisString+=TString::Format("deltaP%d:qPt:tgl:dalphaQ:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut>>hisDeltaP%d_Allv_qPt_tgl_dalphaQ(100,%f,%f,48,-3,3,10,-1,1,50,-0.18,0.18);",iPar,iPar, -range[iPar],range[iPar]);
     hisString+=TString::Format("deltaP%d:qPt:tgl:dalphaQ:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut&&TRDOn>>hisDeltaP%d_TRDv_qPt_tgl_dalphaQ(100,%f,%f,48,-3,3,10,-1,1,50,-0.18,0.18);",iPar,iPar, -range[iPar],range[iPar]);
@@ -417,14 +433,14 @@ TObjArray * FillPerformanceHistogram(Int_t maxEntries){
     hisString+=TString::Format("covarP%dITS:qPt:tgl:dalphaQ:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut>>hisCovarP%dITS_Allv_qPt_tgl_dalphaQ(100,%f,%f,48,-3,3,10,-1,1,50,-0.18,0.18);",iPar,iPar, fnull,rangeCITS[iPar]);
     hisString+=TString::Format("covarP%dITS:qPt:tgl:dalphaQ:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut&&TRDOn>>hisCovarP%dITS_TRDv_qPt_tgl_dalphaQ(100,%f,%f,48,-3,3,10,-1,1,50,-0.18,0.18);",iPar,iPar, fnull,rangeCITS[iPar]);
     //
-    hisString+=TString::Format("deltaP%d:qPt:tgl:dSector:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut>>hisDeltaP%d_Allv_qPt_tgl_dSector(100,%f,%f,48,-3,3,10,-1,1,50,0,1);",iPar,iPar, -range[iPar],range[iPar]);
-    hisString+=TString::Format("deltaP%d:qPt:tgl:dSector:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut&&TRDOn>>hisDeltaP%d_TRDv_qPt_tgl_dSector(100,%f,%f,48,-3,3,10,-1,1,50,0,1);",iPar,iPar, -range[iPar],range[iPar]);
-    hisString+=TString::Format("pullP%d:qPt:tgl:dSector:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut>>hisPullP%d_Allv_qPt_tgl_dSector(100,%f,%f,48,-3,3,10,-1,1,50,0,1);",iPar,iPar, -rangeP[iPar],rangeP[iPar]);
-    hisString+=TString::Format("pullP%d:qPt:tgl:dSector:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut&&TRDOn>>hisPullP%d_TRDv_qPt_tgl_dSector(100,%f,%f,48,-3,3,10,-1,1,50,0,1);",iPar,iPar, -rangeP[iPar],rangeP[iPar]);
-    hisString+=TString::Format("covarP%d:qPt:tgl:dSector:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut>>hisCovarP%d_Allv_qPt_tgl_dSector(100,%f,%f,48,-3,3,10,-1,1,50,0,1);",iPar,iPar, fnull,range[iPar]);
-    hisString+=TString::Format("covarP%d:qPt:tgl:dSector:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut&&TRDOn>>hisCovarP%d_TRDv_qPt_tgl_dSector(100,%f,%f,48,-3,3,10,-1,1,50,0,1);",iPar,iPar, fnull,range[iPar]);
-    hisString+=TString::Format("covarP%dITS:qPt:tgl:dSector:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut>>hisCovarP%dITS_Allv_qPt_tgl_dSector(100,%f,%f,48,-3,3,10,-1,1,50,0,1);",iPar,iPar, fnull,rangeCITS[iPar]);
-    hisString+=TString::Format("covarP%dITS:qPt:tgl:dSector:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut&&TRDOn>>hisCovarP%dITS_TRDv_qPt_tgl_dSector(100,%f,%f,48,-3,3,10,-1,1,50,0,1);",iPar,iPar, fnull,rangeCITS[iPar]);
+    hisString+=TString::Format("deltaP%d:qPt:tgl:dSectorM:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut>>hisDeltaP%d_Allv_qPt_tgl_dSectorM(100,%f,%f,48,-3,3,10,-1,1,50,0,1);",iPar,iPar, -range[iPar],range[iPar]);
+    hisString+=TString::Format("deltaP%d:qPt:tgl:dSectorM:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut&&TRDOn>>hisDeltaP%d_TRDv_qPt_tgl_dSectorM(100,%f,%f,48,-3,3,10,-1,1,50,0,1);",iPar,iPar, -range[iPar],range[iPar]);
+    hisString+=TString::Format("pullP%d:qPt:tgl:dSectorM:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut>>hisPullP%d_Allv_qPt_tgl_dSectorM(100,%f,%f,48,-3,3,10,-1,1,50,0,1);",iPar,iPar, -rangeP[iPar],rangeP[iPar]);
+    hisString+=TString::Format("pullP%d:qPt:tgl:dSectorM:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut&&TRDOn>>hisPullP%d_TRDv_qPt_tgl_dSectorM(100,%f,%f,48,-3,3,10,-1,1,50,0,1);",iPar,iPar, -rangeP[iPar],rangeP[iPar]);
+    hisString+=TString::Format("covarP%d:qPt:tgl:dSectorM:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut>>hisCovarP%d_Allv_qPt_tgl_dSectorM(100,%f,%f,48,-3,3,10,-1,1,50,0,1);",iPar,iPar, fnull,range[iPar]);
+    hisString+=TString::Format("covarP%d:qPt:tgl:dSectorM:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut&&TRDOn>>hisCovarP%d_TRDv_qPt_tgl_dSectorM(100,%f,%f,48,-3,3,10,-1,1,50,0,1);",iPar,iPar, fnull,range[iPar]);
+    hisString+=TString::Format("covarP%dITS:qPt:tgl:dSectorM:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut>>hisCovarP%dITS_Allv_qPt_tgl_dSectorM(100,%f,%f,48,-3,3,10,-1,1,50,0,1);",iPar,iPar, fnull,rangeCITS[iPar]);
+    hisString+=TString::Format("covarP%dITS:qPt:tgl:dSectorM:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut&&TRDOn>>hisCovarP%dITS_TRDv_qPt_tgl_dSectorM(100,%f,%f,48,-3,3,10,-1,1,50,0,1);",iPar,iPar, fnull,rangeCITS[iPar]);
 
     //
     // multiplicity 

--- a/PWGPP/TPC/macros/performanceFiltered.C
+++ b/PWGPP/TPC/macros/performanceFiltered.C
@@ -68,7 +68,7 @@ Int_t    chainEntries=0;
 Int_t run=246272;
 TString period="LHC15o";
 Double_t deltaT=300;  // 5 minutes binning
-
+Float_t bz=0;
 
 Bool_t InitAnalysis();
 TObjArray * FillPerformanceHistogram(Int_t maxEntries);
@@ -140,6 +140,10 @@ void AnalyzeHistograms(){
 
 /// Set aliases and metadata used to describe variables in trees
 void SetMetadata(){
+  //
+  tree->Draw("Bz","1","goff",1);
+  bz=tree->GetV1()[0];
+  tree->SetAlias("dSector",Form("esdTrack.fIp.GetParameterAtRadius(125,%f+0,13)",bz));
   //
   chain->SetAlias("logTracks5","log(1+ntracks/5.)");
   chain->SetAlias("esdTrackPt","esdTrack.Pt()");
@@ -322,6 +326,8 @@ TObjArray * FillPerformanceHistogram(Int_t maxEntries){
 			       qaHistos[iPar],qaHistos[iPar],hisBins[iPar],hisMin[iPar],hisMax[iPar]);
     hisString+=TString::Format("%s:qPt:tgl:dalphaQ:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut>>qahis%s_v_qPt_tgl_dalphaQ(%d,%f,%f,48,-3,3,10,-1,1,50,-0.18,0.18);", \
 			       qaHistos[iPar],qaHistos[iPar],hisBins[iPar],hisMin[iPar],hisMax[iPar]);
+    hisString+=TString::Format("%s:qPt:tgl:dSector:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut>>qahis%s_v_qPt_tgl_dSector(%d,%f,%f,48,-3,3,10,-1,1,50,0,1);", \
+			       qaHistos[iPar],qaHistos[iPar],hisBins[iPar],hisMin[iPar],hisMax[iPar]);
     hisString+=TString::Format("%s:qPt:tgl:alphaV:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut>>qahis%s_v_qPt_tgl_alphaV(%d,%f,%f,48,-3,3,10,-1,1,90,-3.145,3.145);",\
 			       qaHistos[iPar],qaHistos[iPar],hisBins[iPar],hisMin[iPar],hisMax[iPar]);
   }
@@ -336,6 +342,8 @@ TObjArray * FillPerformanceHistogram(Int_t maxEntries){
     hisMatch+=TString::Format("%s:qPt:tgl:#TPCOn&&TOFOn&&IsPrim4&&IsPrim4TPC>>matchhis%s_v_qPt_tgl(2,-0.5,1.5,200,-5,5,10,-1,1);", \
 			       matchHistos[iPar],matchHistos[iPar]);
     hisMatch+=TString::Format("%s:qPt:tgl:dalphaQ:#TPCOn&&TOFOn&&IsPrim4&&IsPrim4TPC>>matchhis%s_v_qPt_tgl_dalphaQ(2,-0.5,1.5,48,-3,3,10,-1,1,50,-0.18,0.18);", \
+			       matchHistos[iPar],matchHistos[iPar]);
+    hisMatch+=TString::Format("%s:qPt:tgl:dSector:#TPCOn&&TOFOn&&IsPrim4&&IsPrim4TPC>>matchhis%s_v_qPt_tgl_dSector(2,-0.5,1.5,48,-3,3,10,-1,1,50,-0.0,1);", \
 			       matchHistos[iPar],matchHistos[iPar]);
     hisMatch+=TString::Format("%s:qPt:tgl:alphaV:#TPCOn&&TOFOn&&IsPrim4&&IsPrim4TPC>>matchhis%s_v_qPt_tgl_alphaV(2,-0.5,1.5,48,-3,3,10,-1,1,90,-3.145,3.145);", \
 			       matchHistos[iPar],matchHistos[iPar]);
@@ -409,6 +417,16 @@ TObjArray * FillPerformanceHistogram(Int_t maxEntries){
     hisString+=TString::Format("covarP%dITS:qPt:tgl:dalphaQ:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut>>hisCovarP%dITS_Allv_qPt_tgl_dalphaQ(100,%f,%f,48,-3,3,10,-1,1,50,-0.18,0.18);",iPar,iPar, fnull,rangeCITS[iPar]);
     hisString+=TString::Format("covarP%dITS:qPt:tgl:dalphaQ:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut&&TRDOn>>hisCovarP%dITS_TRDv_qPt_tgl_dalphaQ(100,%f,%f,48,-3,3,10,-1,1,50,-0.18,0.18);",iPar,iPar, fnull,rangeCITS[iPar]);
     //
+    hisString+=TString::Format("deltaP%d:qPt:tgl:dSector:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut>>hisDeltaP%d_Allv_qPt_tgl_dSector(100,%f,%f,48,-3,3,10,-1,1,50,0,1);",iPar,iPar, -range[iPar],range[iPar]);
+    hisString+=TString::Format("deltaP%d:qPt:tgl:dSector:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut&&TRDOn>>hisDeltaP%d_TRDv_qPt_tgl_dSector(100,%f,%f,48,-3,3,10,-1,1,50,0,1);",iPar,iPar, -range[iPar],range[iPar]);
+    hisString+=TString::Format("pullP%d:qPt:tgl:dSector:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut>>hisPullP%d_Allv_qPt_tgl_dSector(100,%f,%f,48,-3,3,10,-1,1,50,0,1);",iPar,iPar, -rangeP[iPar],rangeP[iPar]);
+    hisString+=TString::Format("pullP%d:qPt:tgl:dSector:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut&&TRDOn>>hisPullP%d_TRDv_qPt_tgl_dSector(100,%f,%f,48,-3,3,10,-1,1,50,0,1);",iPar,iPar, -rangeP[iPar],rangeP[iPar]);
+    hisString+=TString::Format("covarP%d:qPt:tgl:dSector:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut>>hisCovarP%d_Allv_qPt_tgl_dSector(100,%f,%f,48,-3,3,10,-1,1,50,0,1);",iPar,iPar, fnull,range[iPar]);
+    hisString+=TString::Format("covarP%d:qPt:tgl:dSector:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut&&TRDOn>>hisCovarP%d_TRDv_qPt_tgl_dSector(100,%f,%f,48,-3,3,10,-1,1,50,0,1);",iPar,iPar, fnull,range[iPar]);
+    hisString+=TString::Format("covarP%dITS:qPt:tgl:dSector:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut>>hisCovarP%dITS_Allv_qPt_tgl_dSector(100,%f,%f,48,-3,3,10,-1,1,50,0,1);",iPar,iPar, fnull,rangeCITS[iPar]);
+    hisString+=TString::Format("covarP%dITS:qPt:tgl:dSector:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut&&TRDOn>>hisCovarP%dITS_TRDv_qPt_tgl_dSector(100,%f,%f,48,-3,3,10,-1,1,50,0,1);",iPar,iPar, fnull,rangeCITS[iPar]);
+
+    //
     // multiplicity 
     //
     hisString+=TString::Format("deltaP%d:qPt:tgl:logTracks5:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut>>hisDeltaP%d_Allv_qPt_tgl_logTracks5(400,%f,%f,200,-5,5,10,-1,1,10,0,10);",iPar,iPar,-range[iPar],range[iPar]);
@@ -424,6 +442,9 @@ TObjArray * FillPerformanceHistogram(Int_t maxEntries){
     // K0 performance
     hisV0String+="K0Delta:mpt:tglV0:#K0cut>>hisK0DMassQPtTgl(100,-0.03,0.03,80,0,2,10,-1,1);";  
     hisV0String+="K0Pull:mpt:tglV0:#K0cut>>hisK0PullQPtTgl(100,-6.0,6.0,80,0,2,10,-1,1);";
+    //hisV0String+="LDelta:mpt:tglV0:#K0cut>>hisK0DMassQPtTgl(100,-0.03,0.03,80,0,2,10,-1,1);";
+    //hisV0String+="LPull:mpt:tglV0:#K0cut>>hisK0PullQPtTgl(100,-6.0,6.0,80,0,2,10,-1,1);";
+
     // K0 resolution/maps - in respect to sector edge
     hisV0String+="K0Delta:mpt:tglV0:dalphaV0:#K0cut>>hisK0DMassQPtTglDSec(100,-0.03,0.03,10,0,1,10,-1,1,10,0.0,0.35);";  
     hisV0String+="K0Pull:mpt:tglV0:dalphaV0:#K0cut>>hisK0PullQPtTglDSec(100,-6.0,6.0,10,0,1,10,-1,1,10,0.0,0.35);";

--- a/PWGPP/TPC/macros/performanceFiltered.C
+++ b/PWGPP/TPC/macros/performanceFiltered.C
@@ -141,8 +141,8 @@ void AnalyzeHistograms(){
 /// Set aliases and metadata used to describe variables in trees
 void SetMetadata(){
   //
-  tree->Draw("Bz","1","goff",1);
-  bz=tree->GetV1()[0];
+  chain->Draw("Bz","1","goff",1);
+  bz=chain->GetV1()[0];
   chain->SetAlias("bz",Form("%f",bz));
   //
   chain->SetAlias("logTracks5","log(1+ntracks/5.)");


### PR DESCRIPTION
## PWGPP-545 - small fixes
* AliAnalysisTaskFilteredTree.cxx
  * setting proper alias for expected dEdx
* AliPIDtools.cxx
  * set default Probability to 0.2 in case detectors are not responding

## PWGPP-545, ATO-465, PWGPP-312 - performance maps position at middle IROC …
* AliAnalysisTaskFilteredTree.cxx
  * adding aliases to calculate alpha and sector position in middle of IROC
* performanceFiltered.C
  * modifying defaultCut for matching studies - pt dependent NCR cut
```
TString defaultCutMatch="esdTrack.GetTPCClusterInfo(3,1)>110-abs(qPt)*10&&selectionPtMask>0&&normChi2TPC<4";
```
  * adding histograms with dSectorM, alphaM for all existing 
  * adding histograms with logTracks5 for matching histograms (missing before)


## PWGPP-545, ATO-465, PWGPP-312 - splitting map creation in chunks to speed up final step