### PR TITLE
PWGPP-545, ATO-465 -"naive likelihood" combining V0+ detector PID + AliPIDtools bug fix

### DIFF
--- a/PWGPP/AliAnalysisTaskFilteredTree.cxx
+++ b/PWGPP/AliAnalysisTaskFilteredTree.cxx
@@ -3257,7 +3257,10 @@ void  AliAnalysisTaskFilteredTree::SetDefaultAliasesV0(TTree *tree) {
   tree->SetAlias("dalphaV0", "alphaV0-((int(36+9*(alphaV0/pi))-36)*pi/9.)");
   // Status
   tree->SetAlias("TOFOnMI0","(track0.fFlags&0x1000)>0&&abs(tofClInfo0.fElements[4])<10");   // TOF hit0 present
-  tree->SetAlias("TOFOnMI1","(track1.fFlags&0x1000)>0&&abs(tofClInfo1.fElements[4])<10");   // TOF hit0 present
+  tree->SetAlias("TOFOnMI1","(track1.fFlags&0x1000)>0&&abs(tofClInfo1.fElements[4])<10");   // TOF hit1 present
+  tree->SetAlias("TOFOn0","(track0.fFlags&0x2000)>0");   // TOF hit0 present
+  tree->SetAlias("TOFOn1","(track1.fFlags&0x2000)>0");   // TOF hit1 present
+
   tree->SetAlias("ITSRefit0","(track0.fFlags&0x4)>0");   // ITS refit0
   tree->SetAlias("ITSRefit1","(track1.fFlags&0x4)>0");   // ITS refit1
   tree->SetAlias("IRDRefit0","(track0.fFlags&0x400)>0");   // TRD refit0
@@ -3336,6 +3339,7 @@ void  AliAnalysisTaskFilteredTree::SetDefaultAliasesHighPt(TTree *tree){
   tree->SetAlias("TOFOn","((esdTrack.fFlags&0x2000)>0)");
   tree->SetAlias("TRDOn","((esdTrack.fFlags&0x400)>0)");
   tree->SetAlias("TOFOnMI","(esdTrack.fFlags&0x1000)>0&&abs(tofClInfo.fElements[4])<10");   // TOF hit present
+  //tree->SetAlias("TOFOnPID","(esdTrack.fFlags&0x1000)>0&&abs(tofNSigma.fElements[0])0");   // TOF hit present
   tree->SetAlias("ITSOn0","esdTrack.fITSncls>4&&esdTrack.HasPointOnITSLayer(0)&&esdTrack.HasPointOnITSLayer(1)");
   tree->SetAlias("ITSOn01","esdTrack.fITSncls>3&&(esdTrack.HasPointOnITSLayer(0)||esdTrack.HasPointOnITSLayer(1))");
   tree->SetAlias("nclCut","(esdTrack.GetTPCClusterInfo(3,1)+esdTrack.fTRDncls)>140-5*(abs(esdTrack.fP[4]))");

--- a/PWGPP/AliPIDtools.cxx
+++ b/PWGPP/AliPIDtools.cxx
@@ -634,6 +634,7 @@ Float_t AliPIDtools::ComputePIDProbability(Int_t hash, Int_t detCode, Int_t part
     pid->SetUseTPCEtaCorrection(corrMask&kEtaCorr);
     pid->SetUseTPCMultiplicityCorrection(corrMask&kMultCorr);
     pid->SetUseTPCPileupCorrection(corrMask&kPileUpCorr);
+    if (corrMask&kPileUpCorr) pid->GetTPCResponse().SetPileupCorrectionStrategy(AliTPCPIDResponse::kPileupCorrectionInExpectedSignal);
   }
   AliESDtrack *track=NULL;
   if (source<0){

--- a/PWGPP/AliPIDtools.cxx
+++ b/PWGPP/AliPIDtools.cxx
@@ -534,6 +534,7 @@ Float_t AliPIDtools::NumberOfSigmas(Int_t hash, Int_t detCode, Int_t particleTyp
   if (pid->UseTPCEtaCorrection()) maskBackup+=kEtaCorr;
   if (pid->UseTPCMultiplicityCorrection()) maskBackup+=kMultCorr;
   if (pid->UseTPCPileupCorrection()) maskBackup+=kPileUpCorr;
+  /// TODO - backup also strategy
   //
   if (corrMask<0) {
     corrMask=maskBackup;
@@ -541,6 +542,7 @@ Float_t AliPIDtools::NumberOfSigmas(Int_t hash, Int_t detCode, Int_t particleTyp
     pid->SetUseTPCEtaCorrection(corrMask&kEtaCorr);
     pid->SetUseTPCMultiplicityCorrection(corrMask&kMultCorr);
     pid->SetUseTPCPileupCorrection(corrMask&kPileUpCorr);
+    if (corrMask&kPileUpCorr) pid->GetTPCResponse().SetPileupCorrectionStrategy(AliTPCPIDResponse::kPileupCorrectionInExpectedSignal);
   }
   AliESDtrack *track=NULL;
   Bool_t status=kTRUE;

--- a/PWGPP/AliPIDtools.h
+++ b/PWGPP/AliPIDtools.h
@@ -69,6 +69,7 @@ public:
   static Float_t ComputePIDProbabilityCombinedMask(Int_t hash, Int_t detMask, Int_t particleMask, Int_t source=-1, Int_t corrMask=-1,Int_t norm=1, Float_t fakeProb=0.01);
   //
   static Bool_t    RegisterPIDAliases(Int_t pidHash, TString fakeRate="0.1", Int_t suffix=-1);
+  static Bool_t    RegisterPIDAliasesV0(Int_t pidHash, Float_t powerLike=0.6, Float_t powerLegN=0.2, Float_t powerLeg=0.2,  const char *fakeR="0.1", const char *  suffix="");
   //
   //
   static std::map<Int_t, AliTPCPIDResponse *> pidTPC;     /// we should use better hash map


### PR DESCRIPTION
## PWGPP-545, ATO-465 -"naive likelihood" combining V0+ detector PID …
define "likelihood" for clean PID selection in first round of calibration
(later ML technique plan be used)

* V0 likelihood
  * defined in other place
* likelihod - combined PID for complementary track
* likelihood - combined PID for track except of detectro of interest

```
/// RegisterPIDAliasesV0 - to selec clean PID samples using V0 likelihood and PID selection on the leg
/// \param pidHash     - PID hash identifier
/// \param powerLike   - power for the V0 likelihood - default 0.6
/// \param powerLegN   - power leg for second track
/// \param powerLeg    - power leg for signal track
/// \param fakeRate    - fake rate query
/// \param suffix      - suffix to add
/// \return
 Bool_t    AliPIDtools::RegisterPIDAliasesV0(Int_t pidHash, Float_t powerLike, Float_t powerLegN, Float_t powerLeg,  const char * fakeR, const char * suffix){
```

Example usage:
```
AliPIDtools::RegisterPIDAliasesV0(pidHash, 0.6, 0.2, 0.2, "ntracks/200000", "");
treeV0->Draw("nSigma0_1_0:1/track0.fIp.P()>>his(10,0,3,100,-10,10)","ELike>0.4&&likeTPCEl0>0.3","colz",100000)
```

# AliPIDtools:: PWGPP-545, ATO-465 - pileup correction strategy has to be set

not enough to enable only pile-up correction.

