### PR TITLE
ATO-465 - adding probability/weights to the tree - to recover  spectras without downsampling

### DIFF
--- a/PWGPP/AliAnalysisTaskFilteredTree.h
+++ b/PWGPP/AliAnalysisTaskFilteredTree.h
@@ -111,7 +111,7 @@ class AliAnalysisTaskFilteredTree : public AliAnalysisTaskSE {
   // v0s selection
   Int_t  GetKFParticle(AliESDv0 *const v0, AliESDEvent * const event, AliKFParticle & kfparticle);
   Bool_t IsV0Downscaled(AliESDv0 *const v0);
-  Int_t  V0DownscaledMask(AliESDv0 *const v0);
+  Int_t  V0DownscaledMask(AliESDv0 *const v0,Double_t *weight);
   Bool_t IsHighDeDxParticle(AliESDtrack * const track);
 
   void SetLowPtTrackDownscaligF(Double_t fact) { fLowPtTrackDownscaligF = fact; }
@@ -142,7 +142,7 @@ class AliAnalysisTaskFilteredTree : public AliAnalysisTaskSE {
   static Int_t GetMCTrackDiff(const TParticle &particle, const AliExternalTrackParam &param, TClonesArray &trackRefArray, TVectorF &mcDiff); //TODO test before enabling
   /// sqrt s - mass dependent downsampling trigger (pt spectra as parameterized in https://iopscience.iop.org/article/10.1088/2399-6528/aab00f/pdf)
   static Double_t TsalisCharged(Double_t pt, Double_t mass, Double_t sqrts);
-  static Int_t    DownsampleTsalisCharged(Double_t pt, Double_t factorPt, Double_t factor1Pt,  Double_t sqrts=5020, Double_t mass=0.2);
+  static Int_t    DownsampleTsalisCharged(Double_t pt, Double_t factorPt, Double_t factor1Pt,  Double_t sqrts, Double_t mass, Double_t *weight);
   Int_t  PIDSelection(AliESDtrack *track, TParticle *particle = nullptr);
  private:
   AliESDEvent *fESD;    //! ESD event

--- a/PWGPP/AliPIDtools.cxx
+++ b/PWGPP/AliPIDtools.cxx
@@ -820,56 +820,56 @@ Bool_t AliPIDtools::RegisterPIDAliases(Int_t pidHash, TString fakeRate, Int_t su
   for (Int_t jPID=0; jPID<AliPID::kSPECIESC+1; jPID++) {
     Int_t iPID = (jPID < AliPID::kSPECIESC) ? jPID : AliPID::kPion;
     fFilteredTree->SetAlias(Form("ldEdxITS%d%s", iPID, sSufix.Data()),
-                            Form("log(esdTrack.fITSsignal/AliPIDtools::GetExpectedITSsignal(pidHash,esdTrack.fIp.P(),%d))", iPID));
+                            Form("log(esdTrack.fITSsignal/AliPIDtools::GetExpectedITSSignal(pidHash,esdTrack.fIp.P(),%d+0))", iPID));
     fFilteredTree->SetAlias(Form("ldEdxTPC%d%s", iPID, sSufix.Data()),
-                            Form("log(esdTrack.fTPCsignal/AliPIDtools::GetExpectedTPCsignal(pidHash,esdTrack.fIp.P(),%d))", iPID));
+                            Form("log(esdTrack.fTPCsignal/AliPIDtools::GetExpectedTPCSignal(pidHash,esdTrack.fIp.P(),%d+0))", iPID));
     fFilteredTreeV0->SetAlias(Form("ldEdx0ITS%d%s", iPID, sSufix.Data()),
-                              Form("log(track0.fITSsignal/AliPIDtools::GetExpectedITSsignal(pidHash,esdTrack.fIp.P(),%d))", iPID));
+                              Form("log(track0.fITSsignal/AliPIDtools::GetExpectedITSSignal(pidHash,esdTrack.fIp.P(),%d+0))", iPID));
     fFilteredTreeV0->SetAlias(Form("ldEdx0TPC%d%s", iPID, sSufix.Data()),
-                              Form("log(track0.fTPCsignal/AliPIDtools::GetExpectedTPCsignal(pidHash,esdTrack.fIp.P(),%d))", iPID));
+                              Form("log(track0.fTPCsignal/AliPIDtools::GetExpectedTPCSignal(pidHash,esdTrack.fIp.P(),%d+0))", iPID));
     fFilteredTreeV0->SetAlias(Form("ldEdx1ITS%d%s", iPID, sSufix.Data()),
-                              Form("log(track1.fITSsignal/AliPIDtools::GetExpectedITSsignal(pidHash,esdTrack.fIp.P(),%d))", iPID));
+                              Form("log(track1.fITSsignal/AliPIDtools::GetExpectedITSSignal(pidHash,esdTrack.fIp.P(),%d+0))", iPID));
     fFilteredTreeV0->SetAlias(Form("ldEdx1TPC%d%s", iPID, sSufix.Data()),
-                              Form("log(track1.fTPCsignal/AliPIDtools::GetExpectedTPCsignal(pidHash,esdTrack.fIp.P(),%d))", iPID));
+                              Form("log(track1.fTPCsignal/AliPIDtools::GetExpectedTPCSignal(pidHash,esdTrack.fIp.P(),%d+0))", iPID));
 
     for (Int_t iR = 0; iR <= 3; iR++) {
       fFilteredTree->SetAlias(Form("ldEdxMax%d%d%s", iR, iPID, sSufix.Data()),
-                              Form("log(fTPCdEdxInfo.GetSignalMax(%d)/AliPIDtools::GetExpectedTPCsignal(pidHash,esdTrack.fIp.P(),%d))", iR, iPID));
+                              Form("log(fTPCdEdxInfo.GetSignalMax(%d)/AliPIDtools::GetExpectedTPCSignal(pidHash,esdTrack.fIp.P(),%d+0))", iR, iPID));
       fFilteredTree->SetAlias(Form("ldEdxTot%d%d%s", iR, iPID, sSufix.Data()),
-                              Form("log(fTPCdEdxInfo.GetSignalTot(%d)/AliPIDtools::GetExpectedTPCsignal(pidHash,esdTrack.fIp.P(),%d))", iR, iPID));
+                              Form("log(fTPCdEdxInfo.GetSignalTot(%d)/AliPIDtools::GetExpectedTPCSignal(pidHash,esdTrack.fIp.P(),%d+0))", iR, iPID));
       fFilteredTree->SetAlias(Form("ldEdxMaxTot%d%s", iR, sSufix.Data()),
-                              Form("log(fTPCdEdxInfo.GetSignalMax(%d)/fTPCdEdxInfo.GetSignalTot(%d))", iR, iR));
+                              Form("log(fTPCdEdxInfo.GetSignalMax(%d)/fTPCdEdxInfo.GetSignalTot(%d+0))", iR, iR));
       fFilteredTree->SetAlias(Form("ldEdxMax%d%d%s", iR, (iR + 1) % 3, sSufix.Data()),
-                              Form("log(fTPCdEdxInfo.GetSignalMax(%d)/fTPCdEdxInfo.GetSignalMax(%d))", iR, (iR + 1) % 3));
+                              Form("log(fTPCdEdxInfo.GetSignalMax(%d)/fTPCdEdxInfo.GetSignalMax(%d+0))", iR, (iR + 1) % 3));
       fFilteredTree->SetAlias(Form("ldEdxTot%d%d%s", iR, (iR + 1) % 3, sSufix.Data()),
-                              Form("log(fTPCdEdxInfo.GetSignalTot(%d)/fTPCdEdxInfo.GetSignalTot(%d))", iR, (iR + 1) % 3));
+                              Form("log(fTPCdEdxInfo.GetSignalTot(%d)/fTPCdEdxInfo.GetSignalTot(%d+0))", iR, (iR + 1) % 3));
       //
       //
       fFilteredTreeV0->SetAlias(Form("ldEdx0Max%d%d%s", iR, iPID, sSufix.Data()),
-                                Form("log(track0.fTPCdEdxInfo.GetSignalMax(%d)/AliPIDtools::GetExpectedTPCsignal(pidHash,track0.fIp.P(),%d))", iR, iPID));
+                                Form("log(track0.fTPCdEdxInfo.GetSignalMax(%d)/AliPIDtools::GetExpectedTPCSignal(pidHash,track0.fIp.P(),%d+0))", iR, iPID));
       fFilteredTreeV0->SetAlias(Form("ldEdx0Tot%d%d%s", iR, iPID, sSufix.Data()),
-                                Form("log(track0.fTPCdEdxInfo.GetSignalTot(%d)/AliPIDtools::GetExpectedTPCsignal(pidHash,track0.fIp.P(),%d))", iR, iPID));
+                                Form("log(track0.fTPCdEdxInfo.GetSignalTot(%d)/AliPIDtools::GetExpectedTPCSignal(pidHash,track0.fIp.P(),%d+0))", iR, iPID));
       fFilteredTreeV0->SetAlias(Form("ldEdx0MaxTot%d%s", iR, sSufix.Data()),
-                                Form("log(track0.fTPCdEdxInfo.GetSignalMax(%d)/track0.fTPCdEdxInfo.GetSignalTot(%d))", iR, iR));
+                                Form("log(track0.fTPCdEdxInfo.GetSignalMax(%d)/track0.fTPCdEdxInfo.GetSignalTot(%d+0))", iR, iR));
       fFilteredTreeV0->SetAlias(Form("ldEdx1Max%d%d%s", iR, iPID, sSufix.Data()),
-                                Form("log(track1.fTPCdEdxInfo.GetSignalMax(%d)/AliPIDtools::GetExpectedTPCsignal(pidHash,track1.fIp.P(),%d))", iR, iPID));
+                                Form("log(track1.fTPCdEdxInfo.GetSignalMax(%d)/AliPIDtools::GetExpectedTPCSignal(pidHash,track1.fIp.P(),%d+0))", iR, iPID));
       fFilteredTreeV0->SetAlias(Form("ldEdx1Tot%d%d%s", iR, iPID, sSufix.Data()),
-                                Form("log(track1.fTPCdEdxInfo.GetSignalTot(%d)/AliPIDtools::GetExpectedTPCsignal(pidHash,track1.fIp.P(),%d))", iR, iPID));
+                                Form("log(track1.fTPCdEdxInfo.GetSignalTot(%d)/AliPIDtools::GetExpectedTPCSignal(pidHash,track1.fIp.P(),%d+0))", iR, iPID));
       fFilteredTreeV0->SetAlias(Form("ldEdx1MaxTot%d%s", iR, sSufix.Data()),
-                                Form("log(track1.fTPCdEdxInfo.GetSignalMax(%d)/track1.fTPCdEdxInfo.GetSignalTot(%d))", iR, iR));
+                                Form("log(track1.fTPCdEdxInfo.GetSignalMax(%d)/track1.fTPCdEdxInfo.GetSignalTot(%d+0))", iR, iR));
       //
       fFilteredTreeV0->SetAlias(Form("ldEdx0Max%d%d%s", iR, (iR + 1) % 3, sSufix.Data()),
-                                Form("log(track0.fTPCdEdxInfo.GetSignalMax(%d)/track0.fTPCdEdxInfo.GetSignalMax(%d))", iR, (iR + 1) % 3));
+                                Form("log(track0.fTPCdEdxInfo.GetSignalMax(%d)/track0.fTPCdEdxInfo.GetSignalMax(%d+0))", iR, (iR + 1) % 3));
       fFilteredTreeV0->SetAlias(Form("ldEdx0Tot%d%d%s", iR, (iR + 1) % 3, sSufix.Data()),
-                                Form("log(track0.fTPCdEdxInfo.GetSignalTot(%d)/track0.fTPCdEdxInfo.GetSignalTot(%d))", iR, (iR + 1) % 3));
+                                Form("log(track0.fTPCdEdxInfo.GetSignalTot(%d)/track0.fTPCdEdxInfo.GetSignalTot(%d+0))", iR, (iR + 1) % 3));
       fFilteredTreeV0->SetAlias(Form("ldEdx1Max%d%d%s", iR, (iR + 1) % 3, sSufix.Data()),
-                                Form("log(track1.fTPCdEdxInfo.GetSignalMax(%d)/track1.fTPCdEdxInfo.GetSignalMax(%d))", iR, (iR + 1) % 3));
+                                Form("log(track1.fTPCdEdxInfo.GetSignalMax(%d)/track1.fTPCdEdxInfo.GetSignalMax(%d+0))", iR, (iR + 1) % 3));
       fFilteredTreeV0->SetAlias(Form("ldEdx1Tot%d%d%s", iR, (iR + 1) % 3, sSufix.Data()),
-                                Form("log(track1.fTPCdEdxInfo.GetSignalTot(%d)/track1.fTPCdEdxInfo.GetSignalTot(%d))", iR, (iR + 1) % 3));
+                                Form("log(track1.fTPCdEdxInfo.GetSignalTot(%d)/track1.fTPCdEdxInfo.GetSignalTot(%d+0))", iR, (iR + 1) % 3));
     }
   }
 
-  for (Int_t iPID=0; iPID<8; iPID++){
+  for (Int_t iPID=0; iPID<AliPID::kSPECIESC; iPID++){
     for (Int_t iDet=0; iDet<5; iDet++){
       Float_t mass=AliPID::ParticleMass(iPID);
       Float_t charge=AliPID::ParticleCharge(iPID);

--- a/PWGPP/AliPIDtools.cxx
+++ b/PWGPP/AliPIDtools.cxx
@@ -818,58 +818,56 @@ Bool_t AliPIDtools::RegisterPIDAliases(Int_t pidHash, TString fakeRate, Int_t su
   if (suffix>=0) sSufix=TString::Format("_%d",suffix);
   //
   for (Int_t jPID=0; jPID<AliPID::kSPECIESC+1; jPID++) {
-    Int_t iPID=(jPID<AliPID::kSPECIESC)?jPID:AliPID::kPion;
+    Int_t iPID = (jPID < AliPID::kSPECIESC) ? jPID : AliPID::kPion;
     fFilteredTree->SetAlias(Form("ldEdxITS%d%s", iPID, sSufix.Data()),
-            Form("log(esdTrack.fITSsignal/AliPIDtools::GetExpectedITSsignal(pidHash,esdTrack.fIp.P(),%d))", iPID));
+                            Form("log(esdTrack.fITSsignal/AliPIDtools::GetExpectedITSsignal(pidHash,esdTrack.fIp.P(),%d))", iPID));
     fFilteredTree->SetAlias(Form("ldEdxTPC%d%s", iPID, sSufix.Data()),
                             Form("log(esdTrack.fTPCsignal/AliPIDtools::GetExpectedTPCsignal(pidHash,esdTrack.fIp.P(),%d))", iPID));
     fFilteredTreeV0->SetAlias(Form("ldEdx0ITS%d%s", iPID, sSufix.Data()),
-            Form("log(track0.fITSsignal/AliPIDtools::GetExpectedITSsignal(pidHash,esdTrack.fIp.P(),%d))", iPID));
+                              Form("log(track0.fITSsignal/AliPIDtools::GetExpectedITSsignal(pidHash,esdTrack.fIp.P(),%d))", iPID));
     fFilteredTreeV0->SetAlias(Form("ldEdx0TPC%d%s", iPID, sSufix.Data()),
-                            Form("log(track0.fTPCsignal/AliPIDtools::GetExpectedTPCsignal(pidHash,esdTrack.fIp.P(),%d))", iPID));
+                              Form("log(track0.fTPCsignal/AliPIDtools::GetExpectedTPCsignal(pidHash,esdTrack.fIp.P(),%d))", iPID));
     fFilteredTreeV0->SetAlias(Form("ldEdx1ITS%d%s", iPID, sSufix.Data()),
-            Form("log(track1.fITSsignal/AliPIDtools::GetExpectedITSsignal(pidHash,esdTrack.fIp.P(),%d))", iPID));
+                              Form("log(track1.fITSsignal/AliPIDtools::GetExpectedITSsignal(pidHash,esdTrack.fIp.P(),%d))", iPID));
     fFilteredTreeV0->SetAlias(Form("ldEdx1TPC%d%s", iPID, sSufix.Data()),
-                            Form("log(track1.fTPCsignal/AliPIDtools::GetExpectedTPCsignal(pidHash,esdTrack.fIp.P(),%d))", iPID));
+                              Form("log(track1.fTPCsignal/AliPIDtools::GetExpectedTPCsignal(pidHash,esdTrack.fIp.P(),%d))", iPID));
 
-    for (Int_t iR=0; iR<=3; iR++) {
-      fFilteredTree->SetAlias(Form("ldEdxMax%d%d%s", iR,iPID, sSufix.Data()),
-                            Form("log(fTPCdEdxInfo.GetSignalMax(%d)/AliPIDtools::GetExpectedTPCsignal(pidHash,esdTrack.fIp.P(),%d))", iR,iPID));
-      fFilteredTree->SetAlias(Form("ldEdxTot%d%d%s", iR,iPID, sSufix.Data()),
-                            Form("log(fTPCdEdxInfo.GetSignalTot(%d)/AliPIDtools::GetExpectedTPCsignal(pidHash,esdTrack.fIp.P(),%d))", iR,iPID));
+    for (Int_t iR = 0; iR <= 3; iR++) {
+      fFilteredTree->SetAlias(Form("ldEdxMax%d%d%s", iR, iPID, sSufix.Data()),
+                              Form("log(fTPCdEdxInfo.GetSignalMax(%d)/AliPIDtools::GetExpectedTPCsignal(pidHash,esdTrack.fIp.P(),%d))", iR, iPID));
+      fFilteredTree->SetAlias(Form("ldEdxTot%d%d%s", iR, iPID, sSufix.Data()),
+                              Form("log(fTPCdEdxInfo.GetSignalTot(%d)/AliPIDtools::GetExpectedTPCsignal(pidHash,esdTrack.fIp.P(),%d))", iR, iPID));
       fFilteredTree->SetAlias(Form("ldEdxMaxTot%d%s", iR, sSufix.Data()),
-                            Form("log(fTPCdEdxInfo.GetSignalMax(%d)/fTPCdEdxInfo.GetSignalTot(%d))", iR,iR));
-      fFilteredTree->SetAlias(Form("ldEdxMax%d%d%s", iR,(iR+1)%3,  sSufix.Data()),
-                            Form("log(fTPCdEdxInfo.GetSignalMax(%d)/fTPCdEdxInfo.GetSignalMax(%d))", iR,(iR+1)%3));
-      fFilteredTree->SetAlias(Form("ldEdxTot%d%d%s", iR,(iR+1)%3,  sSufix.Data()),
-                            Form("log(fTPCdEdxInfo.GetSignalTot(%d)/fTPCdEdxInfo.GetSignalTot(%d))", iR,(iR+1)%3));
+                              Form("log(fTPCdEdxInfo.GetSignalMax(%d)/fTPCdEdxInfo.GetSignalTot(%d))", iR, iR));
+      fFilteredTree->SetAlias(Form("ldEdxMax%d%d%s", iR, (iR + 1) % 3, sSufix.Data()),
+                              Form("log(fTPCdEdxInfo.GetSignalMax(%d)/fTPCdEdxInfo.GetSignalMax(%d))", iR, (iR + 1) % 3));
+      fFilteredTree->SetAlias(Form("ldEdxTot%d%d%s", iR, (iR + 1) % 3, sSufix.Data()),
+                              Form("log(fTPCdEdxInfo.GetSignalTot(%d)/fTPCdEdxInfo.GetSignalTot(%d))", iR, (iR + 1) % 3));
       //
       //
-      fFilteredTreeV0->SetAlias(Form("ldEdx0Max%d%d%s", iR,iPID, sSufix.Data()),
-                            Form("log(track0.fTPCdEdxInfo.GetSignalMax(%d)/AliPIDtools::GetExpectedTPCsignal(pidHash,track0.fIp.P(),%d))", iR,iPID));
-      fFilteredTreeV0->SetAlias(Form("ldEdx0Tot%d%d%s", iR,iPID, sSufix.Data()),
-                            Form("log(track0.fTPCdEdxInfo.GetSignalTot(%d)/AliPIDtools::GetExpectedTPCsignal(pidHash,track0.fIp.P(),%d))", iR,iPID));
+      fFilteredTreeV0->SetAlias(Form("ldEdx0Max%d%d%s", iR, iPID, sSufix.Data()),
+                                Form("log(track0.fTPCdEdxInfo.GetSignalMax(%d)/AliPIDtools::GetExpectedTPCsignal(pidHash,track0.fIp.P(),%d))", iR, iPID));
+      fFilteredTreeV0->SetAlias(Form("ldEdx0Tot%d%d%s", iR, iPID, sSufix.Data()),
+                                Form("log(track0.fTPCdEdxInfo.GetSignalTot(%d)/AliPIDtools::GetExpectedTPCsignal(pidHash,track0.fIp.P(),%d))", iR, iPID));
       fFilteredTreeV0->SetAlias(Form("ldEdx0MaxTot%d%s", iR, sSufix.Data()),
-                            Form("log(track0.fTPCdEdxInfo.GetSignalMax(%d)/track0.fTPCdEdxInfo.GetSignalTot(%d))", iR,iR));
-      fFilteredTreeV0->SetAlias(Form("ldEdx1Max%d%d%s", iR,iPID, sSufix.Data()),
-                            Form("log(track1.fTPCdEdxInfo.GetSignalMax(%d)/AliPIDtools::GetExpectedTPCsignal(pidHash,track1.fIp.P(),%d))", iR,iPID));
-      fFilteredTreeV0->SetAlias(Form("ldEdx1Tot%d%d%s", iR,iPID, sSufix.Data()),
-                            Form("log(track1.fTPCdEdxInfo.GetSignalTot(%d)/AliPIDtools::GetExpectedTPCsignal(pidHash,track1.fIp.P(),%d))", iR,iPID));
+                                Form("log(track0.fTPCdEdxInfo.GetSignalMax(%d)/track0.fTPCdEdxInfo.GetSignalTot(%d))", iR, iR));
+      fFilteredTreeV0->SetAlias(Form("ldEdx1Max%d%d%s", iR, iPID, sSufix.Data()),
+                                Form("log(track1.fTPCdEdxInfo.GetSignalMax(%d)/AliPIDtools::GetExpectedTPCsignal(pidHash,track1.fIp.P(),%d))", iR, iPID));
+      fFilteredTreeV0->SetAlias(Form("ldEdx1Tot%d%d%s", iR, iPID, sSufix.Data()),
+                                Form("log(track1.fTPCdEdxInfo.GetSignalTot(%d)/AliPIDtools::GetExpectedTPCsignal(pidHash,track1.fIp.P(),%d))", iR, iPID));
       fFilteredTreeV0->SetAlias(Form("ldEdx1MaxTot%d%s", iR, sSufix.Data()),
-                            Form("log(track1.fTPCdEdxInfo.GetSignalMax(%d)/track1.fTPCdEdxInfo.GetSignalTot(%d))", iR,iR));
+                                Form("log(track1.fTPCdEdxInfo.GetSignalMax(%d)/track1.fTPCdEdxInfo.GetSignalTot(%d))", iR, iR));
       //
-      fFilteredTreeV0->SetAlias(Form("ldEdx0Max%d%d%s", iR,(iR+1)%3,  sSufix.Data()),
-                            Form("log(track0.fTPCdEdxInfo.GetSignalMax(%d)/track0.fTPCdEdxInfo.GetSignalMax(%d))", iR,(iR+1)%3));
-      fFilteredTreeV0->SetAlias(Form("ldEdx0Tot%d%d%s", iR,(iR+1)%3,  sSufix.Data()),
-                            Form("log(track0.fTPCdEdxInfo.GetSignalTot(%d)/track0.fTPCdEdxInfo.GetSignalTot(%d))", iR,(iR+1)%3));
-      fFilteredTreeV0->SetAlias(Form("ldEdx1Max%d%d%s", iR,(iR+1)%3,  sSufix.Data()),
-                            Form("log(track1.fTPCdEdxInfo.GetSignalMax(%d)/track1.fTPCdEdxInfo.GetSignalMax(%d))", iR,(iR+1)%3));
-      fFilteredTreeV0->SetAlias(Form("ldEdx1Tot%d%d%s", iR,(iR+1)%3,  sSufix.Data()),
-                            Form("log(track1.fTPCdEdxInfo.GetSignalTot(%d)/track1.fTPCdEdxInfo.GetSignalTot(%d))", iR,(iR+1)%3));
-
+      fFilteredTreeV0->SetAlias(Form("ldEdx0Max%d%d%s", iR, (iR + 1) % 3, sSufix.Data()),
+                                Form("log(track0.fTPCdEdxInfo.GetSignalMax(%d)/track0.fTPCdEdxInfo.GetSignalMax(%d))", iR, (iR + 1) % 3));
+      fFilteredTreeV0->SetAlias(Form("ldEdx0Tot%d%d%s", iR, (iR + 1) % 3, sSufix.Data()),
+                                Form("log(track0.fTPCdEdxInfo.GetSignalTot(%d)/track0.fTPCdEdxInfo.GetSignalTot(%d))", iR, (iR + 1) % 3));
+      fFilteredTreeV0->SetAlias(Form("ldEdx1Max%d%d%s", iR, (iR + 1) % 3, sSufix.Data()),
+                                Form("log(track1.fTPCdEdxInfo.GetSignalMax(%d)/track1.fTPCdEdxInfo.GetSignalMax(%d))", iR, (iR + 1) % 3));
+      fFilteredTreeV0->SetAlias(Form("ldEdx1Tot%d%d%s", iR, (iR + 1) % 3, sSufix.Data()),
+                                Form("log(track1.fTPCdEdxInfo.GetSignalTot(%d)/track1.fTPCdEdxInfo.GetSignalTot(%d))", iR, (iR + 1) % 3));
+    }
   }
-
-
 
   for (Int_t iPID=0; iPID<8; iPID++){
     for (Int_t iDet=0; iDet<5; iDet++){

--- a/PWGPP/TPC/macros/performanceFiltered.C
+++ b/PWGPP/TPC/macros/performanceFiltered.C
@@ -49,6 +49,7 @@
 #include "TKey.h"
 #include "AliDrawStyle.h"
 #include "AliAnalysisTaskFilteredTree.h"
+#include "AliCDBManager.h"
 //
 TChain * chain=0;
 TChain * chainV0=0;
@@ -67,7 +68,7 @@ Int_t    chainEntries=0;
 //   parameters
 Int_t run=246272;
 TString period="LHC15o";
-TString year="";
+TString year="2015";
 Double_t deltaT=300;  // 5 minutes binning
 Float_t bz=0;
 
@@ -212,11 +213,15 @@ Bool_t  InitAnalysis(){
   if (gSystem->Getenv("run")==NULL  || gSystem->Getenv("period")==0 || gSystem->Getenv("year")==0){
     ::Error("performaceFiltered::InitAnalisys","run and period to be set using env variables run, period");   /// todo add them as a paremeters
     return kFALSE;
-  }
+  }else{
+    ::Info("using setting","%s\n\t%s\n\t%s",gSystem->Getenv("run"),  gSystem->Getenv("period"),  gSystem->Getenv("year"));
+     }
   run=TString(gSystem->Getenv("run")).Atoi();
   period=gSystem->Getenv("period");
   year=gSystem->Getenv("year");
   if (gSystem->Getenv("deltaT")!=NULL) deltaT=TString(gSystem->Getenv("deltaT")).Atof();
+  AliCDBManager::Instance()->SetDefaultStorage(Form("local:///cvmfs/alice.cern.ch/calibration/data/%s/OCDB/",year.Data()));
+  AliCDBManager::Instance()->SetRun(run);
   //
   // get chain
   chain = AliXRDPROOFtoolkit::MakeChainRandom("filtered.list","highPt",0,40000,0,1);


### PR DESCRIPTION
## PWGPP-538, ATO-465+ AliPIDtools aliases + new specie for muon+pion
* muon and pions above 200 MeV difficult to disentangle - makes species pion or muon
* used in tree queries in AliPIDtools

## ATO-465 - adding probability/weights to the tree - to be able to recover  spectra without down sampling
* using weight not need to keep back compatibility in functions
* original spectra should be possible to extract using weights stored in trees 
* procedure to extract original spectra to be crosschecked with MB trigger