### PR TITLE
Add option for run1 runrange in trending plots

### DIFF
--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalClustersRef.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalClustersRef.cxx
@@ -471,12 +471,12 @@ bool AliAnalysisTaskEmcalClustersRef::Run(){
         maxpointFull[1] = 1;
       }
     } else if(maxclusterEMCAL){
-      maxclusterEMCAL = maxclusterEMCAL;
+      maxcluster = maxclusterEMCAL;
       energyMax = energyMaxEMCAL;
       maxpointFull[1] = 0;
     } 
     else if(maxclusterDCAL) {
-      maxclusterDCAL = maxclusterDCAL;
+      maxcluster = maxclusterDCAL;
       energyMax = energyMaxDCAL;
       maxpointFull[1] = 1;
     }

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetEnergySpectrum.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetEnergySpectrum.cxx
@@ -68,7 +68,7 @@ AliAnalysisTaskEmcalJetEnergySpectrum::AliAnalysisTaskEmcalJetEnergySpectrum():
   fNameJetContainer("datajets"),
   fRequestTriggerClusters(true),
   fRequestCentrality(false),
-  fUseAliEventCuts(false),
+  fUseRun1Range(false),
   fUseSumw2(false),
   fUseMuonCalo(false),
   fUseStandardOutlierRejection(false),
@@ -94,7 +94,7 @@ AliAnalysisTaskEmcalJetEnergySpectrum::AliAnalysisTaskEmcalJetEnergySpectrum(EMC
   fNameJetContainer("datajets"),
   fRequestTriggerClusters(true),
   fRequestCentrality(false),
-  fUseAliEventCuts(false),
+  fUseRun1Range(false),
   fUseSumw2(false),
   fUseMuonCalo(false),
   fUseStandardOutlierRejection(false),
@@ -122,13 +122,14 @@ void AliAnalysisTaskEmcalJetEnergySpectrum::UserCreateOutputObjects(){
       current += 1; 
     }
   }
-
+  double runmin = fUseRun1Range ? 100000. : 200000.,
+         runmax = fUseRun1Range ? 200000. : 300000.;
   fHistos = new THistManager(Form("Histos_%s", GetName()));
   fHistos->CreateTH1("hEventCounter", "Event counter histogram", 1, 0.5, 1.5);
   fHistos->CreateTH1("hEventCounterAbs", "Event counter histogram absolute", 1, 0.5, 1.5);
-  fHistos->CreateTH1("hEventCounterRun", "Runwise event counter", 100000, 200000, 300000);
-  fHistos->CreateTH1("hEventCounterRunWeighted", "Runwise event counter (weighted)", 100000, 200000, 300000);
-  fHistos->CreateTProfile("hDownscaleFactorsRunwise", "Runwise downscale factors", 100000, 200000, 300000);
+  fHistos->CreateTH1("hEventCounterRun", "Runwise event counter", 100000, runmin, runmax);
+  fHistos->CreateTH1("hEventCounterRunWeighted", "Runwise event counter (weighted)", 100000, runmin, runmax);
+  fHistos->CreateTProfile("hDownscaleFactorsRunwise", "Runwise downscale factors", 100000, runmin, runmax);
   fHistos->CreateTH1("hEventCentrality", "Event centrality", 100., 0., 100.);
   fHistos->CreateTH1("hEventCentralityAbs", "Event centrality absolute", 100., 0., 100.);
   fHistos->CreateTH1("hClusterCounter", "Event counter histogram", kTrgClusterN, -0.5, kTrgClusterN - 0.5);

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetEnergySpectrum.h
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetEnergySpectrum.h
@@ -42,20 +42,6 @@ namespace EMCALJetTasks {
 
 class AliAnalysisTaskEmcalJetEnergySpectrum : public AliAnalysisTaskEmcalJet, public AliAnalysisEmcalTriggerSelectionHelperImpl {
 public:
-  enum TriggerCluster_t {
-    kTrgClusterANY,
-    kTrgClusterCENT,
-    kTrgClusterCENTNOTRD,
-    kTrgClusterCALO,
-    kTrgClusterCALOFAST,
-    kTrgClusterCENTBOTH,
-    kTrgClusterOnlyCENT,
-    kTrgClusterOnlyCENTNOTRD,
-    kTrgClusterCALOBOTH,
-    kTrgClusterOnlyCALO,
-    kTrgClusterOnlyCALOFAST,
-    kTrgClusterN
-  };
   enum EJetTypeOutliers_t {
     kOutlierPartJet,
     kOutlierDetJet
@@ -73,6 +59,7 @@ public:
   }
   void SetUseDownscaleWeight(bool doUse) { fUseDownscaleWeight = doUse; }
   void SetUseSumw2(Bool_t doUse) { fUseSumw2 = doUse; }
+  void SetRangeRun1(Bool_t doUse) { fUseRun1Range = doUse; }
   void SetUseTriggerSelectionForData(bool doUse) { fUseTriggerSelectionForData = doUse; }
   void SetRequireSubsetMB(bool doRequire, ULong_t minbiastrigger = AliVEvent::kAny) { fRequireSubsetMB = doRequire; fMinBiasTrigger = minbiastrigger; }
   void SetUserPtBinning(int nbins, double *binning) { fUserPtBinning.Set(nbins+1, binning); }
@@ -121,7 +108,7 @@ private:
   TString                       fNameJetContainer;              ///< Name of the jet container 
   Bool_t                        fRequestTriggerClusters;        ///< Request distinction of trigger clusters
   Bool_t                        fRequestCentrality;             ///< Request centrality
-  Bool_t                        fUseAliEventCuts;               ///< Flag switching on AliEventCuts;
+  Bool_t                        fUseRun1Range;                  ///< Use run1 run range for trending plots     
   Bool_t                        fUseSumw2;                      ///< Switch for sumw2 option in THnSparse (should not be used when a downscale weight is applied)
   Bool_t                        fUseMuonCalo;                   ///< Use events from the (muon)-calo-(fast) cluster
   Bool_t                        fUseStandardOutlierRejection;   ///< Use standard outlier rejection


### PR DESCRIPTION

In addition
- Remove duplicated trigger cluster enum
- Fix assignment of max cluster in case of EDCAL triggers
  and only clusters in one of the two subdetectors