### PR TITLE
PWGHF: Event ID bug fix TTreeCreatorApply

### DIFF
--- a/PWGHF/vertexingHF/vHFML/AliAnalysisTaskSEHFTreeCreatorApply.h
+++ b/PWGHF/vertexingHF/vHFML/AliAnalysisTaskSEHFTreeCreatorApply.h
@@ -190,7 +190,7 @@ private:
   Int_t                   fPIDoptDs;                             /// PID option for Ds tree
   Int_t                   fPIDoptLc2V0bachelor;                  /// PID option for Lc2V0bachelor tree
 
-  UInt_t                  fEventID;                              /// event ID (unique when combined with run number)
+  Int_t                   fEventID;                              /// event ID (unique when combined with run number)
   Int_t                   fEventIDExt;                           /// upper 32-bit of event ID
   Long64_t                fEventIDLong;                          /// single unique event id (long64)
   TString                 fFileName;                             /// Store filename for an unique event ID
@@ -265,7 +265,7 @@ private:
   AliHFMLResponse* fMLResponse;                                  //!<! object to handle ML response
 
   /// \cond CLASSIMP
-  ClassDef(AliAnalysisTaskSEHFTreeCreatorApply,2);
+  ClassDef(AliAnalysisTaskSEHFTreeCreatorApply,3);
   /// \endcond
 };
 


### PR DESCRIPTION
Bug/typo fix. 

When the event ID was large, the ID was stored differently in the event properties TTree and the reconstructed HF candidate TTree due to Int_t vs UInt_t. When matching both TTrees at Pandas dataframe level, this mismatch rejected ~50% of the candidates

(not sure about classdef)