### PR TITLE
Changing to Lambda Lambda

### DIFF
--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliAnalysisTaskGeorgiosNTuple.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliAnalysisTaskGeorgiosNTuple.cxx
@@ -731,7 +731,8 @@ void AliAnalysisTaskGeorgiosNTuple::UserExec(Option_t *option) {
 
   }
   //fill Tree
-  if(fTnv0>0&&fTnCascade>0) fGeorgiosTree->Fill(); //
+  //if(fTnv0>0&&fTnCascade>0) fGeorgiosTree->Fill(); //Select here events with at least on Xi and one Lambda
+  if(fTnv0>1) fGeorgiosTree->Fill();
 
   //pair cleaner
   fPairCleaner->ResetArray();


### PR DESCRIPTION
Changing the selection criteria to events with at least two Lambdas in order to study Lambda-Lambda correlations