### PR TITLE
Rdev rsn timerangecut

### DIFF
--- a/PWGLF/RESONANCES/AliRsnMiniAnalysisTask.h
+++ b/PWGLF/RESONANCES/AliRsnMiniAnalysisTask.h
@@ -38,6 +38,7 @@ class AliRsnMiniEvent;
 class AliRsnCutSet;
 class AliQnCorrectionsManager;
 class AliQnCorrectionsQnVector;
+class AliTimeRangeCut;
 
 class AliRsnMiniAnalysisTask : public AliAnalysisTaskSE {
 
@@ -66,6 +67,7 @@ public:
    void                SetMaxDiffVz   (Double_t val)      {fMaxDiffVz    = val;}
    void                SetMaxDiffAngle(Double_t val)      {fMaxDiffAngle = val;}
    void                SetUseBuiltinEventCuts(Bool_t use = kTRUE)   {fUseBuiltinEventCuts    = use;}
+   void                SetUseTimeRangeCut(Bool_t use = kTRUE)   {fUseTimeRangeCut    = use;}
    void                SetEventCuts(AliRsnCutSet *cuts)   {fEventCuts    = cuts;}
    void                SetMixPrintRefresh(Int_t n)        {fMixPrintRefresh = n;}
    void                SetCheckDecay(Bool_t checkDecay = kTRUE) {fCheckDecay = checkDecay;}
@@ -151,6 +153,8 @@ private:
    TH2F                *fHAEventPlane;        //!<! histogram of event plane vs. multiplicity/centrality
 
    Bool_t              fUseBuiltinEventCuts; //< use Built-in AliEventCuts
+   Bool_t              fUseTimeRangeCut; //< use time range cut
+   AliTimeRangeCut     *fTimeRangeCut; //!<! time range cut
    AliRsnCutSet        *fEventCuts;       ///< cuts on events
    TObjArray            fTrackCuts;       ///< list of single track cuts
    AliRsnEvent          fRsnEvent;        ///< interface object to the event
@@ -179,7 +183,7 @@ private:
    TObjArray            fResonanceFinders;  ///< list of AliRsnMiniResonanceFinder objects
 
 /// \cond CLASSIMP
-   ClassDef(AliRsnMiniAnalysisTask, 21);     
+   ClassDef(AliRsnMiniAnalysisTask, 22);     
 /// \endcond
 };
 

--- a/PWGLF/RESONANCES/macros/mini/AddAnalysisTaskLStar_PbPb2018.C
+++ b/PWGLF/RESONANCES/macros/mini/AddAnalysisTaskLStar_PbPb2018.C
@@ -28,7 +28,8 @@ AddAnalysisTaskLStar_PbPb2018(
 			      Float_t     nsKa              = 1.0, // factor wrt. default n-sigma
 			      Int_t       nMix              = 15,
 			      Bool_t      isMC              = kFALSE, 
-			      const char *suffix            = ""
+			      const char *suffix            = "",
+			      Bool_t      timeRangeCut      = kFALSE
 			      )
 {  
   //
@@ -55,6 +56,7 @@ AddAnalysisTaskLStar_PbPb2018(
    task->SetMaxDiffVz(1.0);
    task->SetMaxDiffMult(10.);
    task->SetMaxDiffAngle(20.*TMath::DegToRad());
+   task->SetUseTimeRangeCut(timeRangeCut);
    mgr->AddTask(task);
    
    //


### PR DESCRIPTION
This PR adds to the RSN analysis package the possibility to use `TimeRangeCut` event cuts.
The use of this extra cut is driven by a flag that can be set by the user via `AliRsnMiniAnalysisTask::SetUseTimeRangeCut`.
The default is `kFALSE` and the cut is not applied.

This development is useful to add those runs (8 runs in LHC18r) that are flagged by the DPG as being bad for TPC PID.

> 8 runs, 296749, 296750, 296849, 296890, 297029, 297194, 297219, 297481 have been excluded from lists including TPC, because they are bad for TPC PID due to a problem in the gain in one or two sectors. This problem happens at the end of the run: by excluding the problematic time range, the remaining events can be used for PID analyses.

The Lambda(1520) add-analysis-task macro is updated to make use of this addition.