### PR TITLE
Update Lambda(1520) to allow for continuous/binned mixing

### DIFF
--- a/PWGLF/RESONANCES/macros/mini/AddAnalysisTaskLStar_PbPb2018.C
+++ b/PWGLF/RESONANCES/macros/mini/AddAnalysisTaskLStar_PbPb2018.C
@@ -50,9 +50,9 @@ AddAnalysisTaskLStar_PbPb2018(
    task->SelectCollisionCandidates(triggerMask);
    task->UseMultiplicity("AliMultSelection_V0M");
    // set event mixing options
-   task->UseContinuousMix();
-   //task->UseBinnedMix();
-   task->SetNMix(nMix);
+   if (nMix > 0) task->UseContinuousMix();
+   else task->UseBinnedMix();
+   task->SetNMix(TMath::Abs(nMix));
    task->SetMaxDiffVz(1.0);
    task->SetMaxDiffMult(10.);
    task->SetMaxDiffAngle(20.*TMath::DegToRad());


### PR DESCRIPTION
If negative `nMix` use binned event mixing instead of the default continuous.