### PR TITLE
Rdev rsn pileup

### DIFF
--- a/PWGLF/RESONANCES/AliRsnMiniOutput.cxx
+++ b/PWGLF/RESONANCES/AliRsnMiniOutput.cxx
@@ -142,6 +142,7 @@ AliRsnMiniOutput::AliRsnMiniOutput(const char *name, const char *outType, const 
 //    -- "ROTATE2" --> rotated background (rotate second track)
 //    -- "TRUE"    --> true pairs (like track pair, but checking that come from same mother)
 //    -- "MOTHER"  --> mother (loop on MC directly for mothers --> denominator of efficiency)
+//    -- "MOTHER_NO_PILEUP"  --> mother (loop on MC directly for mothers --> denominator of efficiency) that does not come from a pileup event
 //    -- "MOTHER_IN_ACC"  --> mother (loop on MC directly for mothers (in a defined acceptance interval)--> needed for efficiency calcutation using  an enriched sample)
 //
 
@@ -174,6 +175,8 @@ AliRsnMiniOutput::AliRsnMiniOutput(const char *name, const char *outType, const 
       fComputation = kTruePair;
    else if (!input.CompareTo("MOTHER"))
       fComputation = kMother;
+   else if (!input.CompareTo("MOTHER_NO_PILEUP"))
+      fComputation = kMotherNoPileup;
    else if (!input.CompareTo("MOTHER_IN_ACC"))
       fComputation = kMotherInAcc;
    else if (!input.CompareTo("SINGLE"))
@@ -470,7 +473,7 @@ Bool_t AliRsnMiniOutput::FillMother(const AliRsnMiniPair *pair, AliRsnMiniEvent 
 //
 
    // check computation type
-   if (fComputation != kMother) {
+   if (fComputation != kMother && fComputation != kMotherNoPileup) {
       AliError("This method can be called only for mother-based computations");
       return kFALSE;
    }

--- a/PWGLF/RESONANCES/AliRsnMiniOutput.h
+++ b/PWGLF/RESONANCES/AliRsnMiniOutput.h
@@ -44,6 +44,7 @@ public:
       kTrackPairRotated2,
       kTruePair,
       kMother,
+      kMotherNoPileup,
       kMotherInAcc,
       kSingle,
       kComputations
@@ -60,9 +61,10 @@ public:
    Bool_t          IsTrackPairMix()     const {return (fComputation == kTrackPairMix);}
    Bool_t          IsTruePair()         const {return (fComputation == kTruePair);}
    Bool_t          IsMother()           const {return (fComputation == kMother);}
+   Bool_t          IsMotherNoPileup()   const {return (fComputation == kMotherNoPileup);}
    Bool_t          IsMotherInAcc()      const {return (fComputation == kMotherInAcc);}
    Bool_t          IsSingle()           const {return (fComputation == kSingle);}
-   Bool_t          IsDefined()          const {return (IsEventOnly() || IsTrackPair() || IsTrackPairMix() || IsTruePair() || IsMother());}
+   Bool_t          IsDefined()          const {return (IsEventOnly() || IsTrackPair() || IsTrackPairMix() || IsTruePair() || IsMother() || IsMotherNoPileup());}
    Bool_t          IsLikeSign()         const {return (fCharge[0] == fCharge[1]);}
    Bool_t          IsSameCut()          const {return (fCutID[0] == fCutID[1]);}
    Bool_t          IsSameDaughter()     const {return (fDaughter[0] == fDaughter[1]);}

--- a/PWGLF/RESONANCES/macros/mini/ConfigLStar_PbPb2018.C
+++ b/PWGLF/RESONANCES/macros/mini/ConfigLStar_PbPb2018.C
@@ -105,18 +105,18 @@ Bool_t ConfigLStar_PbPb2018(
 
   // -- Create all needed outputs -----------------------------------------------------------------
 
-  Bool_t  use       [14] = { !isMC      ,  !isMC     ,  !isMC   , !isMC    , !isMC      , !isMC      , !isMC      , !isMC      , isMC     , isMC     , isMC     , isMC     , isMC     , isMC     };
-  TString name      [14] = { "UnlikePM" , "UnlikeMP" , "LikePP" , "LikeMM" , "MixingPM" , "MixingMP" , "MixingPP" , "MixingMM" , "RecoPM" , "RecoMP" , "ResoPM" , "ResoMP" , "TruePM" , "TrueMP" };
-  TString comp      [14] = { "PAIR"     , "PAIR"     , "PAIR"   , "PAIR"   , "MIX"      , "MIX"      , "MIX"      , "MIX"      , "TRUE"   , "TRUE"   , "TRUE"   , "TRUE"   , "MOTHER" , "MOTHER" };
-  Char_t  charge1   [14] = { '+'        , '-'        , '+'      , '-'      , '+'        , '-'        , '+'        , '-'        , '+'      , '-'      , '+'      , '-'      , 0        , 0        };
-  Char_t  charge2   [14] = { '-'        , '+'        , '+'      , '-'      , '-'        , '+'        , '+'        , '-'        , '-'      , '+'      , '-'      , '+'      , 0        , 0        };
-  Int_t   motherPDG [14] = { 0          , 0          , 0        , 0        , 0          , 0          , 0          , 0          , 3124     , -3124    , 3124     , -3124    , 3124     , -3124    };
-  Int_t   xaxis     [14] = { imID       , imID       , imID     , imID     , imID       , imID       , imID       , imID       , imID     , imID     , resID    , resID    , imID     , imID     };
+  Bool_t  use       [16] = { !isMC      ,  !isMC      ,  !isMC   , !isMC    , !isMC      , !isMC      , !isMC      , !isMC      , isMC     , isMC     , isMC     , isMC     , isMC     , isMC     , isMC               , isMC};
+  TString name      [16] = { "UnlikePM" ,  "UnlikeMP" , "LikePP" , "LikeMM" , "MixingPM" , "MixingMP" , "MixingPP" , "MixingMM" , "RecoPM" , "RecoMP" , "ResoPM" , "ResoMP" , "TruePM" , "TrueMP" , "TruePM_NoPileUp"  , "TrueMP_NoPileUp"};
+  TString comp      [16] = { "PAIR"     , "PAIR"      , "PAIR"   , "PAIR"   , "MIX"      , "MIX"      , "MIX"      , "MIX"      , "TRUE"   , "TRUE"   , "TRUE"   , "TRUE"   , "MOTHER" , "MOTHER" , "MOTHER_NO_PILEUP" , "MOTHER_NO_PILEUP"};
+  Char_t  charge1   [16] = { '+'        , '-'         , '+'      , '-'      , '+'        , '-'        , '+'        , '-'        , '+'      , '-'      , '+'      , '-'      , 0        , 0        , 0                  , 0 };
+  Char_t  charge2   [16] = { '-'        , '+'         , '+'      , '-'      , '-'        , '+'        , '+'        , '-'        , '-'      , '+'      , '-'      , '+'      , 0        , 0        , 0                  , 0 };
+  Int_t   motherPDG [16] = { 0          , 0           , 0        , 0        , 0          , 0          , 0          , 0          , 3124     , -3124    , 3124     , -3124    , 3124     , -3124    , 3124               , -3124};
+  Int_t   xaxis     [16] = { imID       , imID        , imID     , imID     , imID       , imID       , imID       , imID       , imID     , imID     , resID    , resID    , imID     , imID     , imID               , imID};
   Int_t   cutID1         =   icutP   ;
   Int_t   cutID2         =   icutK   ;
   TString output         =  "SPARSE" ;
   
-  for (Int_t i = 0; i < 14; i++) {
+  for (Int_t i = 0; i < 16; i++) {
     if (!use[i]) continue;
     AliRsnMiniOutput *out = task->CreateOutput(Form("Lstar_PbPb_%s%s", name[i].Data(), suffix), output.Data(), comp[i].Data());
     //


### PR DESCRIPTION
This PR updates the RSN analysis code in order to be able to cut particles coming from out-of-bunch pile-up in case of pile-up MC productions.

Nothing will change for users that do not take action, namely the current behaviour of not cutting particles from pile-up is preserved.

Selection of mothers not coming from pileup is driven by the `MOTHER_NO_PILEUP` label of the mini output definition.
Please, check the updated `ConfigLStar_PbPb2018.C` for example of use.