### PR TITLE
add option to disable QA tree in output

### DIFF
--- a/PWGHF/vertexingHF/AliAnalysisTaskSELc2pKs0fromKFP.cxx
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSELc2pKs0fromKFP.cxx
@@ -81,6 +81,7 @@ AliAnalysisTaskSELc2pKs0fromKFP::AliAnalysisTaskSELc2pKs0fromKFP() :
   fHTrigger(0),
   fWriteLcTree(kFALSE),
   fWriteLcMCGenTree(kFALSE),
+  fWriteLcQATree(kFALSE),
   fWeight(0),
   fHistMCGen_LcPt_weight(0),
   f2DHistMCRec_LcPt_weight(0)
@@ -115,6 +116,7 @@ AliAnalysisTaskSELc2pKs0fromKFP::AliAnalysisTaskSELc2pKs0fromKFP(const char* nam
   fHTrigger(0),
   fWriteLcTree(kFALSE),
   fWriteLcMCGenTree(kFALSE),
+  fWriteLcQATree(kFALSE),
   fWeight(0),
   fHistMCGen_LcPt_weight(0),
   f2DHistMCRec_LcPt_weight(0)
@@ -1305,7 +1307,7 @@ void AliAnalysisTaskSELc2pKs0fromKFP::FillTreeRecLcFromCascadeHF(AliAODRecoCasca
   if (fIsMC && lab_Lc>=0) fTree_Lc->Fill();
   if (!fIsMC) fTree_Lc->Fill();
 
-  fTree_Lc_QA->Fill();
+  if (fWriteLcQATree) {fTree_Lc_QA->Fill();}
 
   /*
   cout << "==========" << endl;

--- a/PWGHF/vertexingHF/AliAnalysisTaskSELc2pKs0fromKFP.h
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSELc2pKs0fromKFP.h
@@ -64,6 +64,8 @@ class AliAnalysisTaskSELc2pKs0fromKFP : public AliAnalysisTaskSE
         void SetWriteLcTree(Bool_t a) {fWriteLcTree = a;}
         Bool_t GetWriteLcTree() const {return fWriteLcTree;}
 
+        void SetWriteLcQATree(Bool_t a) {fWriteLcQATree = a;}
+        Bool_t GetWriteLcQATree() const {return fWriteLcQATree;}
         void FillEventROOTObjects();
         void FillTreeGenLc(AliAODMCParticle *mcpart, Int_t CheckOrigin);
         void FillTreeRecLcFromCascadeHF(AliAODRecoCascadeHF *Lc2pKs0, KFParticle kfpLc, AliAODTrack *trackPr, KFParticle kfpPr, KFParticle kfpKs0, KFParticle kfpKs0_massConstraint, AliAODTrack *v0Pos, AliAODTrack *v0Neg, KFParticle PV, TClonesArray *mcArray, Int_t lab_Ks0, Int_t lab_Lc, KFParticle kfpLc_woKs0MassConst);
@@ -103,6 +105,7 @@ class AliAnalysisTaskSELc2pKs0fromKFP : public AliAnalysisTaskSE
         TH1F*                   fHTrigger;            //!<! Histogram of trigger
         Bool_t                  fWriteLcMCGenTree; ///< flag to decide whether to write the MC candidate variables on a tree variables
         Bool_t                  fWriteLcTree; ///< flag to decide whether to write Lc tree
+        Bool_t                  fWriteLcQATree; ///< flag to decide whether to write QA output tree
         TF1*                    fWeight; ///< weight of Data/MC_gen
         TH1D*                   fHistMCGen_LcPt_weight; //!<! pt of Lc after weight at gen. level
         TH2D*                   f2DHistMCRec_LcPt_weight; //!<! pt of Lc after weight at rec. level
@@ -110,7 +113,7 @@ class AliAnalysisTaskSELc2pKs0fromKFP : public AliAnalysisTaskSE
         AliAnalysisTaskSELc2pKs0fromKFP(const AliAnalysisTaskSELc2pKs0fromKFP &source); // not implemented
         AliAnalysisTaskSELc2pKs0fromKFP& operator=(const AliAnalysisTaskSELc2pKs0fromKFP& source); // not implemented
 
-        ClassDef(AliAnalysisTaskSELc2pKs0fromKFP, 2);
+        ClassDef(AliAnalysisTaskSELc2pKs0fromKFP, 3);
 };
 
 #endif

--- a/PWGHF/vertexingHF/macros/AddTaskLc2pKs0FromKFParticle.C
+++ b/PWGHF/vertexingHF/macros/AddTaskLc2pKs0FromKFParticle.C
@@ -5,7 +5,7 @@
 #include <TList.h>
 #endif
 
-AliAnalysisTaskSELc2pKs0fromKFP* AddTaskLc2pKs0FromKFParticle(TString finname="", Bool_t IsMC=kTRUE, TString cuttype="")
+AliAnalysisTaskSELc2pKs0fromKFP* AddTaskLc2pKs0FromKFParticle(TString finname="", Bool_t IsMC=kTRUE, TString cuttype="", Bool_t writeQATree=kTRUE)
 {
     Bool_t writeLcRecTree = kTRUE;
     Bool_t writeLcMCGenTree = kFALSE;
@@ -63,7 +63,7 @@ AliAnalysisTaskSELc2pKs0fromKFP* AddTaskLc2pKs0FromKFParticle(TString finname=""
     task->SetDebugLevel(1);
     task->SetWriteLcMCGenTree(writeLcMCGenTree);
     task->SetWriteLcTree(writeLcRecTree);
-
+    task->SetWriteLcQATree(writeQATree);
     // weight
     TF1 *weight = new TF1("weight", "expo", 0., 50.);
     weight->SetParameter(0, 0.853544);


### PR DESCRIPTION
Adds possibility to disable QA tree in the output of vertexingHF/AliAnalysisTaskSELc2pKs0FromKFParticle