### PR TITLE
Add trigger cluster information to the softdrop histograms

### DIFF
--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalSoftDropData.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalSoftDropData.cxx
@@ -52,6 +52,8 @@ using namespace PWGJE::EMCALJetTasks;
 
 AliAnalysisTaskEmcalSoftDropData::AliAnalysisTaskEmcalSoftDropData() : 
   AliAnalysisTaskEmcalJet(),
+  AliAnalysisEmcalSoftdropHelperImpl(),
+  AliAnalysisEmcalTriggerSelectionHelperImpl(),
   fTriggerBits(AliVEvent::kAny),
   fTriggerString(""),
   fUseDownscaleWeight(false),
@@ -68,6 +70,8 @@ AliAnalysisTaskEmcalSoftDropData::AliAnalysisTaskEmcalSoftDropData() :
 
 AliAnalysisTaskEmcalSoftDropData::AliAnalysisTaskEmcalSoftDropData(EMCAL_STRINGVIEW name) : 
   AliAnalysisTaskEmcalJet(name.data(), kTRUE),
+  AliAnalysisEmcalSoftdropHelperImpl(),
+  AliAnalysisEmcalTriggerSelectionHelperImpl(),
   fTriggerBits(AliVEvent::kAny),
   fTriggerString(""),
   fUseDownscaleWeight(false),
@@ -95,29 +99,38 @@ void AliAnalysisTaskEmcalSoftDropData::UserCreateOutputObjects() {
   std::unique_ptr<TBinning> zgBinning(GetZgBinning(fZcut)),
                             rgBinning(GetRgBinning(R)),
                             nsdBinning(new TLinearBinning(22, -1.5, 20.5)),     // Negative bins for untagged jets
-                            thetagBinning(new TLinearBinning(11, -0.1, 1.)); 
+                            thetagBinning(new TLinearBinning(11, -0.1, 1.)),
+                            triggerClusterBinning(new TLinearBinning(kTrgClusterN, -0.5, kTrgClusterN - 0.5));
   TArrayD edgesPt;
   fPtBinning->CreateBinEdges(edgesPt);
+
+  // Define binnings for substructure THnSparses
+  const TBinning *binningSparseZg[3] = {zgBinning.get(), fPtBinning, triggerClusterBinning.get()},
+                 *binningSparseRg[3] = {rgBinning.get(), fPtBinning, triggerClusterBinning.get()},
+                 *binningSparseThethag[3] = {thetagBinning.get(), fPtBinning, triggerClusterBinning.get()},
+                 *binningSparseNsd[3] = {nsdBinning.get(), fPtBinning, triggerClusterBinning.get()};
 
   fHistos = new THistManager("histosSoftdrop");
   fHistos->CreateTH1("hEventCounter", "EventCounter", 1, 0.5, 1.5);
   fHistos->CreateTH1("hEventCounterRun", "Runwise event counter", 100000, 200000, 300000);
-  fHistos->CreateTH1("hJetPtRaw", "raw jet pt", 300, 0., 300.);
-  fHistos->CreateTH2("hZgVsPt", "zg vs pt", *zgBinning, *fPtBinning, "s");
-  fHistos->CreateTH2("hRgVsPt", "rg vs pt", *rgBinning,  *fPtBinning, "s");
-  fHistos->CreateTH2("hNsdVsPt", "nsd vs pt", *nsdBinning, *fPtBinning, "s");
-  fHistos->CreateTH2("hThetagVsPt", "thetag vs pt", *thetagBinning,  *fPtBinning, "s");
-  fHistos->CreateTH1("hSkippedJets", "Number of skipped jets", *fPtBinning);
+  fHistos->CreateTH1("hClusterCounterAbs", "Event counter histogram absolute", kTrgClusterN, -0.5, kTrgClusterN - 0.5);
+  fHistos->CreateTH2("hJetPtRaw", "raw jet pt", kTrgClusterN, -0.5, kTrgClusterN - 0.5, 300, 0., 300.);
+  fHistos->CreateTHnSparse("hZgVsPt", "zg vs pt", 3, binningSparseZg, "s");
+  fHistos->CreateTHnSparse("hRgVsPt", "rg vs pt", 3, binningSparseRg, "s");
+  fHistos->CreateTHnSparse("hNsdVsPt", "nsd vs pt", 3, binningSparseNsd, "s");
+  fHistos->CreateTHnSparse("hThetagVsPt", "thetag vs pt", 3, binningSparseThethag, "s");
+  fHistos->CreateTH2("hSkippedJets", "Number of skipped jets", *triggerClusterBinning, *fPtBinning);
   if(fUseDownscaleWeight){
-    fHistos->CreateTH2("hZgVsPtWeighted", "zg vs pt (weighted)", *zgBinning, *fPtBinning, "s");
-    fHistos->CreateTH2("hRgVsPtWeighted", "rg vs pt (weighted)", *rgBinning,  *fPtBinning, "s");
-    fHistos->CreateTH2("hNsdVsPtWeighted", "nsd vs pt (weighted)", *nsdBinning, *fPtBinning, "s");
-    fHistos->CreateTH2("hThetagVsPtWeighted", "thetag vs pt (weighted)", *thetagBinning,  *fPtBinning, "s");
+    fHistos->CreateTH1("hClusterCounter", "Event counter histogram", kTrgClusterN, -0.5, kTrgClusterN - 0.5);
+    fHistos->CreateTHnSparse("hZgVsPtWeighted", "zg vs pt (weighted)", 3, binningSparseZg, "s");
+    fHistos->CreateTHnSparse("hRgVsPtWeighted", "rg vs pt (weighted)", 3, binningSparseRg, "s");
+    fHistos->CreateTHnSparse("hNsdVsPtWeighted", "nsd vs pt (weighted)", 3, binningSparseNsd, "s");
+    fHistos->CreateTHnSparse("hThetagVsPtWeighted", "thetag vs pt (weighted)", 3, binningSparseThethag, "s");
     fHistos->CreateTH1("hEventCounterWeighted", "Event counter, weighted", 1., 0.5, 1.5);
     fHistos->CreateTH1("hEventCounterRunWeighted", "Runwise event counter (weighted)", 100000, 200000, 300000);
     fHistos->CreateTProfile("hDownscaleFactorsRunwise", "Runwise downscale factors", 100000, 200000, 300000);
-    fHistos->CreateTH1("hJetPtRawWeighted", "raw jet pt", 300, 0., 300., "s");
-    fHistos->CreateTH1("hSkippedJetsWeighted", "Number of skipped jets (weighted)", *fPtBinning);
+    fHistos->CreateTH2("hJetPtRawWeighted", "raw jet pt", kTrgClusterN, -0.5, kTrgClusterN - 0.5, 300, 0., 300., "s");
+    fHistos->CreateTH2("hSkippedJetsWeighted", "Number of skipped jets (weighted)", *triggerClusterBinning, *fPtBinning);
   }
 
   // A bit of QA stuff
@@ -184,40 +197,54 @@ Bool_t AliAnalysisTaskEmcalSoftDropData::Run() {
     return false;
   }
 
+  auto trgclusters = GetTriggerClusterIndices(fInputEvent->GetFiredTriggerClasses().Data());
   Double_t weight = fUseDownscaleWeight ? 1./GetDownscaleWeight() : 1.;
   Double_t Rjet = jets->GetJetRadius();
   fHistos->FillTH1("hEventCounter", 1.);
   fHistos->FillTH1("hEventCounterRun", fRunNumber);
+  for(auto icl : trgclusters) fHistos->FillTH1("hClusterCounterAbs", icl);
   if(fUseDownscaleWeight) {
     fHistos->FillTH1("hEventCounterWeighted", 1., weight);
     fHistos->FillTH1("hEventCounterRunWeighted", fRunNumber, weight);
     fHistos->FillProfile("hDownscaleFactorsRunwise", fRunNumber, 1./weight);
+    for(auto icl : trgclusters) fHistos->FillTH1("hClusterCounter", icl, weight);
   }
 
   for(auto jet : jets->accepted()){
     AliDebugStream(2) << "Next accepted jet with pt " << jet->Pt() << std::endl;
-    fHistos->FillTH1("hJetPtRaw", jet->Pt());
-    if(fUseDownscaleWeight) fHistos->FillTH1("hJetPtRawWeighted", jet->Pt(), weight);
+    for(auto icl : trgclusters) {
+      fHistos->FillTH2("hJetPtRaw", icl, jet->Pt());
+      if(fUseDownscaleWeight) fHistos->FillTH2("hJetPtRawWeighted", icl, jet->Pt(), weight);
+    }
     try {
       FillJetQA(*jet, (AliVCluster::VCluUserDefEnergy_t)clusters->GetDefaultClusterEnergy());
       auto sdparams = MakeSoftdrop(*jet, jets->GetJetRadius(), false, {(AliAnalysisEmcalSoftdropHelperImpl::EReclusterizer_t)fReclusterizer, fBeta, fZcut, fUseChargedConstituents, fUseNeutralConstituents}, (AliVCluster::VCluUserDefEnergy_t)clusters->GetDefaultClusterEnergy(), fVertex);
       bool untagged = sdparams.fZg < fZcut;
       AliDebugStream(2) << "Found jet with pt " << jet->Pt() << " and zg " << sdparams.fZg << std::endl;
-      fHistos->FillTH2("hZgVsPt", sdparams.fZg, jet->Pt());
-      fHistos->FillTH2("hRgVsPt", untagged ? -0.01 : sdparams.fRg, jet->Pt());
-      fHistos->FillTH2("hNsdVsPt", untagged ? -1. : double(sdparams.fNsd), jet->Pt());
-      fHistos->FillTH2("hThetagVsPt", untagged ? -0.05 : sdparams.fRg/Rjet, jet->Pt());
-      if(fUseDownscaleWeight) {
-        fHistos->FillTH2("hZgVsPtWeighted", sdparams.fZg, jet->Pt(), weight);
-        fHistos->FillTH2("hRgVsPtWeighted", untagged ? -0.01 : sdparams.fRg, jet->Pt(), weight);
-        fHistos->FillTH2("hNsdVsPtWeighted", untagged ? -1. : double(sdparams.fNsd), jet->Pt(), weight);
-        fHistos->FillTH2("hThetagVsPtWeighted", untagged ? -0.05 : sdparams.fRg/Rjet, jet->Pt(), weight);
-      } 
+      Double_t pointZg[3] = {sdparams.fZg, jet->Pt(), -1},
+               pointRg[3] = {untagged ? -0.01 : sdparams.fRg, jet->Pt(), -1},
+               pointThetaG[3] = {untagged ? -0.05 : sdparams.fRg/Rjet, jet->Pt(), -1},
+               pointNSD[3] = {untagged ? -1. : double(sdparams.fNsd), jet->Pt(), -1};
+      for(auto icl : trgclusters) {
+        pointZg[2] = pointRg[2] = pointNSD[2] = pointThetaG[2] = icl;
+        fHistos->FillTHnSparse("hZgVsPt", pointZg);
+        fHistos->FillTHnSparse("hRgVsPt", pointRg);
+        fHistos->FillTHnSparse("hNsdVsPt", pointNSD);
+        fHistos->FillTHnSparse("hThetagVsPt", pointThetaG);
+        if(fUseDownscaleWeight) {
+          fHistos->FillTHnSparse("hZgVsPtWeighted", pointZg, weight);
+          fHistos->FillTHnSparse("hRgVsPtWeighted", pointRg, weight);
+          fHistos->FillTHnSparse("hNsdVsPtWeighted", pointNSD, weight);
+          fHistos->FillTHnSparse("hThetagVsPtWeighted", pointThetaG, weight);
+        } 
+      }
     } catch (int e) {
       if(fUseChargedConstituents && fUseNeutralConstituents) AliErrorStream() << "Softdrop error " << e << ": Having 0 constituents for reclustering" << std::endl;
-      fHistos->FillTH1("hSkippedJets", jet->Pt());
-      if(fUseDownscaleWeight) 
-        fHistos->FillTH1("hSkippedJetsWeighted", jet->Pt(), weight);
+      for(auto icl : trgclusters) {
+        fHistos->FillTH2("hSkippedJets", icl, jet->Pt());
+        if(fUseDownscaleWeight) 
+          fHistos->FillTH2("hSkippedJetsWeighted", icl, jet->Pt(), weight);
+      }
     }
 
     // Fill QA plots - trigger cluster independent

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalSoftDropData.h
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalSoftDropData.h
@@ -28,6 +28,7 @@
 #define ALIANALYSISTASKEMCALSOFTDROPDATA_H
 
 #include <AliAnalysisTaskEmcalJet.h>
+#include "AliAnalysisEmcalTriggerSelectionHelper.h"
 #include "AliAnalysisEmcalSoftdropHelper.h"
 #include <string>
 #include <vector>
@@ -39,7 +40,7 @@ namespace PWGJE{
 
 namespace EMCALJetTasks {
 
-class AliAnalysisTaskEmcalSoftDropData : public AliAnalysisTaskEmcalJet, public AliAnalysisEmcalSoftdropHelperImpl {
+class AliAnalysisTaskEmcalSoftDropData : public AliAnalysisTaskEmcalJet, public AliAnalysisEmcalSoftdropHelperImpl, public AliAnalysisEmcalTriggerSelectionHelperImpl {
 public:
   enum EReclusterizer_t {
     kCAAlgo = 0,


### PR DESCRIPTION
For each jet 1 entry is created in the softdrop histograms.
2D histograms need to be projected to the trigger cluster
bin. Change is necessary for trigger matching in
reconstructions w TRD in combined tracking.