### PR TITLE
PWGGA/GammaConv: fix for c6fff645377685feb08c268ce4ca62ba6707d637

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvV1.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvV1.cxx
@@ -2596,12 +2596,12 @@ void AliAnalysisTaskGammaConvV1::ProcessPhotonCandidates()
         Int_t isNegFromMBHeader = fiEventCut->IsParticleFromBGEvent(PhotonCandidate->GetMCLabelNegative(), fMCEvent, fInputEvent);
         isFromSelectedHeader = (isNegFromMBHeader+isPosFromMBHeader)==4;
       }
-      else{ // 1,2
+      else{ // 1,2,4
         if (!isPosFromMBHeader) continue;
         Int_t isNegFromMBHeader = fiEventCut->IsParticleFromBGEvent(PhotonCandidate->GetMCLabelNegative(), fMCEvent, fInputEvent);
         if (!isNegFromMBHeader) continue;
 
-        if (signalRejection==1) isFromSelectedHeader = (isNegFromMBHeader+isPosFromMBHeader)==4;
+        if (signalRejection!=2) isFromSelectedHeader = (isNegFromMBHeader+isPosFromMBHeader)==4;
       }
     }
 


### PR DESCRIPTION
small fix for the case of signalRejection==4 and both
UseElecSharingCut() and UseToCloseV0sCut() disabled