### PR TITLE
PWGGA/GammaConv: refactor ProcessPhotonCandidates()

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvV1.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvV1.cxx
@@ -23,7 +23,7 @@
 // Class used to do analysis on conversion pairs
 //---------------------------------------------
 ///////////////////////////////////////////////
-#include <unordered_set>
+#include <set>
 
 #include "TChain.h"
 #include "TTree.h"

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvV1.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvV1.cxx
@@ -23,6 +23,8 @@
 // Class used to do analysis on conversion pairs
 //---------------------------------------------
 ///////////////////////////////////////////////
+#include <unordered_set>
+
 #include "TChain.h"
 #include "TTree.h"
 #include "TBranch.h"
@@ -356,7 +358,8 @@ AliAnalysisTaskGammaConvV1::AliAnalysisTaskGammaConvV1(): AliAnalysisTaskSE(),
   tBrokenFiles(NULL),
   fFileNameBroken(NULL),
   fFileWasAlreadyReported(kFALSE),
-  fAODMCTrackArray(NULL)
+  fAODMCTrackArray(NULL),
+  fElectronLabels()
 {
 
 }
@@ -658,7 +661,8 @@ AliAnalysisTaskGammaConvV1::AliAnalysisTaskGammaConvV1(const char *name):
   tBrokenFiles(NULL),
   fFileNameBroken(NULL),
   fFileWasAlreadyReported(kFALSE),
-  fAODMCTrackArray(NULL)
+  fAODMCTrackArray(NULL),
+  fElectronLabels()
 {
   // Define output slots here
   DefineOutput(1, TList::Class());
@@ -2561,280 +2565,125 @@ void AliAnalysisTaskGammaConvV1::UserExec(Option_t *)
 
   PostData(1, fOutputContainer);
 }
+
+// one could think about moving that to another class..
+/* checks for a photon candidate if its tracks come from an accepted injector.
+ * return value kFALSE: photon gets discarded completely
+ *              kTRUE:  photon will get added to fGammaCandidates
+ *
+ * (only for return value kTRUE):
+ * theIsFromSelectedHeader=kTRUE:  photon will get processed fully (gamma histos will get filled)
+ * theIsFromSelectedHeader=kFALSE: will only get added to fGammaCandidates
+ *
+ * note: fiEventCut->IsParticleFromBGEvent()>0 : particle comes from an injector on AliConvEventCuts::fHeaderList
+ *                                          ==2: injector is first on that list */
+//________________________________________________________________________
+Bool_t AliAnalysisTaskGammaConvV1::PassesAddedParticlesCriterion(AliAODConversionPhoton &thePhoton,
+                                                                 Int_t                   theSignalRejection,
+                                                                 Bool_t                 &theIsFromSelectedHeader) const
+{
+  theIsFromSelectedHeader = kTRUE;
+  Int_t lIsPosFromMBHeader = fiEventCut->IsParticleFromBGEvent(thePhoton.GetMCLabelPositive(), fMCEvent, fInputEvent);
+
+  if (theSignalRejection==3){
+    Int_t lIsNegFromMBHeader = fiEventCut->IsParticleFromBGEvent(thePhoton.GetMCLabelNegative(), fMCEvent, fInputEvent);
+    theIsFromSelectedHeader = (lIsNegFromMBHeader+lIsPosFromMBHeader)==4;
+  }
+  else{ // 1,2,4
+    if (!lIsPosFromMBHeader) return kFALSE;
+    Int_t lIsNegFromMBHeader = fiEventCut->IsParticleFromBGEvent(thePhoton.GetMCLabelNegative(), fMCEvent, fInputEvent);
+    if (!lIsNegFromMBHeader) return kFALSE;
+
+    if (theSignalRejection!=2) {
+      theIsFromSelectedHeader = (lIsNegFromMBHeader+lIsPosFromMBHeader)==4;
+    }
+  }
+  return kTRUE;
+}
+
 //________________________________________________________________________
 void AliAnalysisTaskGammaConvV1::ProcessPhotonCandidates()
 {
-  Int_t nV0 = 0;
-  TList *GammaCandidatesStepOne = new TList();
-  TList *GammaCandidatesStepTwo = new TList();
-  Double_t magField = fInputEvent->GetMagneticField();
-  Int_t signalRejection = fiEventCut->GetSignalRejection();
+  auto fillHistosAndTree = [&](AliAODConversionPhoton *thePhoton){
+    Double_t lPt = thePhoton->Pt();
+    Float_t lWeightMatBudgetGamma = 1.;
+    if (fDoMaterialBudgetWeightingOfGammasForTrueMesons && fiPhotonCut->GetMaterialBudgetWeightsInitialized()) {
+      lWeightMatBudgetGamma = fiPhotonCut->GetMaterialBudgetCorrectingWeightForTrueGamma(thePhoton, fInputEvent->GetMagneticField());
+    }
 
+    Double_t lTotalWeight = (fDoCentralityFlat > 0) ? fWeightJetJetMC*lWeightMatBudgetGamma*fWeightCentrality[fiCut]
+                                                    : fWeightJetJetMC*lWeightMatBudgetGamma;
+    fHistoConvGammaPt[fiCut]->Fill(lPt, lTotalWeight);
+
+    if (fDoPhotonQA > 0 && fIsMC < 2){
+      fHistoConvGammaPsiPairPt[fiCut]->Fill(thePhoton->GetPsiPair(),lPt, lTotalWeight);
+      fHistoConvGammaR[fiCut]->Fill(thePhoton->GetConversionRadius(), lTotalWeight);
+      fHistoConvGammaEta[fiCut]->Fill(thePhoton->Eta(), lTotalWeight);
+      fHistoConvGammaPhi[fiCut]->Fill(thePhoton->Phi(), lTotalWeight);
+
+      if ((fDoPhotonQA == 4)||(fDoPhotonQA == 5)){
+        fHistoConvGammaInvMass[fiCut]->Fill(thePhoton->GetMass(), lTotalWeight);
+        fHistoConvGammaInvMassReco[fiCut]->Fill(GetOriginalInvMass(thePhoton,fInputEvent), lTotalWeight);
+      }
+    }
+
+    if ((fDoPhotonQA == 2)||(fDoPhotonQA == 5)){
+      if ((fIsHeavyIon == 1                             && lPt > 0.399 && lPt < 12.) ||
+          (fiPhotonCut->GetSingleElectronPtCut() < 0.04 && lPt > 0.099 && lPt < 16.) ||
+          (                                                lPt > 0.299 && lPt < 16.))
+      {
+        fPtGamma = lPt;
+        fDCAzPhoton = thePhoton->GetDCAzToPrimVtx();
+        fRConvPhoton = thePhoton->GetConversionRadius();
+        fEtaPhoton = thePhoton->GetPhotonEta();
+        iCatPhoton = thePhoton->GetPhotonQuality();
+        tESDConvGammaPtDcazCat[fiCut]->Fill();
+      }
+    }
+  };
+
+  if(fiPhotonCut->GetDoElecDeDxPostCalibration()){
+    if(!(fiPhotonCut->LoadElecDeDxPostCalibration(fInputEvent->GetRunNumber()))){
+      AliFatal(Form("ERROR: LoadElecDeDxPostCalibration returned kFALSE for %d despite being requested!",fInputEvent->GetRunNumber()));
+    }
+  }
+
+  fElectronLabels.clear(); // declared this globally to reduce memory fragmentation
+  Int_t lSignalRejection = fiEventCut->GetSignalRejection();
 
   // Loop over Photon Candidates allocated by ReaderV1
-  for(Int_t i = 0; i < fReaderGammas->GetEntriesFast(); i++){
-    AliAODConversionPhoton* PhotonCandidate = (AliAODConversionPhoton*) fReaderGammas->At(i);
-    if(!PhotonCandidate) continue;
-    Bool_t isFromSelectedHeader = kTRUE;
+  for (TObject* iObj : *fReaderGammas){
 
-    Float_t weightMatBudgetGamma = 1.;
-    if (fDoMaterialBudgetWeightingOfGammasForTrueMesons && fiPhotonCut->GetMaterialBudgetWeightsInitialized()) {
-      weightMatBudgetGamma = fiPhotonCut->GetMaterialBudgetCorrectingWeightForTrueGamma(PhotonCandidate, magField);
-    }
-    if(fiPhotonCut->GetDoElecDeDxPostCalibration()){
-      if(!(fiPhotonCut->LoadElecDeDxPostCalibration(fInputEvent->GetRunNumber()))){
-        AliFatal(Form("ERROR: LoadElecDeDxPostCalibration returned kFALSE for %d despite being requested!",fInputEvent->GetRunNumber()));
-      }
+    AliAODConversionPhoton* iCandidate = dynamic_cast<AliAODConversionPhoton*>(iObj);
+    if (!iCandidate) continue;
+
+    Bool_t lIsFromSelectedHeader = kTRUE;
+    if( fIsMC > 0 && lSignalRejection){
+      if (!PassesAddedParticlesCriterion(*iCandidate, lSignalRejection, lIsFromSelectedHeader)) continue;
     }
 
+    if(!fiPhotonCut->PhotonIsSelected(iCandidate,fInputEvent)) continue;
+    if(!fiPhotonCut->InPlaneOutOfPlaneCut(iCandidate->GetPhotonPhi(),fEventPlaneAngle)) continue;
 
-    if( fIsMC > 0 && signalRejection){
+    if (fiPhotonCut->UseElecSharingCut() &&
+        !fiPhotonCut->AllowedBySharedElectronCut(fElectronLabels, *iCandidate)) continue;
 
-      Int_t isPosFromMBHeader = fiEventCut->IsParticleFromBGEvent(PhotonCandidate->GetMCLabelPositive(), fMCEvent, fInputEvent);
+    if (fiPhotonCut->UseToCloseV0sCut() &&
+        !fiPhotonCut->AllowedByTooCloseV0sCut(*fGammaCandidates, *iCandidate)) continue;
 
-      if (signalRejection==3){
-        Int_t isNegFromMBHeader = fiEventCut->IsParticleFromBGEvent(PhotonCandidate->GetMCLabelNegative(), fMCEvent, fInputEvent);
-        isFromSelectedHeader = (isNegFromMBHeader+isPosFromMBHeader)==4;
+    // passed all cuts, add to fGammaCandidates
+    fGammaCandidates->Add(iCandidate);
+
+    if (lIsFromSelectedHeader){
+
+      if( fIsMC > 0 ){
+        if(fInputEvent->IsA()==AliESDEvent::Class()) ProcessTruePhotonCandidates(iCandidate);
+        if(fInputEvent->IsA()==AliAODEvent::Class()) ProcessTruePhotonCandidatesAOD(iCandidate);
       }
-      else{ // 1,2,4
-        if (!isPosFromMBHeader) continue;
-        Int_t isNegFromMBHeader = fiEventCut->IsParticleFromBGEvent(PhotonCandidate->GetMCLabelNegative(), fMCEvent, fInputEvent);
-        if (!isNegFromMBHeader) continue;
 
-        if (signalRejection!=2) isFromSelectedHeader = (isNegFromMBHeader+isPosFromMBHeader)==4;
-      }
-    }
-
-
-    if(!fiPhotonCut->PhotonIsSelected(PhotonCandidate,fInputEvent)) continue;
-    if(!fiPhotonCut->InPlaneOutOfPlaneCut(PhotonCandidate->GetPhotonPhi(),fEventPlaneAngle)) continue;
-    if(!fiPhotonCut->UseElecSharingCut() && !fiPhotonCut->UseToCloseV0sCut()){
-      fGammaCandidates->Add(PhotonCandidate); // if no second loop is required add to events good gammas
-
-      if(isFromSelectedHeader){
-        if(fDoCentralityFlat > 0) fHistoConvGammaPt[fiCut]->Fill(PhotonCandidate->Pt(), fWeightCentrality[fiCut]*fWeightJetJetMC*weightMatBudgetGamma);
-        else fHistoConvGammaPt[fiCut]->Fill(PhotonCandidate->Pt(), fWeightJetJetMC*weightMatBudgetGamma);
-        if (fDoPhotonQA > 0 && fIsMC < 2){
-          if(fDoCentralityFlat > 0){
-            fHistoConvGammaPsiPairPt[fiCut]->Fill(PhotonCandidate->GetPsiPair(),PhotonCandidate->Pt(), fWeightCentrality[fiCut]*fWeightJetJetMC*weightMatBudgetGamma);
-            fHistoConvGammaR[fiCut]->Fill(PhotonCandidate->GetConversionRadius(), fWeightCentrality[fiCut]*fWeightJetJetMC*weightMatBudgetGamma);
-            fHistoConvGammaEta[fiCut]->Fill(PhotonCandidate->Eta(), fWeightCentrality[fiCut]*fWeightJetJetMC*weightMatBudgetGamma);
-            fHistoConvGammaPhi[fiCut]->Fill(PhotonCandidate->Phi(), fWeightCentrality[fiCut]*fWeightJetJetMC*weightMatBudgetGamma);
-            if ((fDoPhotonQA == 4)||(fDoPhotonQA == 5)){
-              fHistoConvGammaInvMass[fiCut]->Fill(PhotonCandidate->GetMass(), fWeightCentrality[fiCut]*fWeightJetJetMC*weightMatBudgetGamma);
-              fHistoConvGammaInvMassReco[fiCut]->Fill(GetOriginalInvMass(PhotonCandidate,fInputEvent), fWeightCentrality[fiCut]*fWeightJetJetMC*weightMatBudgetGamma);
-            }
-          } else {
-            fHistoConvGammaPsiPairPt[fiCut]->Fill(PhotonCandidate->GetPsiPair(),PhotonCandidate->Pt(),fWeightJetJetMC*weightMatBudgetGamma);
-            fHistoConvGammaR[fiCut]->Fill(PhotonCandidate->GetConversionRadius(),fWeightJetJetMC*weightMatBudgetGamma);
-            fHistoConvGammaEta[fiCut]->Fill(PhotonCandidate->Eta(),fWeightJetJetMC*weightMatBudgetGamma);
-            fHistoConvGammaPhi[fiCut]->Fill(PhotonCandidate->Phi(),fWeightJetJetMC*weightMatBudgetGamma);
-            if ((fDoPhotonQA == 4)||(fDoPhotonQA == 5)){
-              fHistoConvGammaInvMass[fiCut]->Fill(PhotonCandidate->GetMass(),fWeightJetJetMC*weightMatBudgetGamma);
-              fHistoConvGammaInvMassReco[fiCut]->Fill(GetOriginalInvMass(PhotonCandidate,fInputEvent),fWeightJetJetMC*weightMatBudgetGamma);
-            }
-          }
-        }
-        if( fIsMC > 0 ){
-          if(fInputEvent->IsA()==AliESDEvent::Class())
-          ProcessTruePhotonCandidates(PhotonCandidate);
-          if(fInputEvent->IsA()==AliAODEvent::Class())
-          ProcessTruePhotonCandidatesAOD(PhotonCandidate);
-        }
-        if ((fDoPhotonQA == 2)||(fDoPhotonQA == 5)){
-          if (fIsHeavyIon == 1 && PhotonCandidate->Pt() > 0.399 && PhotonCandidate->Pt() < 12.){
-            fPtGamma = PhotonCandidate->Pt();
-            fDCAzPhoton = PhotonCandidate->GetDCAzToPrimVtx();
-            fRConvPhoton = PhotonCandidate->GetConversionRadius();
-            fEtaPhoton = PhotonCandidate->GetPhotonEta();
-            iCatPhoton = PhotonCandidate->GetPhotonQuality();
-            tESDConvGammaPtDcazCat[fiCut]->Fill();
-            } else if ( fiPhotonCut->GetSingleElectronPtCut() < 0.04 && PhotonCandidate->Pt() > 0.099 && PhotonCandidate->Pt() < 16.){
-            fPtGamma = PhotonCandidate->Pt();
-            fDCAzPhoton = PhotonCandidate->GetDCAzToPrimVtx();
-            fRConvPhoton = PhotonCandidate->GetConversionRadius();
-            fEtaPhoton = PhotonCandidate->GetPhotonEta();
-            iCatPhoton = PhotonCandidate->GetPhotonQuality();
-            tESDConvGammaPtDcazCat[fiCut]->Fill();
-          } else if ( PhotonCandidate->Pt() > 0.299 && PhotonCandidate->Pt() < 16.){
-            fPtGamma = PhotonCandidate->Pt();
-            fDCAzPhoton = PhotonCandidate->GetDCAzToPrimVtx();
-            fRConvPhoton = PhotonCandidate->GetConversionRadius();
-            fEtaPhoton = PhotonCandidate->GetPhotonEta();
-            iCatPhoton = PhotonCandidate->GetPhotonQuality();
-            tESDConvGammaPtDcazCat[fiCut]->Fill();
-          }
-        }
-      }
-    } else if(fiPhotonCut->UseElecSharingCut()){ // if Shared Electron cut is enabled, Fill array, add to step one
-      fiPhotonCut->FillElectonLabelArray(PhotonCandidate,nV0);
-      nV0++;
-      GammaCandidatesStepOne->Add(PhotonCandidate);
-    } else if(!fiPhotonCut->UseElecSharingCut() && fiPhotonCut->UseToCloseV0sCut()){ // shared electron is disabled, step one not needed -> step two
-      GammaCandidatesStepTwo->Add(PhotonCandidate);
+      fillHistosAndTree(iCandidate);
     }
   }
-  if(fiPhotonCut->UseElecSharingCut()){
-    for(Int_t i = 0;i<GammaCandidatesStepOne->GetEntries();i++){
-      AliAODConversionPhoton *PhotonCandidate= (AliAODConversionPhoton*) GammaCandidatesStepOne->At(i);
-      if(!PhotonCandidate) continue;
-      Bool_t isFromSelectedHeader = kTRUE;
-
-      Float_t weightMatBudgetGamma = 1.;
-      if (fDoMaterialBudgetWeightingOfGammasForTrueMesons && fiPhotonCut->GetMaterialBudgetWeightsInitialized()) {
-	    weightMatBudgetGamma = fiPhotonCut->GetMaterialBudgetCorrectingWeightForTrueGamma(PhotonCandidate,magField);
-      }
-
-
-     if(fMCEvent && signalRejection && signalRejection!=2){
-        Int_t isPosFromMBHeader = fiEventCut->IsParticleFromBGEvent(PhotonCandidate->GetMCLabelPositive(), fMCEvent, fInputEvent);
-        Int_t isNegFromMBHeader = fiEventCut->IsParticleFromBGEvent(PhotonCandidate->GetMCLabelNegative(), fMCEvent, fInputEvent);
-        isFromSelectedHeader = (isNegFromMBHeader+isPosFromMBHeader)==4;
-      }
-      if(!fiPhotonCut->RejectSharedElectronV0s(PhotonCandidate,i,GammaCandidatesStepOne->GetEntries())) continue;
-      if(!fiPhotonCut->UseToCloseV0sCut()){ // To Colse v0s cut diabled, step two not needed
-        fGammaCandidates->Add(PhotonCandidate);
-
-        if(isFromSelectedHeader){
-          if(fDoCentralityFlat > 0) fHistoConvGammaPt[fiCut]->Fill(PhotonCandidate->Pt(), fWeightCentrality[fiCut]*fWeightJetJetMC*weightMatBudgetGamma);
-          else fHistoConvGammaPt[fiCut]->Fill(PhotonCandidate->Pt(),fWeightJetJetMC*weightMatBudgetGamma);
-          if (fDoPhotonQA > 0 && fIsMC < 2){
-            if(fDoCentralityFlat > 0){
-              fHistoConvGammaPsiPairPt[fiCut]->Fill(PhotonCandidate->GetPsiPair(),PhotonCandidate->Pt(), fWeightCentrality[fiCut]*fWeightJetJetMC*weightMatBudgetGamma);
-              fHistoConvGammaR[fiCut]->Fill(PhotonCandidate->GetConversionRadius(), fWeightCentrality[fiCut]*fWeightJetJetMC*weightMatBudgetGamma);
-              fHistoConvGammaEta[fiCut]->Fill(PhotonCandidate->Eta(), fWeightCentrality[fiCut]*fWeightJetJetMC*weightMatBudgetGamma);
-              fHistoConvGammaPhi[fiCut]->Fill(PhotonCandidate->Phi(), fWeightCentrality[fiCut]*fWeightJetJetMC*weightMatBudgetGamma);
-              if ((fDoPhotonQA == 4)||(fDoPhotonQA == 5)){
-                fHistoConvGammaInvMass[fiCut]->Fill(PhotonCandidate->GetMass(), fWeightCentrality[fiCut]*fWeightJetJetMC*weightMatBudgetGamma);
-                fHistoConvGammaInvMassReco[fiCut]->Fill(GetOriginalInvMass(PhotonCandidate,fInputEvent), fWeightCentrality[fiCut]*fWeightJetJetMC*weightMatBudgetGamma);
-              }
-            } else {
-              fHistoConvGammaPsiPairPt[fiCut]->Fill(PhotonCandidate->GetPsiPair(),PhotonCandidate->Pt(),fWeightJetJetMC*weightMatBudgetGamma);
-              fHistoConvGammaR[fiCut]->Fill(PhotonCandidate->GetConversionRadius(),fWeightJetJetMC*weightMatBudgetGamma);
-              fHistoConvGammaEta[fiCut]->Fill(PhotonCandidate->Eta(),fWeightJetJetMC*weightMatBudgetGamma);
-              fHistoConvGammaPhi[fiCut]->Fill(PhotonCandidate->Phi(),fWeightJetJetMC*weightMatBudgetGamma);
-              if ((fDoPhotonQA == 4)||(fDoPhotonQA == 5)){
-                fHistoConvGammaInvMass[fiCut]->Fill(PhotonCandidate->GetMass(),fWeightJetJetMC*weightMatBudgetGamma);
-                fHistoConvGammaInvMassReco[fiCut]->Fill(GetOriginalInvMass(PhotonCandidate,fInputEvent),fWeightJetJetMC*weightMatBudgetGamma);
-              }
-            }
-          }
-          if( fIsMC > 0 ){
-            if(fInputEvent->IsA()==AliESDEvent::Class())
-              ProcessTruePhotonCandidates(PhotonCandidate);
-            if(fInputEvent->IsA()==AliAODEvent::Class())
-              ProcessTruePhotonCandidatesAOD(PhotonCandidate);
-          }
-          if ((fDoPhotonQA == 2)||(fDoPhotonQA == 5)){
-            if (fIsHeavyIon ==1 && PhotonCandidate->Pt() > 0.399 && PhotonCandidate->Pt() < 12.){
-              fPtGamma = PhotonCandidate->Pt();
-              fDCAzPhoton = PhotonCandidate->GetDCAzToPrimVtx();
-              fRConvPhoton = PhotonCandidate->GetConversionRadius();
-              fEtaPhoton = PhotonCandidate->GetPhotonEta();
-              iCatPhoton = PhotonCandidate->GetPhotonQuality();
-              tESDConvGammaPtDcazCat[fiCut]->Fill();
-            } else if ( fiPhotonCut->GetSingleElectronPtCut() < 0.04 && PhotonCandidate->Pt() > 0.099 && PhotonCandidate->Pt() < 16.){
-              fPtGamma = PhotonCandidate->Pt();
-              fDCAzPhoton = PhotonCandidate->GetDCAzToPrimVtx();
-              fRConvPhoton = PhotonCandidate->GetConversionRadius();
-              fEtaPhoton = PhotonCandidate->GetPhotonEta();
-              iCatPhoton = PhotonCandidate->GetPhotonQuality();
-              tESDConvGammaPtDcazCat[fiCut]->Fill();
-            } else if ( PhotonCandidate->Pt() > 0.299 && PhotonCandidate->Pt() < 16.){
-              fPtGamma = PhotonCandidate->Pt();
-              fDCAzPhoton = PhotonCandidate->GetDCAzToPrimVtx();
-              fRConvPhoton = PhotonCandidate->GetConversionRadius();
-              fEtaPhoton = PhotonCandidate->GetPhotonEta();
-              iCatPhoton = PhotonCandidate->GetPhotonQuality();
-              tESDConvGammaPtDcazCat[fiCut]->Fill();
-            }
-          }
-        }
-      } else GammaCandidatesStepTwo->Add(PhotonCandidate); // Close v0s cut enabled -> add to list two
-    }
-  }
-  if(fiPhotonCut->UseToCloseV0sCut()){
-    for(Int_t i = 0;i<GammaCandidatesStepTwo->GetEntries();i++){
-      AliAODConversionPhoton* PhotonCandidate = (AliAODConversionPhoton*) GammaCandidatesStepTwo->At(i);
-      if(!PhotonCandidate) continue;
-      Bool_t isFromSelectedHeader = kTRUE;
-
-     Float_t weightMatBudgetGamma = 1.;
-      if (fDoMaterialBudgetWeightingOfGammasForTrueMesons && fiPhotonCut->GetMaterialBudgetWeightsInitialized()) {
-    	weightMatBudgetGamma = fiPhotonCut->GetMaterialBudgetCorrectingWeightForTrueGamma(PhotonCandidate,magField);
-      }
-
-      if(fMCEvent && signalRejection && signalRejection!=2){
-        Int_t isPosFromMBHeader = fiEventCut->IsParticleFromBGEvent(PhotonCandidate->GetMCLabelPositive(), fMCEvent, fInputEvent);
-        Int_t isNegFromMBHeader = fiEventCut->IsParticleFromBGEvent(PhotonCandidate->GetMCLabelNegative(), fMCEvent, fInputEvent);
-        isFromSelectedHeader = (isNegFromMBHeader+isPosFromMBHeader)==4;
-      }
-      if(!fiPhotonCut->RejectToCloseV0s(PhotonCandidate,GammaCandidatesStepTwo,i)) continue;
-      fGammaCandidates->Add(PhotonCandidate); // Add gamma to current cut TList
-
-      if(isFromSelectedHeader){
-        if(fDoCentralityFlat > 0) fHistoConvGammaPt[fiCut]->Fill(PhotonCandidate->Pt(), fWeightCentrality[fiCut]*fWeightJetJetMC*weightMatBudgetGamma);
-        else fHistoConvGammaPt[fiCut]->Fill(PhotonCandidate->Pt(),fWeightJetJetMC*weightMatBudgetGamma);
-        if (fDoPhotonQA > 0 && fIsMC < 2 ){
-          if(fDoCentralityFlat > 0){
-            fHistoConvGammaPsiPairPt[fiCut]->Fill(PhotonCandidate->GetPsiPair(),PhotonCandidate->Pt(), fWeightCentrality[fiCut]*fWeightJetJetMC*weightMatBudgetGamma);
-            fHistoConvGammaR[fiCut]->Fill(PhotonCandidate->GetConversionRadius(), fWeightCentrality[fiCut]*fWeightJetJetMC*weightMatBudgetGamma);
-            fHistoConvGammaEta[fiCut]->Fill(PhotonCandidate->Eta(), fWeightCentrality[fiCut]*fWeightJetJetMC*weightMatBudgetGamma);
-            fHistoConvGammaPhi[fiCut]->Fill(PhotonCandidate->Phi(), fWeightCentrality[fiCut]*fWeightJetJetMC*weightMatBudgetGamma);
-            if ((fDoPhotonQA == 4)||(fDoPhotonQA == 5)){
-              fHistoConvGammaInvMass[fiCut]->Fill(PhotonCandidate->GetMass(), fWeightCentrality[fiCut]*fWeightJetJetMC*weightMatBudgetGamma);
-              fHistoConvGammaInvMassReco[fiCut]->Fill(GetOriginalInvMass(PhotonCandidate,fInputEvent), fWeightCentrality[fiCut]*fWeightJetJetMC*weightMatBudgetGamma);
-            }
-          } else {
-            fHistoConvGammaPsiPairPt[fiCut]->Fill(PhotonCandidate->GetPsiPair(),PhotonCandidate->Pt(),fWeightJetJetMC*weightMatBudgetGamma);
-            fHistoConvGammaR[fiCut]->Fill(PhotonCandidate->GetConversionRadius(),fWeightJetJetMC*weightMatBudgetGamma);
-            fHistoConvGammaEta[fiCut]->Fill(PhotonCandidate->Eta(),fWeightJetJetMC*weightMatBudgetGamma);
-            fHistoConvGammaPhi[fiCut]->Fill(PhotonCandidate->Phi(),fWeightJetJetMC*weightMatBudgetGamma);
-            if ((fDoPhotonQA == 4)||(fDoPhotonQA == 5)){
-              fHistoConvGammaInvMass[fiCut]->Fill(PhotonCandidate->GetMass(),fWeightJetJetMC*weightMatBudgetGamma);
-              fHistoConvGammaInvMassReco[fiCut]->Fill(GetOriginalInvMass(PhotonCandidate,fInputEvent),fWeightJetJetMC*weightMatBudgetGamma);
-            }
-          }
-        }
-        if( fIsMC > 0 ){
-          if(fInputEvent->IsA()==AliESDEvent::Class())
-            ProcessTruePhotonCandidates(PhotonCandidate);
-          if(fInputEvent->IsA()==AliAODEvent::Class())
-            ProcessTruePhotonCandidatesAOD(PhotonCandidate);
-        }
-        if ((fDoPhotonQA == 2)||(fDoPhotonQA == 5)){
-          if (fIsHeavyIon == 1 && PhotonCandidate->Pt() > 0.399 && PhotonCandidate->Pt() < 12.){
-            fPtGamma = PhotonCandidate->Pt();
-            fDCAzPhoton = PhotonCandidate->GetDCAzToPrimVtx();
-            fRConvPhoton = PhotonCandidate->GetConversionRadius();
-            fEtaPhoton = PhotonCandidate->GetPhotonEta();
-            iCatPhoton = PhotonCandidate->GetPhotonQuality();
-            tESDConvGammaPtDcazCat[fiCut]->Fill();
-          } else if ( fiPhotonCut->GetSingleElectronPtCut() < 0.04 && PhotonCandidate->Pt() > 0.099 && PhotonCandidate->Pt() < 16.){
-            fPtGamma = PhotonCandidate->Pt();
-            fDCAzPhoton = PhotonCandidate->GetDCAzToPrimVtx();
-            fRConvPhoton = PhotonCandidate->GetConversionRadius();
-            fEtaPhoton = PhotonCandidate->GetPhotonEta();
-            iCatPhoton = PhotonCandidate->GetPhotonQuality();
-            tESDConvGammaPtDcazCat[fiCut]->Fill();
-          } else if ( PhotonCandidate->Pt() > 0.299 && PhotonCandidate->Pt() < 16.){
-            fPtGamma = PhotonCandidate->Pt();
-            fDCAzPhoton = PhotonCandidate->GetDCAzToPrimVtx();
-            fRConvPhoton = PhotonCandidate->GetConversionRadius();
-            fEtaPhoton = PhotonCandidate->GetPhotonEta();
-            iCatPhoton = PhotonCandidate->GetPhotonQuality();
-            tESDConvGammaPtDcazCat[fiCut]->Fill();
-          }
-        }
-      }
-    }
-  }
-
-  delete GammaCandidatesStepOne;
-  GammaCandidatesStepOne = 0x0;
-  delete GammaCandidatesStepTwo;
-  GammaCandidatesStepTwo = 0x0;
-
 }
 
 //________________________________________________________________________

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvV1.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvV1.h
@@ -20,6 +20,8 @@
 #include <vector>
 #include <map>
 
+class unordered_set;
+
 class AliAnalysisTaskGammaConvV1 : public AliAnalysisTaskSE {
 
   public:
@@ -93,6 +95,9 @@ class AliAnalysisTaskGammaConvV1 : public AliAnalysisTaskSE {
     void FillMultipleCountMap(map<Int_t,Int_t> &ma, Int_t tobechecked);
     void FillMultipleCountHistoAndClear(map<Int_t,Int_t> &ma, TH1F* hist);
     Double_t GetOriginalInvMass(const AliConversionPhotonBase * photon, AliVEvent * event) const;
+    Bool_t PassesAddedParticlesCriterion(AliAODConversionPhoton &thePhoton,
+                                         Int_t                   theSignalRejection,
+                                         Bool_t                 &theIsFromSelectedHeader) const;
 
   protected:
     AliV0ReaderV1*                    fV0Reader;                                  //
@@ -407,12 +412,13 @@ class AliAnalysisTaskGammaConvV1 : public AliAnalysisTaskSE {
     TObjString*                       fFileNameBroken;                            // string object for broken file name
     Bool_t                            fFileWasAlreadyReported;                    // to store if the current file was already marked broken
     TClonesArray*                     fAODMCTrackArray;                           //! pointer to track array
+    unordered_set<Int_t>              fElectronLabels;                            //! to hold labels for electron sharing cut
 
   private:
 
     AliAnalysisTaskGammaConvV1(const AliAnalysisTaskGammaConvV1&); // Prevent copy-construction
     AliAnalysisTaskGammaConvV1 &operator=(const AliAnalysisTaskGammaConvV1&); // Prevent assignment
-    ClassDef(AliAnalysisTaskGammaConvV1, 52);
+    ClassDef(AliAnalysisTaskGammaConvV1, 53);
 };
 
 #endif

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvV1.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvV1.h
@@ -20,7 +20,7 @@
 #include <vector>
 #include <map>
 
-class unordered_set;
+class set;
 
 class AliAnalysisTaskGammaConvV1 : public AliAnalysisTaskSE {
 
@@ -412,7 +412,7 @@ class AliAnalysisTaskGammaConvV1 : public AliAnalysisTaskSE {
     TObjString*                       fFileNameBroken;                            // string object for broken file name
     Bool_t                            fFileWasAlreadyReported;                    // to store if the current file was already marked broken
     TClonesArray*                     fAODMCTrackArray;                           //! pointer to track array
-    unordered_set<Int_t>              fElectronLabels;                            //! to hold labels for electron sharing cut
+    set<Int_t>              fElectronLabels;                            //! to hold labels for electron sharing cut
 
   private:
 

--- a/PWGGA/GammaConvBase/AliConversionPhotonCuts.cxx
+++ b/PWGGA/GammaConvBase/AliConversionPhotonCuts.cxx
@@ -19,7 +19,7 @@
 // Gamma Conversion analysis
 //---------------------------------------------
 ////////////////////////////////////////////////
-#include <unordered_set>
+#include <set>
 
 #include "AliConversionPhotonCuts.h"
 
@@ -4781,7 +4781,7 @@ Bool_t AliConversionPhotonCuts::RejectToCloseV0s(AliAODConversionPhoton* photon,
 }
 
 ///________________________________________________________________________
-Bool_t AliConversionPhotonCuts::AllowedBySharedElectronCut(unordered_set<Int_t> &theLabels, AliAODConversionPhoton &thePhoton) const {
+Bool_t AliConversionPhotonCuts::AllowedBySharedElectronCut(set<Int_t> &theLabels, AliAODConversionPhoton &thePhoton) const {
   // todo: check if two separate sets for electrons and positrons are safe to use. I think it is and would bring speedup
 
   // since it is quite rare that this cut cuts, we insert the positive track before checking if the negative one can be inserted as well

--- a/PWGGA/GammaConvBase/AliConversionPhotonCuts.cxx
+++ b/PWGGA/GammaConvBase/AliConversionPhotonCuts.cxx
@@ -19,6 +19,7 @@
 // Gamma Conversion analysis
 //---------------------------------------------
 ////////////////////////////////////////////////
+#include <unordered_set>
 
 #include "AliConversionPhotonCuts.h"
 
@@ -1641,7 +1642,7 @@ Bool_t AliConversionPhotonCuts::AcceptanceCuts(AliConversionPhotonBase *photon) 
 
   } else if (fDoShrinkTPCAcceptance == 4){   // accept only photons in eta-phi region from PHOS-PCM (pi0 and eta meson analysis)
     Double_t photonPhi = photon->GetPhotonPhi();
-      
+
     if(photon->GetPhotonEta() > fEtaForPhiCutMin && photon->GetPhotonEta() < fEtaForPhiCutMax ){
       //cout << "A and C side, eta=" << photon->GetPhotonEta() <<  endl;
       if(!(photonPhi>fMinPhiCut  && photonPhi<fMaxPhiCut )){
@@ -4779,6 +4780,63 @@ Bool_t AliConversionPhotonCuts::RejectToCloseV0s(AliAODConversionPhoton* photon,
   return kTRUE;
 }
 
+///________________________________________________________________________
+Bool_t AliConversionPhotonCuts::AllowedBySharedElectronCut(unordered_set<Int_t> &theLabels, AliAODConversionPhoton &thePhoton) const {
+  // todo: check if two separate sets for electrons and positrons are safe to use. I think it is and would bring speedup
+
+  // since it is quite rare that this cut cuts, we insert the positive track before checking if the negative one can be inserted as well
+  auto lItInsWorkedPositive = theLabels.insert(thePhoton.GetTrackLabelPositive());
+  if (!lItInsWorkedPositive.second){
+    return  kFALSE;
+  }
+
+  Bool_t lInsWorkedNegative = theLabels.insert(thePhoton.GetTrackLabelNegative()).second;
+  if (!lInsWorkedNegative){
+    theLabels.erase(lItInsWorkedPositive.first);
+    return kFALSE;
+  }
+  return kTRUE;
+}
+
+/* Strategy: keep a list of accepted photons. On inserting a new one, check if it is too close to
+ * any of the ones already on the list
+ * I expect slight changes in comparison to before: other photons will get kicked out and less will get kicked out*/
+Bool_t AliConversionPhotonCuts::AllowedByTooCloseV0sCut(TList &theNotTooClosePhotons, AliAODConversionPhoton &thePhoton) const {
+
+    if (fDoDoubleCountingCut && thePhoton.GetConversionRadius() < fMinRDC){
+      return kTRUE;
+    }
+
+    for (TObject* iObj : theNotTooClosePhotons){
+      AliAODConversionPhoton* iPhoton = dynamic_cast<AliAODConversionPhoton*>(iObj);
+      if (!iPhoton) continue;
+
+      if (!fDoDoubleCountingCut){
+        TVector3 v1(thePhoton.GetConversionX(),
+                    thePhoton.GetConversionY(),
+                    thePhoton.GetConversionZ());
+
+        TVector3 v2(iPhoton->GetConversionX(),
+                    iPhoton->GetConversionY(),
+                    iPhoton->GetConversionZ());
+
+        TVector3 d = v2 - v1;
+
+        if(d.Mag2() < fminV0Dist*fminV0Dist){
+          if(thePhoton.GetChi2perNDF() > iPhoton->GetChi2perNDF()) return kFALSE;
+        }
+      }
+      else{
+        TVector3 v1(thePhoton.Px(),thePhoton.Py(),thePhoton.Pz());
+        TVector3 v2(iPhoton->Px(),iPhoton->Py(),iPhoton->Pz());
+        Double_t OpeningAngle=v1.Angle(v2);
+        if( OpeningAngle < fOpenAngle && TMath::Abs(thePhoton.GetConversionRadius()-iPhoton->GetConversionRadius()) < fDeltaR){
+          if(thePhoton.GetChi2perNDF() > iPhoton->GetChi2perNDF()) return kFALSE;
+        }
+      }
+    }
+  return kTRUE;
+}
 
 ///________________________________________________________________________
 AliConversionPhotonCuts* AliConversionPhotonCuts::GetStandardCuts2010PbPb(){
@@ -4869,7 +4927,7 @@ UChar_t AliConversionPhotonCuts::DeterminePhotonQualityTRD(AliAODConversionPhoto
 
   Int_t negNTrdTracklets = negTrack->GetTRDntrackletsPID();
   Int_t posNTrdTracklets = posTrack->GetTRDntrackletsPID();
-  
+
   if (negNTrdTracklets > 0 && posNTrdTracklets > 0){
     return 3;
   } else if (negNTrdTracklets > 0 || posNTrdTracklets > 0){
@@ -4943,16 +5001,16 @@ Bool_t AliConversionPhotonCuts::InitializeMaterialBudgetWeights(Int_t flag, TStr
     Float_t gammaConversionRadius = gamma->GetConversionRadius();
     Float_t scalePt=1.;
     Float_t nomMagField = 5.;
-    if(magField!=0) 
+    if(magField!=0)
       scalePt = nomMagField/(TMath::Abs(magField));
-    
+
     // AM:  Scale the pT for correction in case of lowB field
     //    cout<< "scalePt::"<< scalePt<< "    " <<  magField<< endl;
 
-    //AM.  the Omega correction for pT > 0.4 is flat and at high pT the statistics reduces. 
+    //AM.  the Omega correction for pT > 0.4 is flat and at high pT the statistics reduces.
     // So take the correction  at pT=0.5 if pT is > 0.7 GeV/c
-    Float_t maxPtForCor = 0.7;  
-    Float_t defaultPtForCor = 0.5;  
+    Float_t maxPtForCor = 0.7;
+    Float_t defaultPtForCor = 0.5;
     Float_t gammaPt = scalePt * gamma->Pt();
 
 

--- a/PWGGA/GammaConvBase/AliConversionPhotonCuts.h
+++ b/PWGGA/GammaConvBase/AliConversionPhotonCuts.h
@@ -19,6 +19,7 @@
 #include "AliDalitzAODESDMC.h"
 #include "AliDalitzEventMC.h"
 
+class unordered_set;
 
 class AliESDEvent;
 class AliAODEvent;
@@ -209,6 +210,9 @@ class AliConversionPhotonCuts : public AliAnalysisCuts {
     Bool_t CosinePAngleCut(const AliConversionPhotonBase * photon, AliVEvent * event) const;
     Bool_t RejectSharedElectronV0s(AliAODConversionPhoton* photon, Int_t nV0, Int_t nV0s);
     Bool_t RejectToCloseV0s(AliAODConversionPhoton* photon, TList *photons, Int_t nV0);
+
+    Bool_t AllowedBySharedElectronCut(unordered_set<Int_t> &theLabels, AliAODConversionPhoton &thePhoton) const;
+    Bool_t AllowedByTooCloseV0sCut(TList &theNotTooClosePhotons, AliAODConversionPhoton &thePhoton) const;
 
     UChar_t DeterminePhotonQualityAOD(AliAODConversionPhoton*, AliVEvent*);
     UChar_t DeterminePhotonQualityTRD(AliAODConversionPhoton*, AliVEvent*);

--- a/PWGGA/GammaConvBase/AliConversionPhotonCuts.h
+++ b/PWGGA/GammaConvBase/AliConversionPhotonCuts.h
@@ -211,7 +211,7 @@ class AliConversionPhotonCuts : public AliAnalysisCuts {
     Bool_t RejectSharedElectronV0s(AliAODConversionPhoton* photon, Int_t nV0, Int_t nV0s);
     Bool_t RejectToCloseV0s(AliAODConversionPhoton* photon, TList *photons, Int_t nV0);
 
-    Bool_t AllowedBySharedElectronCut(set<Int_t> &theLabels, AliAODConversionPhoton &thePhoton) const;
+    Bool_t AllowedBySharedElectronCut(std::set<Int_t> &theLabels, AliAODConversionPhoton &thePhoton) const;
     Bool_t AllowedByTooCloseV0sCut(TList &theNotTooClosePhotons, AliAODConversionPhoton &thePhoton) const;
 
     UChar_t DeterminePhotonQualityAOD(AliAODConversionPhoton*, AliVEvent*);

--- a/PWGGA/GammaConvBase/AliConversionPhotonCuts.h
+++ b/PWGGA/GammaConvBase/AliConversionPhotonCuts.h
@@ -19,7 +19,7 @@
 #include "AliDalitzAODESDMC.h"
 #include "AliDalitzEventMC.h"
 
-class unordered_set;
+class set;
 
 class AliESDEvent;
 class AliAODEvent;
@@ -211,7 +211,7 @@ class AliConversionPhotonCuts : public AliAnalysisCuts {
     Bool_t RejectSharedElectronV0s(AliAODConversionPhoton* photon, Int_t nV0, Int_t nV0s);
     Bool_t RejectToCloseV0s(AliAODConversionPhoton* photon, TList *photons, Int_t nV0);
 
-    Bool_t AllowedBySharedElectronCut(unordered_set<Int_t> &theLabels, AliAODConversionPhoton &thePhoton) const;
+    Bool_t AllowedBySharedElectronCut(set<Int_t> &theLabels, AliAODConversionPhoton &thePhoton) const;
     Bool_t AllowedByTooCloseV0sCut(TList &theNotTooClosePhotons, AliAODConversionPhoton &thePhoton) const;
 
     UChar_t DeterminePhotonQualityAOD(AliAODConversionPhoton*, AliVEvent*);


### PR DESCRIPTION
This change reduces the complexity of AliConversionPhotonCuts::
ProcessPhotonCandidates significantly. The semantics of the
sharedElectron and toCloseV0s cuts are slightly changed.
Before this change:
Say we have photons A B C. Then RejectToCloseV0s will cut photon A
if its too close to B. However, also C gets cut, if C is too close to A.
Even though A has already been thrown out.
For RejectSharedElectronV0s its the same: Say A and B have an electron track
in common -> A gets kicked out. Then C will still get kicked out,
if it is shares the positron track with A.
With this change, photon C does not get cut.

This affects typically 10% of photons for the shared electron
cut and sometimes one out of 200 photons for the tooclose cut.

Extensive automated tests were carried out to ensure that
the change does not break anything and does not have further
semantic consequences.