### PR TITLE
I want to add the new method to determine the scale rho function which trances form charge to full.

### DIFF
--- a/PWGJE/EMCALJetTasks/AliAnalysisTaskRhoBase.cxx
+++ b/PWGJE/EMCALJetTasks/AliAnalysisTaskRhoBase.cxx
@@ -51,6 +51,7 @@ AliAnalysisTaskRhoBase::AliAnalysisTaskRhoBase() :
   fCompareRhoScaledName(),
   fRhoFunction(0),
   fScaleFunction(0),
+  fScaleFunctionKind(0),
   fInEventSigmaRho(35.83),
   fAttachToEvent(kTRUE),
   fIsPbPb(kTRUE),
@@ -92,7 +93,7 @@ AliAnalysisTaskRhoBase::AliAnalysisTaskRhoBase(const char *name, Bool_t histo) :
   fCompareRhoName(),
   fCompareRhoScaledName(),
   fRhoFunction(0),
-  fScaleFunction(0),
+  fScaleFunctionKind(0),
   fInEventSigmaRho(35.83),
   fAttachToEvent(kTRUE),
   fIsPbPb(kTRUE),
@@ -241,7 +242,7 @@ void AliAnalysisTaskRhoBase::UserCreateOutputObjects()
     }
   }
 
-  if (fScaleFunction) {
+  if (fScaleFunction || fScaleFunctionKind) {
     fHistRhoScaledvsCent = new TH2F("fHistRhoScaledvsCent", "fHistRhoScaledvsCent", 101, -1, 100, fNbins, fMinBinPt , fMaxBinPt*2);
     fHistRhoScaledvsCent->GetXaxis()->SetTitle("Centrality (%)");
     fHistRhoScaledvsCent->GetYaxis()->SetTitle("#rho_{scaled} (GeV/c * rad^{-1})");
@@ -283,7 +284,7 @@ Bool_t AliAnalysisTaskRhoBase::Run()
   Double_t rho = GetRhoFactor(fCent);
   fOutRho->SetVal(rho);
 
-  if (fScaleFunction) {
+  if (fScaleFunction || fScaleFunctionKind) {
     Double_t rhoScaled = rho * GetScaleFactor(fCent);
     fOutRhoScaled->SetVal(rhoScaled);
   }
@@ -416,7 +417,7 @@ void AliAnalysisTaskRhoBase::ExecOnce()
     }
   }
 
-  if (fScaleFunction && !fOutRhoScaled) {
+  if ((fScaleFunction || fScaleFunctionKind) && !fOutRhoScaled) {
     fOutRhoScaled = new AliRhoParameter(fOutRhoScaledName, 0);
 
     if (fAttachToEvent) {
@@ -459,6 +460,11 @@ Double_t AliAnalysisTaskRhoBase::GetScaleFactor(Double_t cent)
   Double_t scale = 1;
   if (fScaleFunction)
     scale = fScaleFunction->Eval(cent);
+
+  if (fScaleFunctionKind == 1){
+    if(cent){ scale = 1.34214 - 4.23066e-03 * cent + 1.15901e-04 * cent*cent  - 1.00008e-06 * cent*cent*cent;}
+    else scale = 1.2925289;
+  }
   return scale;
 }
 

--- a/PWGJE/EMCALJetTasks/AliAnalysisTaskRhoBase.h
+++ b/PWGJE/EMCALJetTasks/AliAnalysisTaskRhoBase.h
@@ -74,6 +74,7 @@ class AliAnalysisTaskRhoBase : public AliAnalysisTaskEmcalJet {
   void                   SetCompareRhoName(const char *name)                   { fCompareRhoName       = name    ;                   }
   void                   SetCompareRhoScaledName(const char *name)             { fCompareRhoScaledName = name    ;                   }
   void                   SetScaleFunction(TF1* sf)                             { fScaleFunction        = sf      ;                   }
+  void                   SetScaleFunctionKind(Int_t sfk)                             { fScaleFunctionKind        = sfk      ;                   }
   void                   SetRhoFunction(TF1* rf)                               { fRhoFunction          = rf      ;                   }
   /**
    * @brief Load the scale function from a file.
@@ -126,6 +127,7 @@ class AliAnalysisTaskRhoBase : public AliAnalysisTaskEmcalJet {
   TString                fCompareRhoScaledName;          ///< name of scaled rho object to compare
   TF1                   *fRhoFunction;                   ///< pre-computed rho as a function of centrality
   TF1                   *fScaleFunction;                 ///< pre-computed scale factor as a function of centrality
+  Int_t                   fScaleFunctionKind;                 ///< pre-computed scale factor as a function of centrality
   Double_t               fInEventSigmaRho;               ///< in-event sigma rho
   Bool_t                 fAttachToEvent;                 ///< whether or not attach rho to the event objects list
   Bool_t                 fIsPbPb;                        ///< different histogram ranges for pp/pPb and PbPb


### PR DESCRIPTION
I want to add the new method to determine the scale rho function which trances form charge to full.
Now we need to read TF1 of the root file, but it could not be defined in each various region of the x-axis.
Therefore, I created the new option that the scale function was defined in this task.
@jdmuligan