### PR TITLE
Make usage of negative noise optional

### DIFF
--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerKernel.cxx
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerKernel.cxx
@@ -73,6 +73,7 @@ AliEmcalTriggerMakerKernel::AliEmcalTriggerMakerKernel():
   fSigmaNoiseFEESmear(0.),
   fAddConstantNoiseFEESmear(false),
   fAddGaussianNoiseFEESmear(false),
+  fUseNegPartGaussNoise(false),
   fDoBackgroundSubtraction(false),
   fGeometry(nullptr),
   fPatchAmplitudes(nullptr),
@@ -498,7 +499,10 @@ void AliEmcalTriggerMakerKernel::ReadCellData(AliVCaloCells *cells){
         }
         if(fAddGaussianNoiseFEESmear) {
           // Accept also the negative part of the gaussian to simulate underfluctuations
-          (*fPatchEnergySimpleSmeared)(icol, irow) += gRandom->Gaus(fMeanNoiseFEESmear, fSigmaNoiseFEESmear);
+          double noisevalue = gRandom->Gaus(fMeanNoiseFEESmear, fSigmaNoiseFEESmear);
+          if(noisevalue < 0. && !fUseNegPartGaussNoise) 
+            noisevalue = 0.;
+          (*fPatchEnergySimpleSmeared)(icol, irow) += noisevalue;
         }
         // Truncate to 0
         (*fPatchEnergySimpleSmeared)(icol, irow) = TMath::Max((*fPatchEnergySimpleSmeared)(icol, irow), 0.);

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerKernel.h
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerKernel.h
@@ -404,6 +404,19 @@ public:
   void SetGaussianNoiseFEESmear(double mean, double sigma) { fMeanNoiseFEESmear = mean; fSigmaNoiseFEESmear = sigma; fAddGaussianNoiseFEESmear = true; }
 
   /**
+   * @brief Define whether using also the negative part of the gaussian noise 
+   * 
+   * Per default the noise simulation is truncated at 0, meaning that FastORs 
+   * for which the noise value is negative the noise is set to 0. In case also
+   * the negative part of the gaussian is used the noise can be subtracted from
+   * the signal, this simulates undefluctuations of the baseline. In any case
+   * the sum of noise + signal is always truncated to 0.
+   * 
+   * @param doUse If true also the negative part of the gauss curve is used
+   */
+  void SetUseNegPartGaussNoise(bool doUse) { fUseNegPartGaussNoise = doUse; }
+
+  /**
    * @brief Set energy-dependent models for gaussian energy smearing
    * @param[in] mean Parameterization of the mean
    * @param[in] width Parameterization of the width
@@ -556,6 +569,7 @@ protected:
   Double_t                                  fSigmaNoiseFEESmear;          ///< Sigma for gaussian noise model applied to smeared FEE
   Bool_t                                    fAddConstantNoiseFEESmear;    ///< Switch adding constnat noise to smeared FEE data
   Bool_t                                    fAddGaussianNoiseFEESmear;    ///< Switch adding noise to smeared FEE data using a gaussian model
+  Bool_t                                    fUseNegPartGaussNoise;        ///< Switch using also negative side of the gauss in the noise model
   Bool_t                                    fDoBackgroundSubtraction;     ///< Swtich for background subtraction (only online ADC)
 
   const AliEMCALGeometry                    *fGeometry;                   //!<! Underlying EMCAL geometry


### PR DESCRIPTION
Negative noise simulating baseline underfluctuations. In
case it is disabled negative noise values are set to 0.