### PR TITLE
Fix correlation of the interaction trigger with the EMCAL trigger dec…

### DIFF
--- a/PWG/EMCAL/EMCALtasks/AliAnalysisTaskEmcalTriggerSelection.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliAnalysisTaskEmcalTriggerSelection.cxx
@@ -280,6 +280,7 @@ Bool_t AliAnalysisTaskEmcalTriggerSelection::IsSupportedMCSample(const char *dat
 }
 
 void AliAnalysisTaskEmcalTriggerSelection::ConfigurePP7TeV2011(){
+  std::cout << "AutoConfigure: Configuring for data pp 7 TeV" << std::endl;
   AliEmcalTriggerSelectionCuts *emcl0cuts = new AliEmcalTriggerSelectionCuts;
   emcl0cuts->SetAcceptanceType(AliEmcalTriggerSelectionCuts::kEMCALAcceptance);
   emcl0cuts->SetPatchType(AliEmcalTriggerSelectionCuts::kL0Patch);
@@ -290,6 +291,7 @@ void AliAnalysisTaskEmcalTriggerSelection::ConfigurePP7TeV2011(){
 }
 
 void AliAnalysisTaskEmcalTriggerSelection::ConfigureMCPP7TeV2011() {
+  std::cout << "AutoConfigure: Configuring for MC pp 7 TeV" << std::endl;
   AliEmcalTriggerSelectionCuts *emcl0cuts = new AliEmcalTriggerSelectionCuts;
   emcl0cuts->SetAcceptanceType(AliEmcalTriggerSelectionCuts::kEMCALAcceptance);
   emcl0cuts->SetPatchType(AliEmcalTriggerSelectionCuts::kL0Patch);
@@ -300,6 +302,7 @@ void AliAnalysisTaskEmcalTriggerSelection::ConfigureMCPP7TeV2011() {
 }
 
 void AliAnalysisTaskEmcalTriggerSelection::ConfigurePP2012(){
+  std::cout << "AutoConfigure: Configuring for data pp 8 TeV" << std::endl;
   AliEmcalTriggerSelectionCuts *eg1cuts = new AliEmcalTriggerSelectionCuts;
   eg1cuts->SetAcceptanceType(AliEmcalTriggerSelectionCuts::kEMCALAcceptance);
   eg1cuts->SetPatchType(AliEmcalTriggerSelectionCuts::kL1GammaHighPatch);
@@ -318,6 +321,7 @@ void AliAnalysisTaskEmcalTriggerSelection::ConfigurePP2012(){
 }
 
 void AliAnalysisTaskEmcalTriggerSelection::ConfigureMCPP2012() {
+  std::cout << "AutoConfigure: Configuring for MC pp 8 TeV" << std::endl;
   AliEmcalTriggerSelectionCuts *eg1cuts = new AliEmcalTriggerSelectionCuts;
   eg1cuts->SetAcceptanceType(AliEmcalTriggerSelectionCuts::kEMCALAcceptance);
   eg1cuts->SetPatchType(AliEmcalTriggerSelectionCuts::kL1GammaHighPatch);
@@ -336,6 +340,7 @@ void AliAnalysisTaskEmcalTriggerSelection::ConfigureMCPP2012() {
 }
 
 void AliAnalysisTaskEmcalTriggerSelection::ConfigurePPB5TeV2013(){
+  std::cout << "AutoConfigure: Configuring for data p-Pb 5.02 TeV (2013)" << std::endl;
   AliEmcalTriggerSelectionCuts *emcl0cuts = new AliEmcalTriggerSelectionCuts;
   emcl0cuts->SetAcceptanceType(AliEmcalTriggerSelectionCuts::kEMCALAcceptance);
   emcl0cuts->SetPatchType(AliEmcalTriggerSelectionCuts::kL0Patch);
@@ -379,6 +384,7 @@ void AliAnalysisTaskEmcalTriggerSelection::ConfigurePPB5TeV2013(){
 }
 
 void AliAnalysisTaskEmcalTriggerSelection::ConfigureMCPPB5TeV2013() {
+  std::cout << "AutoConfigure: Configuring for MC p-Pb 5.02 TeV (2013)" << std::endl;
   AliEmcalTriggerSelectionCuts *emcl0cuts = new AliEmcalTriggerSelectionCuts;
   emcl0cuts->SetAcceptanceType(AliEmcalTriggerSelectionCuts::kEMCALAcceptance);
   emcl0cuts->SetPatchType(AliEmcalTriggerSelectionCuts::kL0Patch);
@@ -422,6 +428,7 @@ void AliAnalysisTaskEmcalTriggerSelection::ConfigureMCPPB5TeV2013() {
 }
 
 void AliAnalysisTaskEmcalTriggerSelection::ConfigurePP5TeV2015(){
+  std::cout << "AutoConfigure: Configuring for data pp 5.02 TeV (2015)" << std::endl;
   AliEmcalTriggerSelectionCuts *emcl0cuts = new AliEmcalTriggerSelectionCuts;
   emcl0cuts->SetAcceptanceType(AliEmcalTriggerSelectionCuts::kEMCALAcceptance);
   emcl0cuts->SetPatchType(AliEmcalTriggerSelectionCuts::kL0Patch);
@@ -441,6 +448,7 @@ void AliAnalysisTaskEmcalTriggerSelection::ConfigurePP5TeV2015(){
 }
 
 void AliAnalysisTaskEmcalTriggerSelection::ConfigureMCPP5TeV2015() {
+  std::cout << "AutoConfigure: Configuring for MC pp 5.02 TeV (2015)" << std::endl;
   AliEmcalTriggerSelectionCuts *emcl0cuts = new AliEmcalTriggerSelectionCuts;
   emcl0cuts->SetAcceptanceType(AliEmcalTriggerSelectionCuts::kEMCALAcceptance);
   emcl0cuts->SetPatchType(AliEmcalTriggerSelectionCuts::kL0Patch);
@@ -450,7 +458,7 @@ void AliAnalysisTaskEmcalTriggerSelection::ConfigureMCPP5TeV2015() {
   this->AddTriggerSelection(new AliEmcalTriggerSelection("EMCL0", emcl0cuts));
 
   AliEmcalTriggerSelectionCuts *dmcl0cuts = new AliEmcalTriggerSelectionCuts;
-  dmcl0cuts->SetAcceptanceType(AliEmcalTriggerSelectionCuts::kEMCALAcceptance);
+  dmcl0cuts->SetAcceptanceType(AliEmcalTriggerSelectionCuts::kDCALAcceptance);
   dmcl0cuts->SetPatchType(AliEmcalTriggerSelectionCuts::kL0Patch);
   dmcl0cuts->SetSelectionMethod(AliEmcalTriggerSelectionCuts::kEnergyOfflineSmeared);
   dmcl0cuts->SetUseSimpleOfflinePatches(true);
@@ -460,6 +468,7 @@ void AliAnalysisTaskEmcalTriggerSelection::ConfigureMCPP5TeV2015() {
 }
 
 void AliAnalysisTaskEmcalTriggerSelection::ConfigurePP2016(){
+  std::cout << "AutoConfigure: Configuring for data pp 13 TeV" << std::endl;
   AliEmcalTriggerSelectionCuts *eg1cuts = new AliEmcalTriggerSelectionCuts;
   eg1cuts->SetAcceptanceType(AliEmcalTriggerSelectionCuts::kEMCALAcceptance);
   eg1cuts->SetPatchType(AliEmcalTriggerSelectionCuts::kL1GammaHighPatch);
@@ -528,6 +537,7 @@ void AliAnalysisTaskEmcalTriggerSelection::ConfigurePP2016(){
 }
 
 void AliAnalysisTaskEmcalTriggerSelection::ConfigureMCPP2016() {
+  std::cout << "AutoConfigure: Configuring for MC pp 13 TeV" << std::endl;
   AliEmcalTriggerSelectionCuts *eg1cuts = new AliEmcalTriggerSelectionCuts;
   eg1cuts->SetAcceptanceType(AliEmcalTriggerSelectionCuts::kEMCALAcceptance);
   eg1cuts->SetPatchType(AliEmcalTriggerSelectionCuts::kL1GammaHighPatch);
@@ -591,9 +601,26 @@ void AliAnalysisTaskEmcalTriggerSelection::ConfigureMCPP2016() {
   dj2cuts->SetUseSimpleOfflinePatches(true);
   dj2cuts->SetThreshold(16.);
   this->AddTriggerSelection(new AliEmcalTriggerSelection("DJ2", dj2cuts));
+
+  AliEmcalTriggerSelectionCuts *emc7cuts = new AliEmcalTriggerSelectionCuts;
+  emc7cuts->SetAcceptanceType(AliEmcalTriggerSelectionCuts::kEMCALAcceptance);
+  emc7cuts->SetPatchType(AliEmcalTriggerSelectionCuts::kL0Patch);
+  emc7cuts->SetSelectionMethod(AliEmcalTriggerSelectionCuts::kEnergyOfflineSmeared);
+  emc7cuts->SetUseSimpleOfflinePatches(true);
+  emc7cuts->SetThreshold(2.5);
+  this->AddTriggerSelection(new AliEmcalTriggerSelection("EMCL0", emc7cuts));
+
+  AliEmcalTriggerSelectionCuts *dmc7cuts = new AliEmcalTriggerSelectionCuts;
+  dmc7cuts->SetAcceptanceType(AliEmcalTriggerSelectionCuts::kDCALAcceptance);
+  dmc7cuts->SetPatchType(AliEmcalTriggerSelectionCuts::kL0Patch);
+  dmc7cuts->SetSelectionMethod(AliEmcalTriggerSelectionCuts::kEnergyOfflineSmeared);
+  dmc7cuts->SetUseSimpleOfflinePatches(true);
+  dmc7cuts->SetThreshold(2.5);
+  this->AddTriggerSelection(new AliEmcalTriggerSelection("DMCL0", dmc7cuts));
 }
 
 void AliAnalysisTaskEmcalTriggerSelection::ConfigurePPB5TeV2016(){
+  std::cout << "AutoConfigure: Configuring for data p-Pb 5.02 TeV (2016)" << std::endl;
   AliEmcalTriggerSelectionCuts *eg1cuts = new AliEmcalTriggerSelectionCuts;
   eg1cuts->SetAcceptanceType(AliEmcalTriggerSelectionCuts::kEMCALAcceptance);
   eg1cuts->SetPatchType(AliEmcalTriggerSelectionCuts::kL1GammaHighPatch);
@@ -658,10 +685,10 @@ void AliAnalysisTaskEmcalTriggerSelection::ConfigurePPB5TeV2016(){
   dj2cuts->SetUseRecalcPatches(true);
   dj2cuts->SetThreshold(255);
   this->AddTriggerSelection(new AliEmcalTriggerSelection("DJ2", dj2cuts));
-
 }
 
 void AliAnalysisTaskEmcalTriggerSelection::ConfigureMCPPB5TeV2016() {
+  std::cout << "AutoConfigure: Configuring for MC p-Pb 5.02 TeV (2016)" << std::endl;
   AliEmcalTriggerSelectionCuts *eg1cuts = new AliEmcalTriggerSelectionCuts;
   eg1cuts->SetAcceptanceType(AliEmcalTriggerSelectionCuts::kEMCALAcceptance);
   eg1cuts->SetPatchType(AliEmcalTriggerSelectionCuts::kL1GammaHighPatch);
@@ -725,9 +752,26 @@ void AliAnalysisTaskEmcalTriggerSelection::ConfigureMCPPB5TeV2016() {
   dj2cuts->SetUseSimpleOfflinePatches(true);
   dj2cuts->SetThreshold(20.);
   this->AddTriggerSelection(new AliEmcalTriggerSelection("DJ2", dj2cuts));
+
+  AliEmcalTriggerSelectionCuts *emc7cuts = new AliEmcalTriggerSelectionCuts;
+  emc7cuts->SetAcceptanceType(AliEmcalTriggerSelectionCuts::kEMCALAcceptance);
+  emc7cuts->SetPatchType(AliEmcalTriggerSelectionCuts::kL0Patch);
+  emc7cuts->SetSelectionMethod(AliEmcalTriggerSelectionCuts::kEnergyOfflineSmeared);
+  emc7cuts->SetUseSimpleOfflinePatches(true);
+  emc7cuts->SetThreshold(2.5);
+  this->AddTriggerSelection(new AliEmcalTriggerSelection("EMCL0", emc7cuts));
+
+  AliEmcalTriggerSelectionCuts *dmc7cuts = new AliEmcalTriggerSelectionCuts;
+  dmc7cuts->SetAcceptanceType(AliEmcalTriggerSelectionCuts::kDCALAcceptance);
+  dmc7cuts->SetPatchType(AliEmcalTriggerSelectionCuts::kL0Patch);
+  dmc7cuts->SetSelectionMethod(AliEmcalTriggerSelectionCuts::kEnergyOfflineSmeared);
+  dmc7cuts->SetUseSimpleOfflinePatches(true);
+  dmc7cuts->SetThreshold(2.5);
+  this->AddTriggerSelection(new AliEmcalTriggerSelection("DMCL0", dmc7cuts));
 }
 
 void AliAnalysisTaskEmcalTriggerSelection::ConfigurePPB8TeV2016(){
+  std::cout << "AutoConfigure: Configuring for data p-Pb 8.16 TeV (2016)" << std::endl;
   AliEmcalTriggerSelectionCuts *eg1cuts = new AliEmcalTriggerSelectionCuts;
   eg1cuts->SetAcceptanceType(AliEmcalTriggerSelectionCuts::kEMCALAcceptance);
   eg1cuts->SetPatchType(AliEmcalTriggerSelectionCuts::kL1GammaHighPatch);
@@ -796,6 +840,7 @@ void AliAnalysisTaskEmcalTriggerSelection::ConfigurePPB8TeV2016(){
 }
 
 void AliAnalysisTaskEmcalTriggerSelection::ConfigureMCPPB8TeV2016() {
+  std::cout << "AutoConfigure: Configuring for MC p-Pb 8.16 TeV (2016)" << std::endl;
   AliEmcalTriggerSelectionCuts *eg1cuts = new AliEmcalTriggerSelectionCuts;
   eg1cuts->SetAcceptanceType(AliEmcalTriggerSelectionCuts::kEMCALAcceptance);
   eg1cuts->SetPatchType(AliEmcalTriggerSelectionCuts::kL1GammaHighPatch);
@@ -859,9 +904,26 @@ void AliAnalysisTaskEmcalTriggerSelection::ConfigureMCPPB8TeV2016() {
   dj2cuts->SetUseSimpleOfflinePatches(true);
   dj2cuts->SetThreshold(18.);
   this->AddTriggerSelection(new AliEmcalTriggerSelection("DJ2", dj2cuts));
+
+  AliEmcalTriggerSelectionCuts *emc7cuts = new AliEmcalTriggerSelectionCuts;
+  emc7cuts->SetAcceptanceType(AliEmcalTriggerSelectionCuts::kEMCALAcceptance);
+  emc7cuts->SetPatchType(AliEmcalTriggerSelectionCuts::kL0Patch);
+  emc7cuts->SetSelectionMethod(AliEmcalTriggerSelectionCuts::kEnergyOfflineSmeared);
+  emc7cuts->SetUseSimpleOfflinePatches(true);
+  emc7cuts->SetThreshold(2.5);
+  this->AddTriggerSelection(new AliEmcalTriggerSelection("EMCL0", emc7cuts));
+
+  AliEmcalTriggerSelectionCuts *dmc7cuts = new AliEmcalTriggerSelectionCuts;
+  dmc7cuts->SetAcceptanceType(AliEmcalTriggerSelectionCuts::kDCALAcceptance);
+  dmc7cuts->SetPatchType(AliEmcalTriggerSelectionCuts::kL0Patch);
+  dmc7cuts->SetSelectionMethod(AliEmcalTriggerSelectionCuts::kEnergyOfflineSmeared);
+  dmc7cuts->SetUseSimpleOfflinePatches(true);
+  dmc7cuts->SetThreshold(2.5);
+  this->AddTriggerSelection(new AliEmcalTriggerSelection("DMCL0", dmc7cuts));
 }
 
 void AliAnalysisTaskEmcalTriggerSelection::ConfigurePP5TeV2017(){
+  std::cout << "AutoConfigure: Configuring for data pp 5.02 TeV (2017)" << std::endl;
   AliEmcalTriggerSelectionCuts *eg1cuts = new AliEmcalTriggerSelectionCuts;
   eg1cuts->SetAcceptanceType(AliEmcalTriggerSelectionCuts::kEMCALAcceptance);
   eg1cuts->SetPatchType(AliEmcalTriggerSelectionCuts::kL1GammaHighPatch);
@@ -930,6 +992,7 @@ void AliAnalysisTaskEmcalTriggerSelection::ConfigurePP5TeV2017(){
 }
 
 void AliAnalysisTaskEmcalTriggerSelection::ConfigureMCPP5TeV2017() {
+  std::cout << "AutoConfigure: Configuring for MC pp 5.02 TeV (2017)" << std::endl;
   AliEmcalTriggerSelectionCuts *eg1cuts = new AliEmcalTriggerSelectionCuts;
   eg1cuts->SetAcceptanceType(AliEmcalTriggerSelectionCuts::kEMCALAcceptance);
   eg1cuts->SetPatchType(AliEmcalTriggerSelectionCuts::kL1GammaHighPatch);

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerKernel.cxx
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerKernel.cxx
@@ -52,6 +52,7 @@ AliEmcalTriggerMakerKernel::AliEmcalTriggerMakerKernel():
   fLevel0PatchFinder(nullptr),
   fL0MinTime(7),
   fL0MaxTime(10),
+  fApplyL0TimeCut(true),
   fMinCellAmp(0),
   fMinL0FastORAmp(0),
   fMinL1FastORAmp(0),
@@ -741,8 +742,12 @@ AliEmcalTriggerMakerKernel::ELevel0TriggerStatus_t AliEmcalTriggerMakerKernel::C
       }
       if(col + jpos >= kColsEta) AliError(Form("Boundary error in col [%d, %d + %d]", col + jpos, col, jpos));
       if(row + ipos >= kNRowsPhi) AliError(Form("Boundary error in row [%d, %d + %d]", row + ipos, row, ipos));
-      Char_t l0times = (*fLevel0TimeMap)(col + jpos,row + ipos);
-      if(l0times > fL0MinTime && l0times < fL0MaxTime) nvalid++;
+      if(fApplyL0TimeCut) {
+        Char_t l0times = (*fLevel0TimeMap)(col + jpos,row + ipos);
+        if(l0times > fL0MinTime && l0times < fL0MaxTime) nvalid++;
+      } else {
+        nvalid++;
+      }
     }
   }
   if (nvalid == 4) result = kLevel0Fired;

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerKernel.h
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerKernel.h
@@ -206,6 +206,12 @@ public:
   void SetL0TimeRange(Int_t min, Int_t max) { fL0MinTime = min; fL0MaxTime = max; }
 
   /**
+   * @brief Switch for applying the L0 time cut for L0 patch selection (default: applied)
+   * @param doApply If true the L0 time cut is applied for L0 patch selection
+   */
+  void SetApplyL0TimeCut(Bool_t doApply) { fApplyL0TimeCut = doApply; }
+
+  /**
    * @brief Set thresholds applied to FastORs and offline cells before patch reconstruction
    * @param[in] l0 Threshold for L0 FastOR amplitudes
    * @param[in] l1 Threshold for L1 FastOR amplitudes
@@ -545,6 +551,7 @@ protected:
   AliEMCALTriggerAlgorithm<double>         *fLevel0PatchFinder;           ///< Patch finder for Level0 patches
   Int_t                                     fL0MinTime;                   ///< Minimum L0 time
   Int_t                                     fL0MaxTime;                   ///< Maximum L0 time
+  Bool_t                                    fApplyL0TimeCut;              ///< Apply time cut (L0 time between fL0MinTime and fL0MaxTime) for L0 patch selection
   Int_t                                     fMinCellAmp;                  ///< Minimum offline amplitude of the cells used to generate the patches
   Int_t                                     fMinL0FastORAmp;              ///< Minimum L0 amplitude of the FastORs used to generate the patches
   Int_t                                     fMinL1FastORAmp;              ///< Minimum L1 amplitude of the FastORs used to generate the patches

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalTriggerBase.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalTriggerBase.cxx
@@ -348,15 +348,16 @@ void AliAnalysisTaskEmcalTriggerBase::TriggerSelection(){
     if(fUseTriggerSelectionContainer){
       for(int iclass = 0; iclass < AliEmcalTriggerOfflineSelection::kTrgn; iclass++){
         auto emcalSelectionStatus = MatchTriggerFromContainer(kEmcalSelectTriggerStrings[iclass], triggersel);
-        if(isT0trigger) {
-          emc8Triggers[iclass] &= emcalSelectionStatus;
-        } 
-        if(isVZEROtrigger){
-          emcalTriggers[iclass] &= emcalSelectionStatus;
-        } 
-        if(!(isT0trigger || isVZEROtrigger)){
-          // No coincidence with interaction trigger
-          emcNoIntTriggers[iclass] &= emcalSelectionStatus; 
+        if(emcalSelectionStatus) {
+          // trigger selected - correlate with interaction trigger status
+          emcalTriggers[iclass] &= isVZEROtrigger;
+          emc8Triggers[iclass] &= isT0trigger;
+          emcNoIntTriggers[iclass] &= !(isT0trigger || isVZEROtrigger);
+        } else {
+          // trigger not selected, set trigger bit to false
+          emcalTriggers[iclass] = false;
+          emc8Triggers[iclass] = false;
+          emcNoIntTriggers[iclass] = false;
         }
         if(emcalTriggers[iclass])
           AliDebugStream(1) << GetName() << ": Event selected as trigger " << kEmcalSelectTriggerStrings[iclass] << " (INT7 suite)" << std::endl;
@@ -384,6 +385,7 @@ void AliAnalysisTaskEmcalTriggerBase::TriggerSelection(){
       if(isSemiCENT) fSelectedTriggers.push_back("SEMICENT");
     }
     if(emcalTriggers[AliEmcalTriggerOfflineSelection::kTrgEL0]){
+      std::cout << "Found L0 trigger" << std::endl;
       AliDebugStream(1) << "Event selected as EMC7" << std::endl;
       fSelectedTriggers.push_back("EMC7");
       if(fEnableEDCombinedTriggers && (combinedtriggers.find("EDMC7") == combinedtriggers.end())) combinedtriggers.insert("EDMC7");

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalTriggerBase.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalTriggerBase.cxx
@@ -262,7 +262,7 @@ void AliAnalysisTaskEmcalTriggerBase::TriggerSelection(){
   if(fEnableT0Triggers) for(int itrg = 0; itrg < AliEmcalTriggerOfflineSelection::kTrgn; itrg++) emc8Triggers[itrg] = true;
   if(fEnableNoINTTriggers) for(int itrg = 0; itrg < AliEmcalTriggerOfflineSelection::kTrgn; itrg++) emcNoIntTriggers[itrg] = true;
   const std::array<std::string, AliEmcalTriggerOfflineSelection::kTrgn> kEmcalSelectTriggerStrings = {
-    		"=CEMC7|CEMC8|C0EMC", "EG1|EGA", "EG2", "EJ1|EJE", "EJ2", "=CDMC7|CDMC8|C0DMC", "DG1", "DG2", "DJ1", "DJ2"
+    		"=CEMC7|CEMC8|C0EMC|EMCL0", "EG1|EGA", "EG2", "EJ1|EJE", "EJ2", "=CDMC7|CDMC8|C0DMC|DMCL0", "DG1", "DG2", "DJ1", "DJ2"
   };
   if(!isMC){
     // In case of data select events as bunch-bunch (-B-) events.
@@ -385,7 +385,6 @@ void AliAnalysisTaskEmcalTriggerBase::TriggerSelection(){
       if(isSemiCENT) fSelectedTriggers.push_back("SEMICENT");
     }
     if(emcalTriggers[AliEmcalTriggerOfflineSelection::kTrgEL0]){
-      std::cout << "Found L0 trigger" << std::endl;
       AliDebugStream(1) << "Event selected as EMC7" << std::endl;
       fSelectedTriggers.push_back("EMC7");
       if(fEnableEDCombinedTriggers && (combinedtriggers.find("EDMC7") == combinedtriggers.end())) combinedtriggers.insert("EDMC7");


### PR DESCRIPTION
…ision for MC

Logics needs to be inversed: Instead of logical and
with the EMCAL trigger decision for each interaction
trigger the logical and has to be performed for each
interaction trigger in case the EMCAL trigger fired (if
not the trigger status has to be set to false). If not it
is possible that events pass the trigger selection which
are rejected by the interaction trigger.