### PR TITLE
TriggerMaker: Enable noise by default in case of MC

### DIFF
--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerKernel.h
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerKernel.h
@@ -181,6 +181,12 @@ public:
   bool HasSmearModel() const { return fSmearModelMean && fSmearModelSigma; }
 
   /**
+   * @brief Check whether noise settings have already been provided
+   * @return True if the noise model has been configured, false otherwise 
+   */
+  bool HasNoiseModel() const { return fAddConstantNoiseFEESmear || fAddGaussianNoiseFEESmear; }
+
+  /**
    * @brief Define whether running on MC or not (for offset)
    * @param isMC Flag for MC
    */

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerTask.cxx
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerTask.cxx
@@ -59,6 +59,7 @@ AliEmcalTriggerMakerTask::AliEmcalTriggerMakerTask():
   fLoadFastORMaskingFromOCDB(kFALSE),
   fCaloTriggersOut(0),
   fRunSmearing(kTRUE),
+  fSimulateNoise(kTRUE),
   fDoQA(kFALSE),
   fQAHistos(NULL)
 {
@@ -77,6 +78,7 @@ AliEmcalTriggerMakerTask::AliEmcalTriggerMakerTask(const char *name, Bool_t doQA
   fLoadFastORMaskingFromOCDB(kFALSE),
   fCaloTriggersOut(NULL),
   fRunSmearing(kTRUE),
+  fSimulateNoise(kTRUE),
   fDoQA(doQA),
   fQAHistos(NULL)
 {
@@ -240,6 +242,12 @@ void AliEmcalTriggerMakerTask::ExecOnce(){
       InitializeSmearModel(); // Initialize smear model if not yet set from outside
       fTriggerMaker->SetApplyOnlineBadChannelMaskingToSmeared();
     } 
+
+    if(MCEvent() && fSimulateNoise) {
+      // In MC mode add noise 
+      // Using noise sigma of 50 MeV/channel as found during the optimization of the trigger efficiency to run2 data
+      if(!fTriggerMaker->HasNoiseModel()) fTriggerMaker->SetGaussianNoiseFEESmear(0., 0.05);
+    }
   }
 
   fTriggerMaker->SetGeometry(fGeom);

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerTask.h
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerTask.h
@@ -209,10 +209,16 @@ public:
   void SetUseL0Amplitudes(Bool_t b)        { fUseL0Amplitudes = b           ; }
 
   /**
-   * @brief Switch for smearing mode
+   * @brief Switch for smearing mode (default: enabled)
    * @param doRun If true also the smeared patch energy is calculated
    */
   void SetRunSmearing(Bool_t doRun) { fRunSmearing = doRun; }
+
+  /**
+   * @brief Switch for simulating noise in MC mode (default: enabled)
+   * @param doSimulate If true noise is simulated when calculating the smeared FastOR energies
+   */
+  void SetSimulateNoise(Bool_t doSimulate) { fSimulateNoise = doSimulate; }
 
 protected:
 
@@ -315,6 +321,7 @@ protected:
   TClonesArray                            *fCaloTriggersOut;          //!<! trigger array out
 
   Bool_t                                  fRunSmearing;               ///< Also calculate smeared patch energy based on FastOR energy resolution
+  Bool_t                                  fSimulateNoise;             ///< Simulate noise
   Bool_t                                  fDoQA;                      ///< Fill QA histograms
   THistManager                            *fQAHistos;                 //!<! Histograms for QA
 


### PR DESCRIPTION
Change default configuration for MC so that noise is
always simulated with a sigma of 50 MeV