### PR TITLE
Added a cut for MC events jets with pt>4*pt_hard

### DIFF
--- a/PWGCF/Correlations/JCORRAN/Pro/AliJCDijetAna.cxx
+++ b/PWGCF/Correlations/JCORRAN/Pro/AliJCDijetAna.cxx
@@ -164,6 +164,7 @@ void AliJCDijetAna::SetSettings(int    lDebug,
     pionmass = 0.139570;//AliPID::ParticleMass(AliPID::kPion);
     matchingR = lmatchingR;
     fDeltaPt = -9999.0;
+    fptHardBin = 0; // Default value
 
     //Initialize jet lists
     fastjet::PseudoJet emptyJet;
@@ -236,25 +237,24 @@ void AliJCDijetAna::SetSettings(int    lDebug,
     bge = fastjet::JetMedianBackgroundEstimator(selectorEta, jet_def_bge, area_def_bge);
 
 
-
+    return;
 }
 
 //______________________________________________________________________________
-void AliJCDijetAna::CalculateJets(TClonesArray *inList, AliJCDijetHistos *fhistos, int lCBin){
+int AliJCDijetAna::CalculateJets(TClonesArray *inList, AliJCDijetHistos *fhistos, int lCBin){
 
     ResetObjects();
 
     //--------------------------------------------------------
     //         B e g i n    e v e n t    l o o p.
     //--------------------------------------------------------
-    if (inList==0) { cout << "No list!" << endl; return;}
+    if (inList==0) { cout << "No list!" << endl; return 0;}
     noTracks = inList->GetEntriesFast();
     //cout << "Number of tracks: " << noTracks << endl;
     
     fDeltaPt = -9999.0;
     double randConePhi = randomGenerator->Uniform(-TMath::Pi(),TMath::Pi());
     double randConeEta = randomGenerator->Uniform(-etaMaxCutForJet,etaMaxCutForJet);
-    fhistos->fh_randConeEtaPhi[lCBin]->Fill(randConeEta,randConePhi);
     double randConePt = 0.0;
 
     //cout << "Number of tracks in Ana code: " << noTracks << endl;
@@ -263,17 +263,9 @@ void AliJCDijetAna::CalculateJets(TClonesArray *inList, AliJCDijetHistos *fhisto
         AliJBaseTrack *trk = (AliJBaseTrack*)inList->At(utrack);
         pt = trk->Pt();
         eta = trk->Eta();
-        fhistos->fh_events[lCBin]->Fill("particles",1.0);
         if (pt>fParticlePtCut && TMath::Abs(eta) < fParticleEtaCut){
             if(ftrackingIneff>0.0 && randomGenerator->Uniform(0.0,1.0) < ftrackingIneff) continue;
-            fhistos->fh_events[lCBin]->Fill("acc. particles",1.0);
             phi = trk->Phi();
-            fhistos->fh_eta[lCBin]->Fill(eta);
-            fhistos->fh_phi[lCBin]->Fill(phi);
-            fhistos->fh_etaPhi[lCBin]->Fill(eta,phi);
-            fhistos->fh_pt[lCBin]->Fill(pt);
-            if(eta>0.0) fhistos->fh_ptPosEta[lCBin]->Fill(pt);
-            else        fhistos->fh_ptNegEta[lCBin]->Fill(pt);
             if(DeltaR(randConeEta, eta, randConePhi, phi) < fJetCone) randConePt += pt;
             if(fusePionMass) {
                 chparticles.push_back(fastjet::PseudoJet(trk->Px(), trk->Py(), trk->Pz(), TMath::Sqrt(trk->Px()*trk->Px() + trk->Py()*trk->Py() + trk->Pz()*trk->Pz() + pionmass*pionmass)));
@@ -285,8 +277,6 @@ void AliJCDijetAna::CalculateJets(TClonesArray *inList, AliJCDijetHistos *fhisto
             }
         }
     }
-    fhistos->fh_nch[lCBin]->Fill(chparticles.size());
-    if(chparticles.size()==0) return; // We are not intereted in empty events.
 
     //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
     // Run the clustering, Reconstruct jets
@@ -295,7 +285,31 @@ void AliJCDijetAna::CalculateJets(TClonesArray *inList, AliJCDijetHistos *fhisto
     cs_bge.reset(new fastjet::ClusterSequenceArea(ktchparticles, jet_def_bge, area_def_bge));
 
     rawJets   = fastjet::sorted_by_pt(cs->inclusive_jets(MinJetPt)); // APPLY Min pt cut for jet
+
+    // For MC runs: If we find jets with over 4 times pt_hard bin, reject the event.
+    if( fptHardBin!=0 && rawJets.size()>0 && rawJets.at(0).pt() > fptHardBin*4 ) {
+        fhistos->fh_events[lCBin]->Fill("pt_hard bin cuts",1.0);
+        return -1;
+    }
+    fhistos->fh_randConeEtaPhi[lCBin]->Fill(randConeEta,randConePhi);
+
     rawKtJets = fastjet::sorted_by_pt(cs_bge->inclusive_jets(0.0)); // APPLY Min pt cut for jet
+
+    fhistos->fh_events[lCBin]->Fill("particles",noTracks);
+    for (utrack = 0; utrack < chparticles.size(); utrack++) {
+        fhistos->fh_events[lCBin]->Fill("acc. particles",1.0);
+        pt = chparticles.at(utrack).pt();
+        eta = chparticles.at(utrack).eta();
+        phi = chparticles.at(utrack).phi();
+        fhistos->fh_eta[lCBin]->Fill(eta);
+        fhistos->fh_phi[lCBin]->Fill(phi);
+        fhistos->fh_etaPhi[lCBin]->Fill(eta,phi);
+        fhistos->fh_pt[lCBin]->Fill(pt);
+        if(eta>0.0) fhistos->fh_ptPosEta[lCBin]->Fill(pt);
+        else        fhistos->fh_ptNegEta[lCBin]->Fill(pt);
+    }
+    fhistos->fh_nch[lCBin]->Fill(chparticles.size());
+    if(chparticles.size()==0) return 0; // We are not intereted in empty events.
 
     // Here one can choose to calculate background from kt jets which has left out the dijet with
     // delta phi cut used.
@@ -337,6 +351,7 @@ void AliJCDijetAna::CalculateJets(TClonesArray *inList, AliJCDijetHistos *fhisto
     fhistos->fh_deltaPt[lCBin]->Fill(fDeltaPt);
 
     bEvtHasAreaInfo = true;
+    return 0;
 }
 
 // If user wants to add jets from outside this function can be used.
@@ -344,6 +359,7 @@ void AliJCDijetAna::SetJets(vector<fastjet::PseudoJet> jetsOutside) {
     ResetObjects();
     rawJets = fastjet::sorted_by_pt(jetsOutside);
     bEvtHasAreaInfo = false;
+    return;
 }
 
 //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -555,6 +571,7 @@ void AliJCDijetAna::FillJetsDijets(AliJCDijetHistos *fhistos, int lCBin) {
             }
         }
     }
+    return;
 }
 
 // Response matrices are calculated in this function.
@@ -788,6 +805,7 @@ void AliJCDijetAna::ResetObjects() {
     bHasDeltaPhiDijet = false;
     bHasDeltaPhiSubLeadJet = false;
     bEvtHasAreaInfo = false;
+    return;
 }
 
 double AliJCDijetAna::DeltaR(fastjet::PseudoJet jet1, fastjet::PseudoJet jet2) {
@@ -884,6 +902,7 @@ void AliJCDijetAna::InitHistos(AliJCDijetHistos *histos, bool bIsMC, int nCentBi
         histos->fh_events[iBin]->Fill("kt dijets leading cut",0.0);
         histos->fh_events[iBin]->Fill("kt acc. dijets",0.0);
         histos->fh_events[iBin]->Fill("kt deltaphi cut dijets",0.0);
+        histos->fh_events[iBin]->Fill("pt_hard bin cuts",0.0);
         if(bIsMC) {
             histos->fh_responseInfo->Fill("True jet has pair",0.0);
             histos->fh_responseInfo->Fill("True jet has no pair",0.0);
@@ -898,5 +917,6 @@ void AliJCDijetAna::InitHistos(AliJCDijetHistos *histos, bool bIsMC, int nCentBi
             histos->fh_responseInfo->Fill("Dijet DPhi true not found",0.0);
         }
     }
+    return;
 }
 #endif

--- a/PWGCF/Correlations/JCORRAN/Pro/AliJCDijetAna.h
+++ b/PWGCF/Correlations/JCORRAN/Pro/AliJCDijetAna.h
@@ -58,8 +58,9 @@ class AliJCDijetAna : public TObject
                          double lmatchingR,
                          double ltrackingIneff);
 
-        void CalculateJets(TClonesArray *inList, AliJCDijetHistos *fhistos, int lCBin);
+        int CalculateJets(TClonesArray *inList, AliJCDijetHistos *fhistos, int lCBin);
         void SetJets(vector<fastjet::PseudoJet> jetsOutside);
+        void SetPtHardBin(double flptHardBin) {fptHardBin = flptHardBin; }
         void FillJetsDijets(AliJCDijetHistos *fhistos, int lCBin);
         void CalculateResponse(AliJCDijetAna *anaDetMC, AliJCDijetHistos *fhistos);
         void ResetObjects();
@@ -101,6 +102,7 @@ class AliJCDijetAna : public TObject
         bool bHasDeltaPhiSubLeadJet;
         TRandom3 *randomGenerator;
         double fDeltaPt;
+        double fptHardBin;
 
 #if !defined(__CINT__) && !defined(__MAKECINT__)
         vector<fastjet::PseudoJet> chparticles;

--- a/PWGCF/Correlations/JCORRAN/Pro/AliJCDijetHistos.cxx
+++ b/PWGCF/Correlations/JCORRAN/Pro/AliJCDijetHistos.cxx
@@ -198,6 +198,7 @@ void AliJCDijetHistos::CreateEventTrackHistos(){
     // 27: Number of kt-dijets after leading pt cut
     // 28: Number of accepted kt-dijets
     // 29: Number of accepted kt-dijets with delta phi cut
+    // 30: Number of MC events discarded because of pt_jet > 4*pt_hard
     fh_events
         << TH1D("h_events", "h_events", 40, 0.0, 40.0 )
         << fHistCentBin

--- a/PWGCF/Correlations/JCORRAN/Pro/AliJCDijetTask.cxx
+++ b/PWGCF/Correlations/JCORRAN/Pro/AliJCDijetTask.cxx
@@ -319,40 +319,11 @@ void AliJCDijetTask::UserExec(Option_t* /*option*/)
     if(fDebug > 5) cout << "------- AliJCDijetTask Exec-------"<<endl;
     if(!((Entry()-1)%1000))  AliInfo(Form(" Processing event # %lld",  Entry())); 
     if( fJCatalystTask->GetJCatalystEntry() != fEntry) return;
-    fhistos->fh_eventSel->Fill("catalyst entry ok",1.0);
-    if( !fJCatalystTask->GetIsGoodEvent() ) return;
-    fhistos->fh_eventSel->Fill("catalyst ok",1.0);
-
-    if(flags & DIJET_VERTEX13PA) {
-        if(!fUtils->IsVertexSelected2013pA(InputEvent())) return;
-        fhistos->fh_eventSel->Fill("vertex2013pA ok",1.0);
-    }
-
-    if(flags & DIJET_PILEUPSPD) {
-        if(InputEvent()->IsPileupFromSPD(3,0.6,3,2,5)) return;
-        fhistos->fh_eventSel->Fill("pileupSPD ok",1.0);
-    }
-
-    if(flags & DIJET_UTILSPILEUPSPD) {
-        if(fUtils->IsPileUpSPD(InputEvent())) return;
-        fhistos->fh_eventSel->Fill("utils pileupSPD ok",1.0);
-    }
 
     fCBin = AliJCDijetHistos::GetCentralityClass(fJCatalystTask->GetCentrality());
     fhistos->fh_centrality->Fill(fJCatalystTask->GetCentrality());
     if(fCBin == -1) return;
 
-    fhistos->fh_eventSel->Fill("events",1.0);
-    fhistos->fh_events[fCBin]->Fill("events",1.0);
-    fhistos->fh_zvtx->Fill(fJCatalystTask->GetZVertex());
-    
-    TClonesArray *fInputList = (TClonesArray*)fJCatalystTask->GetInputList();
-
-#if !defined(__CINT__) && !defined(__MAKECINT__)
-    //cout << "Next true level calculations:" << endl;
-    fana->CalculateJets(fInputList, fhistos, fCBin);
-    fana->FillJetsDijets(fhistos, fCBin);
-#endif
 
     if(fIsMC) {
         fhistosDetMC->fh_eventSel->Fill("events wo/ cuts",1.0);
@@ -380,6 +351,12 @@ void AliJCDijetTask::UserExec(Option_t* /*option*/)
         fhistosDetMC->fh_centrality->Fill(fJCatalystTask->GetCentrality());
         if(fCBinDetMC == -1) return;
 
+        AliMCEvent *mcEvent = MCEvent();
+        AliGenPythiaEventHeader *pythiaGenHeader = AliAnalysisHelperJetTasks::GetPythiaEventHeader(mcEvent);
+        fptHardBin = pythiaGenHeader->GetPtHard();
+        //cout << "fptHardBin: " << fptHardBin << endl;
+        fana->SetPtHardBin(fptHardBin);
+
         fhistosDetMC->fh_eventSel->Fill("events",1.0);
         fhistosDetMC->fh_events[fCBin]->Fill("events",1.0);
         fhistosDetMC->fh_zvtx->Fill(fJCatalystTask->GetZVertex());
@@ -388,10 +365,46 @@ void AliJCDijetTask::UserExec(Option_t* /*option*/)
 
 #if !defined(__CINT__) && !defined(__MAKECINT__)
         //cout << "Next det level calculations:" << endl;
-        fanaMC->CalculateJets(fInputListDetMC, fhistosDetMC, fCBinDetMC);
+        fDetMCFlag = fanaMC->CalculateJets(fInputListDetMC, fhistosDetMC, fCBinDetMC);
+        if(fDetMCFlag != 0) return;
         fanaMC->FillJetsDijets(fhistosDetMC, fCBinDetMC);
+#endif
+    }
 
-        // Here response matrix calculation.
+    fhistos->fh_eventSel->Fill("catalyst entry ok",1.0);
+    if( !fJCatalystTask->GetIsGoodEvent() ) return;
+    fhistos->fh_eventSel->Fill("catalyst ok",1.0);
+
+    if(flags & DIJET_VERTEX13PA) {
+        if(!fUtils->IsVertexSelected2013pA(InputEvent())) return;
+        fhistos->fh_eventSel->Fill("vertex2013pA ok",1.0);
+    }
+
+    if(flags & DIJET_PILEUPSPD) {
+        if(InputEvent()->IsPileupFromSPD(3,0.6,3,2,5)) return;
+        fhistos->fh_eventSel->Fill("pileupSPD ok",1.0);
+    }
+
+    if(flags & DIJET_UTILSPILEUPSPD) {
+        if(fUtils->IsPileUpSPD(InputEvent())) return;
+        fhistos->fh_eventSel->Fill("utils pileupSPD ok",1.0);
+    }
+
+    fhistos->fh_eventSel->Fill("events",1.0);
+    fhistos->fh_events[fCBin]->Fill("events",1.0);
+    fhistos->fh_zvtx->Fill(fJCatalystTask->GetZVertex());
+    
+    TClonesArray *fInputList = (TClonesArray*)fJCatalystTask->GetInputList();
+
+#if !defined(__CINT__) && !defined(__MAKECINT__)
+    //cout << "Next true level calculations:" << endl;
+    fana->CalculateJets(fInputList, fhistos, fCBin);
+    fana->FillJetsDijets(fhistos, fCBin);
+#endif
+
+    // Here response matrix calculation.
+    if(fIsMC) {
+#if !defined(__CINT__) && !defined(__MAKECINT__)
         fana->CalculateResponse(fanaMC,fhistosDetMC);
 #endif
     }

--- a/PWGCF/Correlations/JCORRAN/Pro/AliJCDijetTask.h
+++ b/PWGCF/Correlations/JCORRAN/Pro/AliJCDijetTask.h
@@ -24,6 +24,9 @@
 #include <AliJCatalystTask.h>
 #include "AliJCDijetHistos.h"
 #include "AliJCDijetAna.h"
+#include "AliMCEvent.h"
+#include "AliGenPythiaEventHeader.h"
+#include "AliAnalysisHelperJetTasks.h"
 
 
 
@@ -116,6 +119,8 @@ class AliJCDijetTask : public AliAnalysisTaskSE {
         TDirectory     *fOutput; // Output directory
         UInt_t flags; //
         AliAnalysisUtils *fUtils; //!
+        double fptHardBin;
+        int fDetMCFlag;
 
         ClassDef(AliJCDijetTask, 1); 
 };


### PR DESCRIPTION
Detector MC events with jets with pt>4*pt_hard are not processed. This
required a bit code reorganizing so that no histograms are filled before
this check is done.