### PR TITLE
FemtoDream: use PDG masses for kstar vs inv.mass

### DIFF
--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamControlSample.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamControlSample.cxx
@@ -165,7 +165,8 @@ void AliFemtoDreamControlSample::CorrelatedSample(
       RelativeK = fHigherMath->FillSameEvent(HistCounter, fMult, fCent,
                                              *itPart1, PDGPart1,
                                              *itPart2, PDGPart2);
-      fHigherMath->MassQA(HistCounter, RelativeK, *itPart1, *itPart2);
+      fHigherMath->MassQA(HistCounter, RelativeK, *itPart1, PDGPart1,
+                                                  *itPart2, PDGPart2);
       fHigherMath->SEDetaDPhiPlots(HistCounter, *itPart1, PDGPart1, *itPart2,
                                    PDGPart2, RelativeK, true);
 

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCorrHists.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCorrHists.cxx
@@ -1029,7 +1029,7 @@ AliFemtoDreamCorrHists::AliFemtoDreamCorrHists(AliFemtoDreamCollConfig *conf,
           TString MassQANamePart2 = TString::Format("MassQA_Particle%d_2", iPar2);
           TString MassQANamePart3 = TString::Format("InvMassQA_Particle%d_Particle%d",
                                          iPar1, iPar2);  //???????
-          TString MassQANamePart4 = TString::Format("InvMassKstarQA_Particle%d_Particle%d",
+          TString MassQANamePart4 = TString::Format("PDGInvMassKstarQA_Particle%d_Particle%d",
                                          iPar1, iPar2);  //???????
 
           const float massPart1 = TDatabasePDG::Instance()->GetParticle(
@@ -1069,10 +1069,10 @@ AliFemtoDreamCorrHists::AliFemtoDreamCorrHists(AliFemtoDreamCollConfig *conf,
           fPairQA[Counter]->Add(fPairInvMassQAD[Counter]);
 
           fPairInvMassKstarQAD[Counter] = new TH2F(MassQANamePart4.Data(),
-                                              MassQANamePart4.Data(), 100,
+                                              MassQANamePart4.Data(), 500,
                                               massPart1 + massPart2,
-                                              4 * (massPart1 + massPart2),
-                                              *itNBins, *itKMin, *itKMax);
+                                              1.5 * (massPart1 + massPart2),
+                                              *itNBins / 2, *itKMin, *itKMax / 2.);
           fPairInvMassKstarQAD[Counter]->GetXaxis()->SetTitle(
               TString::Format("InvMass_{Particle %d_1}_{Particle %d_2} (GeV/#it{c}^{2})",
                    iPar1, iPar2));
@@ -1085,7 +1085,7 @@ AliFemtoDreamCorrHists::AliFemtoDreamCorrHists(AliFemtoDreamCollConfig *conf,
           TString MEMassQANamePart2 = TString::Format("MEMassQA_Particle%d_2", iPar2);
           TString MEMassQANamePart3 = TString::Format("InvMEMassQA_Particle%d_Particle%d",
                                          iPar1, iPar2);  //???????
-          TString MEMassQANamePart4 = TString::Format("InvMEMassKstarQA_Particle%d_Particle%d",
+          TString MEMassQANamePart4 = TString::Format("PDGInvMEMassKstarQA_Particle%d_Particle%d",
                                          iPar1, iPar2);  //???????
 
           fMEMassQADistPart1[Counter] = new TH2F(MEMassQANamePart1.Data(),
@@ -1120,10 +1120,10 @@ AliFemtoDreamCorrHists::AliFemtoDreamCorrHists(AliFemtoDreamCollConfig *conf,
           fPairQA[Counter]->Add(fPairInvMEMassQAD[Counter]);
 
           fPairInvMEMassKstarQAD[Counter] = new TH2F(MEMassQANamePart4.Data(),
-                                              MEMassQANamePart4.Data(), 100,
+                                              MEMassQANamePart4.Data(), 500,
                                               massPart1 + massPart2,
-                                              4 * (massPart1 + massPart2),
-                                              *itNBins, *itKMin, *itKMax);
+                                              1.5 * (massPart1 + massPart2),
+                                              *itNBins / 2, *itKMin, *itKMax / 2.);
           fPairInvMEMassKstarQAD[Counter]->GetXaxis()->SetTitle(
               TString::Format("InvMass_{Particle %d_1}_{Particle %d_2} (GeV/#it{c}^{2})",
                    iPar1, iPar2));

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCorrHists.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCorrHists.h
@@ -174,8 +174,7 @@ class AliFemtoDreamCorrHists {
     }
   }
 
-  void FillPairInvMassQAD(int i, float kstar,
-                          AliFemtoDreamBasePart &part1,
+  void FillPairInvMassQAD(int i, AliFemtoDreamBasePart &part1,
                           AliFemtoDreamBasePart &part2) {
     if (!fMinimalBooking) {
       if (fPairInvMassQAD[i]) {
@@ -189,12 +188,10 @@ class AliFemtoDreamCorrHists {
         TLorentzVector trackSum = trackPos + trackNeg;
 
         fPairInvMassQAD[i]->Fill(trackSum.M());
-        fPairInvMassKstarQAD[i]->Fill(trackSum.M(), kstar);
       }
     }
   }
-  void FillPairInvMEMassQAD(int i, float kstar,
-                          AliFemtoDreamBasePart &part1,
+  void FillPairInvMEMassQAD(int i, AliFemtoDreamBasePart &part1,
                           AliFemtoDreamBasePart &part2) {
     if (!fMinimalBooking) {
       if (fPairInvMEMassQAD[i]) {
@@ -208,6 +205,42 @@ class AliFemtoDreamCorrHists {
         TLorentzVector trackSum = trackPos + trackNeg;
 
         fPairInvMEMassQAD[i]->Fill(trackSum.M());
+      }
+    }
+  }
+
+  void FillPDGPairInvMassQAD(int i, float kstar,
+                          AliFemtoDreamBasePart &part1, float massPart1,
+                          AliFemtoDreamBasePart &part2, float massPart2) {
+    if (!fMinimalBooking) {
+      if (fPairInvMassQAD[i]) {
+        TVector3 momPart1 = part1.GetMomentum();
+        TVector3 momPart2 = part2.GetMomentum();
+        TLorentzVector trackPos, trackNeg;
+        trackPos.SetXYZM(momPart1.Px(), momPart1.Py(), momPart1.Pz(),
+                         massPart1);
+        trackNeg.SetXYZM(momPart2.Px(), momPart2.Py(), momPart2.Pz(),
+                         massPart2);
+        TLorentzVector trackSum = trackPos + trackNeg;
+
+        fPairInvMassKstarQAD[i]->Fill(trackSum.M(), kstar);
+      }
+    }
+  }
+  void FillPDGPairInvMEMassQAD(int i, float kstar,
+                          AliFemtoDreamBasePart &part1, float massPart1,
+                          AliFemtoDreamBasePart &part2, float massPart2) {
+    if (!fMinimalBooking) {
+      if (fPairInvMEMassQAD[i]) {
+        TVector3 momPart1 = part1.GetMomentum();
+        TVector3 momPart2 = part2.GetMomentum();
+        TLorentzVector trackPos, trackNeg;
+        trackPos.SetXYZM(momPart1.Px(), momPart1.Py(), momPart1.Pz(),
+                         massPart1);
+        trackNeg.SetXYZM(momPart2.Px(), momPart2.Py(), momPart2.Pz(),
+                         massPart2);
+        TLorentzVector trackSum = trackPos + trackNeg;
+
         fPairInvMEMassKstarQAD[i]->Fill(trackSum.M(), kstar);
       }
     }

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamHigherPairMath.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamHigherPairMath.cxx
@@ -210,19 +210,29 @@ float AliFemtoDreamHigherPairMath::FillSameEvent(int iHC, int Mult, float cent,
 }
 
 void AliFemtoDreamHigherPairMath::MassQA(int iHC, float RelK,
-                                         AliFemtoDreamBasePart &part1,
-                                         AliFemtoDreamBasePart &part2) {
+                                         AliFemtoDreamBasePart &part1, int PDGPart1,
+                                         AliFemtoDreamBasePart &part2, int PDGPart2) {
   if (fWhichPairs.at(iHC) && fHists->GetDoMassQA()) {
+    const float massPart1 = TDatabasePDG::Instance()->GetParticle(
+              PDGPart1)->Mass();
+    const float massPart2 = TDatabasePDG::Instance()->GetParticle(
+              PDGPart2)->Mass();
     fHists->FillMassQADist(iHC, RelK, part1.GetInvMass(), part2.GetInvMass());
-    fHists->FillPairInvMassQAD(iHC, RelK, part1, part2);
+    fHists->FillPairInvMassQAD(iHC, part1, part2);
+    fHists->FillPDGPairInvMassQAD(iHC, RelK, part1, massPart1, part2, massPart2);
   }
 }
 void AliFemtoDreamHigherPairMath::MEMassQA(int iHC, float RelK,
-                                         AliFemtoDreamBasePart &part1,
-                                         AliFemtoDreamBasePart &part2) {
+                                         AliFemtoDreamBasePart &part1, int PDGPart1,
+                                         AliFemtoDreamBasePart &part2, int PDGPart2) {
   if (fWhichPairs.at(iHC) && fHists->GetDoMassQA()) {
+    const float massPart1 = TDatabasePDG::Instance()->GetParticle(
+              PDGPart1)->Mass();
+    const float massPart2 = TDatabasePDG::Instance()->GetParticle(
+              PDGPart2)->Mass();
     fHists->FillMEMassQADist(iHC, RelK, part1.GetInvMass(), part2.GetInvMass());
-    fHists->FillPairInvMEMassQAD(iHC, RelK, part1, part2);
+    fHists->FillPairInvMEMassQAD(iHC, part1, part2);
+    fHists->FillPDGPairInvMEMassQAD(iHC, RelK, part1, massPart1, part2, massPart2);
   }
 }
 

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamHigherPairMath.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamHigherPairMath.h
@@ -38,10 +38,10 @@ class AliFemtoDreamHigherPairMath {
   void RecalculatePhiStar(AliFemtoDreamBasePart &part);
   float FillSameEvent(int iHC, int Mult, float cent, AliFemtoDreamBasePart& part1,
                       int PDGPart1, AliFemtoDreamBasePart& part2, int PDGPart2);
-  void MassQA(int iHC, float RelK, AliFemtoDreamBasePart &part1,
-              AliFemtoDreamBasePart &part2);
-  void MEMassQA(int iHC, float RelK, AliFemtoDreamBasePart &part1,
-              AliFemtoDreamBasePart &part2);
+  void MassQA(int iHC, float RelK, AliFemtoDreamBasePart &part1, int PDGPart1,
+              AliFemtoDreamBasePart &part2, int PDGPart2);
+  void MEMassQA(int iHC, float RelK, AliFemtoDreamBasePart &part1, int PDGPart1,
+              AliFemtoDreamBasePart &part2, int PDGPart2);
   void SEMomentumResolution(int iHC, AliFemtoDreamBasePart* part1, int PDGPart1,
                             AliFemtoDreamBasePart* part2, int PDGPart2,
                             float RelativeK);

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamZVtxMultContainer.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamZVtxMultContainer.cxx
@@ -101,7 +101,8 @@ void AliFemtoDreamZVtxMultContainer::PairParticlesSE(
                                                 *itPDGPar1,
                                                 part2,
                                                 *itPDGPar2);
-          HigherMath->MassQA(HistCounter, RelativeK, *itPart1, *itPart2);
+          HigherMath->MassQA(HistCounter, RelativeK, *itPart1, *itPDGPar1,
+                                                     *itPart2, *itPDGPar2);
           HigherMath->SEDetaDPhiPlots(HistCounter, *itPart1, *itPDGPar1,
                                       *itPart2, *itPDGPar2, RelativeK, false);
           HigherMath->SEMomentumResolution(HistCounter, &(*itPart1), *itPDGPar1,
@@ -162,8 +163,9 @@ void AliFemtoDreamZVtxMultContainer::PairParticlesME(
                 HistCounter, iMult, cent, *itPart1, *itPDGPar1,
                 *itPart2, *itPDGPar2,
                 AliFemtoDreamCollConfig::kNone);
-			
-			HigherMath->MEMassQA(HistCounter, RelativeK, *itPart1, *itPart2);
+
+            HigherMath->MEMassQA(HistCounter, RelativeK, *itPart1, *itPDGPar1,
+                                                         *itPart2, *itPDGPar2);
             HigherMath->MEDetaDPhiPlots(HistCounter, *itPart1, *itPDGPar1,
                                         *itPart2, *itPDGPar2, RelativeK, false);
             HigherMath->MEMomentumResolution(HistCounter, &(*itPart1),


### PR DESCRIPTION
o Put into new function to separate from 1D inclusive
  pair inv.mass with measured masses
o Change the scale and binning of kstar vs inv.mass hists