### PR TITLE
Quick bugfix for TPC variables

### DIFF
--- a/PWGLF/SPECTRA/PiKaPr/TPCTOFCascades/AliAnalysisPIDCascadeTrack.cxx
+++ b/PWGLF/SPECTRA/PiKaPr/TPCTOFCascades/AliAnalysisPIDCascadeTrack.cxx
@@ -260,6 +260,9 @@ AliAnalysisPIDCascadeTrack::Reset()
   //TPC
   fTPCdEdx = 0.;
   fTPCdEdxN = 0;
+  fTPCNcls = 0; 
+  fTPCNclsF = 0;
+  fTPCNcr = 0.;
   //TOF
   fTOFIndex = 0;
   fTOFLength = 0.;


### PR DESCRIPTION
Just forgot to include the new class members in the Reset() function.
This has now been fixed!