### PR TITLE
Add function updating the collection name

### DIFF
--- a/PWG/JETFW/AliJetContainer.cxx
+++ b/PWG/JETFW/AliJetContainer.cxx
@@ -12,8 +12,12 @@
  * about the suitability of this software for any purpose. It is          *
  * provided "as is" without express or implied warranty.                  *
  **************************************************************************/
+#include <iostream>
+#include <memory>
 
 #include <TClonesArray.h>
+#include <TObjArray.h>
+#include <TObjString.h>
 
 #include "AliVEvent.h"
 #include "AliLog.h"
@@ -179,6 +183,18 @@ void AliJetContainer::SetArray(const AliVEvent *event)
   // Set jet array
 
   AliEmcalContainer::SetArray(event);
+}
+
+void AliJetContainer::UpdateArrayName(){
+  TString tag = "Jet";
+  if(fClArrayName.Length()) {
+    // obtain tag from previous name
+    std::unique_ptr<TObjArray> arrnametoks(fClArrayName.Tokenize("_")); 
+    tag = static_cast<TObjString *>(arrnametoks->At(0))->String();
+  }
+  TString updateName = GenerateJetName(fJetType, fJetAlgorithm, fRecombinationScheme, fJetRadius, fParticleContainer, fClusterContainer, tag);
+  std::cout << "[AliJetContainer] Update collection name of the jet container to " << updateName << std::endl;
+  SetArrayName(updateName);
 }
 
 /**

--- a/PWG/JETFW/AliJetContainer.h
+++ b/PWG/JETFW/AliJetContainer.h
@@ -189,6 +189,16 @@ class AliJetContainer : public AliParticleContainer {
   AliClusterContainer        *GetClusterContainer() const                    {return fClusterContainer;}
   Double_t                    GetFractionSharedPt(const AliEmcalJet *jet, AliParticleContainer *cont2 = 0x0) const;
 
+  /**
+   * @brief Regenerate jet collection name and update in AliEmcalContainer
+   * 
+   * This only updates the name of the array of the jet collection the container is
+   * subscribing to. The container name stays unmodified. Intended to be called at
+   * runtime in case relevant entries in the associated particle or cluster collection 
+   * change after the jet collection is created (i.e. in the wagon configuration).
+   */
+  void                        UpdateArrayName();
+
   const char*                 GetTitle() const;
 
   static TString              GenerateJetName(EJetType_t jetType, EJetAlgo_t jetAlgo, ERecoScheme_t recoScheme, Double_t radius, AliParticleContainer* partCont, AliClusterContainer* clusCont, TString tag);


### PR DESCRIPTION
Function regenerating the collection name from the
settings in the jet container and the connected
constituent level containers (particles and clusters).
Intended to be called at runtime or after changes in the
wagon customization.