### PR TITLE
Added dE/dx calibration parameters for 2018 data

### DIFF
--- a/PWGLF/SPECTRA/PiKaPr/TPC/rTPC/AliAnalysisTaskSpectraRT.cxx
+++ b/PWGLF/SPECTRA/PiKaPr/TPC/rTPC/AliAnalysisTaskSpectraRT.cxx
@@ -1818,9 +1818,12 @@ double AliAnalysisTaskSpectraRT::EtaCalibration(const double &eta){
 	}else if(strcmp(fPeriod,"16k")==0){
 		aPos = 49.9421; bPos = 2.3446; cPos = -41.2765; dPos = 279.695; ePos = -1027.73; fPos = 2022.84; gPos = -1967.79; hPos = 738.823;
 		aNeg = 50.0477; bNeg = 8.27344; cNeg = 125.29;  dNeg = 736.8;   eNeg = 2057.75;  fNeg = 2935.38; gNeg = 2064.03;  hNeg = 565.983;
-	}else{
+	}else if(strcmp(fPeriod,"16deghijop")==0){
 		aPos = 49.9743; bPos = 2.3388; cPos = -44.1496; dPos = 296.029; ePos = -1056.56; fPos = 2031.44; gPos = -1946.51; hPos = 723.89;
 		aNeg = 50.0329; bNeg = 6.99747; cNeg = 107.168;  dNeg = 649.001; eNeg = 1875.17;  fNeg = 2785.78; gNeg = 2063.77;  hNeg = 606.868;
+	}else{
+		aPos = 49.6975; bPos = 2.32535; cPos = -42.6516; dPos = 283.058; ePos = -1009.58; fPos = 1945.89; gPos = -1871.23; hPos = 698.552;
+		aNeg = 49.8071; bNeg = 9.78466; cNeg = 120.018;  dNeg = 603.325; eNeg = 1470.92;  fNeg = 1819.63; gNeg = 1073.82;  hNeg = 230.142;
 	}
 
 	for(int i=0; i<8; ++i)
@@ -1871,9 +1874,12 @@ double AliAnalysisTaskSpectraRT::EtaCalibrationEl(const double &eta){
 	}else if(strcmp(fPeriod,"16k")==0){
 		aPos = 80.254; bPos = 6.37076; cPos = -50.9878; dPos = 116.611; ePos = -79.0483;
 		aNeg = 79.8728; bNeg = -3.08265; cNeg = -11.3778; dNeg = -20.6605; eNeg = -12.3861;
-	}else{
+	}else if(strcmp(fPeriod,"16deghijop")==0){
 		aPos = 80.0719; bPos = 7.10053; cPos = -42.4788; dPos = 86.1074; ePos = -54.0891;
 		aNeg = 79.6155; bNeg = -12.1254; cNeg = -66.2488; dNeg = -132.426; eNeg = -85.0155;
+	}else{
+		aPos = 79.7726; bPos = 6.83744; cPos = -40.0469; dPos = 78.987; ePos = -50.1373;
+		aNeg = 79.4863; bNeg = -5.00403; cNeg = -21.6184;  dNeg = -39.1295; eNeg = -24.8757;
 	}
 
 	for(int i=0; i<5; ++i)


### PR DESCRIPTION
Added the dE/dx calibration parameters for the 2018 data. This is relevant for the rTPC analysis