### PR TITLE
Fixes for XicTopKpi task

### DIFF
--- a/PWGHF/vertexingHF/AliAnalysisTaskSEXicTopKpi.h
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSEXicTopKpi.h
@@ -371,6 +371,11 @@ class AliAnalysisTaskSEXicTopKpi : public AliAnalysisTaskSE
   // double to change the min pT for the soft pion
   Double_t fMinPtSoftPion;  // !
 
+  // histogram to look at the vtx_z in MC
+  TH1D* fZvtx_gen_within10_MC; //!<!
+  TH1D* fZvtx_gen_noSel10_MC; //!<!
+  TH1D* fZvtx_reco_noSel10_MC; //!<!
+
   /// \cond CLASSIMP
   ClassDef(AliAnalysisTaskSEXicTopKpi,15); /// AliAnalysisTaskSE for Xic->pKpi
   /// \endcond


### PR DESCRIPTION
 - event selection in MC fixed: events having generated primary vertex with |vtx_z|<10cm rejected for both gen. and reco. candidates (main fix)
 - enlarge the pT range from 16 GeV/c to 24 GeV/c for reconstructed pKpi candidates
 - monitoring histograms for vtx_z added
 - missing delete command for a dynamic array in the UserExec added