### PR TITLE
Fill TTrees Only if Set

### DIFF
--- a/PWGMM/Lumi/vdM/VdmStability/AddTask_ilofnes_Vdm.C
+++ b/PWGMM/Lumi/vdM/VdmStability/AddTask_ilofnes_Vdm.C
@@ -1,4 +1,4 @@
-AliAnalysisTaskVdmStability* AddTask_ilofnes_Vdm(TString name = "name", char *year = "16") {
+AliAnalysisTaskVdmStability* AddTask_ilofnes_Vdm(TString name = "name", char *year = "16", Bool_t fillTTree = false) {
     
     AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
   
@@ -11,6 +11,7 @@ AliAnalysisTaskVdmStability* AddTask_ilofnes_Vdm(TString name = "name", char *ye
     if (year == "16") task->SetNRuns(627);
     if (year == "17") task->SetNRuns(816);
     task->SetNCases(20);
+    task->SetFillTTree(fillTTree);
 
     // add your task to the manager
     mgr->AddTask(task);

--- a/PWGMM/Lumi/vdM/VdmStability/AliAnalysisTaskVdmStability.cxx
+++ b/PWGMM/Lumi/vdM/VdmStability/AliAnalysisTaskVdmStability.cxx
@@ -56,7 +56,8 @@ fEventStatV0(0x0),
 fEventStatT0(0x0),
 fEventTree(0x0),
 fNRuns(1000),
-fNSelectionCases(20)
+fNSelectionCases(20),
+fFillTTree(false)
 {
     // ROOT IO constructor, don't allocate memory here!
 }
@@ -82,7 +83,8 @@ fEventStatV0(0x0),
 fEventStatT0(0x0),
 fEventTree(0x0),
 fNRuns(1000),
-fNSelectionCases(20)
+fNSelectionCases(20),
+fFillTTree(false)
 {
     DefineInput(0, TChain::Class());
     DefineOutput(1, TList::Class());    //TList of event statistics
@@ -97,7 +99,6 @@ AliAnalysisTaskVdmStability::~AliAnalysisTaskVdmStability()
     if(fEventStatT0)       { delete fEventStatT0;       fEventStatT0=0; }
     if (fEventTree)         { delete fEventTree;        fEventTree=0; }
     for (Int_t i=0; i<20; ++i) {
-
       if (v0_H[i])         		{ delete v0_H[i]; }
       if (t0_H[i])         		{ delete t0_H[i]; }
       if (v0_Timing[i])         { delete v0_Timing[i]; }
@@ -184,7 +185,7 @@ void AliAnalysisTaskVdmStability::UserCreateOutputObjects()
     
     // add the list to our output file
     PostData(1,&fOutputList);
-    PostData(2,fEventTree);
+    if (fFillTTree) PostData(2,fEventTree);
 }
 
 //Event loop
@@ -491,10 +492,10 @@ void AliAnalysisTaskVdmStability::UserExec(Option_t *)
 	}
     
     //Fill tree with event information
-    fEventTree->Fill();
+    if (fFillTTree) fEventTree->Fill();
     
     PostData(1,&fOutputList);
-    PostData(2,fEventTree);
+    if (fFillTTree) PostData(2,fEventTree);
     
 }
 

--- a/PWGMM/Lumi/vdM/VdmStability/AliAnalysisTaskVdmStability.h
+++ b/PWGMM/Lumi/vdM/VdmStability/AliAnalysisTaskVdmStability.h
@@ -35,6 +35,7 @@ public:
     
     void SetNRuns(Int_t n){ fNRuns = n;}
     void SetNCases(Int_t c){ fNSelectionCases = c;}
+    void SetFillTTree(Bool_t set){ fFillTTree = set;}
     
 private:
     // bits toggled in the fEventTag data member
@@ -71,6 +72,7 @@ private:
     
     Int_t fNRuns;						//
     Int_t fNSelectionCases;				//
+    Bool_t fFillTTree;					//
     TH1D* v0_H[20];						//!
 	TH1D* t0_H[20];						//!
 	TH2D* v0_Timing[20];					//!


### PR DESCRIPTION
Really small changes applied. Now the TTrees will only be filled if someone wants to check something offline, otherwise it will not be filled. This will reduce the total output for quick and well known checks.