### PR TITLE
Added a Pt selection cut for charged pions

### DIFF
--- a/PWGUD/UPC/AliAnalysisTaskUpcFourPi.cxx
+++ b/PWGUD/UPC/AliAnalysisTaskUpcFourPi.cxx
@@ -1333,7 +1333,8 @@ void AliAnalysisTaskUpcFourPi::RunAODhist()
 				fHistNeventsFourPicharge->Fill(2);
 
 				vCandidateCharged = vPion[0] + vPion[1] + vPion[2] + vPion[3];
-
+				
+				if (vCandidateCharged.Pt() <0.11)
 				fAllChargedFourPion->Fill(vCandidateCharged.M());
 
 			}


### PR DESCRIPTION
Added line 1337 "if (vCandidateCharged.Pt() <0.11)". Adding transverse momentum selection cut for charged pions. 