### PR TITLE
PWGGA/GammaConv: implemented merging studies in GammaCalo tasks 

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskElectronStudies.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskElectronStudies.h
@@ -78,6 +78,9 @@ class AliAnalysisTaskElectronStudies : public AliAnalysisTaskSE{
     void SetMinClsTPC(Int_t mincls){
         fMinClsTPC = mincls;
     }
+    void SetMinFracClsTPC(Double_t mincls){
+        fMinFracClsTPC = mincls;
+    }
     void SetMinClsITS(Int_t mincls){
         fMinClsITS = mincls;
     }
@@ -95,6 +98,10 @@ class AliAnalysisTaskElectronStudies : public AliAnalysisTaskSE{
     }
     void SetMaxNSigmaElec(Double_t nsigma){
         fMaxNsigmaElec = nsigma;
+    }
+    void SetMaxDCA(Double_t DCAxy, Double_t DCAz){
+        fMaxDCAxy = DCAxy;
+        fMaxDCAz = DCAz;
     }
     void SetUseRTrackMatching(Bool_t b){
         fUseRTrackMatching = b;
@@ -133,6 +140,7 @@ class AliAnalysisTaskElectronStudies : public AliAnalysisTaskSE{
     
     // Track cuts
     Int_t                       fMinClsTPC;  // 
+    Double_t                    fMinFracClsTPC;  // 
     Double_t                    fChi2PerClsTPC;  // 
     Int_t                       fMinClsITS;  // 
     Double_t                    fEtaCut;  // 
@@ -140,6 +148,9 @@ class AliAnalysisTaskElectronStudies : public AliAnalysisTaskSE{
     Double_t                    fYMCCut;  // 
     Double_t                    fMinNsigmaElec; // only needed for signal histos
     Double_t                    fMaxNsigmaElec; // only needed for signal histos
+    
+    Double_t                    fMaxDCAxy; // 
+    Double_t                    fMaxDCAz; // 
 
     Double_t                    fMatchingParamsPhi[3];// [0] + (pt + [1])^[2]
     Double_t                    fMatchingParamsEta[3];//
@@ -212,7 +223,7 @@ class AliAnalysisTaskElectronStudies : public AliAnalysisTaskSE{
 
     AliAnalysisTaskElectronStudies(const AliAnalysisTaskElectronStudies&); // Prevent copy-construction
     AliAnalysisTaskElectronStudies& operator=(const AliAnalysisTaskElectronStudies&); // Prevent assignment  
-    ClassDef(AliAnalysisTaskElectronStudies, 5);
+    ClassDef(AliAnalysisTaskElectronStudies, 6);
 };
 
 #endif

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.h
@@ -21,6 +21,12 @@
 #include <vector>
 #include <map>
 
+// simple struct used for merging studies
+typedef struct {
+  Int_t mesonID,clusID,daughterID,daughterPDG;
+  Float_t EClus,EFrac,ETrue,PtMeson,EtaMeson;
+} clusterLabel;
+
 class AliAnalysisTaskGammaCalo : public AliAnalysisTaskSE {
   public:
 
@@ -129,6 +135,10 @@ class AliAnalysisTaskGammaCalo : public AliAnalysisTaskSE {
     void SetTrackMatcherRunningMode(Int_t mode){fTrackMatcherRunningMode = mode;}
 
     void SetSoftAnalysis(Bool_t DoSoft)  {fDoSoftAnalysis = DoSoft;}
+
+    Int_t CheckClustersForMCContribution(Int_t mclabel, Bool_t leading = kFALSE);
+    Bool_t CheckSpecificClusterForMCContribution(Int_t mclabel, Int_t cluslabel);
+    Int_t CountPhotonsInCluster(Int_t cluslabel);
 
   protected:
     AliV0ReaderV1*        fV0Reader;                                            // basic photon Selection Task
@@ -418,7 +428,10 @@ class AliAnalysisTaskGammaCalo : public AliAnalysisTaskSE {
     TH2F**                 fHistoTruePi0JetFragmFunc;                            // Histogram to determine true pi0 fragmentation function
     TH2F**                 fHistoTruePi0JetFragmFuncZInvMass;                    // Histogram to determine true pi0 Inv Mass distribution with z
     TH2F**                 fHistoTrueEtaJetFragmFunc;                            // Histogram to determine true eta fragmentation function
-    TH2F**                 fHistoTrueEtaJetFragmFuncZInvMass;                    // Histogram to determine true eta Inv Mass distribution with z
+    TH2F**                 fHistoTrueEtaJetFragmFuncZInvMass;                    // Histogram to determine true eta Inv Mass distribution with z 
+    TH2F**                 fHistoMCPi0GenVsNClus;                                // pi0 produced on gen level vs Nclus for merging studies
+    TH2F**                 fHistoMCPi0GenFoundInOneCluster;                      // pi0 produced on gen level where both decay photons were found in same cluster (merged)
+    TH2F**                 fHistoMCPi0GenFoundInTwoCluster;                      // pi0 produced on gen level where both decay photons were found in different clusters
     TH1F**                 fHistoMCPi0JetInAccPt;                                // Histogram with weighted pi0 in a jet event in acceptance, pT
     TH1F**                 fHistoMCPi0inJetInAccPt;                              // Histogram with weighted pi0 in a jet in acceptance, pT
     TH1F**                 fHistoMCEtaJetInAccPt;                                // Histogram with weighted eta in a jet event in acceptance, pT
@@ -566,7 +579,7 @@ class AliAnalysisTaskGammaCalo : public AliAnalysisTaskSE {
     AliAnalysisTaskGammaCalo(const AliAnalysisTaskGammaCalo&);                  // Prevent copy-construction
     AliAnalysisTaskGammaCalo &operator=(const AliAnalysisTaskGammaCalo&);       // Prevent assignment
 
-    ClassDef(AliAnalysisTaskGammaCalo, 79);
+    ClassDef(AliAnalysisTaskGammaCalo, 80);
 };
 
 #endif

--- a/PWGGA/GammaConv/macros/AddTask_ElectronStudies.C
+++ b/PWGGA/GammaConv/macros/AddTask_ElectronStudies.C
@@ -51,27 +51,83 @@ void AddTask_ElectronStudies(
   Double_t                    fEtaCut = 0.9;  
   Double_t                    fPtCut= 0.5;  
   Double_t                    fYMCCut = 9999;  
+  Double_t                    fMaxDCAxy = 9999;  
+  Double_t                    fMaxDCAz = 9999;  
+  Double_t                    fMinFracClsTPC = 0;
 
   Double_t               fEtaMatch[3]={0.,0.,0.};
   Double_t                 fPhiMatch[3]={0.,0.,0.};
   Bool_t  fUseRTrackMatching = kTRUE;
   Double_t fRTrackMatching   = 0.01; 
-  if(trainConfig == 1){  // min bias (cuts from PCMEMC 84 + loose iso)
+  if(trainConfig == 1){  // min bias 
       TaskEventCutnumber                = "00010113";
-      TaskClusterCutnumberEMC           = "4117937060032000000";
+      TaskClusterCutnumberEMC           = "4117921060e32000000";
+                                         //411792106fe32220000 latest and greates
       TaskConvCutnumber                 = "0dm00009f9730000dge0404000";
-      TaskTMCut                         = "4117900002000000000";
+      TaskTMCut                         = "4117921062e32000000";
   } else if(trainConfig == 2){  // trigger
       TaskEventCutnumber                = "0008e113";
-      TaskClusterCutnumberEMC           = "4117937060032000000";
+      TaskClusterCutnumberEMC           = "4117921060e32000000";
       TaskConvCutnumber                 = "0dm00009f9730000dge0404000";
-      TaskTMCut                         = "4117900002000000000"; // only used for track mathing
+      TaskTMCut                         = "4117921062e32000000"; // only used for track mathing
 
   } else if(trainConfig == 3){  // trigger
       TaskEventCutnumber                = "0008d113";
-      TaskClusterCutnumberEMC           = "4117937060032000000";
+      TaskClusterCutnumberEMC           = "4117921060e32000000";
       TaskConvCutnumber                 = "0dm00009f9730000dge0404000";
-      TaskTMCut                         = "4117900002000000000";
+      TaskTMCut                         = "4117921062e32000000";
+  // Same cluster cuts as default
+  // but trying to replicate track cuts used for electrons as close as possible
+  } else if(trainConfig == 4){  // mb
+      // Track cuts
+      fMinClsTPC = 80;  
+      fChi2PerClsTPC = 4;   
+      fMinClsITS = 3;  
+      fEtaCut = 0.8;  
+      fPtCut= 0.5;  
+      fYMCCut = 9999;  
+      fMaxDCAxy = 1;  
+      fMaxDCAz = 2;  
+      fMinFracClsTPC = 0.6;
+      // cluster cuts
+      TaskEventCutnumber                = "00010113";
+      TaskClusterCutnumberEMC           = "4117921060e32000000";
+                                         //411792106fe32220000 latest and greates
+      TaskConvCutnumber                 = "0dm00009f9730000dge0404000";
+      TaskTMCut                         = "4117921062e32000000";
+  } else if(trainConfig == 5){  // trigger
+      // Track cuts
+      fMinClsTPC = 80;  
+      fChi2PerClsTPC = 4;   
+      fMinClsITS = 3;  
+      fEtaCut = 0.8;  
+      fPtCut= 0.5;  
+      fYMCCut = 9999;  
+      fMaxDCAxy = 1;  
+      fMaxDCAz = 2;  
+      fMinFracClsTPC = 0.6;
+      // cluster cuts
+      TaskEventCutnumber                = "0008e113";
+      TaskClusterCutnumberEMC           = "4117921060e32000000";
+      TaskConvCutnumber                 = "0dm00009f9730000dge0404000";
+      TaskTMCut                         = "4117921062e32000000"; // only used for track mathing
+
+  } else if(trainConfig == 6){  // trigger
+      // Track cuts
+      fMinClsTPC = 80;  
+      fChi2PerClsTPC = 4;   
+      fMinClsITS = 3;  
+      fEtaCut = 0.8;  
+      fPtCut= 0.5;  
+      fYMCCut = 9999;  
+      fMaxDCAxy = 1;  
+      fMaxDCAz = 2;  
+      fMinFracClsTPC = 0.6;
+      // cluster cuts
+      TaskEventCutnumber                = "0008d113";
+      TaskClusterCutnumberEMC           = "4117921060e32000000";
+      TaskConvCutnumber                 = "0dm00009f9730000dge0404000";
+      TaskTMCut                         = "4117921062e32000000";
   } 
 
   TString clusterTypeString(TaskTMCut(0,1));
@@ -215,6 +271,8 @@ void AddTask_ElectronStudies(
   fQA->SetEtaCut(fEtaCut);
   fQA->SetMinPtCut(fPtCut);
   fQA->SetTrackMatcherName(TrackMatcherNameSignal);
+  fQA->SetMaxDCA(fMaxDCAxy,fMaxDCAz);
+  fQA->SetMinFracClsTPC(fMinFracClsTPC);
 
   fQA->SetEtaMatching(fEtaMatch[0],fEtaMatch[1],fEtaMatch[2]);
   fQA->SetPhiMatching(fPhiMatch[0],fPhiMatch[1],fPhiMatch[2]);


### PR DESCRIPTION
- implemented merging studies for EMCal cluster merging into GammaCalo tasks to be able to study merging on GRID. Wirll only e run if mesonQA>=10, so no effect on normal running
- implemented functions that iteratively search for cluster contributions from given MC particles (and all daughters)
- Electron studies cut changes. Change of NonLin to latest and greatest 21 & enabled exotics cut
- implemented new track cuts and configs that mimic the cuts used in other electron analyses (mainly addition of DCA and frac clus TPC cut)
- added proper naming scheme for ElectronStudies tree