### PR TITLE
PWGGA/GammaConv: refactor ProcessPhotonCandidates() take2

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvV1.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvV1.h
@@ -408,11 +408,13 @@ class AliAnalysisTaskGammaConvV1 : public AliAnalysisTaskSE {
     Bool_t                            fFileWasAlreadyReported;                    // to store if the current file was already marked broken
     TClonesArray*                     fAODMCTrackArray;                           //! pointer to track array
 
+    AliConversionPhotonCuts::TMapPhotonBool fMapPhotonHeaders;                   // map to remember if the photon tracks are from selected headers
+
   private:
 
     AliAnalysisTaskGammaConvV1(const AliAnalysisTaskGammaConvV1&); // Prevent copy-construction
     AliAnalysisTaskGammaConvV1 &operator=(const AliAnalysisTaskGammaConvV1&); // Prevent assignment
-    ClassDef(AliAnalysisTaskGammaConvV1, 52);
+    ClassDef(AliAnalysisTaskGammaConvV1, 53);
 };
 
 #endif

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvV1_PbPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvV1_PbPb.C
@@ -3729,6 +3729,29 @@ void AddTask_GammaConvV1_PbPb(
   } else if (trainConfig == 2000){
     cuts.AddCutPCM("10910a13","40200009327000008250400000","0163103100000000"); // BDT test
 
+    /// ________________ Pb-Pb 5.02 TeV Stephan configs ______________________________
+    //  next two configs for testing refactoring change
+    /* varying added particles parameters, two-photon cuts disabled since these get
+     * new semantics with the refactoring change */
+  } else if (trainConfig == 2500){ // == 681
+    cuts.AddCutPCM("10930d13","00000000000000000000000000","0153101100000000"); //
+    cuts.AddCutPCM("10930d13","0dm21109a4771c00amd1400002","0153101100000000"); //
+    cuts.AddCutPCM("10930d23","00000000000000000000000000","0153101100000000"); //
+    cuts.AddCutPCM("10930d23","0dm21109a4771c00amd1400001","0153101100000000"); //
+    cuts.AddCutPCM("10930d33","0dm21109a4771c00amd1400001","0153101100000000"); //
+    cuts.AddCutPCM("10930d33","0dm21109a4771c00amd1400002","0153101100000000"); //
+    cuts.AddCutPCM("10930d43","00000000000000000000000000","0153101100000000"); //
+    cuts.AddCutPCM("10930d43","0dm21109a4771c00amd1400002","0153101100000000"); //
+    // testing elecsharing and tooclose cuts
+    /* compare histograms visually with histos from before refactoring. For
+     * elecsharing cut there is a unit test in place. The TooClose cut's implementation is
+     * is almost identical to the elecsharing ones so we trust for the one unit test
+     * for both of these cuts */
+  } else if (trainConfig == 2501){ // == 681        xy x: elecsharing y: TooCloseCut
+    cuts.AddCutPCM("10910d13","00000000000000000000000000","0153101100000000"); //
+    cuts.AddCutPCM("10910d13","00000000000000000000410000","0153101100000000"); //
+    cuts.AddCutPCM("10910d13","00000000000000000000404000","0153101100000000"); //
+    cuts.AddCutPCM("10910d13","00000000000000000000414000","0153101100000000"); //
 
   } else {
     Error(Form("GammaConvV1_%i",trainConfig), "wrong trainConfig variable no cuts have been specified for the configuration");

--- a/PWGGA/GammaConv/macros/runTests_GammaConvROOT6.C
+++ b/PWGGA/GammaConv/macros/runTests_GammaConvROOT6.C
@@ -1,0 +1,77 @@
+#include "/Users/stephanstiefelmaier/work/projects/a_helper/usefullFunctions.C"
+
+#if !defined(__CINT__) || defined(__CLING__)
+#include "AliMCEventHandler.h"
+#include "AliESDInputHandler.h"
+#include "AliAODInputHandler.h"
+#include "AliAnalysisAlien.h"
+#include "AliAnalysisManager.h"
+
+R__ADD_INCLUDE_PATH($ALICE_PHYSICS)
+#include <PWGGA/GammaConv/macros/AddTask_V0Reader.C>
+#include <PWGGA/GammaConv/macros/AddTask_PhotonQA.C>
+#include <PWGGA/GammaConv/macros/AddTask_GammaConvV1_PbPb.C>
+
+#endif
+
+void PrintPhotons(AliConversionPhotonCuts::TMapPhotonBool &theMap){
+  cout << "printPhotons start\nGetTrackLabelPositive() GetTrackLabelNegative() GetChi2perNDF()\n";
+
+  for (auto it = theMap.begin(); it!= theMap.end(); ++it){
+    cout << it->first->GetTrackLabelPositive() << " " << it->first->GetTrackLabelNegative() << " " << it->first->GetChi2perNDF() << endl;
+  }
+ cout << "end\n";
+}
+
+Bool_t TestSharedElectronCut(AliConversionPhotonCuts &thePhotonCuts){
+
+  // define photon sample        x       x    x       x
+  vector<Int_t> posLabels     = {0,  2,  5,   2,  8,  7,  5 };
+  vector<Int_t> negLabels     = {1,  3,  1,   4,  7,  9, 12 };
+  vector<Double_t> chi2s      = {5., 4., 3.,  4., 8., 9., 1.};
+  vector<Bool_t> expectations = {1,  0,  1,   1,  0,  1,  0 }; // 1 means should get kicked if working as expected
+  Size_t nPhotons = posLabels.size();
+
+  // create photon sample
+  AliConversionPhotonCuts::TMapPhotonBool lSample_before;
+  AliConversionPhotonCuts::TMapPhotonBool lSample_targetAfter;
+
+  // lets contruct the AliAODConversionPhotons into a TClonesArray. This should (I hope) ensure
+  // a fixed order in memory of the photons each time this code runs
+  TClonesArray lArray("AliAODConversionPhoton", 100);
+  for (auto i : RangeFrom0(nPhotons)){
+
+    new(lArray[i]) AliAODConversionPhoton();
+    AliAODConversionPhoton *lPhot = dynamic_cast<AliAODConversionPhoton*>(lArray[i]);
+    lPhot->SetTrackLabels(posLabels[i], negLabels[i]);
+    lPhot->SetChi2perNDF(chi2s[i]);
+
+    lSample_before.insert({lPhot, kTRUE});
+    if (!expectations[i]){ lSample_targetAfter.insert({lPhot, kTRUE}); }
+  }
+
+  // check if indeed the order got preserved
+  Size_t i = 0;
+  for (const auto &iPhotBool : lSample_before){
+    if (iPhotBool.first != lArray[i]) { break; }
+    ++i;
+  }
+  if (i!=nPhotons) {
+    cout << "INFO: TestSharedElectronCut(): The order did not get preserved. If this test fails, this might be the reason.\n";
+  }
+
+  // apply cut
+  thePhotonCuts.RemovePhotonsWithSharedTracks(lSample_before);
+  lArray.Delete();
+
+  // check if the right photons were removed
+  return lSample_before==lSample_targetAfter;
+}
+
+
+void runTests_GammaConvROOT6(){
+
+  AliConversionPhotonCuts lPhotCuts;
+  cout << (TestSharedElectronCut(lPhotCuts) ? "TestSharedElectronCut OK." : "TestSharedElectronCut failed!" )  << endl;
+  return;
+}

--- a/PWGGA/GammaConvBase/AliConvEventCuts.cxx
+++ b/PWGGA/GammaConvBase/AliConvEventCuts.cxx
@@ -36,6 +36,7 @@
 #include "TF1.h"
 #include "TObjString.h"
 #include "AliMCEvent.h"
+#include "AliAODConversionPhoton.h"
 #include "AliAODEvent.h"
 #include "AliESDEvent.h"
 #include "AliCentrality.h"
@@ -6336,6 +6337,44 @@ void AliConvEventCuts::GetNotRejectedParticles(Int_t rejection, TList *HeaderLis
 
 }
 
+/* checks for a photon candidate if its tracks come from an accepted injector.
+ * return value kFALSE: photon gets discarded completely
+ *              kTRUE:  photon will get added to fGammaCandidates
+ *
+ * (only for return value kTRUE):
+ * theIsFromSelectedHeader=kTRUE:  photon will get processed fully (gamma histos will get filled)
+ * theIsFromSelectedHeader=kFALSE: will only get added to fGammaCandidates
+ *
+ * note: IsParticleFromBGEvent()>0 : particle comes from an injector on AliConvEventCuts::fHeaderList
+ *                              ==2: injector is first on that list */
+//________________________________________________________________________
+Bool_t AliConvEventCuts::PhotonPassesAddedParticlesCriterion(AliMCEvent             *theMCEvent,
+                                                             AliVEvent              *theInputEvent,
+                                                             AliAODConversionPhoton &thePhoton,
+                                                             Bool_t                 &theIsFromSelectedHeader)
+{
+  theIsFromSelectedHeader = kTRUE;
+  if (!fRejectExtraSignals) return kTRUE;
+
+  auto bothFromFirstHeader = [](Int_t thePos, Int_t theNeg){ return (thePos+theNeg)==4; };
+  Int_t lIsPosFromMBHeader = IsParticleFromBGEvent(thePhoton.GetMCLabelPositive(), theMCEvent, theInputEvent);
+
+  if (fRejectExtraSignals==3){
+    Int_t lIsNegFromMBHeader = IsParticleFromBGEvent(thePhoton.GetMCLabelNegative(), theMCEvent, theInputEvent);
+    theIsFromSelectedHeader = bothFromFirstHeader(lIsNegFromMBHeader, lIsPosFromMBHeader);
+  }
+  else{ // 1,2,4
+    if (!lIsPosFromMBHeader) return kFALSE;
+    Int_t lIsNegFromMBHeader = IsParticleFromBGEvent(thePhoton.GetMCLabelNegative(), theMCEvent, theInputEvent);
+    if (!lIsNegFromMBHeader) return kFALSE;
+
+    if (fRejectExtraSignals!=2) {
+      theIsFromSelectedHeader = bothFromFirstHeader(lIsNegFromMBHeader, lIsPosFromMBHeader);
+    }
+  }
+  return kTRUE;
+}
+
 //_________________________________________________________________________
 Int_t AliConvEventCuts::IsParticleFromBGEvent(Int_t index, AliMCEvent *mcEvent, AliVEvent *InputEvent, Int_t debug ){
 
@@ -6425,7 +6464,7 @@ TString AliConvEventCuts::GetParticleHeaderName(Int_t index, AliMCEvent *mcEvent
           // cout << "accepted:" << index << "\t header " << GeneratorName.Data() << endl;
           headername = GeneratorName;
         }
-        firstindex           = firstindex + gh->NProduced();   
+        firstindex           = firstindex + gh->NProduced();
       }
     }
     else if(InputEvent->IsA()==AliAODEvent::Class()){
@@ -6445,7 +6484,7 @@ TString AliConvEventCuts::GetParticleHeaderName(Int_t index, AliMCEvent *mcEvent
           if(index >= firstindex && index <= lastindex){
             headername = GeneratorName;
           }
-          firstindex           = firstindex + gh->NProduced();   
+          firstindex           = firstindex + gh->NProduced();
         }
       }
     }

--- a/PWGGA/GammaConvBase/AliConvEventCuts.h
+++ b/PWGGA/GammaConvBase/AliConvEventCuts.h
@@ -34,6 +34,7 @@ class AliAODMCParticle;
 class AliEMCALTriggerPatchInfo;
 class AliCaloTriggerMimicHelper;
 class AliV0ReaderV1;
+class AliAODConversionPhoton;
 
 /**
  * @class AliConvEventCuts
@@ -603,6 +604,12 @@ class AliConvEventCuts : public AliAnalysisCuts {
                                       AliVEvent *event = 0x0,
                                       Int_t debug = 0
                                    );
+
+      Bool_t PhotonPassesAddedParticlesCriterion(AliMCEvent             *theMCEvent,
+                                                 AliVEvent              *theInputEvent,
+                                                 AliAODConversionPhoton &thePhoton,
+                                                 Bool_t                 &theIsFromSelectedHeader); // future todo: make this const
+
       void    LoadWeightingFlatCentralityFromFile ();
       void    LoadWeightingMultiplicityFromFile ();
       void    LoadReweightingHistosMCFromFile ();

--- a/PWGGA/GammaConvBase/AliConversionPhotonCuts.cxx
+++ b/PWGGA/GammaConvBase/AliConversionPhotonCuts.cxx
@@ -60,8 +60,8 @@
 #include "AliDalitzEventMC.h"
 
 class iostream;
-
-using namespace std;
+using std::cout;
+using std::endl;
 
 /// \cond CLASSIMP
 ClassImp(AliConversionPhotonCuts)
@@ -185,7 +185,7 @@ AliConversionPhotonCuts::AliConversionPhotonCuts(const char *name,const char *ti
   fIncludeRejectedPsiPair(kFALSE),
   fCosPAngleCut(10000),
   fDoToCloseV0sCut(kFALSE),
-  fminV0Dist(200.),
+  fMinV0DistSquared(4000.),
   fDoSharedElecCut(kFALSE),
   fDoPhotonQualitySelectionCut(kFALSE),
   fDoPhotonQualityRejectionCut(kFALSE),
@@ -373,7 +373,7 @@ AliConversionPhotonCuts::AliConversionPhotonCuts(const AliConversionPhotonCuts &
   fIncludeRejectedPsiPair(ref.fIncludeRejectedPsiPair),
   fCosPAngleCut(ref.fCosPAngleCut),
   fDoToCloseV0sCut(ref.fDoToCloseV0sCut),
-  fminV0Dist(ref.fminV0Dist),
+  fMinV0DistSquared(ref.fMinV0DistSquared),
   fDoSharedElecCut(ref.fDoSharedElecCut),
   fDoPhotonQualitySelectionCut(ref.fDoPhotonQualitySelectionCut),
   fDoPhotonQualityRejectionCut(ref.fDoPhotonQualityRejectionCut),
@@ -2682,7 +2682,6 @@ void AliConversionPhotonCuts::PrintCutsWithValues() {
   if (fDoPhotonQualityRejectionCut) printf("\t rejection based on photon quality with quality %d \n", fPhotonQualityCut );
   if (fPhotonQualityCutTRD || fPhotonQualityCutTOF) printf("\t TRD quality: %d, TOF quality: %d\n", fPhotonQualityCutTRD, fPhotonQualityCutTOF);
   if (fDoDoubleCountingCut) printf("\t Reject doubly counted photons with R > 0., DeltaR < %3.2f, OpenAngle < %3.2f  \n", fDeltaR,fOpenAngle );
-
 }
 
 ///________________________________________________________________________
@@ -4475,19 +4474,19 @@ Bool_t AliConversionPhotonCuts::SetToCloseV0sCut(Int_t toClose) {
   switch(toClose){
   case 0:
     fDoToCloseV0sCut = kFALSE;
-    fminV0Dist = 250;
+    fMinV0DistSquared = TMath::Power(250., 2.);
     break;
   case 1:
     fDoToCloseV0sCut = kTRUE;
-    fminV0Dist = 1;
+    fMinV0DistSquared = TMath::Power(1., 2.);
     break;
   case 2:
     fDoToCloseV0sCut = kTRUE;
-    fminV0Dist = 2;
+    fMinV0DistSquared = TMath::Power(2., 2.);
     break;
   case 3:
     fDoToCloseV0sCut = kTRUE;
-    fminV0Dist = 3;
+    fMinV0DistSquared = TMath::Power(3., 2.);
     break;
   case 4:
     fDoToCloseV0sCut = kTRUE;
@@ -4826,7 +4825,7 @@ Bool_t AliConversionPhotonCuts::RejectToCloseV0s(AliAODConversionPhoton* photon,
     if (!fDoDoubleCountingCut){
       Double_t dist = pow((posX - posCompX),2)+pow((posY - posCompY),2)+pow((posZ - posCompZ),2);
 
-      if(dist < fminV0Dist*fminV0Dist){
+      if(dist < fMinV0DistSquared){
         if(photon->GetChi2perNDF() > photonComp->GetChi2perNDF()) return kFALSE;
       }
     }else{
@@ -4842,6 +4841,115 @@ Bool_t AliConversionPhotonCuts::RejectToCloseV0s(AliAODConversionPhoton* photon,
   return kTRUE;
 }
 
+/// --------------------- TItRemove implementation start -------------------------------------
+///________________________________________________________________________
+AliConversionPhotonCuts::TItRemove::TItRemove(TMapPhotonBool &theMap, TMapPhotonBool::iterator theIt) :
+ fMap(theMap),
+ fIt(theIt),
+ fRemoved(kFALSE)
+{
+  // todo: check if that check is actually necessary and remove if not
+  if (fIt->first->GetConversionRadius()<0){
+    cout << "Photon with conversion radius < 0. Removing from list of good photon candidates.\n";
+    fIt = fMap.erase(fIt);
+  }
+}
+
+///________________________________________________________________________
+void AliConversionPhotonCuts::TItRemove::Remove(){
+  //cout << "removing " << fIt->first->GetTrackLabelPositive() << " " << fIt->first->GetTrackLabelNegative() << " " << fIt->first->GetChi2perNDF() << endl;
+  fIt = fMap.erase(fIt);
+  fRemoved = kTRUE;
+}
+
+///________________________________________________________________________
+void AliConversionPhotonCuts::TItRemove::IncIfNotRemoved(){
+  if (!fRemoved) ++fIt;
+  fRemoved = kFALSE;
+}
+/// --------------------- TItRemove implementation end -------------------------------------
+
+///________________________________________________________________________
+void AliConversionPhotonCuts::RemovePhotonWithHigherChi2(TItRemove &theI1, TItRemove &theI2) const {
+  Bool_t lFstWorse = theI1.fIt->first->GetChi2perNDF() > theI2.fIt->first->GetChi2perNDF();
+  lFstWorse ? theI1.Remove() : theI2.Remove();
+}
+
+// Question: is it actually necessary to compare positive against negative tracks? (Was done so far like this but could be superflous I believe)
+/* Strategy: iterate over all pairs of photons in map: outer loop over all photons, inner loop over photons to the right.
+ * For photons ABCD this will look like:
+ * it1  it2
+ * A    B,C,D
+ * B      C,D
+ * C        D
+ * D    none
+ * For each pair P1P2 check if they share a track.
+ * If they do: If P1 has the higher chi2 kick out P1, otherwise kick out P2.
+ */
+///________________________________________________________________________
+void AliConversionPhotonCuts::RemovePhotonsWithSharedTracks(TMapPhotonBool &thePhotons) const {
+
+  // debug
+  //auto printPhoton = [](AliAODConversionPhoton *p){
+  //  cout << p->GetTrackLabelPositive() << " " << p->GetTrackLabelNegative() << " " << p->GetChi2perNDF() << " ";};
+
+  for (TItRemove i1(thePhotons, thePhotons.begin()); i1.fIt != thePhotons.end(); i1.IncIfNotRemoved()){
+    AliAODConversionPhoton *iPhoton1 = i1.fIt->first;
+
+    for (TItRemove i2(thePhotons, std::next(i1.fIt)); !(i1.fRemoved || i2.fIt == thePhotons.end()); i2.IncIfNotRemoved()){
+      AliAODConversionPhoton *iPhoton2 = i2.fIt->first;
+
+      //cout << "phot1: "; printPhoton(iPhoton1); cout << "phot2: "; printPhoton(iPhoton2); cout << endl;
+      if ( iPhoton1->GetTrackLabelPositive() == iPhoton2->GetTrackLabelPositive() ||
+           iPhoton1->GetTrackLabelPositive() == iPhoton2->GetTrackLabelNegative() ||
+           iPhoton1->GetTrackLabelNegative() == iPhoton2->GetTrackLabelPositive() ||
+           iPhoton1->GetTrackLabelNegative() == iPhoton2->GetTrackLabelNegative() )
+      {
+        RemovePhotonWithHigherChi2(i1, i2);
+      }
+    }
+  }
+}
+
+/* Strategy: iterate over all pairs of photons in map: outer loop over all photons, inner loop over photons to the right.
+ * For photons ABCD this will look like:
+ * it1  it2
+ * A    B,C,D
+ * B      C,D
+ * C        D
+ * D    none
+ * For each pair P1P2 check if it's good (meaning both photons can stay.) If it is not good, kick out the photon
+ * with the higher chi2. fDoDoubleCountingCut defines which one of two goodness criteria is applied.
+*/
+///________________________________________________________________________
+void AliConversionPhotonCuts::RemoveTooClosePhotons(TMapPhotonBool &thePhotons) const {
+
+  for (TItRemove i1(thePhotons, thePhotons.begin()); i1.fIt != thePhotons.end(); i1.IncIfNotRemoved()){
+    AliAODConversionPhoton *iPhoton1 = i1.fIt->first;
+
+    for (TItRemove i2(thePhotons, std::next(i1.fIt)); !(i1.fRemoved || i2.fIt == thePhotons.end()); i2.IncIfNotRemoved()){
+      AliAODConversionPhoton *iPhoton2 = i2.fIt->first;
+
+      if (fDoDoubleCountingCut){
+        TVector3 v1(iPhoton1->Px(),iPhoton1->Py(),iPhoton1->Pz());
+        TVector3 v2(iPhoton2->Px(),iPhoton2->Py(),iPhoton2->Pz());
+        if((v1.Angle(v2) < fOpenAngle) &&
+           (TMath::Abs(iPhoton2->GetConversionRadius()-iPhoton1->GetConversionRadius()) < fDeltaR))
+        {
+          RemovePhotonWithHigherChi2(i1, i2);
+        }
+      }
+      else{
+        TVector3 v1(iPhoton1->GetConversionX(), iPhoton1->GetConversionY(), iPhoton1->GetConversionZ());
+        TVector3 v2(iPhoton2->GetConversionX(), iPhoton2->GetConversionY(), iPhoton2->GetConversionZ());
+        if((v2 - v1).Mag2() < fMinV0DistSquared)
+        {
+          RemovePhotonWithHigherChi2(i1, i2);
+        }
+      }
+    }
+  }
+}
 
 ///________________________________________________________________________
 AliConversionPhotonCuts* AliConversionPhotonCuts::GetStandardCuts2010PbPb(){


### PR DESCRIPTION
commit message yet to be updated

This change reduces the complexity of AliConversionPhotonCuts::
ProcessPhotonCandidates significantly. The semantics of the
sharedElectron and toCloseV0s cuts are slightly changed.
Before this change:
Say we have photons A B C. Then RejectToCloseV0s will cut photon A
if its too close to B. However, also C gets cut, if C is too close to A.
Even though A has already been thrown out.
For RejectSharedElectronV0s its the same: Say A and B have an electron track
in common -> A gets kicked out. Then C will still get kicked out,
if it is shares the positron track with A.
With this change, photon C does not get cut.

This affects typically 10% of photons for the shared electron
cut and sometimes one out of 200 photons for the tooclose cut.

Extensive automated tests were carried out to ensure that
the change does not break anything and does not have further
semantic consequences.