### PR TITLE
Options for looser OOB pileup cuts in Pb-Pb

### DIFF
--- a/OADB/AliEventCuts.cxx
+++ b/OADB/AliEventCuts.cxx
@@ -72,7 +72,7 @@ AliEventCuts::AliEventCuts(bool saveplots) : TList(),
   fUseVariablesCorrelationCuts{false},
   fUseEstimatorsCorrelationCut{false},
   fUseStrongVarCorrelationCut{false},
-  fUseITSTPCCluCorrelationCut{false},
+  fUseITSTPCCluCorrelationCut{0},
   fUseTPCTracklCorrelationCut{false},
   fEstimatorsCorrelationCoef{0.,1.},
   fEstimatorsSigmaPars{10000.,0.,0.,0.},
@@ -252,7 +252,7 @@ bool AliEventCuts::AcceptEvent(AliVEvent *ev) {
   const double its_tpcclus_limit = PolN(double(nCluTPC),fITSvsTPCcluPolCut,2);
   const double vzero_tpcout_limit = PolN(double(fContainer.fMultTrkTPCout),fVZEROvsTPCoutPolCut,4);
   const double fb128 = fContainer.fMultTrkTPC;
-  if(((!fUseITSTPCCluCorrelationCut || (nCluSDDSSD > its_tpcclus_limit)) && 
+  if(((fUseITSTPCCluCorrelationCut<=0 || (nCluSDDSSD > its_tpcclus_limit)) && 
       (!fUseStrongVarCorrelationCut || (fContainer.fMultVZERO > vzero_tpcout_limit)) &&
       (!fUseTPCTracklCorrelationCut || (fb128 < fFB128vsTrklLinearCut[0] + fFB128vsTrklLinearCut[1] * ntrkl)))
      || fMC ) fFlag |= BIT(kTPCPileUp);
@@ -813,6 +813,9 @@ void AliEventCuts::SetupPbPb2018() {
   std::copy(vzero_tpcout_polcut.begin(),vzero_tpcout_polcut.end(),fVZEROvsTPCoutPolCut);
   
   array<double,3> its_tpcclus_polcut = {-3000.,0.0099,9.426e-10};
+  if(fUseITSTPCCluCorrelationCut==2) its_tpcclus_polcut[0]=-8000.;
+  else if(fUseITSTPCCluCorrelationCut==3) its_tpcclus_polcut[0]=-12000.;
+  else if(fUseITSTPCCluCorrelationCut>3) its_tpcclus_polcut[0]=-16000.;
   std::copy(its_tpcclus_polcut.begin(),its_tpcclus_polcut.end(),fITSvsTPCcluPolCut);
   
   if (fCentralityFramework != 0) {

--- a/OADB/AliEventCuts.h
+++ b/OADB/AliEventCuts.h
@@ -129,7 +129,7 @@ class AliEventCuts : public TList {
     void          SetCentralityRange (float min, float max) { fMinCentrality = min; fMaxCentrality = max; }
     void          SetMaxVertexZposition (float max) { fMinVtz = -fabs(max); fMaxVtz = fabs(max); }
     void          SelectOnlyInelGt0(bool toogle) { fOverrideInelGt0 = true; fSelectInelGt0 = toogle; }
-    void          SetRejectTPCPileupWithITSTPCnCluCorr(bool opt) { fUseITSTPCCluCorrelationCut = opt; }
+    void          SetRejectTPCPileupWithITSTPCnCluCorr(bool opt, int cutlevel=1) { if(opt==kTRUE) fUseITSTPCCluCorrelationCut = cutlevel; }
     void          SetRejectTPCPileupWithV0CentTPCnTracksCorr(bool opt) { fUseStrongVarCorrelationCut = opt; }
     
     AliAnalysisUtils fUtils;                      ///< Analysis utils for the pileup rejection
@@ -171,7 +171,7 @@ class AliEventCuts : public TList {
     bool          fUseVariablesCorrelationCuts;   ///< Switch on/off the cuts on the correlation between event variables
     bool          fUseEstimatorsCorrelationCut;   ///< Switch on/off the cut on the correlation between centrality estimators
     bool          fUseStrongVarCorrelationCut;    ///< Switch on/off the strong OOB pileup cut (for Pb-Pb) based on TPC tracks vs V0 mult
-    bool          fUseITSTPCCluCorrelationCut;    ///< Switch on/off the OOB pileup cut (for Pb-Pb) based on ITS and TPC clusters 
+    int  fUseITSTPCCluCorrelationCut;             ///< OOB pileup cut (for Pb-Pb) based on ITS and TPC clusters: 0-> no cut; 1-> default cut (remove all OOB pileup); 2-> looser cut; 3-> even more looser cut; 4-> very loose cut 
     bool          fUseTPCTracklCorrelationCut;    ///< Switch on/off OOB pileup cut (for pp, LHC15n) based on tracklets and TPC only tracks
     double        fEstimatorsCorrelationCoef[2];  ///< fCentEstimators[0] = [0] + [1] * fCentEstimators[1]
     double        fEstimatorsSigmaPars[4];        ///< Sigma parametrisation fCentEstimators[1] vs fCentEstimators[0]
@@ -245,7 +245,7 @@ class AliEventCuts : public TList {
     AliESDtrackCuts* fFB32trackCuts; //!<! Cuts corresponding to FB32 in the ESD (used only for correlations cuts in ESDs)
     AliESDtrackCuts* fTPConlyCuts;   //!<! Cuts corresponding to the standalone TPC cuts in the ESDs (used only for correlations cuts in ESDs)
 
-    ClassDef(AliEventCuts, 15)
+    ClassDef(AliEventCuts, 16)
 };
 
 template<typename F> F AliEventCuts::PolN(F x,F* coef, int n) {


### PR DESCRIPTION
Implementation of looser out-of-bunch pileup cuts provided by @XiaozhiBai , see ATO-496
Usage:
fEventCut.SetRejectTPCPileupWithITSTPCnCluCorr(kTRUE); // enable default cut (removes all OOB pileup, ~32% of events)
fEventCut.SetRejectTPCPileupWithITSTPCnCluCorr(kTRUE,2); // looser cut  (removes 18% of the events with high multiplicity pileup)
fEventCut.SetRejectTPCPileupWithITSTPCnCluCorr(kTRUE,3); // even more looser cut (removes 18% of the events with high multiplicity pileup)
fEventCut.SetRejectTPCPileupWithITSTPCnCluCorr(kTRUE,4); // very loose (removes 6% of the events with high multiplicity pileup)
