### PR TITLE
Update task with TPC tracks cuts and separate EMCal and DCal detector

### DIFF
--- a/PWGHF/hfe/AliAnalysisTaskHFEMultiplicity.h
+++ b/PWGHF/hfe/AliAnalysisTaskHFEMultiplicity.h
@@ -78,10 +78,10 @@ public:
     void            SetTenderSwitch(Bool_t usetender){fUseTender = usetender;};
     void            SetClusterTypeEMC(Bool_t flagClsEMC) {fFlagClsTypeEMC = flagClsEMC;};
     void            SetClusterTypeDCAL(Bool_t flagClsDCAL) {fFlagClsTypeDCAL = flagClsDCAL;};
-    void                  SetEMCalTriggerEG1(Bool_t flagTr1) { fEMCEG1=flagTr1; fEMCEG2=kFALSE;};
-    void                  SetEMCalTriggerEG2(Bool_t flagTr2) { fEMCEG2=flagTr2; fEMCEG1=kFALSE;};
-    void                  SetEMCalTriggerDG1(Bool_t flagTr1) { fDCalDG1=flagTr1; fDCalDG2=kFALSE;};
-    void                  SetEMCalTriggerDG2(Bool_t flagTr2) { fDCalDG2=flagTr2; fDCalDG1=kFALSE;};
+    void                  SetEMCalTriggerEG1(Bool_t flagEG1) { fEMCEG1=flagEG1;};
+    void                  SetEMCalTriggerEG2(Bool_t flagEG2) { fEMCEG2=flagEG2;};
+    void                  SetEMCalTriggerDG1(Bool_t flagDG1) { fDCalDG1=flagDG1;};
+    void                  SetEMCalTriggerDG2(Bool_t flagDG2) { fDCalDG2=flagDG2;};
     void            SelectNonHFElectron(Int_t itrack, AliAODTrack *track, Int_t iMCmom, Int_t MomPDG, Bool_t &fFlagPhotonicElec, Bool_t &fFlagElecLS, Int_t vzeroMultCorr,Int_t correctednAcc);
     void             SetReferenceMultiplicity(Double_t multi){fRefMult=multi;};
     void             SetMultiProfileLHC16s(TProfile * hprof){
@@ -102,7 +102,8 @@ public:
     
     void             SetNcontVCut(Int_t NcontV){fCutNcontV=NcontV;}
     void             SetEtaRange(Double_t Etarange){fCutTrackEta=Etarange;}
-    void             SetMaxTPCCluster(Int_t MaxTPCclus){fCutTPCMaxCls=MaxTPCclus;}
+    void             SetRatioCrossedRowOverFindable(Double_t RatioCrossedRowOverFindable){fRatioCrossedRowOverFindable=RatioCrossedRowOverFindable;}
+    void             SetNTPCCrossRows(Int_t NTPCCrossRows){fCutTPCCrossRows=NTPCCrossRows;}
     void             SetNTPCCluster(Int_t TPCNclus){fCutTPCNCls=TPCNclus;}
     void             SetNITSCluster(Int_t ITSNclus){fCutITSNCls=ITSNclus;}
     void             SetTrackpTMin(Double_t TrackPtMin){fCutpTMin = TrackPtMin;}
@@ -145,10 +146,11 @@ private:
     //--------------------Event Cut------------------
     Int_t         fCutNcontV;
     //--------------------Track Cut------------------
-    Int_t            fCutTPCMaxCls;
+    Double_t            fRatioCrossedRowOverFindable;
+    Int_t            fCutTPCCrossRows;
     Int_t            fCutTPCchi2perNDF;
-    Int_t         fCutTPCNCls;
-    Int_t         fCutITSNCls;
+    Int_t            fCutTPCNCls;
+    Int_t            fCutITSNCls;
     Double_t         fCutDCAxy;
     Double_t         fCutDCAz;
     Double_t         fCutTrackEta;

--- a/PWGHF/hfe/macros/AddTaskHFEMultiplicity.C
+++ b/PWGHF/hfe/macros/AddTaskHFEMultiplicity.C
@@ -1,270 +1,237 @@
 AliAnalysisTask* AddTaskHFEMultiplicity(TString suffixName = "",
-					Bool_t readMC	=	kFALSE,
-                    Bool_t SwitchPi0EtaWeightCalc = kTRUE,
-					Bool_t PhysSelINT7 =  kTRUE,
-					Bool_t useTender   =  kTRUE,
-					Bool_t ClsTypeEMC  =  kTRUE,
-					Bool_t ClsTypeDCAL =  kTRUE,
-					TString estimatorFilename="",
-                    Bool_t zvtxcut =  kTRUE,
-                    Bool_t zvtxQA =  kTRUE,
-					Double_t refMult=61.2,
-					Int_t NcontV =2,
-					Int_t MaxTPCclus = 100.,
-					Int_t TPCNclus =80.,
-  					Int_t ITSNclus =3.,
-  					Double_t DCAxyCut =2.4,
-  					Double_t DCAzCut =3.2,
-  					Double_t Etarange = 0.7,
-  					Double_t TrackPtMin = 1.,
-  					Double_t EopEMin = 0.8,
- 					Double_t EopEMax = 1.2,
-  					Double_t TPCNSigMin = -1.,
-  					Double_t TPCNSigMax = 3.,
-  					Double_t M20Min =0.02,
-  					Double_t M20Max =0.35,
-  					Int_t AssoTPCCluster = 80.,
-  					Int_t AssoITSCluster =3.,
-  					Double_t AssoEPt =0.1,
-  					Double_t AssoEEtarange =0.9,
-  					Double_t AssoENsigma =3.,
-  					Bool_t AssoITSRefit =kTRUE,
-  					Double_t InvmassCut = 0.14					)
+                                        Bool_t readMC    =    kFALSE,
+                                        Bool_t SwitchPi0EtaWeightCalc = kTRUE,
+                                        Bool_t PhysSelINT7 =  kTRUE,
+                                        Bool_t useTender   =  kTRUE,
+                                        Bool_t ClsTypeEMC  =  kTRUE,
+                                        Bool_t ClsTypeDCAL =  kTRUE,
+                                        Bool_t flagEG1=  kTRUE ,
+                                        Bool_t flagEG2=  kTRUE,
+                                        Bool_t flagDG1=  kTRUE,
+                                        Bool_t flagDG2=  kTRUE,
+                                        TString estimatorFilename="",
+                                        Bool_t zvtxcut =  kTRUE,
+                                        Bool_t zvtxQA =  kTRUE,
+                                        Double_t refMult=61.2,
+                                        Int_t NcontV =2,
+                                        Double_t RatioCrossedRowOverFindable=0.8,
+                                        Int_t NTPCCrossRows = 100.,
+                                        Int_t TPCNclus =80.,
+                                        Int_t ITSNclus =3.,
+                                        Double_t DCAxyCut =2.4,
+                                        Double_t DCAzCut =3.2,
+                                        Double_t Etarange = 0.6,
+                                        Double_t TrackPtMin = 2.,
+                                        Double_t EopEMin = 0.8,
+                                        Double_t EopEMax = 1.2,
+                                        Double_t TPCNSigMin = -1.,
+                                        Double_t TPCNSigMax = 3.,
+                                        Double_t M20Min =0.02,
+                                        Double_t M20Max =0.35,
+                                        Int_t AssoTPCCluster = 80.,
+                                        Int_t AssoITSCluster =3.,
+                                        Double_t AssoEPt =0.1,
+                                        Double_t AssoEEtarange =0.9,
+                                        Double_t AssoENsigma =3.,
+                                        Bool_t AssoITSRefit =kTRUE,
+                                        Double_t InvmassCut = 0.14                    )
 
 { // Get the pointer to the existing analysis manager via the static access method.
-  AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
-  if (!mgr) {
-    return 0x0;
-  }
-  
-  if (!mgr->GetInputEventHandler()) {
-    return 0x0;
-  }
-  TString type = mgr->GetInputEventHandler()->GetDataType(); // can be "ESD" or "AOD"
-
-  Bool_t  fReadMC = kTRUE;
-  AliMCEventHandler *mcH = dynamic_cast<AliMCEventHandler*>(mgr->GetMCtruthEventHandler());
-  if(!mcH){
-    fReadMC=kFALSE;
-  }
-
-
-  TString fileName = AliAnalysisManager::GetCommonFileName();
-  fileName += ":MyTask";
-  
-  if(PhysSelINT7){
-    AliAnalysisTaskHFEMultiplicity* HFEtaskINT7 = new AliAnalysisTaskHFEMultiplicity("");
-    mgr->AddTask(HFEtaskINT7); //HFEtask is my task
-    HFEtaskINT7->SetReadMC(readMC);
-    HFEtaskINT7->SelectCollisionCandidates(AliVEvent::kINT7);
-    HFEtaskINT7->SetTenderSwitch(useTender);
-    HFEtaskINT7->SwitchPi0EtaWeightCalc(SwitchPi0EtaWeightCalc);
-    HFEtaskINT7->SetClusterTypeEMC(ClsTypeEMC);
-    HFEtaskINT7->SetClusterTypeDCAL(ClsTypeDCAL);
-    HFEtaskINT7->Setzvtxcut(zvtxcut);
-    HFEtaskINT7->SetzvtxQA(zvtxQA);
-    HFEtaskINT7->SetNcontVCut(NcontV);
-    HFEtaskINT7->SetEtaRange(Etarange);
-    HFEtaskINT7->SetMaxTPCCluster(MaxTPCclus);
-    HFEtaskINT7->SetNTPCCluster(TPCNclus);
-    HFEtaskINT7->SetNITSCluster(ITSNclus);
-    HFEtaskINT7->SetTrackpTMin(TrackPtMin);
-    HFEtaskINT7->SetDCACut(DCAxyCut,DCAzCut);
-    HFEtaskINT7->SetTPCnsigma(TPCNSigMin,TPCNSigMax);
-    HFEtaskINT7->SetEopE(EopEMin,EopEMax);
-    HFEtaskINT7->SetShowerShapeEM20(M20Min,M20Max);
-    HFEtaskINT7->SetInvMassCut(InvmassCut);
-    HFEtaskINT7->SetAssoTPCclus(AssoTPCCluster);
-    HFEtaskINT7->SetAssoITSclus(AssoITSCluster);
-    HFEtaskINT7->SetAssoITSrefit(AssoITSRefit);
-    HFEtaskINT7->SetAssopTMin(AssoEPt);
-    HFEtaskINT7->SetAssoEtarange(AssoEEtarange);
-    HFEtaskINT7->SetAssoTPCnsig(AssoENsigma);
- 
-    TFile* fileEstimator=TFile::Open(estimatorFilename.Data());
-    if(!fileEstimator)  {
-        Printf("File with multiplicity estimator not found\n");
-      return NULL;
+    AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
+    if (!mgr) {
+        return 0x0;
     }
-    HFEtaskINT7->SetReferenceMultiplicity(refMult);
-    const Char_t* profilebasename="SPDmult";
     
-    const Char_t* periodNames[2] = {"LHC16s", "LHC16r"};
-    TProfile* multEstimatorAvg[2];
-    for(Int_t ip=0; ip<2; ip++) {
-      cout<< " Trying to get "<<Form("%s_%s",profilebasename,periodNames[ip])<<endl;
-      multEstimatorAvg[ip] = (TProfile*)(fileEstimator->Get(Form("%s_%s",profilebasename,periodNames[ip]))->Clone(Form("%s_%s_clone",profilebasename,periodNames[ip])));
-      if (!multEstimatorAvg[ip]) {
-	Printf("Multiplicity estimator for %s not found! Please check your estimator file",periodNames[ip]);
-	return NULL;
-      }
+    if (!mgr->GetInputEventHandler()) {
+        return 0x0;
     }
-
-    HFEtaskINT7->SetMultiProfileLHC16s(multEstimatorAvg[0]);
-    HFEtaskINT7->SetMultiProfileLHC16r(multEstimatorAvg[1]);
-
-    // Create containers for input/output
-    TString finDirname         = "_INT7";
-    TString outBasicname       = "EID";
-    TString profname       = "coutputProf";
-      
-    finDirname 	      +=   suffixName.Data();
-    outBasicname      +=   finDirname.Data();
-    profname          +=   finDirname.Data();
-      
-      
-      
-    mgr->ConnectInput(HFEtaskINT7,0,mgr->GetCommonInputContainer());
-    mgr->ConnectOutput(HFEtaskINT7,1,mgr->CreateContainer(outBasicname, TList::Class(), AliAnalysisManager::kOutputContainer, fileName.Data()));
-     mgr->ConnectOutput(HFEtaskINT7,2,mgr->CreateContainer(profname, TList::Class(), AliAnalysisManager::kOutputContainer, fileName.Data()));
-
-   
-
- }
+    TString type = mgr->GetInputEventHandler()->GetDataType(); // can be "ESD" or "AOD"
     
-   if(!PhysSelINT7){
-     
-
-// EMCal EGA GA1
-      
-     AliAnalysisTaskHFEMultiplicity* HFEtaskGA1 = new AliAnalysisTaskHFEMultiplicity("");
-     mgr->AddTask(HFEtaskGA1);
-     HFEtaskGA1->SetReadMC(readMC);
-     HFEtaskGA1->SelectCollisionCandidates(AliVEvent::kEMCEGA);
-     HFEtaskGA1->SetEMCalTriggerEG1(kTRUE);
-     HFEtaskGA1->SetEMCalTriggerDG1(kTRUE);
-     HFEtaskGA1->SetTenderSwitch(useTender);
-     HFEtaskGA1->SwitchPi0EtaWeightCalc(SwitchPi0EtaWeightCalc);
-     HFEtaskGA1->SetClusterTypeEMC(ClsTypeEMC);
-     HFEtaskGA1->SetClusterTypeDCAL(ClsTypeDCAL);
-     HFEtaskGA1->Setzvtxcut(zvtxcut);
-     HFEtaskGA1->SetzvtxQA(zvtxQA);
-     HFEtaskGA1->SetNcontVCut(NcontV);
-     HFEtaskGA1->SetEtaRange(Etarange);
-     HFEtaskGA1->SetMaxTPCCluster(MaxTPCclus);
-     HFEtaskGA1->SetNTPCCluster(TPCNclus);
-     HFEtaskGA1->SetNITSCluster(ITSNclus);
-     HFEtaskGA1->SetTrackpTMin(TrackPtMin);
-     HFEtaskGA1->SetDCACut(DCAxyCut,DCAzCut);
-     HFEtaskGA1->SetTPCnsigma(TPCNSigMin,TPCNSigMax);
-     HFEtaskGA1->SetEopE(EopEMin,EopEMax);
-     HFEtaskGA1->SetShowerShapeEM20(M20Min,M20Max);
-     HFEtaskGA1->SetInvMassCut(InvmassCut);
-     HFEtaskGA1->SetAssoTPCclus(AssoTPCCluster);
-     HFEtaskGA1->SetAssoITSclus(AssoITSCluster);
-     HFEtaskGA1->SetAssoITSrefit(AssoITSRefit);
-     HFEtaskGA1->SetAssopTMin(AssoEPt);
-     HFEtaskGA1->SetAssoEtarange(AssoEEtarange);
-     HFEtaskGA1->SetAssoTPCnsig(AssoENsigma);
-
-    TFile* fileEstimatorGA1=TFile::Open(estimatorFilename.Data());
-    if(!fileEstimatorGA1)  {
-      Printf("File with multiplicity estimator not found\n");
-      return NULL;
+    Bool_t  fReadMC = kTRUE;
+    AliMCEventHandler *mcH = dynamic_cast<AliMCEventHandler*>(mgr->GetMCtruthEventHandler());
+    if(!mcH){
+        fReadMC=kFALSE;
     }
-    HFEtaskGA1->SetReferenceMultiplicity(refMult);
-    const Char_t* profilebasenameEG1="SPDmultEG1";
-       const Char_t* periodNamesGA1[2] = {"LHC16s", "LHC16r"};
-    TProfile* multEstimatorAvgGA1[2];
-    for(Int_t ip=0; ip<2; ip++) {
-      cout<< " Trying to get "<<Form("%s_%s",profilebasenameEG1,periodNamesGA1[ip])<<endl;
-      multEstimatorAvgGA1[ip] = (TProfile*)(fileEstimatorGA1->Get(Form("%s_%s",profilebasenameEG1,periodNamesGA1[ip]))->Clone(Form("%s_%s_clone",profilebasenameEG1,periodNamesGA1[ip])));
-      if (!multEstimatorAvgGA1[ip]) {
-	Printf("Multiplicity estimator for %s not found! Please check your estimator file",periodNamesGA1[ip]);
-	return NULL;
-      }
-    }
-
-    HFEtaskGA1->SetMultiProfileLHC16s(multEstimatorAvgGA1[0]);
-    HFEtaskGA1->SetMultiProfileLHC16r(multEstimatorAvgGA1[1]);
-       
-       
-     TString finDirnameGA1         = "_TrigGA1";
-     TString outBasicnameGA1       = "EID";
-     TString profnameGA1       = "coutputProf";
-       
-     finDirnameGA1 	      +=   suffixName.Data();
-     outBasicnameGA1      +=   finDirnameGA1.Data();
-     profnameGA1          +=   finDirnameGA1.Data();
-       
-       
-     mgr->ConnectInput(HFEtaskGA1,0,mgr->GetCommonInputContainer());
-     mgr->ConnectOutput(HFEtaskGA1,1,mgr->CreateContainer(outBasicnameGA1, TList::Class(), AliAnalysisManager::kOutputContainer, fileName.Data()));
-     mgr->ConnectOutput(HFEtaskGA1,2,mgr->CreateContainer(profnameGA1, TList::Class(), AliAnalysisManager::kOutputContainer, fileName.Data()));
-     
-
-// EMCal EGA GA2
-       
-     AliAnalysisTaskHFEMultiplicity* HFEtaskGA2 = new AliAnalysisTaskHFEMultiplicity("");
-     mgr->AddTask(HFEtaskGA2);
-     HFEtaskGA2->SetReadMC(readMC);
-     HFEtaskGA2->SelectCollisionCandidates(AliVEvent::kEMCEGA);
-     HFEtaskGA2->SetEMCalTriggerEG2(kTRUE);
-     HFEtaskGA2->SetEMCalTriggerDG2(kTRUE);
-     HFEtaskGA2->SetTenderSwitch(useTender);
-     HFEtaskGA2->SwitchPi0EtaWeightCalc(SwitchPi0EtaWeightCalc);
-     HFEtaskGA2->SetClusterTypeEMC(ClsTypeEMC);
-     HFEtaskGA2->SetClusterTypeDCAL(ClsTypeDCAL);
-     HFEtaskGA2->Setzvtxcut(zvtxcut);
-     HFEtaskGA2->SetzvtxQA(zvtxQA);
-     HFEtaskGA2->SetNcontVCut(NcontV);
-     HFEtaskGA2->SetEtaRange(Etarange);
-     HFEtaskGA2->SetNTPCCluster(TPCNclus);
-     HFEtaskGA2->SetNITSCluster(ITSNclus);
-     HFEtaskGA2->SetTrackpTMin(TrackPtMin);
-     HFEtaskGA2->SetDCACut(DCAxyCut,DCAzCut);
-     HFEtaskGA2->SetTPCnsigma(TPCNSigMin,TPCNSigMax);
-     HFEtaskGA2->SetEopE(EopEMin,EopEMax);
-     HFEtaskGA2->SetShowerShapeEM20(M20Min,M20Max);
-     HFEtaskGA2->SetInvMassCut(InvmassCut);
-     HFEtaskGA2->SetAssoTPCclus(AssoTPCCluster);
-     HFEtaskGA2->SetAssoITSclus(AssoITSCluster);
-     HFEtaskGA2->SetAssoITSrefit(AssoITSRefit);
-     HFEtaskGA2->SetAssopTMin(AssoEPt);
-     HFEtaskGA2->SetAssoEtarange(AssoEEtarange);
-     HFEtaskGA2->SetAssoTPCnsig(AssoENsigma);
-
-    TFile* fileEstimatorGA2=TFile::Open(estimatorFilename.Data());
-    if(!fileEstimatorGA2)  {
-      Printf("File with multiplicity estimator not found\n");
-      return NULL;
-    }
-    HFEtaskGA2->SetReferenceMultiplicity(refMult);
-    const Char_t* profilebasenameEG2="SPDmultEG2";
-       const Char_t* periodNamesGA2[2] = {"LHC16s", "LHC16r"};
-    TProfile* multEstimatorAvgGA2[2];
-    for(Int_t ip=0; ip<2; ip++) {
-      cout<< " Trying to get "<<Form("%s_%s",profilebasenameEG2,periodNamesGA2[ip])<<endl;
-      multEstimatorAvgGA2[ip] = (TProfile*)(fileEstimatorGA2->Get(Form("%s_%s",profilebasenameEG2,periodNamesGA2[ip]))->Clone(Form("%s_%s_clone",profilebasenameEG2,periodNamesGA2[ip])));
-      if (!multEstimatorAvgGA2[ip]) {
-	Printf("Multiplicity estimator for %s not found! Please check your estimator file",periodNamesGA2[ip]);
-	return NULL;
-      }
-    }
-
-    HFEtaskGA2->SetMultiProfileLHC16s(multEstimatorAvgGA2[0]);
-    HFEtaskGA2->SetMultiProfileLHC16r(multEstimatorAvgGA2[1]);
-       
-       
-     TString finDirnameGA2         = "_TrigGA2";
-     TString outBasicnameGA2       = "EID";
-     TString profnameGA2       = "coutputProf";
-       
-     finDirnameGA2 	      +=   suffixName.Data();
-     outBasicnameGA2      +=   finDirnameGA2.Data();
-     profnameGA2          +=   finDirnameGA2.Data();
-       
-       
-     mgr->ConnectInput(HFEtaskGA2,0,mgr->GetCommonInputContainer());
-     mgr->ConnectOutput(HFEtaskGA2,1,mgr->CreateContainer(outBasicnameGA2, TList::Class(), AliAnalysisManager::kOutputContainer, fileName.Data()));
-        mgr->ConnectOutput(HFEtaskGA2,2,mgr->CreateContainer(profnameGA2, TList::Class(), AliAnalysisManager::kOutputContainer, fileName.Data()));
-     
-       
     
-     
+    
+    TString fileName = AliAnalysisManager::GetCommonFileName();
+    fileName += ":MyTask";
+    
+    if(PhysSelINT7){
+        AliAnalysisTaskHFEMultiplicity* HFEtaskINT7 = new AliAnalysisTaskHFEMultiplicity("");
+        mgr->AddTask(HFEtaskINT7); //HFEtask is my task
+        HFEtaskINT7->SetReadMC(readMC);
+        HFEtaskINT7->SelectCollisionCandidates(AliVEvent::kINT7);
+        HFEtaskINT7->SetTenderSwitch(useTender);
+        HFEtaskINT7->SwitchPi0EtaWeightCalc(SwitchPi0EtaWeightCalc);
+        HFEtaskINT7->SetClusterTypeEMC(ClsTypeEMC);
+        HFEtaskINT7->SetClusterTypeDCAL(ClsTypeDCAL);
+        HFEtaskINT7->Setzvtxcut(zvtxcut);
+        HFEtaskINT7->SetzvtxQA(zvtxQA);
+        HFEtaskINT7->SetNcontVCut(NcontV);
+        HFEtaskINT7->SetEtaRange(Etarange);
+        HFEtaskINT7->SetRatioCrossedRowOverFindable(RatioCrossedRowOverFindable);
+        HFEtaskINT7->SetNTPCCrossRows(NTPCCrossRows);
+        HFEtaskINT7->SetNTPCCluster(TPCNclus);
+        HFEtaskINT7->SetNITSCluster(ITSNclus);
+        HFEtaskINT7->SetTrackpTMin(TrackPtMin);
+        HFEtaskINT7->SetDCACut(DCAxyCut,DCAzCut);
+        HFEtaskINT7->SetTPCnsigma(TPCNSigMin,TPCNSigMax);
+        HFEtaskINT7->SetEopE(EopEMin,EopEMax);
+        HFEtaskINT7->SetShowerShapeEM20(M20Min,M20Max);
+        HFEtaskINT7->SetInvMassCut(InvmassCut);
+        HFEtaskINT7->SetAssoTPCclus(AssoTPCCluster);
+        HFEtaskINT7->SetAssoITSclus(AssoITSCluster);
+        HFEtaskINT7->SetAssoITSrefit(AssoITSRefit);
+        HFEtaskINT7->SetAssopTMin(AssoEPt);
+        HFEtaskINT7->SetAssoEtarange(AssoEEtarange);
+        HFEtaskINT7->SetAssoTPCnsig(AssoENsigma);
+        
+        TFile* fileEstimator=TFile::Open(estimatorFilename.Data());
+        if(!fileEstimator)  {
+            Printf("File with multiplicity estimator not found\n");
+            return NULL;
+        }
+        HFEtaskINT7->SetReferenceMultiplicity(refMult);
+        const Char_t* profilebasename="SPDmult";
+        
+        const Char_t* periodNames[2] = {"LHC16s", "LHC16r"};
+        TProfile* multEstimatorAvg[2];
+        for(Int_t ip=0; ip<2; ip++) {
+            cout<< " Trying to get "<<Form("%s_%s",profilebasename,periodNames[ip])<<endl;
+            multEstimatorAvg[ip] = (TProfile*)(fileEstimator->Get(Form("%s_%s",profilebasename,periodNames[ip]))->Clone(Form("%s_%s_clone",profilebasename,periodNames[ip])));
+            if (!multEstimatorAvg[ip]) {
+                Printf("Multiplicity estimator for %s not found! Please check your estimator file",periodNames[ip]);
+                return NULL;
+            }
+        }
+        
+        HFEtaskINT7->SetMultiProfileLHC16s(multEstimatorAvg[0]);
+        HFEtaskINT7->SetMultiProfileLHC16r(multEstimatorAvg[1]);
+        
+        // Create containers for input/output
+        TString finDirname         = "_INT7";
+        TString outBasicname       = "EID";
+        TString profname       = "coutputProf";
+        
+        finDirname           +=   suffixName.Data();
+        outBasicname      +=   finDirname.Data();
+        profname          +=   finDirname.Data();
+        
+        
+        
+        mgr->ConnectInput(HFEtaskINT7,0,mgr->GetCommonInputContainer());
+        mgr->ConnectOutput(HFEtaskINT7,1,mgr->CreateContainer(outBasicname, TList::Class(), AliAnalysisManager::kOutputContainer, fileName.Data()));
+        mgr->ConnectOutput(HFEtaskINT7,2,mgr->CreateContainer(profname, TList::Class(), AliAnalysisManager::kOutputContainer, fileName.Data()));
+        
+        
+        
+    }
+    
+    if(!PhysSelINT7){
+        
+        
+        // EMCal EGA GA1
+        
+        AliAnalysisTaskHFEMultiplicity* HFEtaskGA = new AliAnalysisTaskHFEMultiplicity("");
+        mgr->AddTask(HFEtaskGA);
+        HFEtaskGA->SetReadMC(readMC);
+        HFEtaskGA->SelectCollisionCandidates(AliVEvent::kEMCEGA);
+        HFEtaskGA->SetEMCalTriggerEG1(flagEG1);
+        HFEtaskGA->SetEMCalTriggerDG1(flagDG1);
+        HFEtaskGA->SetEMCalTriggerEG2(flagEG2);
+        HFEtaskGA->SetEMCalTriggerDG2(flagDG2);
+        HFEtaskGA->SetTenderSwitch(useTender);
+        HFEtaskGA->SwitchPi0EtaWeightCalc(SwitchPi0EtaWeightCalc);
+        HFEtaskGA->SetClusterTypeEMC(ClsTypeEMC);
+        HFEtaskGA->SetClusterTypeDCAL(ClsTypeDCAL);
+        HFEtaskGA->Setzvtxcut(zvtxcut);
+        HFEtaskGA->SetzvtxQA(zvtxQA);
+        HFEtaskGA->SetNcontVCut(NcontV);
+        HFEtaskGA->SetEtaRange(Etarange);
+        HFEtaskGA->SetRatioCrossedRowOverFindable(RatioCrossedRowOverFindable);
+        HFEtaskGA->SetNTPCCrossRows(NTPCCrossRows);
+        HFEtaskGA->SetNTPCCluster(TPCNclus);
+        HFEtaskGA->SetNITSCluster(ITSNclus);
+        HFEtaskGA->SetTrackpTMin(TrackPtMin);
+        HFEtaskGA->SetDCACut(DCAxyCut,DCAzCut);
+        HFEtaskGA->SetTPCnsigma(TPCNSigMin,TPCNSigMax);
+        HFEtaskGA->SetEopE(EopEMin,EopEMax);
+        HFEtaskGA->SetShowerShapeEM20(M20Min,M20Max);
+        HFEtaskGA->SetInvMassCut(InvmassCut);
+        HFEtaskGA->SetAssoTPCclus(AssoTPCCluster);
+        HFEtaskGA->SetAssoITSclus(AssoITSCluster);
+        HFEtaskGA->SetAssoITSrefit(AssoITSRefit);
+        HFEtaskGA->SetAssopTMin(AssoEPt);
+        HFEtaskGA->SetAssoEtarange(AssoEEtarange);
+        HFEtaskGA->SetAssoTPCnsig(AssoENsigma);
+        
+        if(flagEG1 || flagDG1){
+        
+        TFile* fileEstimatorGA1=TFile::Open(estimatorFilename.Data());
+        if(!fileEstimatorGA1)  {
+            Printf("File with multiplicity estimator not found\n");
+            return NULL;
+        }
+        HFEtaskGA->SetReferenceMultiplicity(refMult);
+        const Char_t* profilebasenameEG1="SPDmultEG1";
+        const Char_t* periodNamesGA1[2] = {"LHC16s", "LHC16r"};
+        TProfile* multEstimatorAvgGA1[2];
+        for(Int_t ip=0; ip<2; ip++) {
+            cout<< " Trying to get "<<Form("%s_%s",profilebasenameEG1,periodNamesGA1[ip])<<endl;
+            multEstimatorAvgGA1[ip] = (TProfile*)(fileEstimatorGA1->Get(Form("%s_%s",profilebasenameEG1,periodNamesGA1[ip]))->Clone(Form("%s_%s_clone",profilebasenameEG1,periodNamesGA1[ip])));
+            if (!multEstimatorAvgGA1[ip]) {
+                Printf("Multiplicity estimator for %s not found! Please check your estimator file",periodNamesGA1[ip]);
+                return NULL;
+            }
+        }
+        
+        HFEtaskGA->SetMultiProfileLHC16s(multEstimatorAvgGA1[0]);
+        HFEtaskGA->SetMultiProfileLHC16r(multEstimatorAvgGA1[1]);
+        }
+        if(flagEG2 || flagDG2){
+        
+            TFile* fileEstimatorGA2=TFile::Open(estimatorFilename.Data());
+            if(!fileEstimatorGA2)  {
+            Printf("File with multiplicity estimator not found\n");
+            return NULL;
+                    
+            }
+            HFEtaskGA->SetReferenceMultiplicity(refMult);
+            const Char_t* profilebasenameEG2="SPDmultEG2";
+            const Char_t* periodNamesGA2[2] = {"LHC16s", "LHC16r"};
+            TProfile* multEstimatorAvgGA2[2];
+            for(Int_t ip=0; ip<2; ip++) {
+            cout<< " Trying to get "<<Form("%s_%s",profilebasenameEG2,periodNamesGA2[ip])<<endl;
+            multEstimatorAvgGA2[ip] = (TProfile*)(fileEstimatorGA2->Get(Form("%s_%s",profilebasenameEG2,periodNamesGA2[ip]))->Clone(Form("%s_%s_clone",profilebasenameEG2,periodNamesGA2[ip])));
+            if (!multEstimatorAvgGA2[ip]) {
+                Printf("Multiplicity estimator for %s not found! Please check your estimator file",periodNamesGA2[ip]);
+                return NULL;
+                    }
+                }
+        
+            HFEtaskGA->SetMultiProfileLHC16s(multEstimatorAvgGA2[0]);
+            HFEtaskGA->SetMultiProfileLHC16r(multEstimatorAvgGA2[1]);
+        
+            }
+        TString finDirnameGA         = "_GA";
+        TString outBasicnameGA       = "EID";
+        TString profnameGA       = "coutputProf";
+        
+        finDirnameGA           +=   suffixName.Data();
+        outBasicnameGA      +=   finDirnameGA.Data();
+        profnameGA          +=   finDirnameGA.Data();
+        
+        
+        mgr->ConnectInput(HFEtaskGA,0,mgr->GetCommonInputContainer());
+        mgr->ConnectOutput(HFEtaskGA,1,mgr->CreateContainer(outBasicnameGA, TList::Class(), AliAnalysisManager::kOutputContainer, fileName.Data()));
+        mgr->ConnectOutput(HFEtaskGA,2,mgr->CreateContainer(profnameGA, TList::Class(), AliAnalysisManager::kOutputContainer, fileName.Data()));
+        
+    
+    }
+    
+    
+    
+    return NULL;
 }
-    
-  
-    
-  return NULL;
-}
+


### PR DESCRIPTION
The task is updated for the latest TPC track cut recommendations (eg. ncrossrows) and also for the separate analysis of EMCal and DCal. The updated event histogram shows the number of events as a function of different event selection cuts and different triggered sample. 