### PR TITLE
Implement OOB pileup selections

### DIFF
--- a/PWGHF/vertexingHF/AliAnalysisTaskSEHFSystPID.h
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSEHFSystPID.h
@@ -91,11 +91,15 @@ public:
   void SetDownSamplingOption(int opt=0)                                       {fDownSamplingOpt=opt;}
 
   void EnableNsigmaDataDrivenCorrection(int syst)                             {fEnableNsigmaTPCDataCorr=true; fSystNsigmaTPCDataCorr=syst;}
-
-  void EnableSelectionWithAliEventCuts(bool useAliEventCuts=true, int opt=2)  {fUseAliEventCuts=useAliEventCuts; fApplyPbPbOutOfBunchPileupCuts=opt;}
   void SetUseTimeRangeCutForPbPb2018(bool opt)                                {fUseTimeRangeCutForPbPb2018=opt;}
-
   void SetConversionFactordEdx(float factor)                                  {fConversionFactordEdx=factor;}
+
+  void EnableSelectionWithAliEventCuts(bool useAliEventCuts=true, int optOOBpileup=0, int optOOBpileupITSTPC=1, bool keepOnlyPileUpEvents=false) {
+    fUseAliEventCuts=useAliEventCuts;
+    fApplyPbPbOutOfBunchPileupCuts=optOOBpileup;
+    fApplyPbPbOutOfBunchPileupCutsITSTPC=optOOBpileupITSTPC;
+    fKeepOnlyPbPbOutOfBunchPileupCutsITSTPC=keepOnlyPileUpEvents;
+  }
 
   void ConfigureCutGeoNcrNcl(double dz, double len, double onept, double fncr, double fncl) {
     fDeadZoneWidth=dz;
@@ -224,10 +228,12 @@ private:
   bool fUseAliEventCuts;                                                             /// flag to enable usage of AliEventCuts foe event-selection
   AliEventCuts fAliEventCuts;                                                        /// event-cut object for centrality correlation event cuts
   int fApplyPbPbOutOfBunchPileupCuts;                                                /// option for Pb-Pb out-of bunch pileup cuts with AliEventCuts
+  int fApplyPbPbOutOfBunchPileupCutsITSTPC;                                          /// option for additional out-of-bunch pileup cut based on ITS-TPC correlation (0=no cut, 1=tight cut, 2=intermediate cut, 3=loose cut)
+  bool fKeepOnlyPbPbOutOfBunchPileupCutsITSTPC;                                      /// flag to keep only out-of-bunch pileup events tagged with ITS-TPC correlation
   bool fUseTimeRangeCutForPbPb2018;                                                  /// flag to enable time-range cut in PbPb 2018
   AliTimeRangeCut fTimeRangeCut;                                                     /// object to manage time range cut
 
-  ClassDef(AliAnalysisTaskSEHFSystPID, 16);
+  ClassDef(AliAnalysisTaskSEHFSystPID, 17);
 };
 
 #endif

--- a/PWGHF/vertexingHF/AliAnalysisTaskSEHFSystPID.h
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSEHFSystPID.h
@@ -58,6 +58,13 @@ public:
     kHasNoTOF    = BIT(7)
   };
 
+  enum OOBpileup {
+    kVeryLooseITSTPC  = BIT(0),
+    kLooseITSTPC  = BIT(1),
+    kMediumITSTPC = BIT(2),
+    kTightITSTPC  = BIT(3)
+  };
+
   enum centest {
     kCentOff,
     kCentV0M,
@@ -129,9 +136,10 @@ private:
   int IsEventSelectedWithAliEventCuts();
   bool IsSelectedByGeometricalCut(AliAODTrack* track);
   bool FillNsigma(int iDet, AliAODTrack* track);
+  void TagOOBPileUpEvent();
 
-  enum {kPion,kKaon,kProton,kElectron,kDeuteron,kTriton,kHe3};
-  enum {kITS,kTPC,kTOF,kHMPID};
+  enum {kPion, kKaon, kProton, kElectron, kDeuteron, kTriton, kHe3};
+  enum {kITS, kTPC, kTOF, kHMPID};
 
   const float kCSPEED = 2.99792457999999984e-02; // cm / ps
   static const int kNMaxDet = 4;
@@ -171,6 +179,7 @@ private:
   unsigned short fHMPIDsignal;                                                       /// HMPID signal
   unsigned short fHMPIDoccupancy;                                                    /// HMPID occupancy
   unsigned char fTrackInfoMap;                                                       /// bit map with some track info (see enum above)
+  unsigned char fOOBPileupMap;                                                       /// bit map for TPC OOB tagged events with ITS-TPC correlation
   short fEta;                                                                        /// pseudorapidity of the track
   unsigned short fPhi;                                                               /// azimuthal angle of the track
   int fPDGcode;                                                                      /// PDG code in case of MC to fill the tree

--- a/PWGHF/vertexingHF/AliAnalysisTaskSEHFSystPID.h
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSEHFSystPID.h
@@ -59,10 +59,10 @@ public:
   };
 
   enum OOBpileup {
-    kVeryLooseITSTPC  = BIT(0),
-    kLooseITSTPC  = BIT(1),
-    kMediumITSTPC = BIT(2),
-    kTightITSTPC  = BIT(3)
+    kVeryLooseITSTPC = BIT(0),
+    kLooseITSTPC     = BIT(1),
+    kMediumITSTPC    = BIT(2),
+    kTightITSTPC     = BIT(3)
   };
 
   enum centest {

--- a/PWGHF/vertexingHF/AliCFTaskVertexingHF.cxx
+++ b/PWGHF/vertexingHF/AliCFTaskVertexingHF.cxx
@@ -141,8 +141,10 @@ AliCFTaskVertexingHF::AliCFTaskVertexingHF() :
   fUseCascadeTaskForLctoV0bachelor(kFALSE),
   fFillMinimumSteps(kFALSE),
   fCutOnMomConservation(0.00001),
+  fMinLeadPtRT(6.0),
   fAODProtection(0),
-  fMinLeadPtRT(6.0)
+  fRejectOOBPileUpEvents(kFALSE),
+  fKeepOnlyOOBPileupEvents(kFALSE)
 {
   //
   //Default ctor
@@ -211,8 +213,10 @@ AliCFTaskVertexingHF::AliCFTaskVertexingHF(const Char_t* name, AliRDHFCuts* cuts
   fUseCascadeTaskForLctoV0bachelor(kFALSE),
   fFillMinimumSteps(kFALSE),
   fCutOnMomConservation(0.00001),
+  fMinLeadPtRT(6.0),
   fAODProtection(0),
-  fMinLeadPtRT(6.0)
+  fRejectOOBPileUpEvents(kFALSE),
+  fKeepOnlyOOBPileupEvents(kFALSE)
 {
   //
   // Constructor. Initialization of Inputs and Outputs
@@ -313,9 +317,10 @@ AliCFTaskVertexingHF::AliCFTaskVertexingHF(const AliCFTaskVertexingHF& c) :
   fUseCascadeTaskForLctoV0bachelor(c.fUseCascadeTaskForLctoV0bachelor),
   fFillMinimumSteps(c.fFillMinimumSteps),
   fCutOnMomConservation(c.fCutOnMomConservation),
+  fMinLeadPtRT(c.fMinLeadPtRT),
   fAODProtection(c.fAODProtection),
-  fMinLeadPtRT(c.fMinLeadPtRT)
-
+  fRejectOOBPileUpEvents(c.fRejectOOBPileUpEvents),
+  fKeepOnlyOOBPileupEvents(c.fKeepOnlyOOBPileupEvents)
 {
   //
   // Copy Constructor
@@ -708,6 +713,13 @@ void AliCFTaskVertexingHF::UserExec(Option_t *)
     AliError("Could not find MC Header in AOD");
     return;
   }
+
+  // reject / keep events with simulated OOB pileup
+  Bool_t isPileUp = AliAnalysisUtils::IsPileupInGeneratedEvent(mcHeader, "Hijing");
+  if(isPileUp && fRejectOOBPileUpEvents)
+    return;
+  if(!isPileUp && fKeepOnlyOOBPileupEvents)
+    return;
 
   fHistEventsProcessed->Fill(0.5);
 

--- a/PWGHF/vertexingHF/AliCFTaskVertexingHF.h
+++ b/PWGHF/vertexingHF/AliCFTaskVertexingHF.h
@@ -289,14 +289,13 @@ class AliCFTaskVertexingHF: public AliAnalysisTaskSE {
   void QSortTracks(TObjArray& a, Int_t first, Int_t last);
   TObjArray* SortRegionsRT(const AliVParticle* leading, TObjArray *array);
   TObjArray* GetMinMaxRegionRT(TList *transv1, TList *transv2);
-  
-  
- 
-  void SetAODMismatchProtection(Int_t opt=0) {fAODProtection=opt;}
-  
+    
   Double_t GetMinLeadPtRT() const {return fMinLeadPtRT;}
   void SetMinLeadPtRT(Double_t opt) {fMinLeadPtRT = opt;}
   
+  void SetAODMismatchProtection(Int_t opt=0) {fAODProtection=opt;}
+  void SetRejectOOBPileupEvents() {fRejectOOBPileUpEvents=kTRUE; fKeepOnlyOOBPileupEvents=kFALSE;}
+  void SetKeepOnlyOOBPileupEvents() {fRejectOOBPileUpEvents=kFALSE; fKeepOnlyOOBPileupEvents=kTRUE;}
 
  protected:
   AliCFManager   *fCFManager;   ///  pointer to the CF manager
@@ -361,14 +360,14 @@ class AliCFTaskVertexingHF: public AliAnalysisTaskSE {
   Bool_t fUseCascadeTaskForLctoV0bachelor;   /// flag to define which task to use for Lc --> K0S+p
   Bool_t fFillMinimumSteps;   /// Skip filling the unneed steps for most of the analyses to save disk space
   Float_t fCutOnMomConservation; /// cut on momentum conservation
+  Double_t fMinLeadPtRT;   /// minimum pT cut for leading particle in RT calculation
   Int_t fAODProtection;         /// flag to activate protection against AOD-dAOD mismatch.
                                 /// -1: no protection,  0: check AOD/dAOD nEvents only,  1: check AOD/dAOD nEvents + TProcessID names
-
-  Double_t fMinLeadPtRT;   /// minimum pT cut for leading particle in RT calculation
-  
+  Bool_t fRejectOOBPileUpEvents; /// flag to enable rejection of events with simulated pileup
+  Bool_t fKeepOnlyOOBPileupEvents; /// flag to keep only events with simulated pileup
 
   /// \cond CLASSIMP     
-  ClassDef(AliCFTaskVertexingHF,29); /// class for HF corrections as a function of many variables
+  ClassDef(AliCFTaskVertexingHF,30); /// class for HF corrections as a function of many variables
   /// \endcond
 };
 

--- a/PWGHF/vertexingHF/AliRDHFCuts.h
+++ b/PWGHF/vertexingHF/AliRDHFCuts.h
@@ -36,7 +36,7 @@ class AliRDHFCuts : public AliAnalysisCuts
   enum ESelLevel {kAll,kTracks,kPID,kCandidate};
   enum EPileup {kNoPileupSelection,kRejectPileupEvent,kRejectTracksFromPileupVertex,kRejectMVPileupEvent};
   enum ESele {kD0toKpiCuts,kD0toKpiPID,kD0fromDstarCuts,kD0fromDstarPID,kDplusCuts,kDplusPID,kDsCuts,kDsPID,kLcCuts,kLcPID,kDstarCuts,kDstarPID,kLctoV0Cuts,kDplustoK0sCuts,kDstoK0sCuts};
-  enum ERejBits {kNotSelTrigger,kNoVertex,kTooFewVtxContrib,kZVtxOutFid,kPileup,kOutsideCentrality,kPhysicsSelection,kBadSPDVertex,kZVtxSPDOutFid,kCentralityFlattening,kBadTrackV0Correl,kMismatchOldNewCentrality,kBadTrackVertex,kBadCentrEstimCorrel,kBadTimeRange};
+  enum ERejBits {kNotSelTrigger,kNoVertex,kTooFewVtxContrib,kZVtxOutFid,kPileup,kOutsideCentrality,kPhysicsSelection,kBadSPDVertex,kZVtxSPDOutFid,kCentralityFlattening,kBadTrackV0Correl,kMismatchOldNewCentrality,kBadTrackVertex,kBadCentrEstimCorrel,kBadTimeRange,kBadTPCITSCorrel};
   enum EV0sel  {kAllV0s = 0, kOnlyOfflineV0s = 1, kOnlyOnTheFlyV0s = 2};
 
   AliRDHFCuts(const Char_t* name="RDHFCuts", const Char_t* title="");
@@ -201,6 +201,7 @@ class AliRDHFCuts : public AliAnalysisCuts
 
   void SetUseCentralityCorrelationCuts(Bool_t opt){fApplyCentralityCorrCuts=opt;}
   void SetUsePbPbOutOfBunchPileupCut(Int_t opt){fApplyPbPbOutOfBunchPileupCuts=opt;}
+  void SetUsePbPbOutOfBunchPileupCutITSTPC(Int_t opt, Bool_t keepOnlyPileup=kFALSE) {fApplyPbPbOutOfBunchPileupCutsITSTPC=opt; fKeepOnlyPbPbOutOfBunchPileupCutsITSTPC=keepOnlyPileup;}
   void SetUseAliEventCuts(){fUseAliEventCuts=kTRUE;}
   void SetUseTimeRangeCutForPbPb2018(Bool_t opt){fUseTimeRangeCutForPbPb2018=opt;}
   AliEventCuts* GetAliEventCuts() const { return fAliEventCuts;}
@@ -530,6 +531,8 @@ class AliRDHFCuts : public AliAnalysisCuts
   AliEventCuts* fAliEventCuts;   /// AliEventCuts object used in Pb-Pb for cuts on correlations and out-of-bunch pileup
   Bool_t fApplyCentralityCorrCuts; /// swicth to enable/disable cuts on centrality correlations
   Int_t fApplyPbPbOutOfBunchPileupCuts; /// switch for additional correlation cuts for out-of-bunch pileup (0=no cut, 1=AliEVentCuts, 2=Ionut cut vs. nTPC cls)
+  Int_t fApplyPbPbOutOfBunchPileupCutsITSTPC; /// switch for additional cuts for out-of-bunch pileup based on ITS-TPC correlation (0=no cut, 1=tight cut, 2=intermediate cut, 3=loose cut)
+  Bool_t fKeepOnlyPbPbOutOfBunchPileupCutsITSTPC; /// flag to keep only out-of-bunch pileup events tagged with ITS-TPC correlation
   Bool_t fUseAliEventCuts;  /// flag for using AliEventCuts
   Bool_t fUseTimeRangeCutForPbPb2018; /// flag to enable the timestamp based selection of good events in the 7 runs of LHC18r with problems in TPC dE/dx
   AliTimeRangeCut fTimeRangeCut;   /// object to manage time range cut
@@ -540,7 +543,7 @@ class AliRDHFCuts : public AliAnalysisCuts
   Int_t fSystemForNsigmaTPCDataCorr; /// system for data-driven NsigmaTPC correction
 
   /// \cond CLASSIMP
-  ClassDef(AliRDHFCuts,52);  /// base class for cuts on AOD reconstructed heavy-flavour decays
+  ClassDef(AliRDHFCuts,53);  /// base class for cuts on AOD reconstructed heavy-flavour decays
   /// \endcond
 };
 


### PR DESCRIPTION
- Add possibility to apply TPC OOB pileup cut based on ITS-TPC correlation
- Add information about different TPC OOB pileup cuts based on ITS-TPC correlation in PID tree
- Add possibility to keep only/reject MC events with simulated pileup