### PR TITLE
PWGGA/GammaConv: GammaIsoTree refined prompt photon definition & more

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskGammaIsoTree.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaIsoTree.h
@@ -26,6 +26,7 @@
 #include "TLorentzVector.h"
 #include "AliRhoParameter.h"
 #include "AliCaloTrackMatcher.h"
+#include "AliMCAnalysisUtils.h"
 
 #ifndef AliAnalysisTaskGammaIsoTree_cxx
 #define AliAnalysisTaskGammaIsoTree_cxx
@@ -131,6 +132,11 @@ class AliAnalysisTaskGammaIsoTree : public AliAnalysisTaskSE{
     virtual ~AliAnalysisTaskGammaIsoTree();
     AliCalorimeterUtils * GetCaloUtils()     { if (!fCaloUtils) fCaloUtils = new AliCalorimeterUtils() ; 
                                              return fCaloUtils     ; }
+    AliMCAnalysisUtils * GetMCAnalysisUtils()     { if (!fMCAnalysisUtils){
+                                                    fMCAnalysisUtils = new AliMCAnalysisUtils() ; 
+                                                    fMCAnalysisUtils->SetMCGenerator(0);
+                                                    }
+                                             return fMCAnalysisUtils     ; }                                         
     virtual void   UserCreateOutputObjects  ();
     virtual Bool_t Notify                   ();
     void SetV0ReaderName(TString name){fV0ReaderName=name; return;}
@@ -296,6 +302,7 @@ class AliAnalysisTaskGammaIsoTree : public AliAnalysisTaskSE{
     AliConversionPhotonCuts*    fConvCuts;                  // Cuts used by the V0Reader
 
     AliCalorimeterUtils*        fCaloUtils;
+    AliMCAnalysisUtils*         fMCAnalysisUtils;
     
     // Track cuts
     Int_t                       fMinClsTPC;  // 
@@ -673,13 +680,17 @@ class AliAnalysisTaskGammaIsoTree : public AliAnalysisTaskSE{
     Bool_t IsInEMCalAcceptance(AliAODMCParticle *part); // check if mcpart is in emc acceptance
     Bool_t IsTrueConversionPhoton(AliAODConversionPhoton *photon);
     Int_t GetConvPhotonMCLabel(AliAODConversionPhoton *photon);
-    Bool_t IsDecayPhoton(AliAODMCParticle *mcphoton);
+    Bool_t IsDecayPhoton(Int_t label);
     Bool_t IsDecayPhoton(AliAODConversionPhoton *photon);
     Int_t CheckClustersForMCContribution(Int_t mclabel, TClonesArray *vclus);
     Int_t CheckConvForMCContribution(Int_t mclabel, TClonesArray *vconv);
+    Bool_t IsPromptPhoton(AliAODConversionPhoton *photon);
+    Bool_t IsPromptPhoton(Int_t label);
+    Bool_t IsFragPhoton(AliAODConversionPhoton *photon);
+    Bool_t IsFragPhoton(Int_t label);
     AliAnalysisTaskGammaIsoTree(const AliAnalysisTaskGammaIsoTree&); // Prevent copy-construction
     AliAnalysisTaskGammaIsoTree& operator=(const AliAnalysisTaskGammaIsoTree&); // Prevent assignment  
-    ClassDef(AliAnalysisTaskGammaIsoTree, 22);
+    ClassDef(AliAnalysisTaskGammaIsoTree, 23);
 };
 
 #endif

--- a/PWGGA/GammaConv/macros/AddTask_GammaCalo_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaCalo_pp.C
@@ -963,6 +963,9 @@ void AddTask_GammaCalo_pp(
     cuts.AddCutCalo("00000113","11111110b70322l0000","01631031000000d0"); // std
   } else if (trainConfig == 284){ // EMCAL clusters pp 7 TeV
     cuts.AddCutCalo("00000113","11111110b70322l0000","01631031000000d0"); // std
+  } else if (trainConfig == 285){ // FLORIAN TESTING
+    cuts.AddCutCalo("00010103","111113206f532000003","01631031000000d0"); // std
+    // cuts.AddCutCalo("00000000","111113206f532000003","01631031000000d0"); // std
 
 
   // *****************************************************************************************************

--- a/PWGGA/GammaConv/macros/AddTask_GammaIsoTree.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaIsoTree.C
@@ -108,7 +108,7 @@ void AddTask_GammaIsoTree(
       doTagging = kTRUE;
       doCellIso = kTRUE;
   } else if(trainConfig == 5){  // min bias loose cluster cuts
-      TaskEventCutnumber                = "00052113";
+      TaskEventCutnumber                = "00052103";
       TaskClusterCutnumberEMC           = "111113200f000000000";
       TaskClusterCutnumberIsolationEMC = "111113206f022700000";
       TaskClusterCutnumberTaggingEMC = "111113206f022700000";
@@ -123,7 +123,7 @@ void AddTask_GammaIsoTree(
 
   // cut based study
   } else if(trainConfig == 6){  // min bias (cuts from PCMEMC 84 + loose iso)
-      TaskEventCutnumber                = "00010113";
+      TaskEventCutnumber                = "00010103";
       TaskClusterCutnumberEMC           = "111113206f532000003";
       TaskClusterCutnumberIsolationEMC  = "111113206f022000000";
       TaskClusterCutnumberTaggingEMC    = "111113206f000000000";
@@ -139,7 +139,7 @@ void AddTask_GammaIsoTree(
       doTagging = kTRUE;
       doCellIso = kTRUE;
   } else if(trainConfig == 7){  // trigger
-      TaskEventCutnumber                = "00052113";
+      TaskEventCutnumber                = "00052103";
       TaskClusterCutnumberEMC           = "111113206f532000003";
       TaskClusterCutnumberIsolationEMC  = "111113206f022000000";
       TaskClusterCutnumberTaggingEMC    = "111113206f000000000";
@@ -155,7 +155,7 @@ void AddTask_GammaIsoTree(
       doTagging = kTRUE;
       doCellIso = kTRUE;
   } else if(trainConfig == 8){  // trigger
-      TaskEventCutnumber                = "00081113";
+      TaskEventCutnumber                = "00081103";
       TaskClusterCutnumberEMC           = "111113206f532000003";
       TaskClusterCutnumberIsolationEMC  = "111113206f022000000";
       TaskClusterCutnumberTaggingEMC    = "111113206f000000000";

--- a/PWGGA/GammaConvBase/AliCaloPhotonCuts.cxx
+++ b/PWGGA/GammaConvBase/AliCaloPhotonCuts.cxx
@@ -2167,8 +2167,19 @@ Bool_t AliCaloPhotonCuts::ClusterIsSelectedAODMC(AliAODMCParticle *particle,TClo
       if ( particle->Phi() < fMinPhiCut || particle->Phi() > fMaxPhiCut ) return kFALSE;
       if ( fClusterType == 3 && particle->Eta() < fMaxEtaInnerEdge && particle->Eta() > fMinEtaInnerEdge ) return kFALSE;
     }
-    if(particle->GetMother() > -1 && (static_cast<AliAODMCParticle*>(aodmcArray->At(particle->GetMother())))->GetPdgCode() == 22){
-        return kFALSE;// no photon as mothers!
+    // if(particle->GetMother() > -1 && (static_cast<AliAODMCParticle*>(aodmcArray->At(particle->GetMother())))->GetPdgCode() == 22){
+    //     //  cout << "kicking out photon as mother" << endl;
+    //     // printf(Form("UniqueID=%i PDG=%i  MotherID=%i MotherPDG=%i \n",particle->GetUniqueID(),particle->GetPdgCode(),particle->GetMother(),(static_cast<AliAODMCParticle*>(aodmcArray->At(particle->GetMother())))->GetPdgCode()));
+    //     return kFALSE;// no photon as mothers!
+    // }
+    
+    // reject photons with daughter photons instead, to end up only with final photon, not initial
+    for (Int_t i = 0; i < particle->GetNDaughters(); i++)
+    {
+      Int_t dlabel = particle->GetDaughterLabel(i);
+      if((static_cast<AliAODMCParticle*>(aodmcArray->At(dlabel)))->GetPdgCode() == 22){
+         return kFALSE; // no photon with photon daughters
+      }
     }
     return kTRUE;// return in case of accepted gamma
   }

--- a/PWGGA/GammaConvBase/AliCaloPhotonCuts.cxx
+++ b/PWGGA/GammaConvBase/AliCaloPhotonCuts.cxx
@@ -2081,8 +2081,16 @@ Bool_t AliCaloPhotonCuts::ClusterIsSelectedMC(TParticle *particle,AliMCEvent *mc
       if ( particle->Phi() < fMinPhiCut || particle->Phi() > fMaxPhiCut ) return kFALSE;
       if ( fClusterType == 3 && particle->Eta() < fMaxEtaInnerEdge && particle->Eta() > fMinEtaInnerEdge ) return kFALSE;
     }
-    if(particle->GetMother(0) >-1 && mcEvent->Particle(particle->GetMother(0))->GetPdgCode() == 22){
-      return kFALSE;// no photon as mothers!
+    // if(particle->GetMother(0) >-1 && mcEvent->Particle(particle->GetMother(0))->GetPdgCode() == 22){
+    //   return kFALSE;// no photon as mothers!
+    // }
+    // reject photons with daughter photons instead, to end up only with final photon, not initial
+    for (Int_t i = 0; i < particle->GetNDaughters(); i++)
+    {
+      Int_t dlabel = particle->GetDaughter(i);
+      if((static_cast<AliMCParticle*>(mcEvent->GetTrack(dlabel)))->PdgCode() == 22){
+         return kFALSE; // no photon with photon daughters
+      }
     }
     return kTRUE;
   }

--- a/PWGGA/GammaConvBase/AliConvEventCuts.h
+++ b/PWGGA/GammaConvBase/AliConvEventCuts.h
@@ -598,7 +598,11 @@ class AliConvEventCuts : public AliAnalysisCuts {
                                       AliVEvent *event = 0x0,
                                       Int_t debug = 0
                                    );
-
+      TString   GetParticleHeaderName(  Int_t index,
+                                      AliMCEvent *mcEvent,
+                                      AliVEvent *event = 0x0,
+                                      Int_t debug = 0
+                                   );
       void    LoadWeightingFlatCentralityFromFile ();
       void    LoadWeightingMultiplicityFromFile ();
       void    LoadReweightingHistosMCFromFile ();
@@ -787,7 +791,7 @@ class AliConvEventCuts : public AliAnalysisCuts {
   private:
 
       /// \cond CLASSIMP
-      ClassDef(AliConvEventCuts,81)
+      ClassDef(AliConvEventCuts,82)
       /// \endcond
 };
 


### PR DESCRIPTION
- new definition for prompt, frag and decay photons in IsoTree tasks, using utils from AliMCAnalysisUtils by Gustavo
- added function to event cuts that allow to get header name for a given particle
- changed behavior of AliCaloPhotonCuts:
    before, gen level photons are rejected if they have a photon mother. This, I believe, is not the behavior we want. In this way, one ends up with the initial photon of a chain, without any further corrections/modifications done by pythia. We want the final photon. I therefore changed it to reject photons with photon daughters. I believe thischange is not really significant when not working with GJ MC