### PR TITLE
Add option for enable/disable time calib

### DIFF
--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellTimeCalib.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellTimeCalib.cxx
@@ -53,11 +53,13 @@ Bool_t AliEmcalCorrectionCellTimeCalib::Initialize()
   
   AliWarning("Init EMCAL time calibration");
   
-  fCalibrateTime = kTRUE;
-
   // init reco utils
   if (!fRecoUtils)
     fRecoUtils  = new AliEMCALRecoUtils;
+
+  bool doL1PhaseShiftOnly = kFALSE;
+  GetProperty("doL1PhaseShiftOnly", doL1PhaseShiftOnly);
+  fCalibrateTime = !doL1PhaseShiftOnly;
 
   GetProperty("doMergedBCs", fDoMergedBCs);    
 
@@ -516,7 +518,7 @@ Bool_t AliEmcalCorrectionCellTimeCalib::CheckIfRunChanged()
       fDoCalibrateLowGain = kFALSE;    
     }
       
-    Bool_t needTimecalibL1Phase = fCalibrateTime & fCalibrateTimeL1Phase;
+    Bool_t needTimecalibL1Phase = fCalibrateTimeL1Phase;
     
     // init time calibration
     if (needTimecalib && fUseAutomaticTimeCalib) {

--- a/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
+++ b/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
@@ -92,6 +92,7 @@ CellBadChannel:                                     # Bad channel removal at the
 CellTimeCalib:                                      # Cell Time Calibration component
     enabled: false                                  # Whether to enable the task
     createHistos: false                             # Whether the task should create output histograms
+    doL1PhaseShiftOnly: false                       # Whether the task should apply time recalibration
     doMergedBCs: false                              # Whether the task should use the merged BC histogram
     doCalibrateLowGain: false                       # Whether the task should calibrate the low gain cells
     doCalibMergedLG: false                          # Whether the task should calibrate the low gain cells using the all periods merged LG histogram


### PR DESCRIPTION
Default value is enabled, so the switch is there to
switch off time recalibration.

Load Phase calib also in case time calib is disabled