### PR TITLE
Fix loading of aligenmc grid package

### DIFF
--- a/PWG/MCLEGO/ALIGENMC/gen.sh
+++ b/PWG/MCLEGO/ALIGENMC/gen.sh
@@ -115,8 +115,16 @@ then
   ALIGENMC_VERSION="aligenmc::v0.0.5-2"
 fi
 
-#source /cvmfs/alice.cern.ch/etc/login.sh
-eval $(alienv --no-refresh printenv $ALIGENMC_VERSION)
+if [ "x$(echo $ALIGENMC_VERSION | grep :: )" != "x" ]; then
+  # cvmfs packages
+  source /cvmfs/alice.cern.ch/etc/login.sh
+  eval $(alienv printenv $ALIGENMC_VERSION)
+else
+  # dedicated handling for local builds (for local tests):
+  # do not source alienv login script
+  # do not refresh the environment
+  eval $(alienv --no-refresh printenv $ALIGENMC_VERSION)
+fi
 
 
 # build command


### PR DESCRIPTION
Environment command was not properly working for
cvmfs package but implemented as bypass for local
tests (no sourcing of login script, adding --no-refresh
option in order to prevent refreshing local workdir). This
is overcome by implementing two modes (local/cvmfs)
where the cvmfs mode is detected by "::" in the
package name