### PR TITLE
Add histograms for jet finding efficiency and purity

### DIFF
--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalSoftDropResponse.h
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalSoftDropResponse.h
@@ -72,6 +72,7 @@ public:
   void SetIsEmbeddedEvent(bool isEmbedded) {fIsEmbeddedEvent = isEmbedded; }
   void SetUseStandardOutlierRejection(bool doUse) { fUseStandardOutlierRejection = doUse; }
   void SetJetTypeOutlierCut(EJetTypeOutliers_t jtype) { fJetTypeOutliers = jtype; }
+  void SetRequirePartLevelJetInAcceptance(bool doRequest) { fRequirePartJetInAcceptance = doRequest; }
 
   // Switches for histogram groups
   void SetFillPlotsResiduals(Bool_t doFill) { fFillPlotsResiduals = doFill; }
@@ -110,6 +111,7 @@ private:
   TBinning                      *fPartLevelPtBinning;       ///< Particle level pt binning
   TBinning                      *fDetLevelPtBinning;        ///< Detector level pt binning
   Bool_t                        fIsEmbeddedEvent;           ///< true if the event is an embedded event       
+  Bool_t                        fRequirePartJetInAcceptance; ///< Require both part. and det. level jets in same acceptance
   Bool_t                        fFillPlotsResiduals;        ///< Fill residuals plots
   Bool_t                        fFillPlotsQAGeneral;        ///< Fill general QA plots
   Bool_t                        fFillPlotsQAConstituents;   ///< Fill constituent QA plots


### PR DESCRIPTION
New histograms for zg, rg, thetag and nsd:
- Jet finding effiency (observable, part. pt, match status)
- Jet finding purity (observable, det. pt, match status)
- Part level 2D distributions (observable, pt)
Matching status distinguishes between
- No match (0)
- Match, but outside fiducial acceptance (1)
- Match, inside fiducial acceptance (2)
Jet finding purity implemented for pp and PbPb,
jet finding efficiency and part. level distributions
only for pp