### PR TITLE
PWG/EMCal: low gain time calib fix for Run1

### DIFF
--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellTimeCalib.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellTimeCalib.cxx
@@ -72,7 +72,6 @@ Bool_t AliEmcalCorrectionCellTimeCalib::Initialize()
     fRecoUtils->SwitchOnLG();
   else
     fRecoUtils->SwitchOffLG();
-
   fRecoUtils->SetPositionAlgorithm(AliEMCALRecoUtils::kPosTowerGlobal);
 
   return kTRUE;
@@ -513,7 +512,8 @@ Bool_t AliEmcalCorrectionCellTimeCalib::CheckIfRunChanged()
 
     if(fRun<225000 && fCalibrateTime && fDoCalibrateLowGain){
       AliWarning("The low gain calibration histograms don't exist for Run1, switching off the calibration");
-      fDoCalibrateLowGain = kFALSE;    
+      fDoCalibrateLowGain = kFALSE;   
+      fRecoUtils->SwitchOffLG(); 
     }
       
     Bool_t needTimecalibL1Phase = fCalibrateTime & fCalibrateTimeL1Phase;

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.h
@@ -24,7 +24,8 @@
 // simple struct used for merging studies
 typedef struct {
   Int_t mesonID,clusID,daughterID,daughterPDG;
-  Float_t EClus,EFrac,ETrue,PtMeson,EtaMeson;
+  Float_t EClus,EFrac,ETrue,PtMeson,EtaMeson, OpeningAngle;
+  TLorentzVector clusVec;
 } clusterLabel;
 
 class AliAnalysisTaskGammaCalo : public AliAnalysisTaskSE {

--- a/PWGGA/GammaConvBase/AliCaloPhotonCuts.cxx
+++ b/PWGGA/GammaConvBase/AliCaloPhotonCuts.cxx
@@ -2088,9 +2088,12 @@ Bool_t AliCaloPhotonCuts::ClusterIsSelectedMC(TParticle *particle,AliMCEvent *mc
     for (Int_t i = 0; i < particle->GetNDaughters(); i++)
     {
       Int_t dlabel = particle->GetDaughter(i);
+      if(dlabel>mcEvent->GetNumberOfTracks() || dlabel<0) return kFALSE;
       if((static_cast<AliMCParticle*>(mcEvent->GetTrack(dlabel)))->PdgCode() == 22){
          return kFALSE; // no photon with photon daughters
+
       }
+      
     }
     return kTRUE;
   }


### PR DESCRIPTION
- added missing line for LowGainTimeCalib to properly deactivate it in case of Run1. Previously the time calibration completely failed if user has enable lowGainTimeCalib for Run1 data
- rest of commit are things for my cluster merging studies that are unrelated to timecalib