### PR TITLE
Implement possibility to collect and embed signal MC files only for the data run block range used to anchor MC  

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalEmbeddingHelper.cxx
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalEmbeddingHelper.cxx
@@ -634,7 +634,7 @@ void AliAnalysisTaskEmcalEmbeddingHelper::SetRunblockRange()
   
   if ( nBlocks == 0 ) return ;
   
-  AliDebug(1,Form("AliAnalysisTaskEmcalEmbeddingHelper::SetRunblockRange() - nRunBlocks %d\n", nBlocks));
+  AliDebug(1,Form("nRunBlocks %d\n", nBlocks));
   
   // Recover the run number from the input data file path.
   //
@@ -653,18 +653,17 @@ void AliAnalysisTaskEmcalEmbeddingHelper::SetRunblockRange()
   
   Int_t  runMin = -1,      runMax = -1;
   for (Int_t iblock = 0; iblock < nBlocks-1; iblock++) 
-  {
-    std::istringstream(fEmbeddedRunblock.at(iblock  )) >> runMin;
-    std::istringstream(fEmbeddedRunblock.at(iblock+1)) >> runMax;
-    //    runMin = std::stoi(fEmbeddedRunblock.at(iblock  ));
-    //    runMax = std::stoi(fEmbeddedRunblock.at(iblock+1));
-    AliDebug(1,Form("\t block %d, run min %d, run max %d\n",iblock,runMin,runMax));
+  {  
+    runMin = fEmbeddedRunblock.at(iblock  );
+    runMax = fEmbeddedRunblock.at(iblock+1);
+    
+    AliDebug(1,Form("\t block %d, run min %d, run max %d",iblock,runMin,runMax));
     
     if ( runMin <= fDataRunNumber && runMax > fDataRunNumber ) 
     {
       fEmbeddedRunblockMin = runMin;
       fEmbeddedRunblockMax = runMax;
-      AliDebug(1,Form("\t Selected range %d, run min %d, run max %d\n",
+      AliDebug(1,Form("\t Selected range %d, run min %d, run max %d",
                       iblock, fEmbeddedRunblockMin, fEmbeddedRunblockMax));
       
       return ;
@@ -684,14 +683,14 @@ bool AliAnalysisTaskEmcalEmbeddingHelper::IsRunInRunblock(const std::string & pa
 {
   if ( fEmbeddedRunblockMax < 0 && fEmbeddedRunblockMin < 0 ) return true;
   
-  AliDebug(1,Form("Run range [%d,%d]\n",
+  AliDebug(1,Form("Run range [%d,%d]",
          fEmbeddedRunblockMin,fEmbeddedRunblockMax));
-
+ 
   const char * cpath = path.c_str();
 
   Int_t mcrun = AliAnalysisManager::GetRunFromAlienPath(cpath);
   
-  AliDebug(1,Form("file: %s, run %d\n",cpath,mcrun));
+  AliDebug(1,Form("\t file: %s, run %d",cpath,mcrun));
 
   if ( mcrun >= fEmbeddedRunblockMin && 
        mcrun <  fEmbeddedRunblockMax ) 
@@ -898,6 +897,7 @@ void AliAnalysisTaskEmcalEmbeddingHelper::DetermineFirstFileToEmbed()
         fFilenameIndex = TMath::FloorNint(rand.Rndm()*fFilenames.size());
         const char* path = (fFilenames.at(fFilenameIndex)).c_str();
         ok = IsRunInRunblock(path);
+        //printf("\t Path %s, first? %d \n",path,ok);
       }
       
       if ( !ok ) 
@@ -1448,10 +1448,13 @@ Bool_t AliAnalysisTaskEmcalEmbeddingHelper::SetupInputFiles()
   // Keep track of the total number of files in the TChain to ensure that we don't start repeating within the chain
   fMaxNumberOfFiles = fChain->GetListOfFiles()->GetEntries();
 
-  if (fFilenames.size() > fMaxNumberOfFiles) {
+  if ( fFilenames.size() > fMaxNumberOfFiles && fEmbeddedRunblock.size() == 0 ) {
     AliErrorStream() << "Number of input files (" << fFilenames.size() << ") is larger than the number of available files (" << fMaxNumberOfFiles << "). Something went wrong when adding some of those files to the TChain!\n";
   }
-
+  else {
+    AliInfo(Form("Final number of input files to embed %d",fMaxNumberOfFiles));
+  }
+  
   // Setup input event
   Bool_t res = InitEvent();
   if (!res) return kFALSE;

--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalEmbeddingHelper.cxx
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalEmbeddingHelper.cxx
@@ -632,30 +632,30 @@ void AliAnalysisTaskEmcalEmbeddingHelper::FilterRunblockFilenames()
     return ;
   }
   
-  std::cout << "AliAnalysisTaskEmcalEmbeddingHelper::FilterRunblockFilenames() - nRunBlocks " << nBlocks << std::endl;
+  AliInfoStream() << "nRunBlocks " << nBlocks << ".\n";
   
-  // Recover the backgroun data run number
+  // Recover the background data run number
   //
   Int_t runNumber = -1;
   if ( AliAnalysisTaskSE::InputEvent() ) {
     runNumber = AliAnalysisTaskSE::InputEvent()->GetRunNumber();
     
     if ( runNumber < 100000 || runNumber > 300000 ) {
-      AliFatal(Form("Data run number %d not good!",runNumber));
+      AliFatal(Form("Data run number %d is not good!",runNumber));
     }
   }
   
   if ( fDataRunNumber != runNumber ) {
-    AliDebugStream(0) << "    Set data run number, new "<< runNumber << ", previous "<<fDataRunNumber<<"\n";
+    AliDebugStream(1) << "Set data run number, new "<< runNumber << ", previous "<<fDataRunNumber<<".\n";
     fDataRunNumber = runNumber;
   }
   
-  std::cout << "    Data run anchor "<<fDataRunNumber<<"\n";
+  AliInfoStream() << "Data run anchor "<<fDataRunNumber<<".\n";
   
   // Select the run block
   //
   Int_t runMin = -1, runMax = -1;
-  Int_t iblock = 0;
+  UInt_t iblock = 0;
   for (iblock = 0; iblock < nBlocks-1; iblock++) 
   {  
     runMin = fEmbeddedRunblock.at(iblock  );
@@ -668,7 +668,7 @@ void AliAnalysisTaskEmcalEmbeddingHelper::FilterRunblockFilenames()
     }
   } // block loop
   
-  std::cout << "    Selected run range block "<< iblock <<": ["<<runMin<<","<<runMax<<"]"<<std::endl;
+  AliInfoStream() << "Selected run range block "<< iblock <<": ["<<runMin<<","<<runMax<<"].\n";
   
   if ( runMin < 0 && runMax < 0 ) {
     AliFatal("Runblock not found, stop!");
@@ -677,7 +677,7 @@ void AliAnalysisTaskEmcalEmbeddingHelper::FilterRunblockFilenames()
 
   // Filter the list of files
   //
-  std::cout << "    Size of filenames before filtering "<<  fFilenames.size() << std::endl; 
+  AliInfoStream() << "Size of filenames list before filtering "<<  fFilenames.size() << ".\n"; 
   
   fFilenames.erase(std::remove_if( fFilenames.begin(), fFilenames.end(),
                                   [runMin, runMax](const std::string& str) {
@@ -685,10 +685,10 @@ void AliAnalysisTaskEmcalEmbeddingHelper::FilterRunblockFilenames()
     return (run < runMin || run >= runMax); }), 
                    fFilenames.end() );
   
-  std::cout << "    Filenames after filtering "<<  fFilenames.size() <<", selected files: "<< std::endl; 
+  AliInfoStream() << "Size of filenames list after filtering "<<  fFilenames.size() <<".\n"; 
 
   for (auto v : fFilenames) {
-    std::cout <<"        "<< v << "\n";
+    AliDebugStream(1) << v << "\n";
   }
 }
 

--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalEmbeddingHelper.cxx
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalEmbeddingHelper.cxx
@@ -1419,11 +1419,8 @@ Bool_t AliAnalysisTaskEmcalEmbeddingHelper::SetupInputFiles()
   // Keep track of the total number of files in the TChain to ensure that we don't start repeating within the chain
   fMaxNumberOfFiles = fChain->GetListOfFiles()->GetEntries();
 
-  if ( fFilenames.size() > fMaxNumberOfFiles && fEmbeddedRunblock.size() == 0 ) {
+  if (fFilenames.size() > fMaxNumberOfFiles) {
     AliErrorStream() << "Number of input files (" << fFilenames.size() << ") is larger than the number of available files (" << fMaxNumberOfFiles << "). Something went wrong when adding some of those files to the TChain!\n";
-  }
-  else {
-    AliInfo(Form("Final number of input files to embed %d",fMaxNumberOfFiles));
   }
   
   // Setup input event

--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalEmbeddingHelper.cxx
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalEmbeddingHelper.cxx
@@ -662,7 +662,6 @@ void AliAnalysisTaskEmcalEmbeddingHelper::SetRunblockRange()
     
     if ( runMin <= fDataRunNumber && runMax > fDataRunNumber ) 
     {
-      
       fEmbeddedRunblockMin = runMin;
       fEmbeddedRunblockMax = runMax;
       AliDebug(1,Form("\t Selected range %d, run min %d, run max %d\n",
@@ -887,21 +886,22 @@ void AliAnalysisTaskEmcalEmbeddingHelper::DetermineFirstFileToEmbed()
 
     // In case of a fixed block run range
     // make first one of the files within the run range
-    UInt_t iter = 0;
-    UInt_t nfiles = fFilenames.size();
     if ( fEmbeddedRunblock.size() != 0 )
     {
-      printf("AliAnalysisTaskEmcalEmbeddingHelper::DetermineFirstFileToEmbed()");
+      UInt_t iter = 0;
+      UInt_t nfiles = fFilenames.size();
       Bool_t ok = kFALSE;
-      while ( !ok && iter <= nfiles*2 )
+      // Iterate but not too much
+      while ( !ok && iter <= nfiles*10 )
       {
         iter++;
         fFilenameIndex = TMath::FloorNint(rand.Rndm()*fFilenames.size());
         const char* path = (fFilenames.at(fFilenameIndex)).c_str();
         ok = IsRunInRunblock(path);
-        printf("\t First? %s \n",path);
-        if(ok) printf("\t YES \n");
       }
+      
+      if ( !ok ) 
+        AliFatal("No file found with the run range requeirements, check list of MC files and block run ranges STOP!");
     }
     else
       fFilenameIndex = TMath::FloorNint(rand.Rndm()*fFilenames.size());

--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalEmbeddingHelper.cxx
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalEmbeddingHelper.cxx
@@ -630,11 +630,13 @@ bool AliAnalysisTaskEmcalEmbeddingHelper::IsRunInRunlist(const std::string & pat
  */
 void AliAnalysisTaskEmcalEmbeddingHelper::SetRunblockRange() 
 {
-  Int_t nBlocks = fEmbeddedRunblock.size();
+  std::size_t nBlocks = fEmbeddedRunblock.size();
   
-  if ( nBlocks == 0 ) return ;
+  if ( nBlocks == 0 ) {
+    return ;
+  }
   
-  AliDebug(1,Form("nRunBlocks %d\n", nBlocks));
+  AliDebugStream(1) << "nRunBlocks " << nBlocks << "\n";
   
   // Recover the run number from the input data file path.
   //
@@ -900,12 +902,13 @@ void AliAnalysisTaskEmcalEmbeddingHelper::DetermineFirstFileToEmbed()
         //printf("\t Path %s, first? %d \n",path,ok);
       }
       
-      if ( !ok ) 
+      if ( !ok ) {
         AliFatal("No file found with the run range requeirements, check list of MC files and block run ranges STOP!");
+      }
     }
-    else
+    else {
       fFilenameIndex = TMath::FloorNint(rand.Rndm()*fFilenames.size());
-
+    }
     // +1 to account for the fact that the filenames vector is 0 indexed.
     AliInfo(TString::Format("Starting with random file number %i!", fFilenameIndex+1));
   }
@@ -1233,8 +1236,10 @@ Bool_t AliAnalysisTaskEmcalEmbeddingHelper::InitEvent()
  */
 void AliAnalysisTaskEmcalEmbeddingHelper::UserCreateOutputObjects()
 {
-  if ( fEmbeddedRunblock.size() == 0 ) 
+  if ( fEmbeddedRunblock.size() == 0 ) {
     SetupEmbedding();
+  }
+  
   // else, do it on UserExec() at least once
 
   // Reinitialize the YAML config after it was streamed so that it can be used properly.

--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalEmbeddingHelper.cxx
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalEmbeddingHelper.cxx
@@ -638,18 +638,14 @@ void AliAnalysisTaskEmcalEmbeddingHelper::SetRunblockRange()
   
   AliDebugStream(1) << "nRunBlocks " << nBlocks << "\n";
   
-  // Recover the run number from the input data file path.
-  //
-  // InputEvent() seems to be connected to the external event
-  // so one cannot use InputEvent()->GetRunNumber()
-  AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
-   
-   if ( !mgr ) return ;
+  // Recover the run number
+  Int_t runNumber = -1;
+  if ( AliAnalysisTaskSE::InputEvent() ) {
+    runNumber = AliAnalysisTaskSE::InputEvent()->GetRunNumber();
+  }
   
-  Int_t runNumber = mgr->GetRunFromPath(); 
-  if ( fDataRunNumber != runNumber )
-  {
-    //printf("\t Run number, new %d, previous %d\n",runNumber,fDataRunNumber);
+  if ( fDataRunNumber != runNumber ) {
+    AliDebugStream(0) << "Change run number, new "<< runNumber << ", previous "<<fDataRunNumber<<"\n";
     fDataRunNumber = runNumber;
   }
   
@@ -1733,10 +1729,16 @@ void AliAnalysisTaskEmcalEmbeddingHelper::UserExec(Option_t*)
   {
     // I do not think this is enough, I am not sure how to know if the train 
     // was setup for run by run or run mixed analysis
-    AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
-    if ( mgr && fDataRunNumber > -1 && fDataRunNumber!=mgr->GetRunFromPath() )
-      AliError(Form("CAREFUL! Check what you are doing, you are embedding a data run %d that belongs to another runblock [%d,%d]!, setup the train to do the analysis per Run",
-                 InputEvent()->GetRunNumber(),fEmbeddedRunblockMin,fEmbeddedRunblockMax));
+    Int_t runNumber = -1;
+    if ( AliAnalysisTaskSE::InputEvent() ) {
+      runNumber = AliAnalysisTaskSE::InputEvent()->GetRunNumber();
+    }
+    
+    if ( fDataRunNumber > -1 && fDataRunNumber != runNumber ) {
+      AliError(Form("CAREFUL! Check what you are doing, you are embedding a data run %d "
+                    "that belongs to another runblock [%d,%d]!, setup the train to do the analysis per Run",
+                    AliAnalysisTaskSE::InputEvent()->GetRunNumber(),fEmbeddedRunblockMin,fEmbeddedRunblockMax));
+    }
   }
 
   // Apply internal event selection

--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalEmbeddingHelper.h
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalEmbeddingHelper.h
@@ -292,6 +292,8 @@ class AliAnalysisTaskEmcalEmbeddingHelper : public AliAnalysisTaskSE {
   bool            GetFilenames()        ;
   void            DeterminePythiaXSecFilename();
   bool            IsRunInRunlist(const std::string & path) const;
+  bool            IsRunInRunblock(const std::string & path) const;
+  void            SetRunblockRange()    ;
   bool            InitializeYamlConfig();
   bool            AutoConfigurePtHardBins();
   std::string     GenerateUniqueFileListFilename() const;
@@ -358,6 +360,10 @@ class AliAnalysisTaskEmcalEmbeddingHelper : public AliAnalysisTaskSE {
   std::vector <std::string>                     fFilenames        ; ///<  Paths to the files to embed
   std::string                                   fConfigurationPath; ///<  Path to %YAML configuration
   std::vector <std::string>                     fEmbeddedRunlist  ; ///<  Good runlist for files to embed
+  std::vector <std::string>                     fEmbeddedRunblock ; ///<  Good runblock for files to embed, each run corresponds to the first run of a block
+  Int_t                                         fEmbeddedRunblockMin; ///< Minimum run in the run range valid for embedding
+  Int_t                                         fEmbeddedRunblockMax; ///< Maximum run in the run range valid for embedding, this one is first of next block  
+  Int_t                                         fDataRunNumber    ;   ///< Current run number in data file  
   std::string                                  fPythiaXSecFilename; ///<  Name of the pythia x sec filename (either "pyxsec.root" or "pyxsec_hists.root")
   std::vector <std::string>                     fPythiaCrossSectionFilenames; ///< Paths to the pythia xsection files
   TFile                                        *fExternalFile     ; //!<! External file used for embedding
@@ -391,7 +397,7 @@ class AliAnalysisTaskEmcalEmbeddingHelper : public AliAnalysisTaskSE {
   AliAnalysisTaskEmcalEmbeddingHelper &operator=(const AliAnalysisTaskEmcalEmbeddingHelper&); // not implemented
 
   /// \cond CLASSIMP
-  ClassDef(AliAnalysisTaskEmcalEmbeddingHelper, 13);
+  ClassDef(AliAnalysisTaskEmcalEmbeddingHelper, 14);
   /// \endcond
 };
 #endif

--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalEmbeddingHelper.h
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalEmbeddingHelper.h
@@ -292,8 +292,7 @@ class AliAnalysisTaskEmcalEmbeddingHelper : public AliAnalysisTaskSE {
   bool            GetFilenames()        ;
   void            DeterminePythiaXSecFilename();
   bool            IsRunInRunlist(const std::string & path) const;
-  bool            IsRunInRunblock(const std::string & path) const;
-  void            SetRunblockRange()    ;
+  void            FilterRunblockFilenames();
   bool            InitializeYamlConfig();
   bool            AutoConfigurePtHardBins();
   std::string     GenerateUniqueFileListFilename() const;
@@ -360,10 +359,8 @@ class AliAnalysisTaskEmcalEmbeddingHelper : public AliAnalysisTaskSE {
   std::vector <std::string>                     fFilenames        ; ///<  Paths to the files to embed
   std::string                                   fConfigurationPath; ///<  Path to %YAML configuration
   std::vector <std::string>                     fEmbeddedRunlist  ; ///<  Good runlist for files to embed
-  std::vector <int>                            fEmbeddedRunblock ; ///<  Good runblock for files to embed, each run corresponds to the first run of a block
-  Int_t                                         fEmbeddedRunblockMin; ///< Minimum run in the run range valid for embedding
-  Int_t                                         fEmbeddedRunblockMax; ///< Maximum run in the run range valid for embedding, this one is first of next block  
-  Int_t                                         fDataRunNumber    ;   ///< Current run number in data file  
+  std::vector <int>                             fEmbeddedRunblock ; ///<  Good runblock for files to embed, each run corresponds to the first run of a block
+  Int_t                                         fDataRunNumber    ; ///< Current run number in data file  
   std::string                                  fPythiaXSecFilename; ///<  Name of the pythia x sec filename (either "pyxsec.root" or "pyxsec_hists.root")
   std::vector <std::string>                     fPythiaCrossSectionFilenames; ///< Paths to the pythia xsection files
   TFile                                        *fExternalFile     ; //!<! External file used for embedding

--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalEmbeddingHelper.h
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalEmbeddingHelper.h
@@ -360,7 +360,7 @@ class AliAnalysisTaskEmcalEmbeddingHelper : public AliAnalysisTaskSE {
   std::vector <std::string>                     fFilenames        ; ///<  Paths to the files to embed
   std::string                                   fConfigurationPath; ///<  Path to %YAML configuration
   std::vector <std::string>                     fEmbeddedRunlist  ; ///<  Good runlist for files to embed
-  std::vector <std::string>                     fEmbeddedRunblock ; ///<  Good runblock for files to embed, each run corresponds to the first run of a block
+  std::vector <int>                            fEmbeddedRunblock ; ///<  Good runblock for files to embed, each run corresponds to the first run of a block
   Int_t                                         fEmbeddedRunblockMin; ///< Minimum run in the run range valid for embedding
   Int_t                                         fEmbeddedRunblockMax; ///< Maximum run in the run range valid for embedding, this one is first of next block  
   Int_t                                         fDataRunNumber    ;   ///< Current run number in data file  


### PR DESCRIPTION
Make sure that given a grid job only the MC files anchored to a run  that corresponds to the block run range of the input data file are used for the embedding.
Implemented only for analysis in trains running analysis per run.