### PR TITLE
Added a new way to set the total number of runs

### DIFF
--- a/PWGMM/Lumi/vdM/VdmStability/AddTask_ilofnes_Vdm.C
+++ b/PWGMM/Lumi/vdM/VdmStability/AddTask_ilofnes_Vdm.C
@@ -1,4 +1,4 @@
-AliAnalysisTaskVdmStability* AddTask_ilofnes_Vdm(TString name = "name", char *year = "16", Bool_t fillTTree = false) {
+AliAnalysisTaskVdmStability* AddTask_ilofnes_Vdm(TString name = "name", char *year = "16", Bool_t fillTTree = false, Int_t nRuns = 0) {
     
     AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
   
@@ -8,8 +8,10 @@ AliAnalysisTaskVdmStability* AddTask_ilofnes_Vdm(TString name = "name", char *ye
     
     // now we create an instance of your task
     AliAnalysisTaskVdmStability* task = new AliAnalysisTaskVdmStability(name.Data());
-    if (year == "16") task->SetNRuns(627);
-    if (year == "17") task->SetNRuns(816);
+    if (year == "16") task->SetNRuns(650);//max
+    if (year == "17") task->SetNRuns(864);//max
+    if (year == "18") task->SetNRuns(1000);//790 CB
+    if (nRuns > 0) task->SetNRuns(nRuns);
     task->SetNCases(21);
     task->SetFillTTree(fillTTree);
 


### PR DESCRIPTION
Instead of a fixed set of nRuns, with this mod anyone will be available to run different run lists without the need to change the add task. The common number of runs used for stability is there, but if the option nRuns is set then the number of runs to fill the histograms will be modified accordingly. 