### PR TITLE
PWGGA/GammaConv: ElectronStudies fixed types & added EMC CF default conf

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskElectronStudies.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskElectronStudies.cxx
@@ -340,9 +340,9 @@ void AliAnalysisTaskElectronStudies::UserCreateOutputObjects()
   fAnalysisTree->Branch("Cluster_M02","std::vector<UShort_t>", &fBuffer_ClusterM02);
   fAnalysisTree->Branch("Cluster_M20","std::vector<UShort_t>", &fBuffer_ClusterM20);
   fAnalysisTree->Branch("Track_E","std::vector<UShort_t>", &fBuffer_Track_E);
-  fAnalysisTree->Branch("Track_Px","std::vector<UShort_t>", &fBuffer_Track_Px);
-  fAnalysisTree->Branch("Track_Py","std::vector<UShort_t>", &fBuffer_Track_Py);
-  fAnalysisTree->Branch("Track_Pz","std::vector<UShort_t>", &fBuffer_Track_Pz);
+  fAnalysisTree->Branch("Track_Px","std::vector<Short_t>", &fBuffer_Track_Px);
+  fAnalysisTree->Branch("Track_Py","std::vector<Short_t>", &fBuffer_Track_Py);
+  fAnalysisTree->Branch("Track_Pz","std::vector<Short_t>", &fBuffer_Track_Pz);
   fAnalysisTree->Branch("Track_PonEMCal","std::vector<UShort_t>", &fBuffer_Track_PonEMCal);
   fAnalysisTree->Branch("Track_Charge","std::vector<Short_t>", &fBuffer_Track_Charge);
   fAnalysisTree->Branch("Track_dEta","std::vector<Short_t>", &fBuffer_Track_dEta);
@@ -357,9 +357,9 @@ void AliAnalysisTaskElectronStudies::UserCreateOutputObjects()
   if(fIsMC>0){    
      fAnalysisTree->Branch("MC_True_Cluster_E","std::vector<UShort_t>", &fBuffer_MC_True_Cluster_E);
      fAnalysisTree->Branch("MC_True_Track_E","std::vector<UShort_t>", &fBuffer_MC_True_Track_E);
-     fAnalysisTree->Branch("MC_True_Track_Px","std::vector<UShort_t>", &fBuffer_MC_True_Track_Px);
-     fAnalysisTree->Branch("MC_True_Track_Py","std::vector<UShort_t>", &fBuffer_MC_True_Track_Py);
-     fAnalysisTree->Branch("MC_True_Track_Pz","std::vector<UShort_t>", &fBuffer_MC_True_Track_Pz);
+     fAnalysisTree->Branch("MC_True_Track_Px","std::vector<Short_t>", &fBuffer_MC_True_Track_Px);
+     fAnalysisTree->Branch("MC_True_Track_Py","std::vector<Short_t>", &fBuffer_MC_True_Track_Py);
+     fAnalysisTree->Branch("MC_True_Track_Pz","std::vector<Short_t>", &fBuffer_MC_True_Track_Pz);
      fAnalysisTree->Branch("MC_True_Track_MotherPDG","std::vector<Int_t>", &fBuffer_MC_True_Track_MotherPDG);
      fAnalysisTree->Branch("MC_Track_Is_Electron","std::vector<Bool_t>", &fBuffer_MC_Track_Is_Electron);
      fAnalysisTree->Branch("MC_Cluster_Is_Electron","std::vector<Bool_t>", &fBuffer_MC_Cluster_Is_Electron);
@@ -481,6 +481,24 @@ void AliAnalysisTaskElectronStudies::UserExec(Option_t *){
   fAnalysisTree->Fill();
 
   PostData(2, fAnalysisTree);
+
+  // cout << "-------- END OF EVENT" << endl;
+  // cout << "Size vector = " << fBuffer_ClusterE.size() << endl;
+  // for (Int_t i = 0; i < fBuffer_ClusterE.size(); i++)
+  // {
+  //   cout << "i=" << i << "   ClusterE=" << fBuffer_ClusterE.at(i) << endl;
+  //   cout << "i=" << i << "   MatchType=" << fBuffer_MatchType.at(i) << endl;
+  //   cout << "i=" << i << "   TrackPx=" << (Float_t)fBuffer_Track_Px.at(i)/kShortScaleLow << endl;
+  //   cout << "i=" << i << "   TrackPy=" << (Float_t)fBuffer_Track_Py.at(i)/kShortScaleLow  << endl;
+  //   cout << "i=" << i << "   TrackPz=" << (Float_t)fBuffer_Track_Pz.at(i)/kShortScaleLow  << endl;
+  //   cout << "i=" << i << "   TrackdEta=" << (Float_t)fBuffer_Track_dEta.at(i)/kShortScaleHigh << endl;
+  //   cout << "i=" << i << "   TrackdPhi=" << (Float_t)fBuffer_Track_dPhi.at(i)/kShortScaleHigh << endl;
+  //   cout << "i=" << i << "   TrackNSigma=" << (Float_t)fBuffer_Track_NSigmaElec.at(i)/kShortScaleHigh << endl;
+  
+  // }
+       
+    // fBuffer_ClusterM02.push_back(input.ClusterM02); 
+    // fBuffer_ClusterM20.push_back(input.ClusterM20); 
   
   ResetBuffer();
   //gObjectTable->Print();
@@ -757,14 +775,14 @@ void AliAnalysisTaskElectronStudies::ProcessMatchedTrack(AliAODTrack* track, Ali
     output.ClusterM02 =  ConvertToUShort(clus->GetM02(),kShortScaleMiddle);
     output.ClusterM20 = ConvertToUShort(clus->GetM20(),kShortScaleMiddle);
     output.Track_E = ConvertToUShort(track->E(),kShortScaleLow);
-    output.Track_Px = ConvertToUShort(track->Px(),kShortScaleLow);
-    output.Track_Py = ConvertToUShort(track->Py(),kShortScaleLow);
-    output.Track_Pz = ConvertToUShort(track->Pz(),kShortScaleLow);
+    output.Track_Px = ConvertToShort(track->Px(),kShortScaleLow);
+    output.Track_Py = ConvertToShort(track->Py(),kShortScaleLow);
+    output.Track_Pz = ConvertToShort(track->Pz(),kShortScaleLow);
     output.Track_PonEMCal = ConvertToUShort(track->GetTrackPOnEMCal(),kShortScaleLow);
     output.Track_NSigmaElec =  ConvertToShort(fPIDResponse->NumberOfSigmasTPC(track,AliPID::kElectron),kShortScaleMiddle); 
     output.Track_IsFromV0 = isV0; 
     output.Track_Charge = track->Charge();
-    
+
     output.MC_True_Cluster_E = 0; 
     output.MC_True_Track_E = 0; 
     output.MC_True_Track_Px = 0; 
@@ -811,15 +829,15 @@ void AliAnalysisTaskElectronStudies::ProcessMatchedTrack(AliAODTrack* track, Ali
         Int_t trackMCLabel = track->GetLabel();
   
         AliAODMCParticle* trackMC = NULL;
-
+        
         if(trackMCLabel>-1){
           trackMC = (AliAODMCParticle* )fAODMCTrackArray->At(trackMCLabel);
           if(TMath::Abs(trackMC->GetPdgCode()) == 11){
             output.MC_Track_Is_Electron = kTRUE;
             output.MC_True_Track_E = ConvertToUShort(trackMC->E(),kShortScaleLow); 
-            output.MC_True_Track_Px = ConvertToUShort(trackMC->Px(),kShortScaleLow); 
-            output.MC_True_Track_Py = ConvertToUShort(trackMC->Py(),kShortScaleLow);
-            output.MC_True_Track_Pz = ConvertToUShort(trackMC->Pz(),kShortScaleLow);
+            output.MC_True_Track_Px = ConvertToShort(trackMC->Px(),kShortScaleLow); 
+            output.MC_True_Track_Py = ConvertToShort(trackMC->Py(),kShortScaleLow);
+            output.MC_True_Track_Pz = ConvertToShort(trackMC->Pz(),kShortScaleLow);
             Int_t motherLabel = trackMC->GetMother();
             if(motherLabel>=0){
                output.MC_True_Track_MotherPDG = ((AliAODMCParticle* )fAODMCTrackArray->At(motherLabel))->PdgCode();

--- a/PWGGA/GammaConv/AliAnalysisTaskElectronStudies.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskElectronStudies.h
@@ -202,9 +202,9 @@ class AliAnalysisTaskElectronStudies : public AliAnalysisTaskSE{
     std::vector<UShort_t> fBuffer_ClusterM02; 
     std::vector<UShort_t> fBuffer_ClusterM20; 
     std::vector<UShort_t> fBuffer_Track_E; // default is always closest
-    std::vector<UShort_t> fBuffer_Track_Px; // default is always closest
-    std::vector<UShort_t> fBuffer_Track_Py; 
-    std::vector<UShort_t> fBuffer_Track_Pz; 
+    std::vector<Short_t> fBuffer_Track_Px; // default is always closest
+    std::vector<Short_t> fBuffer_Track_Py; 
+    std::vector<Short_t> fBuffer_Track_Pz; 
     std::vector<UShort_t> fBuffer_Track_PonEMCal; 
     std::vector<Short_t> fBuffer_Track_Charge; 
     std::vector<Short_t> fBuffer_Track_dEta; 
@@ -217,9 +217,9 @@ class AliAnalysisTaskElectronStudies : public AliAnalysisTaskSE{
 
     std::vector<UShort_t> fBuffer_MC_True_Cluster_E; 
     std::vector<UShort_t> fBuffer_MC_True_Track_E; 
-    std::vector<UShort_t> fBuffer_MC_True_Track_Px; 
-    std::vector<UShort_t> fBuffer_MC_True_Track_Py; 
-    std::vector<UShort_t> fBuffer_MC_True_Track_Pz; 
+    std::vector<Short_t> fBuffer_MC_True_Track_Px; 
+    std::vector<Short_t> fBuffer_MC_True_Track_Py; 
+    std::vector<Short_t> fBuffer_MC_True_Track_Pz; 
     std::vector<Int_t> fBuffer_MC_True_Track_MotherPDG; 
     std::vector<Bool_t> fBuffer_MC_Track_Is_Electron; 
     std::vector<Bool_t> fBuffer_MC_Cluster_Is_Electron; 
@@ -254,7 +254,7 @@ class AliAnalysisTaskElectronStudies : public AliAnalysisTaskSE{
     std::pair<Double_t,Double_t> ProcessChargedIsolation(AliAODTrack* track);
     AliAnalysisTaskElectronStudies(const AliAnalysisTaskElectronStudies&); // Prevent copy-construction
     AliAnalysisTaskElectronStudies& operator=(const AliAnalysisTaskElectronStudies&); // Prevent assignment  
-    ClassDef(AliAnalysisTaskElectronStudies, 9);
+    ClassDef(AliAnalysisTaskElectronStudies, 10);
 
 };
 

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.cxx
@@ -347,6 +347,8 @@ AliAnalysisTaskGammaCalo::AliAnalysisTaskGammaCalo(): AliAnalysisTaskSE(),
   fHistoMCPi0GenVsNClus(NULL),
   fHistoMCPi0GenFoundInOneCluster(NULL),
   fHistoMCPi0GenFoundInTwoCluster(NULL),
+  fHistoMCEtaGenFoundInOneCluster(NULL),
+  fHistoMCEtaGenFoundInTwoCluster(NULL),
   fHistoMCGammaConvRvsPt(NULL),
   fHistoMCPi0JetInAccPt(NULL),
   fHistoMCPi0inJetInAccPt(NULL),
@@ -766,6 +768,8 @@ AliAnalysisTaskGammaCalo::AliAnalysisTaskGammaCalo(const char *name):
   fHistoMCPi0GenVsNClus(NULL),
   fHistoMCPi0GenFoundInOneCluster(NULL),
   fHistoMCPi0GenFoundInTwoCluster(NULL),
+  fHistoMCEtaGenFoundInOneCluster(NULL),
+  fHistoMCEtaGenFoundInTwoCluster(NULL),
   fHistoMCGammaConvRvsPt(NULL),
   fHistoMCPi0JetInAccPt(NULL),
   fHistoMCPi0inJetInAccPt(NULL),
@@ -2043,6 +2047,8 @@ void AliAnalysisTaskGammaCalo::UserCreateOutputObjects(){
       fHistoMCPi0GenVsNClus                   = new TH2F*[fnCuts];
       fHistoMCPi0GenFoundInOneCluster         = new TH2F*[fnCuts];
       fHistoMCPi0GenFoundInTwoCluster         = new TH2F*[fnCuts];
+      fHistoMCEtaGenFoundInOneCluster         = new TH2F*[fnCuts];
+      fHistoMCEtaGenFoundInTwoCluster         = new TH2F*[fnCuts];
       fHistoMCGammaConvRvsPt                  = new TH2F*[fnCuts];
     }
 
@@ -2374,6 +2380,16 @@ void AliAnalysisTaskGammaCalo::UserCreateOutputObjects(){
           fHistoMCPi0GenFoundInTwoCluster[iCut]->SetXTitle("p_{T} (GeV/c)");
           fHistoMCPi0GenFoundInTwoCluster[iCut]->SetYTitle("#eta");
           fMCList[iCut]->Add(fHistoMCPi0GenFoundInTwoCluster[iCut]);
+
+          fHistoMCEtaGenFoundInOneCluster[iCut]   = new TH2F("MC_EtaGenFoundInOneCluster_Pt", "MC_EtaGenFoundInOneCluster_Pt", 400, 0,100,20,-0.9,0.9);
+          fHistoMCEtaGenFoundInOneCluster[iCut]->SetXTitle("p_{T} (GeV/c)");
+          fHistoMCEtaGenFoundInOneCluster[iCut]->SetYTitle("#eta");
+          fMCList[iCut]->Add(fHistoMCEtaGenFoundInOneCluster[iCut]);
+
+          fHistoMCEtaGenFoundInTwoCluster[iCut]   = new TH2F("MC_EtaGenFoundInTwoCluster_Pt", "MC_EtaGenFoundInTwoCluster_Pt", 400, 0,100,20,-0.9,0.9);
+          fHistoMCEtaGenFoundInTwoCluster[iCut]->SetXTitle("p_{T} (GeV/c)");
+          fHistoMCEtaGenFoundInTwoCluster[iCut]->SetYTitle("#eta");
+          fMCList[iCut]->Add(fHistoMCEtaGenFoundInTwoCluster[iCut]);
 
           fHistoMCGammaConvRvsPt[iCut]   = new TH2F("MC_GammaConvRvsP", "MC_GammaConvRvsP", 400, 0,100,350,0,700);
           fHistoMCGammaConvRvsPt[iCut]->SetXTitle("p_{T} (GeV/c)");
@@ -4210,8 +4226,10 @@ void AliAnalysisTaskGammaCalo::ProcessClusters()
       Double_t pi0Pt = thisLabel.PtMeson;
       Double_t pi0Eta = thisLabel.EtaMeson;
 
-      TLorentzVector thisClus = thisLabel.clusVec;
+      Double_t angle = thisLabel.OpeningAngle;
 
+      TLorentzVector thisClus = thisLabel.clusVec;
+      Int_t pdg = 0;
       // search other labels to find separated
       for (UInt_t b = 1; b < fTrueClusterLabels.size(); b++)
       {
@@ -4222,12 +4240,27 @@ void AliAnalysisTaskGammaCalo::ProcessClusters()
         // printf("MesonID=%i clusID=%i daughterID=%i daughterPDG=%i EClus=%f EFrac=%f ETrue=%f \n",
         // otherLabel.mesonID,otherLabel.clusID,otherLabel.daughterID,otherLabel.daughterPDG,otherLabel.EClus,otherLabel.EFrac,otherLabel.ETrue);
         if(otherLabel.mesonID != thisLabel.mesonID) continue;
+
+        if(fInputEvent->IsA()==AliESDEvent::Class()){
+          pdg = ((AliMCParticle *)fMCEvent->GetTrack(thisLabel.mesonID))->PdgCode();
+        } else{
+          pdg = ((AliAODMCParticle *)fAODMCTrackArray->At(thisLabel.mesonID))->PdgCode();
+        }
+
         if(thisLabel.clusID != otherLabel.clusID){
             if(thisLabel.daughterID != otherLabel.daughterID){
                isSep = kTRUE;
-               if((m > (0.134 + (0.134*0.25))) || (m < (0.134 - (0.134*0.25))) ) 
-                  isSep = kFALSE;
-               
+              if(pdg==221){
+                  if((m > 0.650) || (m < 0.450) ) 
+                    isSep = kFALSE;
+                  // if( angle < 0.0143){
+                  //   // angle too small to be not merged
+                  //   isSep = kFALSE;
+                  // }
+              } else if (pdg==111){
+                  if((m > (0.134 + (0.134*0.25))) || (m < (0.134 - (0.134*0.25))) ) 
+                    isSep = kFALSE;
+              }          
             }
         }
       }
@@ -4245,8 +4278,10 @@ void AliAnalysisTaskGammaCalo::ProcessClusters()
         }
       }
       // Begin fillig of histos
-      if(isMerged) fHistoMCPi0GenFoundInOneCluster[fiCut]->Fill(pi0Pt,pi0Eta,fWeightJetJetMC);
-      if(isSep) fHistoMCPi0GenFoundInTwoCluster[fiCut]->Fill(pi0Pt,pi0Eta,fWeightJetJetMC);
+      if((pdg ==111) && isMerged) fHistoMCPi0GenFoundInOneCluster[fiCut]->Fill(pi0Pt,pi0Eta,fWeightJetJetMC);
+      if((pdg ==111) && isSep) fHistoMCPi0GenFoundInTwoCluster[fiCut]->Fill(pi0Pt,pi0Eta,fWeightJetJetMC);
+      if((pdg ==221) && isMerged) fHistoMCEtaGenFoundInOneCluster[fiCut]->Fill(pi0Pt,pi0Eta,fWeightJetJetMC);
+      if((pdg ==221) && isSep) fHistoMCEtaGenFoundInTwoCluster[fiCut]->Fill(pi0Pt,pi0Eta,fWeightJetJetMC);
   }
 
   return;
@@ -8077,8 +8112,6 @@ Int_t AliAnalysisTaskGammaCalo::CountPhotonsInCluster(Int_t cluslabel)
 }
 void AliAnalysisTaskGammaCalo::DoClusterMergingStudies(AliVCluster* clus,vector<clusterLabel> &labelvect)
 {
-  AliMCParticle* tmpParticle;
-  
   // vertex
   Double_t vertex[3] = {0};
   InputEvent()->GetPrimaryVertex()->GetXYZ(vertex);
@@ -8098,7 +8131,7 @@ void AliAnalysisTaskGammaCalo::DoClusterMergingStudies(AliVCluster* clus,vector<
       while(clusParticleMother->GetMother()!=-1){
         Int_t motherID = clusParticleMother->GetMother();
         clusParticleMother = (AliMCParticle *)fMCEvent->GetTrack(motherID);
-        if(clusParticleMother->PdgCode() == 111){
+        if(clusParticleMother->PdgCode() == 111 || clusParticleMother->PdgCode()==221 ){
             // found pi0
             pi0Pos = motherID;
             break;
@@ -8171,7 +8204,6 @@ void AliAnalysisTaskGammaCalo::DoClusterMergingStudies(AliVCluster* clus,vector<
 }
 void AliAnalysisTaskGammaCalo::DoClusterMergingStudiesAOD(AliVCluster* clus,vector<clusterLabel> &labelvect)
 {
-  AliAODMCParticle* tmpParticle;
   Int_t* mclabelsClus = clus->GetLabels();  
   if (clus->GetNLabels()>0){
     for (Int_t k =0; k< (Int_t)clus->GetNLabels(); k++){
@@ -8187,7 +8219,7 @@ void AliAnalysisTaskGammaCalo::DoClusterMergingStudiesAOD(AliVCluster* clus,vect
       while(clusParticleMother->GetMother()!=-1){
         Int_t motherID = clusParticleMother->GetMother();
         clusParticleMother = (AliAODMCParticle *)fAODMCTrackArray->At(motherID);
-        if(clusParticleMother->GetPdgCode() == 111){
+        if(clusParticleMother->GetPdgCode() == 111 || clusParticleMother->GetPdgCode() == 221){
             // found pi0
             pi0Pos = motherID;
             break;

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.h
@@ -438,6 +438,8 @@ class AliAnalysisTaskGammaCalo : public AliAnalysisTaskSE {
     TH2F**                 fHistoMCPi0GenVsNClus;                                // pi0 produced on gen level vs Nclus for merging studies
     TH2F**                 fHistoMCPi0GenFoundInOneCluster;                      // pi0 produced on gen level where both decay photons were found in same cluster (merged)
     TH2F**                 fHistoMCPi0GenFoundInTwoCluster;                      // pi0 produced on gen level where both decay photons were found in different clusters
+    TH2F**                fHistoMCEtaGenFoundInOneCluster;                      // pi0 produced on gen level where both decay photons were found in same cluster (merged)
+    TH2F**                 fHistoMCEtaGenFoundInTwoCluster;                      // pi0 produced on gen level where both decay photons were found in different clusters
     TH2F**                 fHistoMCGammaConvRvsPt;                      // pi0 produced on gen level where both decay photons were found in different clusters
     TH1F**                 fHistoMCPi0JetInAccPt;                                // Histogram with weighted pi0 in a jet event in acceptance, pT
     TH1F**                 fHistoMCPi0inJetInAccPt;                              // Histogram with weighted pi0 in a jet in acceptance, pT
@@ -586,7 +588,7 @@ class AliAnalysisTaskGammaCalo : public AliAnalysisTaskSE {
     AliAnalysisTaskGammaCalo(const AliAnalysisTaskGammaCalo&);                  // Prevent copy-construction
     AliAnalysisTaskGammaCalo &operator=(const AliAnalysisTaskGammaCalo&);       // Prevent assignment
 
-    ClassDef(AliAnalysisTaskGammaCalo, 82);
+    ClassDef(AliAnalysisTaskGammaCalo, 83);
 };
 
 #endif

--- a/PWGGA/GammaConv/config/PWGGA_CF_config.yaml
+++ b/PWGGA/GammaConv/config/PWGGA_CF_config.yaml
@@ -1,64 +1,494 @@
-configurationName: "PWGGA configuration"
-pass: ""
-inputObjects:
-    cells:
-        defaultCells:
-            branchName: "usedefault"
-    clusterContainers:
-        defaultClusterContainer:
-            branchName: "usedefault"
-        ClusterContainerS500A100:
-            branchName: "S500A100ClustersBranch"
-    trackContainers:
-        defaultTrackContainer:
-            branchName: "usedefault"
-CellEnergy:
-    createHistos: true
-CellEnergy_defaultSetting:
-    enabled: true
+configurationName: "EMCAL electron/gamma configuration"   # Optional - Simply for user convenience
+pass: "default"                                     # Attempts to automatically retrieve the pass if not specified. Usually of the form "pass#".
 
-CellBadChannel:
-    createHistos: true
-CellBadChannel_defaultSetting:
-    enabled: true
+#
+# ─── CLUSTER/TRACK CONTAINERS────────────────────────────────────────────────────
+#
 
-CellTimeCalib:
-    createHistos: true
-CellTimeCalib_defaultSetting:
-    enabled: true
+inputObjects:                                       # Define all of the input objects for the corrections
+    clusterContainers:                              # Configure clusters
+        defaultClusterContainer:                    # Name of a cluster input
+            branchName: "usedefault"
+        defaultClusterContainer_1:                  # Name of another cluster input which inherits from defaultClusterContainer
+            # The branch name is inherited from defaultClusterContainer!
+            minE: 0.5                               # Cluster min E. Formerly clusterEMin
+        defaultClusterContainer_2:                  # Name of another cluster input which inherits from defaultClusterContainer
+            # The branch name is inherited from defaultClusterContainer!
+            minE: 0.5                               # Cluster min E. Formerly clusterEMin
+            clusNonLinCorrEnergyCut: 0.5            # Cluster non-linearity min E. Formerly "minPt" in the non-linearity AddTask()
+        ClusterContainerTMNL:                         # like default but with track matching on corr task level
+            branchName: "TMNLClustersBranch"
+        ClusterContainerS300A100:                   # for own GA settings with special setting: seed 300 Mev, aggregation 100 MeV
+            branchName: "S300A100ClustersBranch"
+        ClusterContainerV1:
+            branchName: "V1ClustersBranch"
+        ClusterContainerV1Unfold:
+            branchName: "V1UnfoldClustersBranch"
+        ClusterContainerNxN:
+            branchName: "NxNClustersBranch"
+        ClusterContainerS500A125:
+            branchName: "S500A125ClustersBranch"
+        ClusterContainerS500A150:
+            branchName: "S500A150ClustersBranch"
+        ClusterContainerS500A300:
+            branchName: "S500A300ClustersBranch"
+        ClusterContainerS1000A300:
+            branchName: "S1000A300ClustersBranch"
+    trackContainers:                                # Configure tracks
+        defaultTrackContainer:                      # Name of a track input
+            branchName: "usedefault"                # Set the branch name. "usedefault" is supported.
+        defaultTrackContainer_1:                    # Name of another track input which inherits from defaultTrackContainer
+            minPt: 0.3                              # Track min pt.
+            trackFilterType: kNoTrackFilter          # Set the track filter type. Check the documentation for possible values
 
-Clusterizer:
+sharedParameters:
+    enableMCGenRemovTrack: false                    # apply the MC generators rejection also for track matching
+
+#
+# ─── CELL CALIBRATION ─────────────────────────────────────────────────────────
+#
+# - setting "false" for all other configs than default ensures no cell correction is applied twice
+
+CellEnergy:                                         # Cell Energy correction component
     createHistos: true
-    clusterizer: kClusterizerv2
+    enabled: true                                   # Whether to enable the task
+    enableNewTempCalib: true                        # ADDED !!
+    enableShaperCorrection: true                    # ADDED !!
+CellBadChannel:                                     # Bad channel removal at the cell level component
+    enabled: true                                   # Whether to enable the task
+    load1DBadChMap: true
+CellTimeCalib:                                      # Cell Time Calibration component
+    enabled: true                                   # Whether to enable the task
+    createHistos: true                              # ADDED !!
+    doCalibrateLowGain: true                        # ADDED !!
+    doMergedBCs: true                               # ADDED !!
+    doCalibMergedLG: false                          # ADDED !!
+
+# put all cell corrections that are not default to FALSE
+# otherwise they will be applied twice
+CellEnergy_TMNL:                                         # Cell Energy correction component
+    enabled: false
+CellBadChannel_TMNL:                                     # Bad channel removal at the cell level component
+    enabled: false                                   # Whether to enable the task
+CellTimeCalib_TMNL:
+    enabled: false
+CellEnergy_S300A100:                                         # Cell Energy correction component
+    enabled: false
+CellBadChannel_S300A100:                                     # Bad channel removal at the cell level component
+    enabled: false                                   # Whether to enable the task
+CellTimeCalib_S300A100:
+    enabled: false
+CellEnergy_V1:                                         # Cell Energy correction component
+    enabled: false
+CellBadChannel_V1:                                     # Bad channel removal at the cell level component
+    enabled: false                                   # Whether to enable the task
+CellTimeCalib_V1:
+    enabled: false
+CellEnergy_V1Unfold:                                         # Cell Energy correction component
+    enabled: false
+CellBadChannel_V1Unfold:                                     # Bad channel removal at the cell level component
+    enabled: false                                   # Whether to enable the task
+CellTimeCalib_V1Unfold:
+    enabled: false
+CellEnergy_NxN:                                         # Cell Energy correction component
+    enabled: false
+CellBadChannel_NxN:                                     # Bad channel removal at the cell level component
+    enabled: false                                   # Whether to enable the task
+CellTimeCalib_NxN:
+    enabled: false
+CellEnergy_S500A125:                                         # Cell Energy correction component
+    enabled: false
+CellBadChannel_S500A125:                                     # Bad channel removal at the cell level component
+    enabled: false                                   # Whether to enable the task
+CellTimeCalib_S500A125:
+    enabled: false
+CellEnergy_S500A150:                                         # Cell Energy correction component
+    enabled: false
+CellBadChannel_S500A150:                                     # Bad channel removal at the cell level component
+    enabled: false                                   # Whether to enable the task
+CellTimeCalib_S500A150:
+    enabled: false
+CellEnergy_S500A300:                                         # Cell Energy correction component
+    enabled: false
+CellBadChannel_S500A300:                                     # Bad channel removal at the cell level component
+    enabled: false                                   # Whether to enable the task
+CellTimeCalib_S500A300:
+    enabled: false
+CellEnergy_S1000A300:                                         # Cell Energy correction component
+    enabled: false
+CellBadChannel_S1000A300:                                     # Bad channel removal at the cell level component
+    enabled: false                                   # Whether to enable the task
+CellTimeCalib_S1000A300:
+    enabled: false
+#
+# ─── DEFAULT ──────────────────────────────────────────────────────────
+#
+# - Description: these settings will be used for all clusters in the default branch and in the subsequent branches if not overwriten
+#                in subsequent additional configuration. These are the default settings and include a nonlin correction 
+# - Clusterizer: V3
+# - NonLinCorr : no
+# - TrackMatch : no
+
+Clusterizer:                                        # Clusterizer component
+    enabled: true                                   # Whether to enable the task
+    clusterizer: kClusterizerv3                     # Type of clusterizer to use. Possible options are defined in the header of the clusterizer
+    cellE: 0.1                                      # Minimum cell energy CHANGED!!
+    seedE: 0.5                                      # Seed energy threshold
     cellTimeMin: -500e-9
     cellTimeMax: +500e-9
     clusterTimeLength: 1e6
     recalDistToBadChannels: true
-    remapMcAod: false
-    diffEAggregation: 0.0
-    cellsNames:
-        - defaultCells
-Clusterizer_defaultSetting:
-    enabled: true
-    cellE: 0.1
-    seedE: 0.5
-    clusterContainersNames:
-        - defaultClusterContainer
-Clusterizer_S500A100:
-    enabled: true
-    cellE: 0.1
-    seedE: 0.5
-    clusterContainersNames:
-        - ClusterContainerS500A100
+    recalShowerShape: true                          # True will recalculate the shower shape
+    load1DBadChMap: true                            # ADDED !!!!
+ClusterExotics:                                     # Cluster exotics identification component (actual removal is handled by the cluster container)
+    enabled: true                                   # Whether to enable the task
+    createHistos: true                              # Whether the task should create outputhistograms
+    fMaxFcross: 0.97                                # ADDED !!
+    fHighEnergyNdiffCut: 50                         # ADDED !!
+    fMinCellEnNdiffCut: 0                           # ADDED !!
+ClusterNonLinearity:                                # Cluster non-linearity correction component
+    enabled: false
+ClusterTrackMatcher:                                # Cluster-track matcher component
+    enabled: false                                  # Whether to enable the task
+ClusterHadronicCorrection:                          # Cluster hadronic correction component
+    enabled: false                                  # Whether to enable the task
 
-ClusterNonLinearity:
-    createHistos: true
-    nonLinFunct: kNoCorrection
-ClusterNonLinearity_defaultSetting:
+#
+# ─── DEFAULT WITH TRACK MATCHING AND NONLIN ──────────────────────────────────────────────────────────
+#
+# - Description: these settings will be used for all clusters in the default branch and in the subsequent branches if not overwriten
+#                in subsequent additional configuration. These are the default settings and include a nonlin correction and track matching
+# - Clusterizer: V3
+# - NonLinCorr : yes
+# - TrackMatch : yes
+
+Clusterizer_TMNL:                                        # Clusterizer component
+    enabled: true                                   # Whether to enable the task
+    clusterizer: kClusterizerv3                     # Type of clusterizer to use. Possible options are defined in the header of the clusterizer
+    cellE: 0.1                                      # Minimum cell energy CHANGED!!
+    seedE: 0.5                                      # Seed energy threshold
+    cellTimeMin: -500e-9
+    cellTimeMax: +500e-9
+    clusterTimeLength: 1e6
+    recalDistToBadChannels: true
+    recalShowerShape: true                          # True will recalculate the shower shape
+    load1DBadChMap: true                            # ADDED !!!!
+    clusterContainersNames:
+        - ClusterContainerTMNL
+ClusterExotics_TMNL:                                     # Cluster exotics identification component (actual removal is handled by the cluster container)
+    enabled: true                                   # Whether to enable the task
+    createHistos: true                              # Whether the task should create outputhistograms
+    fMaxFcross: 0.97                                # ADDED !!
+    fHighEnergyNdiffCut: 50                         # ADDED !!
+    fMinCellEnNdiffCut: 0                           # ADDED !!
+    clusterContainersNames:
+        - ClusterContainerTMNL
+ClusterNonLinearity_TMNL:                                # Cluster non-linearity correction component
+    enabled: true                                   # Whether to enable the task
+    setForceClusterE: true                          #for cluster energy to correct for non-linearity
+    createHistos: true                              # Whether the task should create output histograms
+    nonLinFunct: kTestBeamShaper                    # Sets the non-linearity function. Possible options are defined in the header of the cluster non-linearity correction component
+    clusterContainersNames:
+        - ClusterContainerTMNL
+ClusterTrackMatcher_TMNL:                                # Cluster-track matcher component
+    enabled: true                                  # Whether to enable the task
+    createHistos: true                             # Whether the task should create output histograms
+    maxDist: 0.1                                    # Max distance between a matched cluster and track
+    useDCA: true                                    # Use DCA as starting point for track propagation, rather than primary vertex
+    usePIDmass: true                                # Use PID-based mass hypothesis for track propagation, rather than pion mass hypothesis
+    updateClusters: true                            # Update the matching information in the cluster
+    updateTracks: true                              # Update the matching information in the track histograms
+    clusterContainersNames:
+        - ClusterContainerTMNL
+ClusterHadronicCorrection_TMNL:                          # Cluster hadronic correction component
+    enabled: false                                  # Whether to enable the task
+    clusterContainersNames:
+        - ClusterContainerTMNL
+
+
+#
+# ─── V3 Seed 300 Aggregation 100──────────────────────────────────────────────────────────
+#
+# - Description: Like default GA config but with different seed energy
+# - Clusterizer: V3 (Seed 300MeV Aggregation 100MeV)
+# - NonLinCorr : no (done on task level)
+# - TrackMatch : no (done on task level)
+
+Clusterizer_S300A100:                                     # same settings as "Clusterizer"
+    enabled: true
+    cellTimeMin: -500e-9
+    cellTimeMax: +500e-9
+    cellE: 0.1                                      # Minimum cell energy CHANGED!!
+    seedE: 0.3                                      # Seed energy threshold
+    clusterTimeLength: 1e6
+    recalDistToBadChannels: true
+    clusterContainersNames:
+        - ClusterContainerS300A100
+ClusterNonLinearity_S300A100:                             # Cluster non-linearity correction
+    enabled: false                                  # Whether to enable the task
+    clusterContainersNames:
+        - ClusterContainerS300A100
+ClusterTrackMatcher_S300A100:                             # Cluster-track matcher component
+    enabled: false                                  # Whether to enable the task
+    clusterContainersNames:
+        - ClusterContainerS300A100
+ClusterHadronicCorrection_S300A100:                       # Cluster hadronic correction component
+    enabled: false
+    clusterContainersNames:
+        - ClusterContainerS300A100
+ClusterExotics_S300A100:                                  # Cluster exotics identification component (actual removal is handled by the cluster container)
     enabled: true
     clusterContainersNames:
-        - defaultClusterContainer
-ClusterNonLinearity_S500A100:
+        - ClusterContainerS300A100
+
+#
+# ─── V1 Clusterizer ──────────────────────────────────────────────────────────
+#
+# - Description: Dfeault config for use with V1 clusterizer
+# - Clusterizer: V1 (Seed 500MeV Aggregation 100MeV)
+# - NonLinCorr : no (done on task level)
+# - TrackMatch : no (done on task level)
+
+Clusterizer_V1:                                     # same settings as "Clusterizer"
+    enabled: true
+    clusterizer: kClusterizerv1
+    cellTimeMin: -500e-9
+    cellTimeMax: +500e-9
+    cellE: 0.1                                      # Minimum cell energy CHANGED!!
+    seedE: 0.5                                      # Seed energy threshold
+    clusterTimeLength: 1e6
+    recalDistToBadChannels: true
+    clusterContainersNames:
+        - ClusterContainerV1
+ClusterNonLinearity_V1:                             # Cluster non-linearity correction
+    enabled: false                                  # Whether to enable the task
+    clusterContainersNames:
+        - ClusterContainerV1
+ClusterTrackMatcher_V1:                             # Cluster-track matcher component
+    enabled: false                                  # Whether to enable the task
+    clusterContainersNames:
+        - ClusterContainerV1
+ClusterHadronicCorrection_V1:                       # Cluster hadronic correction component
+    enabled: false
+    clusterContainersNames:
+        - ClusterContainerV1
+ClusterExotics_V1:                                  # Cluster exotics identification component (actual removal is handled by the cluster container)
     enabled: true
     clusterContainersNames:
-        - ClusterContainerS500A100
+        - ClusterContainerV1
+#
+# ─── V1 unfolding Clusterizer ──────────────────────────────────────────────────────────
+#
+# - Description: Default config for use with V1 clusterizer + unfolding
+# - Clusterizer: V1 with unfolding (Seed 500MeV Aggregation 100MeV)
+# - NonLinCorr : no (done on task level)
+# - TrackMatch : no (done on task level)
+
+Clusterizer_V1Unfold:                                     # same settings as "Clusterizer"
+    enabled: true
+    clusterizer: kClusterizerv1
+    unfold: true
+    unfoldRejectBelowThreshold: true
+    unfoldMinCellE: 0.015
+    unfoldMinCellEFrac: 0.0001
+    cellTimeMin: -500e-9
+    cellTimeMax: +500e-9
+    cellE: 0.1                                      # Minimum cell energy CHANGED!!
+    seedE: 0.5                                      # Seed energy threshold
+    clusterTimeLength: 1e6
+    recalDistToBadChannels: true
+    clusterContainersNames:
+        - ClusterContainerV1Unfold
+ClusterNonLinearity_V1Unfold:                             # Cluster non-linearity correction
+    enabled: false                                  # Whether to enable the task
+    clusterContainersNames:
+        - ClusterContainerV1Unfold
+ClusterTrackMatcher_V1Unfold:                             # Cluster-track matcher component
+    enabled: false                                  # Whether to enable the task
+    clusterContainersNames:
+        - ClusterContainerV1Unfold
+ClusterHadronicCorrection_V1Unfold:                       # Cluster hadronic correction component
+    enabled: false
+    clusterContainersNames:
+        - ClusterContainerV1Unfold
+ClusterExotics_V1Unfold:                                  # Cluster exotics identification component (actual removal is handled by the cluster container)
+    enabled: true
+    clusterContainersNames:
+        - ClusterContainerV1Unfold
+
+#
+# ─── NxN Clusterizer ──────────────────────────────────────────────────────────
+#
+# - Description: Default config for use with NxN clusterizer
+# - Clusterizer: NxN with unfolding (Seed 500MeV Aggregation 100MeV)
+# - NonLinCorr : no (done on task level)
+# - TrackMatch : no (done on task level)
+
+Clusterizer_NxN:                                     # same settings as "Clusterizer"
+    enabled: true
+    clusterizer: kClusterizerNxN
+    unfold: false
+    unfoldRejectBelowThreshold: false
+    unfoldMinCellE: 0.015
+    unfoldMinCellEFrac: 0.0001
+    cellTimeMin: -500e-9
+    cellTimeMax: +500e-9
+    cellE: 0.1                                      # Minimum cell energy CHANGED!!
+    seedE: 0.5                                      # Seed energy threshold
+    clusterTimeLength: 1e6
+    recalDistToBadChannels: true
+    clusterContainersNames:
+        - ClusterContainerNxN
+ClusterNonLinearity_NxN:                             # Cluster non-linearity correction
+    enabled: false                                  # Whether to enable the task
+    clusterContainersNames:
+        - ClusterContainerNxN
+ClusterTrackMatcher_NxN:                             # Cluster-track matcher component
+    enabled: false                                  # Whether to enable the task
+    clusterContainersNames:
+        - ClusterContainerNxN
+ClusterHadronicCorrection_NxN:                       # Cluster hadronic correction component
+    enabled: false
+    clusterContainersNames:
+        - ClusterContainerNxN
+ClusterExotics_NxN:                                  # Cluster exotics identification component (actual removal is handled by the cluster container)
+    enabled: true
+    clusterContainersNames:
+        - ClusterContainerNxN
+
+#
+# ─── V3 Seed 500 Aggregation 125──────────────────────────────────────────────────────────
+#
+# - Description: Like default GA config but with different seed energy
+# - Clusterizer: V3 (Seed 500MeV Aggregation 125MeV)
+# - NonLinCorr : no (done on task level)
+# - TrackMatch : no (done on task level)
+
+Clusterizer_S500A125:                                     # same settings as "Clusterizer"
+    enabled: true
+    cellTimeMin: -500e-9
+    cellTimeMax: +500e-9
+    cellE: 0.125                                    # Minimum cell energy CHANGED!!
+    seedE: 0.5                                      # Seed energy threshold
+    clusterTimeLength: 1e6
+    recalDistToBadChannels: true
+    clusterContainersNames:
+        - ClusterContainerS500A125
+ClusterNonLinearity_S500A125:                             # Cluster non-linearity correction
+    enabled: false                                  # Whether to enable the task
+    clusterContainersNames:
+        - ClusterContainerS500A125
+ClusterTrackMatcher_S500A125:                             # Cluster-track matcher component
+    enabled: false                                  # Whether to enable the task
+    clusterContainersNames:
+        - ClusterContainerS500A125
+ClusterHadronicCorrection_S500A125:                       # Cluster hadronic correction component
+    enabled: false
+    clusterContainersNames:
+        - ClusterContainerS500A125
+ClusterExotics_S500A125:                                  # Cluster exotics identification component (actual removal is handled by the cluster container)
+    enabled: true
+    clusterContainersNames:
+        - ClusterContainerS500A125
+
+
+#
+# ─── V3 Seed 500 Aggregation 150──────────────────────────────────────────────────────────
+#
+# - Description: Like default GA config but with different seed energy
+# - Clusterizer: V3 (Seed 500MeV Aggregation 150MeV)
+# - NonLinCorr : no (done on task level)
+# - TrackMatch : no (done on task level)
+
+Clusterizer_S500A150:                                     # same settings as "Clusterizer"
+    enabled: true
+    cellTimeMin: -500e-9
+    cellTimeMax: +500e-9
+    cellE: 0.150                                    # Minimum cell energy CHANGED!!
+    seedE: 0.5                                      # Seed energy threshold
+    recalDistToBadChannels: true
+    clusterContainersNames:
+        - ClusterContainerS500A150
+ClusterNonLinearity_S500A150:                             # Cluster non-linearity correction
+    enabled: false                                  # Whether to enable the task
+    clusterContainersNames:
+        - ClusterContainerS500A150
+ClusterTrackMatcher_S500A150:                             # Cluster-track matcher component
+    enabled: false                                  # Whether to enable the task
+    clusterContainersNames:
+        - ClusterContainerS500A150
+ClusterHadronicCorrection_S500A150:                       # Cluster hadronic correction component
+    enabled: false
+    clusterContainersNames:
+        - ClusterContainerS500A150
+ClusterExotics_S500A150:                                  # Cluster exotics identification component (actual removal is handled by the cluster container)
+    enabled: true
+    clusterContainersNames:
+        - ClusterContainerS500A150
+#
+# ─── V3 Seed 500 Aggregation 300──────────────────────────────────────────────────────────
+#
+# - Description: Like default GA config but with different seed energy
+# - Clusterizer: V3 (Seed 500MeV Aggregation 300MeV)
+# - NonLinCorr : no (done on task level)
+# - TrackMatch : no (done on task level)
+
+Clusterizer_S500A300:                                     # same settings as "Clusterizer"
+    enabled: true
+    cellTimeMin: -500e-9
+    cellTimeMax: +500e-9
+    cellE: 0.3                                    # Minimum cell energy CHANGED!!
+    seedE: 0.5                                      # Seed energy threshold
+    recalDistToBadChannels: true
+    clusterContainersNames:
+        - ClusterContainerS500A300
+ClusterNonLinearity_S500A300:                             # Cluster non-linearity correction
+    enabled: false                                  # Whether to enable the task
+    clusterContainersNames:
+        - ClusterContainerS500A300
+ClusterTrackMatcher_S500A300:                             # Cluster-track matcher component
+    enabled: false                                  # Whether to enable the task
+    clusterContainersNames:
+        - ClusterContainerS500A300
+ClusterHadronicCorrection_S500A300:                       # Cluster hadronic correction component
+    enabled: false
+    clusterContainersNames:
+        - ClusterContainerS500A300
+ClusterExotics_S500A300:                                  # Cluster exotics identification component (actual removal is handled by the cluster container)
+    enabled: true
+    clusterContainersNames:
+        - ClusterContainerS500A300
+
+#
+# ─── V3 Seed 1000 Aggregation 300──────────────────────────────────────────────────────────
+#
+# - Description: Like default GA config but with different seed energy
+# - Clusterizer: V3 (Seed 1000MeV Aggregation 300MeV)
+# - NonLinCorr : no (done on task level)
+# - TrackMatch : no (done on task level)
+
+Clusterizer_S1000A300:                                     # same settings as "Clusterizer"
+    enabled: true
+    cellTimeMin: -500e-9
+    cellTimeMax: +500e-9
+    cellE: 0.3                                    # Minimum cell energy CHANGED!!
+    seedE: 1.0                                      # Seed energy threshold
+    recalDistToBadChannels: true
+    clusterContainersNames:
+        - ClusterContainerS1000A300
+ClusterNonLinearity_S1000A300:                             # Cluster non-linearity correction
+    enabled: false                                  # Whether to enable the task
+    clusterContainersNames:
+        - ClusterContainerS1000A300
+ClusterTrackMatcher_S1000A300:                             # Cluster-track matcher component
+    enabled: false                                  # Whether to enable the task
+    clusterContainersNames:
+        - ClusterContainerS1000A300
+ClusterHadronicCorrection_S1000A300:                       # Cluster hadronic correction component
+    enabled: false
+    clusterContainersNames:
+        - ClusterContainerS1000A300
+ClusterExotics_S1000A300:                                  # Cluster exotics identification component (actual removal is handled by the cluster container)
+    enabled: true
+    clusterContainersNames:
+        - ClusterContainerS1000A300

--- a/PWGGA/GammaConv/config/PWGGA_CF_config_MC.yaml
+++ b/PWGGA/GammaConv/config/PWGGA_CF_config_MC.yaml
@@ -1,65 +1,555 @@
-configurationName: "PWGGA configuration"
-pass: ""
-inputObjects:
-    cells:
-        defaultCells:
-            branchName: "usedefault"
-    clusterContainers:
-        defaultClusterContainer:
-            branchName: "usedefault"
-        ClusterContainerS500A100:
-            branchName: "S500A100ClustersBranch"
-    trackContainers:
-        defaultTrackContainer:
-            branchName: "usedefault"
+configurationName: "EMCAL electron/gamma configuration MC"   # Optional - Simply for user convenience
+pass: "default"                                     # Attempts to automatically retrieve the pass if not specified. Usually of the form "pass#".
 
-CellEnergy:
-    createHistos: false
-CellEnergy_defaultSetting:
-    enabled: false
 
-CellBadChannel:
-    createHistos: true
-CellBadChannel_defaultSetting:
+#
+# ─── CLUSTER/TRACK CONTAINERS────────────────────────────────────────────────────
+#
+inputObjects:                                       # Define all of the input objects for the corrections
+    clusterContainers:                              # Configure clusters
+        defaultClusterContainer:                    # Name of a cluster input
+            branchName: "usedefault"
+        defaultClusterContainer_1:                  # Name of another cluster input which inherits from defaultClusterContainer
+            # The branch name is inherited from defaultClusterContainer!
+            minE: 0.5                               # Cluster min E. Formerly clusterEMin
+        defaultClusterContainer_2:                  # Name of another cluster input which inherits from defaultClusterContainer
+            # The branch name is inherited from defaultClusterContainer!
+            minE: 0.5                               # Cluster min E. Formerly clusterEMin
+            clusNonLinCorrEnergyCut: 0.5            # Cluster non-linearity min E. Formerly "minPt" in the non-linearity AddTask()
+            exoticsCut: true                        # enables cut on exotics flag
+        ClusterContainerTMNL:                         # like default but with track matching on corr task level
+            branchName: "TMNLClustersBranch"
+        ClusterContainerS300A100:                   # for own GA settings with special setting: seed 300 Mev, aggregation 100 MeV
+            branchName: "S300A100ClustersBranch"
+        ClusterContainerV1:
+            branchName: "V1ClustersBranch"
+        ClusterContainerV1Unfold:
+            branchName: "V1UnfoldClustersBranch"
+        ClusterContainerNxN:
+            branchName: "NxNClustersBranch"
+        ClusterContainerS500A125:
+            branchName: "S500A125ClustersBranch"
+        ClusterContainerS500A150:
+            branchName: "S500A150ClustersBranch"
+        ClusterContainerS500A300:
+            branchName: "S500A300ClustersBranch"
+        ClusterContainerS1000A300:
+            branchName: "S1000A300ClustersBranch"
+    trackContainers:                                # Configure tracks
+        defaultTrackContainer:                      # Name of a track input
+            branchName: "usedefault"                # Set the branch name. "usedefault" is supported.
+        defaultTrackContainer_1:                    # Name of another track input which inherits from defaultTrackContainer
+            minPt: 0.3                              # Track min pt.
+            trackFilterType: kNoTrackFilter          # Set the track filter type. Check the documentation for possible values
+
+sharedParameters:
+    enableMCGenRemovTrack: false                    # apply the MC generators rejection also for track matching
+
+#
+# ─── CELL CALIBRATION ─────────────────────────────────────────────────────────
+#
+# - setting "false" for all other configs than default ensures no cell correction is applied twice
+
+CellEnergy:                                         # Cell Energy correction component
+    enabled: false                                   # Whether to enable the task
+    enableNewTempCalib: true                        # ADDED !!
+    enableShaperCorrection: true                    # ADDED !!
+CellBadChannel:                                     # Bad channel removal at the cell level component
+    enabled: true                                   # Whether to enable the task
+    load1DBadChMap: true
+CellTimeCalib:                                      # Cell Time Calibration component
+    enabled: false                                   # Whether to enable the task
+    createHistos: true                              # 
+    doCalibrateLowGain: false                        # 
+    doMergedBCs: true                               # 
+    doCalibMergedLG: false                          #
+CellEmulateCrosstalk:
     enabled: true
+    createHistos: true
 
-CellTimeCalib:
-    createHistos: false
-CellTimeCalib_defaultSetting:
+
+# put all cell corrections that are not default to FALSE
+# otherwise they will be applied twice
+CellEnergy_TMNL:                                         # Cell Energy correction component
+    enabled: false
+CellBadChannel_TMNL:                                     # Bad channel removal at the cell level component
+    enabled: false                                   # Whether to enable the task
+CellTimeCalib_TMNL:
+    enabled: false
+CellEnergy_S300A100:                                 # Cell Energy correction component
+    enabled: false
+CellBadChannel_S300A100:                             # Bad channel removal at the cell level component
+    enabled: false                                   # Whether to enable the task
+CellTimeCalib_S300A100:
+    enabled: false
+CellEmulateCrosstalk_S300A100:
+    enabled: false
+CellEnergy_V1:                                         # Cell Energy correction component
+    enabled: false
+CellBadChannel_V1:                                     # Bad channel removal at the cell level component
+    enabled: false                                   # Whether to enable the task
+CellTimeCalib_V1:
+    enabled: false
+CellEmulateCrosstalk_V1:
+    enabled: false
+CellEnergy_V1Unfold:                                         # Cell Energy correction component
+    enabled: false
+CellBadChannel_V1Unfold:                                     # Bad channel removal at the cell level component
+    enabled: false                                   # Whether to enable the task
+CellTimeCalib_V1Unfold:
+    enabled: false
+CellEmulateCrosstalk_V1Unfold:
+    enabled: false
+CellEnergy_NxN:                                         # Cell Energy correction component
+    enabled: false
+CellBadChannel_NxN:                                     # Bad channel removal at the cell level component
+    enabled: false                                   # Whether to enable the task
+CellTimeCalib_NxN:
+    enabled: false
+CellEmulateCrosstalk_NxN:
+    enabled: false
+CellEnergy_S500A125:                                         # Cell Energy correction component
+    enabled: false
+CellBadChannel_S500A125:                                     # Bad channel removal at the cell level component
+    enabled: false                                   # Whether to enable the task
+CellTimeCalib_S500A125:
+    enabled: false
+CellEmulateCrosstalk_S500A125:
+    enabled: false
+CellEnergy_S500A150:                                         # Cell Energy correction component
+    enabled: false
+CellBadChannel_S500A150:                                     # Bad channel removal at the cell level component
+    enabled: false                                   # Whether to enable the task
+CellTimeCalib_S500A150:
+    enabled: false
+CellEmulateCrosstalk_S500A150:
+    enabled: false
+CellEnergy_S500A300:                                         # Cell Energy correction component
+    enabled: false
+CellBadChannel_S500A300:                                     # Bad channel removal at the cell level component
+    enabled: false                                   # Whether to enable the task
+CellTimeCalib_S500A300:
+    enabled: false
+CellEmulateCrosstalk_S500A300:
+    enabled: false
+CellEnergy_S1000A300:                                         # Cell Energy correction component
+    enabled: false
+CellBadChannel_S1000A300:                                     # Bad channel removal at the cell level component
+    enabled: false                                   # Whether to enable the task
+CellTimeCalib_S1000A300:
+    enabled: false
+CellEmulateCrosstalk_S1000A300:
     enabled: false
 
-Clusterizer:
-    createHistos: true
-    clusterizer: kClusterizerv2
-    cellTimeMin: -1000e-9
-    cellTimeMax: +1000e-9
+#
+# ─── DEFAULT ──────────────────────────────────────────────────────────
+#
+# - Description: these settings will be used for all clusters in the default branch and in the subsequent branches if not overwriten
+#                in subsequent additional configuration. These are the default settinga
+# - Clusterizer: V3
+# - NonLinCorr : false
+# - TrackMatch : false
+
+Clusterizer:                                        # Clusterizer component
+    enabled: true                                   # Whether to enable the task
+    clusterizer: kClusterizerv3                     # Type of clusterizer to use. Possible options are defined in the header of the clusterizer
+    cellE: 0.1                                      # Minimum cell energy 
+    seedE: 0.5                                      # Seed energy threshold
+    recalShowerShape: true                          # True will recalculate the shower shape
+    load1DBadChMap: true                            
+    remapMcAod: false
+    cellTimeMin: -1
+    cellTimeMax: +1
+    diffEAggregation: 0.0
     clusterTimeLength: 1e6
     recalDistToBadChannels: true
-    remapMcAod: false
-    diffEAggregation: 0.0
-    cellsNames:
-        - defaultCells
-Clusterizer_defaultSetting:
-    enabled: true
-    cellE: 0.1
-    seedE: 0.5
-    clusterContainersNames:
-        - defaultClusterContainer
-Clusterizer_S500A100:
-    enabled: true
-    cellE: 0.1
-    seedE: 0.5
-    clusterContainersNames:
-        - ClusterContainerS500A100
+ClusterExotics:                                     # Cluster exotics identification component (actual removal is handled by the cluster container)
+    enabled: true                                   # Whether to enable the task
+    createHistos: true                              # Whether the task should create outputhistograms
+    fMaxFcross: 0.97                                
+    fHighEnergyNdiffCut: 50                         
+    fMinCellEnNdiffCut: 0                           
+ClusterNonLinearity:                                # Cluster non-linearity correction component
+    enabled: false                                   # Whether to enable the task
+ClusterNonLinearityMCAfterburner:
+    enabled: false
+ClusterTrackMatcher:                                # Cluster-track matcher component
+    enabled: false                                  # Whether to enable the task
+ClusterHadronicCorrection:                          # Cluster hadronic correction component
+    enabled: false                                  # Whether to enable the task
 
-ClusterNonLinearity:
-    createHistos: true
-    nonLinFunct: kNoCorrection
-ClusterNonLinearity_defaultSetting:
+#
+# ─── DEFAULT WITH TM ─────────────────────────────────────────────────────────
+#
+# - Description: these settings will be used for all clusters in the default branch and in the subsequent branches if not overwriten
+#                in subsequent additional configuration. These are the default settings and include a nonlin correction and track matching
+# - Clusterizer: V3
+# - NonLinCorr : yes
+# - TrackMatch : yes
+
+Clusterizer_TMNL:                                        # Clusterizer component
+    enabled: true                                   # Whether to enable the task
+    clusterizer: kClusterizerv3                     # Type of clusterizer to use. Possible options are defined in the header of the clusterizer
+    cellE: 0.1                                      # Minimum cell energy 
+    seedE: 0.5                                      # Seed energy threshold
+    recalShowerShape: true                          # True will recalculate the shower shape
+    load1DBadChMap: true                            
+    remapMcAod: false
+    cellTimeMin: -1
+    cellTimeMax: +1
+    diffEAggregation: 0.0
+    clusterTimeLength: 1e6
+    recalDistToBadChannels: true
+    clusterContainersNames:
+        - ClusterContainerTMNL
+ClusterExotics_TMNL:                                     # Cluster exotics identification component (actual removal is handled by the cluster container)
+    enabled: true                                   # Whether to enable the task
+    createHistos: true                              # Whether the task should create outputhistograms
+    fMaxFcross: 0.97                                
+    fHighEnergyNdiffCut: 50                         
+    fMinCellEnNdiffCut: 0    
+    clusterContainersNames:
+        - ClusterContainerTMNL                       
+ClusterNonLinearity_TMNL:                                # Cluster non-linearity correction component
+    enabled: true                                   # Whether to enable the task
+    setForceClusterE: true                          #for cluster energy to correct for non-linearity
+    createHistos: true                              # Whether the task should create output histograms
+    nonLinFunct: kTestBeamFinalMC                    # Sets the non-linearity function. Possible options are defined in the header of the cluster non-linearity correction component
+ClusterNonLinearityMCAfterburner_TMNL:
+    enabled: true
+    afterburnerVersion: kPCM_EMCal
+    setMCPeriod: "kTestBeamFinalMCRun213TeV" # for Run1 choose kTestBeamFinalMCRun1
+    clusterContainersNames:
+        - ClusterContainerTMNL
+ClusterTrackMatcher_TMNL:                                # Cluster-track matcher component
+    enabled: true                                  # Whether to enable the task
+    createHistos: true                             # Whether the task should create output histograms
+    maxDist: 0.1                                    # Max distance between a matched cluster and track
+    useDCA: true                                    # Use DCA as starting point for track propagation, rather than primary vertex
+    usePIDmass: true                                # Use PID-based mass hypothesis for track propagation, rather than pion mass hypothesis
+    updateClusters: true                            # Update the matching information in the cluster
+    updateTracks: true                              # Update the matching information in the track histograms
+    clusterContainersNames:
+        - ClusterContainerTM
+ClusterHadronicCorrection_TMNL:                          # Cluster hadronic correction component
+    enabled: false                                  # Whether to enable the task
+    clusterContainersNames:
+        - ClusterContainerTMNL
+
+#
+# ─── GA  ──────────────────────────────────────────────────────────
+#
+# - Description: Like default GA config but with different seed energy
+# - Clusterizer: V3 (Seed 300MeV Aggregation 100MeV)
+# - NonLinCorr : no (done on task level)
+# - TrackMatch : no (done on task level)
+
+Clusterizer_S300A100:                                # same settings as "Clusterizer"
+    enabled: true
+    cellTimeMin: -1
+    cellTimeMax: +1
+    cellE: 0.1                                      # Minimum cell energy CHANGED!!
+    seedE: 0.3                                      # Seed energy threshold
+    clusterTimeLength: 1e6
+    recalDistToBadChannels: true
+    clusterContainersNames:
+        - ClusterContainerS300A100
+ClusterNonLinearity_S300A100:                       # Cluster non-linearity correction
+    enabled: false                                  # Whether to enable the task
+    clusterContainersNames:
+        - ClusterContainerS300A100
+ClusterNonLinearityMCAfterburner_S300A100:          # Cluster non-linearity correction afterburner
+    enabled: false                                  # Whether to enable the task
+    clusterContainersNames:
+        - ClusterContainerS300A100
+ClusterTrackMatcher_S300A100:                       # Cluster-track matcher component
+    enabled: false                                  # Whether to enable the task
+    clusterContainersNames:
+        - ClusterContainerS300A100
+ClusterHadronicCorrection_S300A100:                 # Cluster hadronic correction component
+    enabled: false
+    clusterContainersNames:
+        - ClusterContainerS300A100
+ClusterExotics_S300A100:                                  # Cluster exotics identification component (actual removal is handled by the cluster container)
     enabled: true
     clusterContainersNames:
-        - defaultClusterContainer
-ClusterNonLinearity_S500A100:
+        - ClusterContainerS300A100
+#
+# ─── V1 Clusterizer ──────────────────────────────────────────────────────────
+#
+# - Description: Dfeault config for use with V1 clusterizer
+# - Clusterizer: V1 (Seed 500MeV Aggregation 100MeV)
+# - NonLinCorr : no (done on task level)
+# - TrackMatch : no (done on task level)
+
+Clusterizer_V1:                                     # same settings as "Clusterizer"
+    enabled: true
+    clusterizer: kClusterizerv1
+    cellTimeMin: -1
+    cellTimeMax: +1
+    cellE: 0.1                                      # Minimum cell energy CHANGED!!
+    seedE: 0.5                                      # Seed energy threshold
+    clusterTimeLength: 1e6
+    recalDistToBadChannels: true
+    clusterContainersNames:
+        - ClusterContainerV1
+ClusterNonLinearity_V1:                             # Cluster non-linearity correction
+    enabled: false                                  # Whether to enable the task
+    clusterContainersNames:
+        - ClusterContainerV1
+ClusterNonLinearityMCAfterburner_V1:                # Cluster non-linearity correction afterburner
+    enabled: false                                  # Whether to enable the task
+    clusterContainersNames:
+        - ClusterContainerV1
+ClusterTrackMatcher_V1:                             # Cluster-track matcher component
+    enabled: false                                  # Whether to enable the task
+    clusterContainersNames:
+        - ClusterContainerV1
+ClusterHadronicCorrection_V1:                       # Cluster hadronic correction component
+    enabled: false
+    clusterContainersNames:
+        - ClusterContainerV1
+ClusterExotics_V1:                                  # Cluster exotics identification component (actual removal is handled by the cluster container)
     enabled: true
     clusterContainersNames:
-        - ClusterContainerS500A100
+        - ClusterContainerV1
+#
+# ─── V1 unfolding Clusterizer ──────────────────────────────────────────────────────────
+#
+# - Description: Default config for use with V1 clusterizer + unfolding
+# - Clusterizer: V1 with unfolding (Seed 500MeV Aggregation 100MeV)
+# - NonLinCorr : no (done on task level)
+# - TrackMatch : no (done on task level)
+
+Clusterizer_V1Unfold:                                     # same settings as "Clusterizer"
+    enabled: true
+    clusterizer: kClusterizerv1
+    unfold: true
+    unfoldRejectBelowThreshold: true
+    unfoldMinCellE: 0.015
+    unfoldMinCellEFrac: 0.0001
+    cellTimeMin: -1
+    cellTimeMax: +1
+    cellE: 0.1                                      # Minimum cell energy CHANGED!!
+    seedE: 0.5                                      # Seed energy threshold
+    clusterTimeLength: 1e6
+    recalDistToBadChannels: true
+    clusterContainersNames:
+        - ClusterContainerV1Unfold
+ClusterNonLinearity_V1Unfold:                             # Cluster non-linearity correction
+    enabled: false                                  # Whether to enable the task
+    clusterContainersNames:
+        - ClusterContainerV1Unfold
+ClusterNonLinearityMCAfterburner_V1Unfold:                # Cluster non-linearity correction afterburner
+    enabled: false                                  # Whether to enable the task
+    clusterContainersNames:
+        - ClusterContainerV1Unfold
+ClusterTrackMatcher_V1Unfold:                             # Cluster-track matcher component
+    enabled: false                                  # Whether to enable the task
+    clusterContainersNames:
+        - ClusterContainerV1Unfold
+ClusterHadronicCorrection_V1Unfold:                       # Cluster hadronic correction component
+    enabled: false
+    clusterContainersNames:
+        - ClusterContainerV1Unfold
+ClusterExotics_V1Unfold:                                  # Cluster exotics identification component (actual removal is handled by the cluster container)
+    enabled: true
+    clusterContainersNames:
+        - ClusterContainerV1Unfold
+
+#
+# ─── NxN Clusterizer ──────────────────────────────────────────────────────────
+#
+# - Description: Default config for use with NxN clusterizer
+# - Clusterizer: NxN with unfolding (Seed 500MeV Aggregation 100MeV)
+# - NonLinCorr : no (done on task level)
+# - TrackMatch : no (done on task level)
+
+Clusterizer_NxN:                                     # same settings as "Clusterizer"
+    enabled: true
+    clusterizer: kClusterizerNxN
+    unfold: false
+    unfoldRejectBelowThreshold: false
+    unfoldMinCellE: 0.015
+    unfoldMinCellEFrac: 0.0001
+    cellTimeMin: -1
+    cellTimeMax: +1
+    cellE: 0.1                                      # Minimum cell energy CHANGED!!
+    seedE: 0.5                                      # Seed energy threshold
+    clusterTimeLength: 1e6
+    recalDistToBadChannels: true
+    clusterContainersNames:
+        - ClusterContainerNxN
+ClusterNonLinearity_NxN:                             # Cluster non-linearity correction
+    enabled: false                                  # Whether to enable the task
+    clusterContainersNames:
+        - ClusterContainerNxN
+ClusterNonLinearityMCAfterburner_NxN:                # Cluster non-linearity correction afterburner
+    enabled: false                                  # Whether to enable the task
+    clusterContainersNames:
+        - ClusterContainerNxN
+ClusterTrackMatcher_NxN:                             # Cluster-track matcher component
+    enabled: false                                  # Whether to enable the task
+    clusterContainersNames:
+        - ClusterContainerNxN
+ClusterHadronicCorrection_NxN:                       # Cluster hadronic correction component
+    enabled: false
+    clusterContainersNames:
+        - ClusterContainerNxN
+ClusterExotics_NxN:                                  # Cluster exotics identification component (actual removal is handled by the cluster container)
+    enabled: true
+    clusterContainersNames:
+        - ClusterContainerNxN
+
+#
+# ─── V3 Seed 500 Aggregation 125──────────────────────────────────────────────────────────
+#
+# - Description: Like default GA config but with different seed energy
+# - Clusterizer: V3 (Seed 500MeV Aggregation 125MeV)
+# - NonLinCorr : no (done on task level)
+# - TrackMatch : no (done on task level)
+
+Clusterizer_S500A125:                                     # same settings as "Clusterizer"
+    enabled: true
+    cellTimeMin: -1
+    cellTimeMax: +1
+    cellE: 0.125                                    # Minimum cell energy CHANGED!!
+    seedE: 0.5                                      # Seed energy threshold
+    clusterTimeLength: 1e6
+    recalDistToBadChannels: true
+    clusterContainersNames:
+        - ClusterContainerS500A125
+ClusterNonLinearity_S500A125:                             # Cluster non-linearity correction
+    enabled: false                                  # Whether to enable the task
+    clusterContainersNames:
+        - ClusterContainerS500A125
+ClusterNonLinearityMCAfterburner_S500A125:                # Cluster non-linearity correction afterburner
+    enabled: false                                  # Whether to enable the task
+    clusterContainersNames:
+        - ClusterContainerS500A125
+ClusterTrackMatcher_S500A125:                             # Cluster-track matcher component
+    enabled: false                                  # Whether to enable the task
+    clusterContainersNames:
+        - ClusterContainerS500A125
+ClusterHadronicCorrection_S500A125:                       # Cluster hadronic correction component
+    enabled: false
+    clusterContainersNames:
+        - ClusterContainerS500A125
+ClusterExotics_S500A125:                                  # Cluster exotics identification component (actual removal is handled by the cluster container)
+    enabled: true
+    clusterContainersNames:
+        - ClusterContainerS500A125
+
+
+#
+# ─── V3 Seed 500 Aggregation 150──────────────────────────────────────────────────────────
+#
+# - Description: Like default GA config but with different seed energy
+# - Clusterizer: V3 (Seed 500MeV Aggregation 150MeV)
+# - NonLinCorr : no (done on task level)
+# - TrackMatch : no (done on task level)
+
+Clusterizer_S500A150:                                     # same settings as "Clusterizer"
+    enabled: true
+    cellTimeMin: -1
+    cellTimeMax: +1
+    cellE: 0.150                                    # Minimum cell energy CHANGED!!
+    seedE: 0.5                                      # Seed energy threshold
+    recalDistToBadChannels: true
+    clusterContainersNames:
+        - ClusterContainerS500A150
+ClusterNonLinearity_S500A150:                             # Cluster non-linearity correction
+    enabled: false                                  # Whether to enable the task
+    clusterContainersNames:
+        - ClusterContainerS500A150
+ClusterNonLinearityMCAfterburner_S500A150:                # Cluster non-linearity correction afterburner
+    enabled: false                                  # Whether to enable the task
+    clusterContainersNames:
+        - ClusterContainerS500A150
+ClusterTrackMatcher_S500A150:                             # Cluster-track matcher component
+    enabled: false                                  # Whether to enable the task
+    clusterContainersNames:
+        - ClusterContainerS500A150
+ClusterHadronicCorrection_S500A150:                       # Cluster hadronic correction component
+    enabled: false
+    clusterContainersNames:
+        - ClusterContainerS500A150
+ClusterExotics_S500A150:                                  # Cluster exotics identification component (actual removal is handled by the cluster container)
+    enabled: true
+    clusterContainersNames:
+        - ClusterContainerS500A150
+#
+# ─── V3 Seed 500 Aggregation 300──────────────────────────────────────────────────────────
+#
+# - Description: Like default GA config but with different seed energy
+# - Clusterizer: V3 (Seed 500MeV Aggregation 300MeV)
+# - NonLinCorr : no (done on task level)
+# - TrackMatch : no (done on task level)
+
+Clusterizer_S500A300:                                     # same settings as "Clusterizer"
+    enabled: true
+    cellTimeMin: -1
+    cellTimeMax: +1
+    cellE: 0.3                                    # Minimum cell energy CHANGED!!
+    seedE: 0.5                                      # Seed energy threshold
+    recalDistToBadChannels: true
+    clusterContainersNames:
+        - ClusterContainerS500A300
+ClusterNonLinearity_S500A300:                             # Cluster non-linearity correction
+    enabled: false                                  # Whether to enable the task
+    clusterContainersNames:
+        - ClusterContainerS500A300
+ClusterNonLinearityMCAfterburner_S500A300:                # Cluster non-linearity correction afterburner
+    enabled: false                                  # Whether to enable the task
+    clusterContainersNames:
+        - ClusterContainerS500A300
+ClusterTrackMatcher_S500A300:                             # Cluster-track matcher component
+    enabled: false                                  # Whether to enable the task
+    clusterContainersNames:
+        - ClusterContainerS500A300
+ClusterHadronicCorrection_S500A300:                       # Cluster hadronic correction component
+    enabled: false
+    clusterContainersNames:
+        - ClusterContainerS500A300
+ClusterExotics_S500A300:                                  # Cluster exotics identification component (actual removal is handled by the cluster container)
+    enabled: true
+    clusterContainersNames:
+        - ClusterContainerS500A300
+
+#
+# ─── V3 Seed 1000 Aggregation 300──────────────────────────────────────────────────────────
+#
+# - Description: Like default GA config but with different seed energy
+# - Clusterizer: V3 (Seed 1000MeV Aggregation 300MeV)
+# - NonLinCorr : no (done on task level)
+# - TrackMatch : no (done on task level)
+
+Clusterizer_S1000A300:                                     # same settings as "Clusterizer"
+    enabled: true
+    cellTimeMin: -1
+    cellTimeMax: +1
+    cellE: 0.3                                    # Minimum cell energy CHANGED!!
+    seedE: 1.0                                      # Seed energy threshold
+    recalDistToBadChannels: true
+    clusterContainersNames:
+        - ClusterContainerS1000A300
+ClusterNonLinearity_S1000A300:                             # Cluster non-linearity correction
+    enabled: false                                  # Whether to enable the task
+    clusterContainersNames:
+        - ClusterContainerS1000A300
+ClusterNonLinearityMCAfterburner_S1000A300:                # Cluster non-linearity correction afterburner
+    enabled: false                                  # Whether to enable the task
+    clusterContainersNames:
+        - ClusterContainerS1000A300
+ClusterTrackMatcher_S1000A300:                             # Cluster-track matcher component
+    enabled: false                                  # Whether to enable the task
+    clusterContainersNames:
+        - ClusterContainerS1000A300
+ClusterHadronicCorrection_S1000A300:                       # Cluster hadronic correction component
+    enabled: false
+    clusterContainersNames:
+        - ClusterContainerS1000A300
+ClusterExotics_S1000A300:                                  # Cluster exotics identification component (actual removal is handled by the cluster container)
+    enabled: true
+    clusterContainersNames:
+        - ClusterContainerS1000A300


### PR DESCRIPTION
- fixed wrong types for momentum in ElectronStudies tree
- added support for eta meson in merging studies
- added yaml configs intended to be used as new default for CF of GA