### PR TITLE
Add possibility to perform application for multi-class models

### DIFF
--- a/ML/AliExternalBDT.cxx
+++ b/ML/AliExternalBDT.cxx
@@ -140,11 +140,15 @@ bool AliExternalBDT::Predict(double *features, int size, std::vector<double> &ou
   }
 
   std::vector<float> output(fOutSize);
-  TreelitePredictorPredictInst(fPredictor, entries.data(),
+  int predict = TreelitePredictorPredictInst(fPredictor, entries.data(),
       static_cast<int>(useRawScore), &output[0],
       &fOutSize);
+  if(predict<0)
+    return false;
+
   for (std::size_t iEntry = 0; iEntry < fOutSize; ++iEntry) {
     outputScores.push_back(static_cast<double>(output[iEntry]));
   }
+
   return true;
 }

--- a/ML/AliExternalBDT.cxx
+++ b/ML/AliExternalBDT.cxx
@@ -35,7 +35,8 @@ AliExternalBDT::AliExternalBDT(std::string name) :
   fModelPath{""},
   fModelName{""},
   fCompiler{},
-  fPredictor{}
+  fPredictor{},
+  fOutSize{0u}
 {
 }
 
@@ -127,17 +128,15 @@ bool AliExternalBDT::LoadModelLibrary(std::string path) {
   return true;
 }
 
-double AliExternalBDT::Predict(double *features, int size, bool useRawScore) {
+double* AliExternalBDT::Predict(double *features, int size, bool useRawScore) {
   std::vector<TreelitePredictorEntry> entries(size);
   for (size_t iEntry = 0; iEntry < entries.size(); ++iEntry) {
     entries[iEntry].fvalue = static_cast<float>(features[iEntry]);
   }
-  size_t out_size{0u};
-  TreelitePredictorQueryResultSizeSingleInst(fPredictor, &out_size);
-  assert(out_size == 1);
-  float output = 0.f;
+  TreelitePredictorQueryResultSizeSingleInst(fPredictor, &fOutSize);
+  float *output = {};
   TreelitePredictorPredictInst(fPredictor, entries.data(),
-      static_cast<int>(useRawScore), &output,
-      &out_size);
-  return output;
+      static_cast<int>(useRawScore), output,
+      &fOutSize);
+  return (double*)output;
 }

--- a/ML/AliExternalBDT.h
+++ b/ML/AliExternalBDT.h
@@ -29,9 +29,10 @@ public:
   bool LoadModelLibrary(std::string path);
   bool LoadXGBoostModel(std::string path);
 
-  double* Predict(double *features, int size, bool useRaw = false);
+  bool Predict(double *features, int size, std::vector<double> &outputScores, bool useRaw = false);
 
-  size_t GetOutputSize() const {return fOutSize;}
+  std::size_t GetOutputSize() const {return fOutSize;}
+  std::size_t GetNumberOfFeatures() const {return fNumFeatures;}
 
 private:
   bool CompileAndLoadModelLibrary();
@@ -45,7 +46,8 @@ private:
   std::string fModelName;
   CompilerHandle fCompiler;
   PredictorHandle fPredictor;
-  size_t fOutSize;
+  std::size_t fOutSize;
+  std::size_t fNumFeatures;
 };
 
 #endif

--- a/ML/AliExternalBDT.h
+++ b/ML/AliExternalBDT.h
@@ -29,7 +29,9 @@ public:
   bool LoadModelLibrary(std::string path);
   bool LoadXGBoostModel(std::string path);
 
-  double Predict(double *features, int size, bool useRaw = false);
+  double* Predict(double *features, int size, bool useRaw = false);
+
+  size_t GetOutputSize() const {return fOutSize;}
 
 private:
   bool CompileAndLoadModelLibrary();
@@ -43,6 +45,7 @@ private:
   std::string fModelName;
   CompilerHandle fCompiler;
   PredictorHandle fPredictor;
+  size_t fOutSize;
 };
 
 #endif

--- a/ML/AliMLModelHandler.cxx
+++ b/ML/AliMLModelHandler.cxx
@@ -46,7 +46,7 @@ AliMLModelHandler::AliMLModelHandler(const YAML::Node &node)
 
   if(node["cut_opt"]) {
     if(node["cut_opt"].IsSequence()) {
-      if(fScoreCut.size() != fScoreCutOpt.size())
+      if(fScoreCut.size() != node["cut_opt"].as<std::vector<std::string> >().size())
         AliFatal("Number of score cuts different from number of score cut options! Exit");
       for (const auto &cutOpt: node["cut_opt"].as<std::vector<std::string> >()) {
         if(cutOpt == "lower")

--- a/ML/AliMLModelHandler.h
+++ b/ML/AliMLModelHandler.h
@@ -26,6 +26,7 @@ class AliExternalBDT;
 class AliMLModelHandler : public TNamed {
 public:
   enum {kXGBoost, kLightGBM, kModelLibrary};
+  enum {kLowerCut, kUpperCut};
 
   AliMLModelHandler();
   AliMLModelHandler(const YAML::Node &node);
@@ -37,21 +38,23 @@ public:
   AliExternalBDT *GetModel() { return fModel; }
   std::string const &GetPath() const { return fPath; }
   std::string const &GetLibrary() const { return fLibrary; }
-  double const &GetScoreCut() const { return fScoreCut; }
+  std::vector<double> const &GetScoreCut() const { return fScoreCut; }
+  std::vector<int> const &GetScoreCutOpt() const { return fScoreCutOpt; }
 
   bool CompileModel();
   static std::string ImportFile(std::string path);
 
 private:
-  AliExternalBDT *fModel;  //!<!
+  AliExternalBDT *fModel;            //!<!
 
-  std::string fPath;       ///
-  std::string fLibrary;    ///
+  std::string fPath;                 ///
+  std::string fLibrary;              ///
 
-  double fScoreCut;        ///
+  std::vector<double> fScoreCut;     /// vector of cuts to be applied on output scores
+  std::vector<int> fScoreCutOpt;     /// vector of options on output scores ("upper" or "lower")
 
 /// \cond CLASSIMP
-ClassDef(AliMLModelHandler, 1);    ///
+ClassDef(AliMLModelHandler, 2);    ///
 /// \endcond
 };
 

--- a/ML/AliMLResponse.cxx
+++ b/ML/AliMLResponse.cxx
@@ -129,6 +129,12 @@ void AliMLResponse::CompileModels(std::string configLocalPath) {
     if (!comp) {
       AliFatal("Error in model compilation! Exit");
     }
+    if(model.GetModel()->GetOutputSize() != model.GetScoreCut().size()) {
+      AliFatal("Inconsistency between output size and score cuts! Exit");
+    }
+    if(model.GetModel()->GetNumberOfFeatures() != fNVariables) {
+      AliFatal("Inconsistency between number of features in model and yaml! Exit");
+    }
   }
 }
 
@@ -168,7 +174,12 @@ double AliMLResponse::Predict(double binvar, map<string, double> varmap) {
   if (bin < 0)
     return -999.;
 
-  return fModels.at(bin - 1).GetModel()->Predict(&features[0], fNVariables, fRaw)[0];
+  vector<double> scores;
+  bool predict = fModels.at(bin - 1).GetModel()->Predict(&features[0], fNVariables, scores, fRaw);
+  if(!predict)
+    return -999.;
+
+  return scores[0];
 }
 
 //_______________________________________________________________________________
@@ -182,11 +193,16 @@ double AliMLResponse::Predict(double binvar, vector<double> variables) {
   if (bin < 0)
     return -999.;
 
-  return fModels.at(bin - 1).GetModel()->Predict(&variables[0], fNVariables, fRaw)[0];
+  vector<double> scores;
+  bool predict = fModels.at(bin - 1).GetModel()->Predict(&variables[0], fNVariables, scores, fRaw);
+  if(!predict)
+    return -999.;
+
+  return scores[0];
 }
 
 //_______________________________________________________________________________
-double* AliMLResponse::PredictMultiClass(double binvar, map<string, double> varmap, size_t &outsize) {
+bool AliMLResponse::PredictMultiClass(double binvar, map<string, double> varmap, vector<double> &outScores) {
   if ((int)varmap.size() < fNVariables) {
     AliFatal("The variable map you provided to the predictor has a size smaller than the variable list size! Exit");
   }
@@ -201,15 +217,13 @@ double* AliMLResponse::PredictMultiClass(double binvar, map<string, double> varm
 
   int bin = FindBin(binvar);
   if (bin < 0)
-    return nullptr;
+    return false;
 
-  outsize = fModels.at(bin - 1).GetModel()->GetOutputSize();
-
-  return fModels.at(bin - 1).GetModel()->Predict(&features[0], fNVariables, fRaw);
+  return fModels.at(bin - 1).GetModel()->Predict(&features[0], fNVariables, outScores, fRaw);
 }
 
 //_______________________________________________________________________________
-double* AliMLResponse::PredictMultiClass(double binvar, vector<double> variables, size_t &outsize) {
+bool AliMLResponse::PredictMultiClass(double binvar, vector<double> variables, vector<double> &outScores) {
   if ((int)variables.size() != fNVariables) {
     AliFatal(Form("Number of variables passed (%d) different from the one used in the model (%d)! Exit",
                   (int)variables.size(), fNVariables));
@@ -217,33 +231,31 @@ double* AliMLResponse::PredictMultiClass(double binvar, vector<double> variables
 
   int bin = FindBin(binvar);
   if (bin < 0)
-    return nullptr;
+    return false;
 
-  outsize = fModels.at(bin - 1).GetModel()->GetOutputSize();
-
-  return fModels.at(bin - 1).GetModel()->Predict(&variables[0], fNVariables, fRaw);
+  return fModels.at(bin - 1).GetModel()->Predict(&variables[0], fNVariables, outScores, fRaw);
 }
 
 //_______________________________________________________________________________
-bool AliMLResponse::IsSelected(double binvar, std::map<std::string, double> varmap) {
+bool AliMLResponse::IsSelected(double binvar, map<std::string, double> varmap) {
   double score{0.};
   return IsSelected(binvar, varmap, score);
 }
 
 //_______________________________________________________________________________
-bool AliMLResponse::IsSelected(double binvar, std::vector<double> variables) {
+bool AliMLResponse::IsSelected(double binvar, vector<double> variables) {
   double score{0.};
   return IsSelected(binvar, variables, score);
 }
 
 //_______________________________________________________________________________
-bool AliMLResponse::IsSelectedMultiClass(double binvar, std::map<std::string, double> varmap, std::size_t &outsize) {
-  double* score{};
-  return IsSelectedMultiClass(binvar, varmap, score, outsize);
+bool AliMLResponse::IsSelectedMultiClass(double binvar, map<std::string, double> varmap) {
+  vector<double> score;
+  return IsSelectedMultiClass(binvar, varmap, score);
 }
 
 //_______________________________________________________________________________
-bool AliMLResponse::IsSelectedMultiClass(double binvar, std::vector<double> variables, std::size_t &outsize) {
-  double* score{};
-  return IsSelectedMultiClass(binvar, variables, score, outsize);
+bool AliMLResponse::IsSelectedMultiClass(double binvar, vector<double> variables) {
+  vector<double> score;
+  return IsSelectedMultiClass(binvar, variables, score);
 }

--- a/PWGHF/vertexingHF/vHFML/AliHFMLResponse.cxx
+++ b/PWGHF/vertexingHF/vHFML/AliHFMLResponse.cxx
@@ -101,20 +101,20 @@ bool AliHFMLResponse::IsSelected(double &prob, AliAODRecoDecayHF *cand, double b
 }
 
 //________________________________________________________________
-double* AliHFMLResponse::PredictMultiClass(std::size_t &outsize, AliAODRecoDecayHF *cand, double bfield, AliAODPidHF *pidHF, int masshypo)
+bool AliHFMLResponse::PredictMultiClass(std::vector<double> &outScores, AliAODRecoDecayHF *cand, double bfield, AliAODPidHF *pidHF, int masshypo)
 {
     SetMapOfVariables(cand, bfield, pidHF, masshypo);
     if (fVars.empty())
     {
         AliWarning("Map of features empty!");
-        return nullptr;
+        return false;
     }
 
-    return PredictMultiClass(cand->Pt(), fVars, outsize);
+    return PredictMultiClass(cand->Pt(), fVars, outScores);
 }
 
 //________________________________________________________________
-bool AliHFMLResponse::IsSelectedMultiClass(double *prob, std::size_t &outsize, AliAODRecoDecayHF *cand, double bfield, AliAODPidHF *pidHF, int masshypo)
+bool AliHFMLResponse::IsSelectedMultiClass(std::vector<double> &outScores, AliAODRecoDecayHF *cand, double bfield, AliAODPidHF *pidHF, int masshypo)
 {   
     SetMapOfVariables(cand, bfield, pidHF, masshypo);
     if (fVars.empty())
@@ -123,5 +123,5 @@ bool AliHFMLResponse::IsSelectedMultiClass(double *prob, std::size_t &outsize, A
         return false;
     }
 
-    return IsSelectedMultiClass(cand->Pt(), fVars, prob, outsize);
+    return IsSelectedMultiClass(cand->Pt(), fVars, outScores);
 }

--- a/PWGHF/vertexingHF/vHFML/AliHFMLResponse.cxx
+++ b/PWGHF/vertexingHF/vHFML/AliHFMLResponse.cxx
@@ -94,8 +94,34 @@ bool AliHFMLResponse::IsSelected(double &prob, AliAODRecoDecayHF *cand, double b
     if (fVars.empty())
     {
         AliWarning("Map of features empty!");
-        return -999.;
+        return false;
     }
 
     return IsSelected(cand->Pt(), fVars, prob);
+}
+
+//________________________________________________________________
+double* AliHFMLResponse::PredictMultiClass(std::size_t &outsize, AliAODRecoDecayHF *cand, double bfield, AliAODPidHF *pidHF, int masshypo)
+{
+    SetMapOfVariables(cand, bfield, pidHF, masshypo);
+    if (fVars.empty())
+    {
+        AliWarning("Map of features empty!");
+        return nullptr;
+    }
+
+    return PredictMultiClass(cand->Pt(), fVars, outsize);
+}
+
+//________________________________________________________________
+bool AliHFMLResponse::IsSelectedMultiClass(double *prob, std::size_t &outsize, AliAODRecoDecayHF *cand, double bfield, AliAODPidHF *pidHF, int masshypo)
+{   
+    SetMapOfVariables(cand, bfield, pidHF, masshypo);
+    if (fVars.empty())
+    {
+        AliWarning("Map of features empty!");
+        return false;
+    }
+
+    return IsSelectedMultiClass(cand->Pt(), fVars, prob, outsize);
 }

--- a/PWGHF/vertexingHF/vHFML/AliHFMLResponse.h
+++ b/PWGHF/vertexingHF/vHFML/AliHFMLResponse.h
@@ -41,6 +41,10 @@ public:
     bool IsSelected(double &prob, AliAODRecoDecayHF *cand, double bfield, AliAODPidHF *pidHF = nullptr, int masshypo = 0);
     using AliMLResponse::Predict; // exposes function from mother class
     double Predict(AliAODRecoDecayHF *cand, double bfield, AliAODPidHF *pidHF = nullptr, int masshypo = 0);
+    using AliMLResponse::IsSelectedMultiClass; // exposes function from mother class
+    bool IsSelectedMultiClass(double *prob, std::size_t &outsize, AliAODRecoDecayHF *cand, double bfield, AliAODPidHF *pidHF = nullptr, int masshypo = 0);
+    using AliMLResponse::PredictMultiClass; // exposes function from mother class
+    double* PredictMultiClass(std::size_t &outsize, AliAODRecoDecayHF *cand, double bfield, AliAODPidHF *pidHF = nullptr, int masshypo = 0);
 
     /// method to get variable (feature) from map
     double GetVariable(std::string name = "") {return fVars[name];}

--- a/PWGHF/vertexingHF/vHFML/AliHFMLResponse.h
+++ b/PWGHF/vertexingHF/vHFML/AliHFMLResponse.h
@@ -42,9 +42,9 @@ public:
     using AliMLResponse::Predict; // exposes function from mother class
     double Predict(AliAODRecoDecayHF *cand, double bfield, AliAODPidHF *pidHF = nullptr, int masshypo = 0);
     using AliMLResponse::IsSelectedMultiClass; // exposes function from mother class
-    bool IsSelectedMultiClass(double *prob, std::size_t &outsize, AliAODRecoDecayHF *cand, double bfield, AliAODPidHF *pidHF = nullptr, int masshypo = 0);
+    bool IsSelectedMultiClass(std::vector<double> &outScores, AliAODRecoDecayHF *cand, double bfield, AliAODPidHF *pidHF = nullptr, int masshypo = 0);
     using AliMLResponse::PredictMultiClass; // exposes function from mother class
-    double* PredictMultiClass(std::size_t &outsize, AliAODRecoDecayHF *cand, double bfield, AliAODPidHF *pidHF = nullptr, int masshypo = 0);
+    bool PredictMultiClass(std::vector<double> &outScores, AliAODRecoDecayHF *cand, double bfield, AliAODPidHF *pidHF = nullptr, int masshypo = 0);
 
     /// method to get variable (feature) from map
     double GetVariable(std::string name = "") {return fVars[name];}


### PR DESCRIPTION
Add several methods for multiclass model application: 

- `PredictMultiClass`
- `IseSelectedMultiClass` 

which work for both binary and multiclass models.
The old methods for binary models 

- `Predict`
- `IseSelected` 

are kept for retrocompatibility.

The yaml config file can be as the old ones, or can take a list of threshold cuts (`cuts` entry) instead of a single value. An optional entry can also be added (`cuts_opt`) to specify if they are "lower" or "upper" cuts, which can be also either a single value or a list in case of multiclass classification.