### PR TITLE
Add Pb-Pb 2018 event selections for ITS-TPC matching studies

### DIFF
--- a/PWGPP/EvTrkSelection/AliAnalysisTrackingUncertaintiesAOT.cxx
+++ b/PWGPP/EvTrkSelection/AliAnalysisTrackingUncertaintiesAOT.cxx
@@ -99,6 +99,7 @@ AliAnalysisTrackingUncertaintiesAOT::AliAnalysisTrackingUncertaintiesAOT()
   ,fUsePbPb2018EvSel(kFALSE)
   ,fPileUpPbPb2018cut(0)
   ,fAliEventCuts(0)
+  ,fKeepOnlyPileUp(kFALSE)
 {
 
   fAliEventCuts.SetManualMode();
@@ -151,6 +152,7 @@ AliAnalysisTrackingUncertaintiesAOT::AliAnalysisTrackingUncertaintiesAOT(const c
   ,fUsePbPb2018EvSel(kFALSE)
   ,fPileUpPbPb2018cut(0)
   ,fAliEventCuts(0)
+  ,fKeepOnlyPileUp(kFALSE)
 {
   //
   // standard constructur
@@ -251,8 +253,8 @@ void AliAnalysisTrackingUncertaintiesAOT::UserCreateOutputObjects()
   fHistNEvents->GetXaxis()->SetBinLabel(5,"|zVertex|<10");
   fHistNEvents->GetXaxis()->SetBinLabel(6,"Error on zVertex<0.5");
   fHistNEvents->GetXaxis()->SetBinLabel(7,"Good Z vertex");
-  fHistNEvents->GetXaxis()->SetBinLabel(8,"Time-range cut rejected");
-  fHistNEvents->GetXaxis()->SetBinLabel(9,"ITS-TPC OOB pile-up rejected");
+  fHistNEvents->GetXaxis()->SetBinLabel(8,"Time-range cut");
+  fHistNEvents->GetXaxis()->SetBinLabel(9,"ITS-TPC OOB pile-up");
 
   fListHist->Add(fHistNEvents);
 
@@ -449,7 +451,12 @@ void AliAnalysisTrackingUncertaintiesAOT::UserExec(Option_t *)
     }
     if(!fAliEventCuts.PassedCut(AliEventCuts::kTPCPileUp)){ // apply the out-of-bunch pile-up rejection according to ITS-TPC cluster correlation
       fHistNEvents->Fill(7);
-      return;
+      if(!fKeepOnlyPileUp){     // the event is pile-up and we want to reject it
+        return;
+      }
+    }
+    else{ // the event is not pile-up one, according to the selection
+      if(fKeepOnlyPileUp) return;
     }
 
 

--- a/PWGPP/EvTrkSelection/AliAnalysisTrackingUncertaintiesAOT.h
+++ b/PWGPP/EvTrkSelection/AliAnalysisTrackingUncertaintiesAOT.h
@@ -106,9 +106,10 @@ class AliAnalysisTrackingUncertaintiesAOT : public AliAnalysisTaskSE {
   ULong64_t GetSpecie() {return fspecie;}
 
   // set event selections for Pb-Pb2018
-  void SetUsePbPb2018EvSel(Bool_t flag, Int_t which_PileUpcut){
+  void SetUsePbPb2018EvSel(Bool_t flag, Int_t which_PileUpcut, Bool_t keep_only_pileup){
     fUsePbPb2018EvSel  = flag;
     fPileUpPbPb2018cut = which_PileUpcut;
+    fKeepOnlyPileUp    = keep_only_pileup;
   }
 
  private:
@@ -180,6 +181,7 @@ class AliAnalysisTrackingUncertaintiesAOT : public AliAnalysisTaskSE {
   /// event-cut object for centrality correlation event cuts
   //  used for Pb-Pb2018
   Bool_t       fUsePbPb2018EvSel;   ///
+  Bool_t       fKeepOnlyPileUp;     ///
   Int_t        fPileUpPbPb2018cut;  /// option for additional out-of-bunch pileup cut based on ITS-TPC correlation (0=no cut, 1=tight cut, 2=intermediate cut, 3=loose cut)
   AliEventCuts fAliEventCuts;       ///
 

--- a/PWGPP/EvTrkSelection/AliAnalysisTrackingUncertaintiesAOT.h
+++ b/PWGPP/EvTrkSelection/AliAnalysisTrackingUncertaintiesAOT.h
@@ -18,6 +18,8 @@ class AliESDpid;
 
 #include "AliAnalysisTaskSE.h"
 #include "AliESDtrackCuts.h"
+#include "AliEventCuts.h"
+
 #include "THn.h"
 #include <THnSparse.h>
 #include <Rtypes.h>
@@ -103,6 +105,12 @@ class AliAnalysisTrackingUncertaintiesAOT : public AliAnalysisTaskSE {
   ULong64_t GetTriggerMask() {return fTriggerMask;}
   ULong64_t GetSpecie() {return fspecie;}
 
+  // set event selections for Pb-Pb2018
+  void SetUsePbPb2018EvSel(Bool_t flag, Int_t which_PileUpcut){
+    fUsePbPb2018EvSel  = flag;
+    fPileUpPbPb2018cut = which_PileUpcut;
+  }
+
  private:
     
   void   BinLogAxis(const THnSparseF *h, Int_t axisNumber);
@@ -169,10 +177,16 @@ class AliAnalysisTrackingUncertaintiesAOT : public AliAnalysisTaskSE {
   UInt_t fWhichCuts;  ///
   UInt_t fTPCclstCut; /// 0: cut on TPC clusters; 1: cuts on the number of crossed rows and on the ration crossed rows/findable clusters
 
+  /// event-cut object for centrality correlation event cuts
+  //  used for Pb-Pb2018
+  Bool_t       fUsePbPb2018EvSel;   ///
+  Int_t        fPileUpPbPb2018cut;  /// option for additional out-of-bunch pileup cut based on ITS-TPC correlation (0=no cut, 1=tight cut, 2=intermediate cut, 3=loose cut)
+  AliEventCuts fAliEventCuts;       ///
+
   AliAnalysisTrackingUncertaintiesAOT(const AliAnalysisTrackingUncertaintiesAOT&);
   AliAnalysisTrackingUncertaintiesAOT& operator=(const AliAnalysisTrackingUncertaintiesAOT&);
     
-  ClassDef(AliAnalysisTrackingUncertaintiesAOT, 11);
+  ClassDef(AliAnalysisTrackingUncertaintiesAOT, 12);
 };
 
 #endif


### PR DESCRIPTION
   1. time-range cut for LHC18r period
   2. out-of-bunch pile-up rejection according to ITS cluster vs. TPC cluster correlation