### PR TITLE
Add switchs to forced track extrapolation to the EMCal surface on AODs

### DIFF
--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterTrackMatcher.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterTrackMatcher.cxx
@@ -87,9 +87,9 @@ Bool_t AliEmcalCorrectionClusterTrackMatcher::Initialize()
   //
   // Calculate extrapolation for all tracks on ESDs
   fDoPropagation = fEsdMode; 
-  // Attempt extrapolation of non extraplated AOD tracks
+  // Attempt extrapolation of non extrapolated AOD tracks
   GetProperty("extrapolateNotMatchedAOD", fAttemptProp);
-  // Attempt extrapolation of non extraplated AOD tracks in EMCal acceptance
+  // Attempt extrapolation of non extrapolated AOD tracks in EMCal acceptance
   GetProperty("extrapolateNotMatchedAODInEMCal", fAttemptPropMatch); 
   
   Bool_t enableFracEMCRecalc = kFALSE;

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterTrackMatcher.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterTrackMatcher.cxx
@@ -82,7 +82,15 @@ Bool_t AliEmcalCorrectionClusterTrackMatcher::Initialize()
   GetProperty("maxDist", fMaxDistance);
   GetProperty("updateClusters", fUpdateClusters);
   GetProperty("updateTracks", fUpdateTracks);
-  fDoPropagation = fEsdMode;
+  
+  // Track extrapolation to EMCal surface
+  //
+  // Calculate extrapolation for all tracks on ESDs
+  fDoPropagation = fEsdMode; 
+  // Attempt extrapolation of non extraplated AOD tracks
+  GetProperty("extrapolateNotMatchedAOD", fAttemptProp);
+  // Attempt extrapolation of non extraplated AOD tracks in EMCal acceptance
+  GetProperty("extrapolateNotMatchedAODInEMCal", fAttemptPropMatch); 
   
   Bool_t enableFracEMCRecalc = kFALSE;
   GetProperty("enableFracEMCRecalc", enableFracEMCRecalc);
@@ -105,7 +113,7 @@ Bool_t AliEmcalCorrectionClusterTrackMatcher::Initialize()
       SetNameOfMCGeneratorsToAccept(1,removeMCGen2);
     }
   }
-
+  
   return kTRUE;
 }
 

--- a/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
+++ b/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
@@ -245,8 +245,8 @@ ClusterTrackMatcher:                                # Cluster-track matcher comp
     useDCA: true                                    # Use DCA as starting point for track propagation, rather than primary vertex
     useOuterParamInESDs: false                      # Use TPC outer parameters instead of inner for track propagation, ESDs only, it does nothing on AODs
     usePIDmass: true                                # Use PID-based mass hypothesis for track propagation, rather than pion mass hypothesis
-    extrapolateNotMatchedAOD: false                 # Attempt extrapolation of non extraplated AOD tracks, false in Run2 or recent AODs, true for Run1 old AODs
-    extrapolateNotMatchedAODInEMCal: false          # Attempt extrapolation of non extraplated AOD tracks in EMCal acceptance
+    extrapolateNotMatchedAOD: false                 # Attempt extrapolation of non extrapolated AOD tracks, false in Run2 or recent AODs, true for Run1 old AODs
+    extrapolateNotMatchedAODInEMCal: false          # Attempt extrapolation of non extrapolated AOD tracks in EMCal acceptance
     enableFracEMCRecalc: "sharedParameters:enableFracEMCRecalc"
     removeNMCGenerators: "sharedParameters:removeNMCGenerators"
     enableMCGenRemovTrack: "sharedParameters:enableMCGenRemovTrack"

--- a/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
+++ b/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
@@ -245,6 +245,8 @@ ClusterTrackMatcher:                                # Cluster-track matcher comp
     useDCA: true                                    # Use DCA as starting point for track propagation, rather than primary vertex
     useOuterParamInESDs: false                      # Use TPC outer parameters instead of inner for track propagation, ESDs only, it does nothing on AODs
     usePIDmass: true                                # Use PID-based mass hypothesis for track propagation, rather than pion mass hypothesis
+    extrapolateNotMatchedAOD: false                 # Attempt extrapolation of non extraplated AOD tracks, false in Run2 or recent AODs, true for Run1 old AODs
+    extrapolateNotMatchedAODInEMCal: false          # Attempt extrapolation of non extraplated AOD tracks in EMCal acceptance
     enableFracEMCRecalc: "sharedParameters:enableFracEMCRecalc"
     removeNMCGenerators: "sharedParameters:removeNMCGenerators"
     enableMCGenRemovTrack: "sharedParameters:enableMCGenRemovTrack"


### PR DESCRIPTION
Avoid unnecessary processing of tracks already discarded during AOD creation
For discussion