### PR TITLE
PWGHF: Add missing track quality selections V0 daughters (Lc->pK0s)

### DIFF
--- a/PWGHF/vertexingHF/AliRDHFCutsLctoV0.cxx
+++ b/PWGHF/vertexingHF/AliRDHFCutsLctoV0.cxx
@@ -1934,6 +1934,9 @@ Bool_t AliRDHFCutsLctoV0::AreLctoV0DaughtersSelected(AliAODRecoDecayHF *dd, AliA
   AliAODTrack *v0negativeTrack = dynamic_cast<AliAODTrack*>(d->Getv0NegativeTrack());
   if (!v0negativeTrack) return kFALSE;
 
+  //Makes part of the selections below redundant, but kept them for safety (Nov 2020)
+  if (!IsDaughterSelected(v0positiveTrack,&vESD,fV0daughtersCuts,aod)) return kFALSE;
+  if (!IsDaughterSelected(v0negativeTrack,&vESD,fV0daughtersCuts,aod)) return kFALSE;
 
   Float_t etaMin=0, etaMax=0; fV0daughtersCuts->GetEtaRange(etaMin,etaMax);
   if ( (v0positiveTrack->Eta()<=etaMin || v0positiveTrack->Eta()>=etaMax) ||


### PR DESCRIPTION
Selection with AliESDtrackCuts object `fV0daughtersCuts` was performed "manually" in `AliRDHFCutsLctoV0::AreLctoV0DaughtersSelected()` for the most important selections (pT, eta, MinNTPCClusters, TPC refit, MinRatioCrossedRowsOverFindableClustersTPC, and kinks). 

For the PbPb analysis additional selections are needed (MinNCrossedRowsTPC, MinNumTPCClsForPID, MaxChi2PerClusterTPC). Added them with the standard procedure, using a call to `AliRDHFCuts::IsDaughterSelected()` which calls `AliESDtrackCuts::AcceptTrack()`. Kept the manual selections for safety reasons