### PR TITLE
update of previously existing files to allow a cut in the mass spectrum

### DIFF
--- a/PWGDQ/dimuons/AliAnalysisTaskTree_MCut.h
+++ b/PWGDQ/dimuons/AliAnalysisTaskTree_MCut.h
@@ -15,7 +15,7 @@ class AliMuonTrackCuts;
 
 //class TList;
 
-class AliAnalysisTaskTree_MCut : public AliAnalysisTaskSE {
+class AliAnalysisTaskTree_MCut: public AliAnalysisTaskSE {
   public:
 
   AliAnalysisTaskTree_MCut();
@@ -28,6 +28,7 @@ class AliAnalysisTaskTree_MCut : public AliAnalysisTaskSE {
   virtual void NotifyRun(); 
   
   void SetBeamEnergy(Double_t en) {fBeamEnergy=en;}
+  void SetMassCut(Double_t MassCut) {fMassCut=MassCut;}
   void SetAnalysisType(const char* type) {fkAnalysisType=type;}
   void SetPeriod(TString period) {fPeriod=period;}
     
@@ -41,6 +42,7 @@ class AliAnalysisTaskTree_MCut : public AliAnalysisTaskSE {
   Double_t      fNevt		;      // event counter
 
   Double_t fBeamEnergy;   // Energy of the beam (required for the CS angle)    
+  Double_t fMassCut;   //  Mass Cut    
   const char* fkAnalysisType; //ESD or AOD based analysis
   TString fPeriod; //period
   Int_t fCountTotEv;   // counter
@@ -52,6 +54,7 @@ class AliAnalysisTaskTree_MCut : public AliAnalysisTaskSE {
   Int_t fCountCMSH7; //counter
   
   Int_t		fNMuons;		// muon tracks in the event
+  Int_t		fNTracks;		// tracks in the event
   Int_t		fNTracklets;		// spd tracklets
   Int_t		fNContributors;		// n contributors
   Int_t		fNDimu;			// dimuons in the event
@@ -69,6 +72,7 @@ class AliAnalysisTaskTree_MCut : public AliAnalysisTaskSE {
   Double_t	fPz[1500];		// single mu pz
   Double_t	fY[1500];		// single mu y
   Double_t	fEta[1500];		// single mu eta
+  Double_t	fPhi[1500];		// single mu phi
   Int_t		fMatchTrig[1500];		// single mu match trigger
   Double_t	fTrackChi2[1500];		// single mu chi2 track
   Double_t	fMatchTrigChi2[1500];	// single mu chi2 of match trigger
@@ -95,7 +99,7 @@ class AliAnalysisTaskTree_MCut : public AliAnalysisTaskSE {
   
 //  TList *fOutput;  //!< List of histograms for data
   
- ClassDef(AliAnalysisTaskTree_MCut,2);
+ ClassDef(AliAnalysisTaskTree_MCut,3);
 };
 
 #endif

--- a/PWGDQ/dimuons/macros/AddTaskTree_Grid_MCut.C
+++ b/PWGDQ/dimuons/macros/AddTaskTree_Grid_MCut.C
@@ -1,4 +1,4 @@
-AliAnalysisTaskTree_MCut *AddTaskTree_Grid_MCut(){
+AliAnalysisTaskTree_MCut *AddTaskTree_Grid_MCut(Int_t RunNumber, Double_t MassCut){
 
 //****************************************************************************************
 // Add task class to fill a tree with dimuon infos
@@ -11,16 +11,22 @@ AliAnalysisTaskTree_MCut *AddTaskTree_Grid_MCut(){
       return NULL;
    }   
    
-   TString outputFileName = AliAnalysisManager::GetCommonFileName();	 
-   outputFileName += ":Tree";
+   TString outputFileName1 = "Tree_MassCut%d_%d.root";  
+   TString outputFileName;  
+   outputFileName.Form(outputFileName1.Data(), (Int_t) MassCut, (Int_t) RunNumber);
+   printf("Output = %s\n",outputFileName.Data());
 
-   Printf("Set OutputFileName : \n %s\n", outputFileName.Data() );
-  
-   AliAnalysisDataContainer *coutput1 = mgr->CreateContainer("ctree0",TTree::Class(),AliAnalysisManager::kOutputContainer,outputFileName);
+   TString treeName1 = "Tree%d";  
+   TString treeName;  
+   treeName.Form(treeName1.Data(), (Int_t) MassCut);
+   printf("Tree name = %s\n",treeName.Data());
+   
+   AliAnalysisDataContainer *coutput1 = mgr->CreateContainer(treeName,TTree::Class(),AliAnalysisManager::kOutputContainer,outputFileName);
 
    AliAnalysisTaskTree_MCut *TreeTask = new AliAnalysisTaskTree_MCut("AliAnalysisTaskTree_MCut");
    
    TreeTask->SetBeamEnergy(13.);  // define by hand the beam energy
+   TreeTask->SetMassCut(MassCut);  // define by hand the beam energy
    mgr->AddTask(TreeTask);
  
    mgr->ConnectInput(TreeTask,0,mgr->GetCommonInputContainer());


### PR DESCRIPTION
Files have been modified in order to allow the possibility to set a mass cut from an external macro (previously it was harcoded in the .cxx). In this way it will be possible to create trees with a given cut in the dimuon mass spectrum