### PR TITLE
PWGHF: Adding TOF mismatch selection (TreeCreator)

### DIFF
--- a/PWGHF/vertexingHF/vHFML/AliAnalysisTaskSEHFTreeCreatorApply.cxx
+++ b/PWGHF/vertexingHF/vHFML/AliAnalysisTaskSEHFTreeCreatorApply.cxx
@@ -1013,7 +1013,7 @@ void AliAnalysisTaskSEHFTreeCreatorApply::Process3Prong(TClonesArray *array3Pron
                 }
                 if(!fReadMC || (issignal || isbkg || isrefl)) {
                   fTreeHandlerDs->SetIsSelectedStd(isSelAnCutsKKpi,isSelAnTopoCutsKKpi,isSelAnPidCutsKKpi,isSelTracksAnCuts);
-                  fTreeHandlerDs->SetVariables(fRunNumber,fEventID,fEventIDExt,fEventIDLong,ptGenDs,modelPred0,ds,bfield,0,fPIDresp);
+                  fTreeHandlerDs->SetVariables(fRunNumber,fEventID,fEventIDExt,fEventIDLong,ptGenDs,modelPred0,ds,bfield,0,fPIDresp,Pid_HF);
                   if(isSelectedMLFilt0) fTreeHandlerDs->FillTree();
                 }
               }
@@ -1041,7 +1041,7 @@ void AliAnalysisTaskSEHFTreeCreatorApply::Process3Prong(TClonesArray *array3Pron
                 }
                 if(!fReadMC || (issignal || isbkg || isrefl)) {
                   fTreeHandlerDs->SetIsSelectedStd(isSelAnCutspiKK,isSelAnTopoCutspiKK,isSelAnPidCutspiKK,isSelTracksAnCuts);
-                  fTreeHandlerDs->SetVariables(fRunNumber,fEventID,fEventIDExt,fEventIDLong,ptGenDs,modelPred1,ds,bfield,1,fPIDresp);
+                  fTreeHandlerDs->SetVariables(fRunNumber,fEventID,fEventIDExt,fEventIDLong,ptGenDs,modelPred1,ds,bfield,1,fPIDresp,Pid_HF);
                   if(isSelectedMLFilt1) fTreeHandlerDs->FillTree();
                 }
               }
@@ -1233,7 +1233,7 @@ void AliAnalysisTaskSEHFTreeCreatorApply::ProcessCasc(TClonesArray *arrayCasc, A
             if(!fReadMC || (issignal || isbkg || isrefl)) {
               fTreeHandlerLc2V0bachelor->SetIsSelectedStd(isSelAnCutstopK0s,isSelAnTopolCutstopK0s,isSelAnPidCutstopK0s,isSelTracksAnCuts);
               fTreeHandlerLc2V0bachelor->SetIsLctoLpi(isSelAnCutstoLpi, isSelAnTopolCutstoLpi, isSelAnPidCutstoLpi);
-              fTreeHandlerLc2V0bachelor->SetVariables(fRunNumber,fEventID,fEventIDExt,fEventIDLong,ptGenLc2V0bachelor,modelPred,d,bfield,masshypo,fPIDresp);
+              fTreeHandlerLc2V0bachelor->SetVariables(fRunNumber,fEventID,fEventIDExt,fEventIDLong,ptGenLc2V0bachelor,modelPred,d,bfield,masshypo,fPIDresp,Pid_HF);
               fTreeHandlerLc2V0bachelor->FillTree();
             }
             if(recVtx)fFiltCutsLc2V0bachelor->CleanOwnPrimaryVtx(d,aod,origownvtx);

--- a/PWGHF/vertexingHF/vHFML/AliHFTreeHandlerApply.h
+++ b/PWGHF/vertexingHF/vHFML/AliHFTreeHandlerApply.h
@@ -72,7 +72,7 @@ public:
   
   //core methods --> implemented in each derived class
   virtual TTree* BuildTree(TString name, TString title) = 0;
-  virtual bool SetVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, float ptgen, float mlprob, AliAODRecoDecayHF* cand, float bfield, int masshypo, AliPIDResponse* pidrespo) = 0;
+  virtual bool SetVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, float ptgen, float mlprob, AliAODRecoDecayHF* cand, float bfield, int masshypo, AliPIDResponse* pidrespo, AliAODPidHF* pidhf) = 0;
 
   //for MC gen --> common implementation
   TTree* BuildTreeMCGen(TString name, TString title);
@@ -163,7 +163,7 @@ protected:
   void AddSingleTrackBranches();
   void AddPidBranches(bool prongusepid[], bool usePionHypo, bool useKaonHypo, bool useProtonHypo, bool useTPC, bool useTOF);
   bool SetSingleTrackVars(AliAODTrack* prongtracks[]);
-  bool SetPidVars(AliAODTrack* prongtracks[], AliPIDResponse* pidrespo, bool usePionHypo, bool useKaonHypo, bool useProtonHypo, bool useTPC, bool useTOF);
+  bool SetPidVars(AliAODTrack* prongtracks[], AliPIDResponse* pidrespo, bool usePionHypo, bool useKaonHypo, bool useProtonHypo, bool useTPC, bool useTOF, AliAODPidHF* pidhf);
   
   //utils methods
   double CombineNsigmaDiffDet(double nsigmaTPC, double nsigmaTOF);

--- a/PWGHF/vertexingHF/vHFML/AliHFTreeHandlerApplyDstoKKpi.cxx
+++ b/PWGHF/vertexingHF/vHFML/AliHFTreeHandlerApplyDstoKKpi.cxx
@@ -94,7 +94,7 @@ TTree* AliHFTreeHandlerApplyDstoKKpi::BuildTree(TString name, TString title)
 }
 
 //________________________________________________________________
-bool AliHFTreeHandlerApplyDstoKKpi::SetVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, float ptgen, float mlprob, AliAODRecoDecayHF* cand, float bfield, int masshypo, AliPIDResponse *pidrespo)
+bool AliHFTreeHandlerApplyDstoKKpi::SetVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, float ptgen, float mlprob, AliAODRecoDecayHF* cand, float bfield, int masshypo, AliPIDResponse *pidrespo, AliAODPidHF* pidhf)
 {
   if(!cand) return false;
   if(fFillOnlySignal) { //if fill only signal and not signal candidate, do not store
@@ -153,7 +153,7 @@ bool AliHFTreeHandlerApplyDstoKKpi::SetVariables(int runnumber, int eventID, int
   //pid variables
   if(fPidOpt==kNoPID) return true;
   
-  bool setpid = SetPidVars(prongtracks,pidrespo,true,true,false,true,true);
+  bool setpid = SetPidVars(prongtracks,pidrespo,true,true,false,true,true,pidhf);
   if(!setpid) return false;
   
   return true;

--- a/PWGHF/vertexingHF/vHFML/AliHFTreeHandlerApplyDstoKKpi.h
+++ b/PWGHF/vertexingHF/vHFML/AliHFTreeHandlerApplyDstoKKpi.h
@@ -31,7 +31,7 @@ public:
   AliHFTreeHandlerApplyDstoKKpi& operator=(const AliHFTreeHandlerApplyDstoKKpi &source) = delete;
   
   virtual TTree* BuildTree(TString name="tree", TString title="tree");
-  virtual bool SetVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, float ptgen, float mlprob, AliAODRecoDecayHF* cand, float bfield, int masshypo=0, AliPIDResponse *pidrespo=nullptr);
+  virtual bool SetVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, float ptgen, float mlprob, AliAODRecoDecayHF* cand, float bfield, int masshypo=0, AliPIDResponse *pidrespo=nullptr, AliAODPidHF *pidhf=nullptr);
   
   void SetMassKKOption(int opt) {fMassKKOpt=opt;}
   void SetIsDplustoKKpi(bool isDplus) {

--- a/PWGHF/vertexingHF/vHFML/AliHFTreeHandlerApplyLc2V0bachelor.cxx
+++ b/PWGHF/vertexingHF/vHFML/AliHFTreeHandlerApplyLc2V0bachelor.cxx
@@ -115,7 +115,7 @@ TTree* AliHFTreeHandlerApplyLc2V0bachelor::BuildTree(TString name, TString title
 }
 
 //________________________________________________________________
-bool AliHFTreeHandlerApplyLc2V0bachelor::SetVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, float ptgen, float mlprob, AliAODRecoDecayHF* cand, float bfield, int masshypo, AliPIDResponse* pidrespo)
+bool AliHFTreeHandlerApplyLc2V0bachelor::SetVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, float ptgen, float mlprob, AliAODRecoDecayHF* cand, float bfield, int masshypo, AliPIDResponse* pidrespo, AliAODPidHF* pidhf)
 {
   if(!cand) return false;
   if(fFillOnlySignal) { //if fill only signal and not signal candidate, do not store
@@ -209,8 +209,8 @@ bool AliHFTreeHandlerApplyLc2V0bachelor::SetVariables(int runnumber, int eventID
   if(fPidOpt == kNoPID) return true;
   
   bool setpid;
-  if(!fReducePbPbBranches) setpid = SetPidVars(prongtracks, pidrespo, true, true, true, true, true);
-  else                     setpid = SetPidVars(prongtracks, pidrespo, false, false, true, true, true);
+  if(!fReducePbPbBranches) setpid = SetPidVars(prongtracks, pidrespo, true, true, true, true, true, pidhf);
+  else                     setpid = SetPidVars(prongtracks, pidrespo, false, false, true, true, true, pidhf);
 
   if(!setpid) return false;
   

--- a/PWGHF/vertexingHF/vHFML/AliHFTreeHandlerApplyLc2V0bachelor.h
+++ b/PWGHF/vertexingHF/vHFML/AliHFTreeHandlerApplyLc2V0bachelor.h
@@ -34,7 +34,7 @@ public:
   AliHFTreeHandlerApplyLc2V0bachelor& operator=(const AliHFTreeHandlerApplyLc2V0bachelor &source) = delete;
   
   virtual TTree* BuildTree(TString name = "tree", TString title = "tree");
-  virtual bool SetVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, float ptgen, float mlprob, AliAODRecoDecayHF* cand, float bfield, int masshypo = 0, AliPIDResponse* pidrespo = nullptr);
+  virtual bool SetVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, float ptgen, float mlprob, AliAODRecoDecayHF* cand, float bfield, int masshypo = 0, AliPIDResponse* pidrespo = nullptr, AliAODPidHF *pidhf=nullptr);
   
   void SetCalcSecoVtx(int opt) {fCalcSecoVtx=opt;}
   void SetReducePbPbBranches(bool b) { fReducePbPbBranches = b; }


### PR DESCRIPTION
Fix for extracted nsigma TOF stored in TTrees. There are two methods:
 * `AliAODPidHF::GetnSigmaTOF()`
 * `AliPIDResponse::NumberOfSigmasTOF()`
First one is adding a TOF mismatch cut (default 0.01) as extra condition for flagging bad TOF-PID tracks (standard procedure in HF). Second option isn't, leading to random nsigma TOF values in a huge range, which were given as input to the ML training. These candidates should have been flagged with nsigmaTOF = -999 instead. 

Switched now from 2nd to 1st method, fixing the issue