### PR TITLE
PWGHF: Flagging candidates that don't pass TOF mismatch

### DIFF
--- a/PWGHF/treeHF/AliAnalysisTaskSEHFTreeCreator.cxx
+++ b/PWGHF/treeHF/AliAnalysisTaskSEHFTreeCreator.cxx
@@ -1889,6 +1889,9 @@ void AliAnalysisTaskSEHFTreeCreator::Process2Prong(TClonesArray *array2prong, Al
       nFilteredD0++;
       if((vHF->FillRecoCand(aod,d))) {//Fill the data members of the candidate only if they are empty.
         
+        // Get AliAODPidHF object for properly filling PID variables
+        AliAODPidHF* fPidHFD0 = fFiltCutsD0toKpi->GetPidHF();
+
         //filtering cuts
         Int_t isSelectedFilt     = fFiltCutsD0toKpi->IsSelected(d,AliRDHFCuts::kAll,aod); //selected
         Int_t isSelectedPidFilt  = fFiltCutsD0toKpi->IsSelectedPID(d);
@@ -1995,7 +1998,7 @@ void AliAnalysisTaskSEHFTreeCreator::Process2Prong(TClonesArray *array2prong, Al
             }//end read MC
             if(!fReadMC || (issignal || isbkg || isrefl)) {
               fTreeHandlerD0->SetIsSelectedStd(isSelAnCutsD0, isSelTopoAnCutsD0, isSelPidAnCutsD0, isSelTracksAnCuts);
-              fTreeHandlerD0->SetVariables(fRunNumber,fEventID,fEventIDExt,fEventIDLong,ptGenD0,d,bfield,masshypo,fPIDresp);
+              fTreeHandlerD0->SetVariables(fRunNumber,fEventID,fEventIDExt,fEventIDLong,ptGenD0,d,bfield,masshypo,fPIDresp,fPidHFD0);
               if (fFillJets) fTreeHandlerD0->SetJetVars(aod->GetTracks(),d,d->InvMassD0(),arrMC,partD0);
               fTreeHandlerD0->FillTree();
             }
@@ -2033,7 +2036,7 @@ void AliAnalysisTaskSEHFTreeCreator::Process2Prong(TClonesArray *array2prong, Al
             }//end readMC
             if(!fReadMC || (issignal || isbkg || isrefl)) {
               fTreeHandlerD0->SetIsSelectedStd(isSelAnCutsD0bar, isSelTopoAnCutsD0bar, isSelPidAnCutsD0bar, isSelTracksAnCuts);
-              fTreeHandlerD0->SetVariables(fRunNumber,fEventID,fEventIDExt,fEventIDLong,ptGenD0,d,bfield,masshypo,fPIDresp);
+              fTreeHandlerD0->SetVariables(fRunNumber,fEventID,fEventIDExt,fEventIDLong,ptGenD0,d,bfield,masshypo,fPIDresp,fPidHFD0);
               if (fFillJets) fTreeHandlerD0->SetJetVars(aod->GetTracks(),d,d->InvMassD0bar(),arrMC,partD0);
               fTreeHandlerD0->FillTree();
             }
@@ -2113,6 +2116,9 @@ void AliAnalysisTaskSEHFTreeCreator::Process3Prong(TClonesArray *array3Prong, Al
       nFilteredDs++;
       if((vHF->FillRecoCand(aod,ds))) {////Fill the data members of the candidate only if they are empty.
         
+        // Get AliAODPidHF object for properly filling PID variables
+        AliAODPidHF* fPidHFDs = fFiltCutsDstoKKpi->GetPidHF();
+
         Int_t isSelectedFilt=fFiltCutsDstoKKpi->IsSelected(ds,AliRDHFCuts::kAll,aod);
         Int_t isKKpi=isSelectedFilt&1;
         Int_t ispiKK=isSelectedFilt&2;
@@ -2251,7 +2257,7 @@ void AliAnalysisTaskSEHFTreeCreator::Process3Prong(TClonesArray *array3Prong, Al
               }
               if(!fReadMC || (issignal || isbkg || isrefl)) {
                 fTreeHandlerDs->SetIsSelectedStd(isSelAnCutsKKpi,isSelAnTopoCutsKKpi,isSelAnPidCutsKKpi,isSelTracksAnCuts);
-                fTreeHandlerDs->SetVariables(fRunNumber,fEventID,fEventIDExt,fEventIDLong,ptGenDs,ds,bfield,0,fPIDresp);
+                fTreeHandlerDs->SetVariables(fRunNumber,fEventID,fEventIDExt,fEventIDLong,ptGenDs,ds,bfield,0,fPIDresp,fPidHFDs);
                 if (fFillJets) fTreeHandlerDs->SetJetVars(aod->GetTracks(),ds,ds->InvMassDsKKpi(),arrMC,partDs);
                 fTreeHandlerDs->FillTree();
               }
@@ -2286,7 +2292,7 @@ void AliAnalysisTaskSEHFTreeCreator::Process3Prong(TClonesArray *array3Prong, Al
               }
               if(!fReadMC || (issignal || isbkg || isrefl)) {
                 fTreeHandlerDs->SetIsSelectedStd(isSelAnCutspiKK,isSelAnTopoCutspiKK,isSelAnPidCutspiKK,isSelTracksAnCuts);
-                fTreeHandlerDs->SetVariables(fRunNumber,fEventID,fEventIDExt,fEventIDLong,ptGenDs,ds,bfield,1,fPIDresp);
+                fTreeHandlerDs->SetVariables(fRunNumber,fEventID,fEventIDExt,fEventIDLong,ptGenDs,ds,bfield,1,fPIDresp,fPidHFDs);
                 if (fFillJets) fTreeHandlerDs->SetJetVars(aod->GetTracks(),ds,ds->InvMassDspiKK(),arrMC,partDs);
                 fTreeHandlerDs->FillTree();
               }
@@ -2336,6 +2342,9 @@ void AliAnalysisTaskSEHFTreeCreator::Process3Prong(TClonesArray *array3Prong, Al
       fNentries->Fill(19);
       if((vHF->FillRecoCand(aod,dplus))) {////Fill the data members of the candidate only if they are empty.
         
+        // Get AliAODPidHF object for properly filling PID variables
+        AliAODPidHF* fPidHFDplus = fFiltCutsDplustoKpipi->GetPidHF();
+
         Int_t isSelectedFilt = fFiltCutsDplustoKpipi->IsSelected(dplus,AliRDHFCuts::kAll,aod);
         
         if(isSelectedFilt){
@@ -2425,7 +2434,7 @@ void AliAnalysisTaskSEHFTreeCreator::Process3Prong(TClonesArray *array3Prong, Al
           // fill tree
           if(!fReadMC || (issignal || isbkg)) {
             fTreeHandlerDplus->SetIsSelectedStd(isSelAnCuts,isSelAnTopolCuts,isSelAnPidCuts,isSelTracksAnCuts);
-            fTreeHandlerDplus->SetVariables(fRunNumber,fEventID,fEventIDExt,fEventIDLong,ptGenDplus,dplus,bfield,0,fPIDresp);
+            fTreeHandlerDplus->SetVariables(fRunNumber,fEventID,fEventIDExt,fEventIDLong,ptGenDplus,dplus,bfield,0,fPIDresp,fPidHFDplus);
             if (fFillJets) fTreeHandlerDplus->SetJetVars(aod->GetTracks(),dplus,dplus->InvMassDplus(),arrMC,partDp);
             fTreeHandlerDplus->FillTree();
           }
@@ -2479,6 +2488,9 @@ void AliAnalysisTaskSEHFTreeCreator::Process3Prong(TClonesArray *array3Prong, Al
       fNentries->Fill(22);
       if((vHF->FillRecoCand(aod,lctopkpi))) {////Fill the data members of the candidate only if they are empty.
         
+        // Get AliAODPidHF object for properly filling PID variables
+        AliAODPidHF* fPidHFLc = fFiltCutsLctopKpi->GetPidHF();
+
         Int_t isSelectedFilt    = fFiltCutsLctopKpi->IsSelected(lctopkpi,AliRDHFCuts::kAll,aod);
 
         if(isSelectedFilt){
@@ -2591,7 +2603,7 @@ void AliAnalysisTaskSEHFTreeCreator::Process3Prong(TClonesArray *array3Prong, Al
             // fill tree
             if(!fReadMC || (issignal || isbkg || isrefl)) {
               fTreeHandlerLctopKpi->SetIsSelectedStd(isSelAnCutspKpi,isSelTopopKpi,isSelPIDpKpi,isSelTracksAnCuts);
-              fTreeHandlerLctopKpi->SetVariables(fRunNumber,fEventID,fEventIDExt,fEventIDLong,ptGenLcpKpi,lctopkpi,bfield,1,fPIDresp);
+              fTreeHandlerLctopKpi->SetVariables(fRunNumber,fEventID,fEventIDExt,fEventIDLong,ptGenLcpKpi,lctopkpi,bfield,1,fPIDresp,fPidHFLc);
               fTreeHandlerLctopKpi->SetVariableResonantDecay(restype);
               if (fFillJets) fTreeHandlerLctopKpi->SetJetVars(aod->GetTracks(),lctopkpi,lctopkpi->InvMassLcpKpi(),arrMC,partDp);
               fTreeHandlerLctopKpi->FillTree();
@@ -2661,7 +2673,7 @@ void AliAnalysisTaskSEHFTreeCreator::Process3Prong(TClonesArray *array3Prong, Al
             // fill tree
             if(!fReadMC || (issignal || isbkg || isrefl)) {
               fTreeHandlerLctopKpi->SetIsSelectedStd(isSelAnCutspiKp,isSelTopopiKp,isSelPIDpiKp,isSelTracksAnCuts);
-              fTreeHandlerLctopKpi->SetVariables(fRunNumber,fEventID,fEventIDExt,fEventIDLong,ptGenLcpKpi,lctopkpi,bfield,2,fPIDresp);
+              fTreeHandlerLctopKpi->SetVariables(fRunNumber,fEventID,fEventIDExt,fEventIDLong,ptGenLcpKpi,lctopkpi,bfield,2,fPIDresp,fPidHFLc);
               fTreeHandlerLctopKpi->SetVariableResonantDecay(restype);
               if (fFillJets) fTreeHandlerLctopKpi->SetJetVars(aod->GetTracks(),lctopkpi,lctopkpi->InvMassLcpiKp(),arrMC,partDp);
               fTreeHandlerLctopKpi->FillTree();
@@ -2750,6 +2762,9 @@ void AliAnalysisTaskSEHFTreeCreator::ProcessDstar(TClonesArray *arrayDstar, AliA
       nFilteredDstar++;
       if((vHF->FillRecoCasc(aod,d,kTRUE))) {//Fill the data members of the candidate only if they are empty.
         
+        // Get AliAODPidHF object for properly filling PID variables
+        AliAODPidHF* fPidHFDstar = fFiltCutsDstartoKpipi->GetPidHF();
+
         Int_t isSelectedFilt = fFiltCutsDstartoKpipi->IsSelected(d,AliRDHFCuts::kAll,aod); //selected
         if(isSelectedFilt > 0){
           fNentries->Fill(30);
@@ -2832,7 +2847,7 @@ void AliAnalysisTaskSEHFTreeCreator::ProcessDstar(TClonesArray *arrayDstar, AliA
           }//end read MC
           if(!fReadMC || (issignal || isbkg || isrefl)) {
             fTreeHandlerDstar->SetIsSelectedStd(isSelAnCuts,isSelAnTopolCuts,isSelAnPidCuts,isSelTracksAnCuts);
-            fTreeHandlerDstar->SetVariables(fRunNumber,fEventID,fEventIDExt,fEventIDLong,ptGenDstar,d,bfield,masshypo,fPIDresp);
+            fTreeHandlerDstar->SetVariables(fRunNumber,fEventID,fEventIDExt,fEventIDLong,ptGenDstar,d,bfield,masshypo,fPIDresp,fPidHFDstar);
             if (fFillJets) fTreeHandlerDstar->SetJetVars(aod->GetTracks(),d,d->InvMassDstarKpipi(),arrMC,partDstar);	
             fTreeHandlerDstar->FillTree();
           }
@@ -2920,6 +2935,9 @@ void AliAnalysisTaskSEHFTreeCreator::ProcessCasc(TClonesArray *arrayCasc, AliAOD
         //Remember to run also CleanUpTask!
         if(d->GetIsFilled()==1 && fLc2V0bachelorCalcSecoVtx) vHF->RecoSecondaryVertexForCascades(aod, d);
         
+        // Get AliAODPidHF object for properly filling PID variables
+        AliAODPidHF* fPidHFLc = fFiltCutsLc2V0bachelor->GetPidHF();
+
         Int_t isSelectedFilt = fFiltCutsLc2V0bachelor->IsSelected(d,AliRDHFCuts::kAll,aod); //selected
         if(isSelectedFilt > 0){
           fNentries->Fill(34);
@@ -3009,7 +3027,7 @@ void AliAnalysisTaskSEHFTreeCreator::ProcessCasc(TClonesArray *arrayCasc, AliAOD
           if(!fReadMC || (issignal || isbkg || isrefl)) {
             fTreeHandlerLc2V0bachelor->SetIsSelectedStd(isSelAnCutstopK0s,isSelAnTopolCutstopK0s,isSelAnPidCutstopK0s,isSelTracksAnCuts);
             fTreeHandlerLc2V0bachelor->SetIsLctoLpi(isSelAnCutstoLpi, isSelAnTopolCutstoLpi, isSelAnPidCutstoLpi);
-            fTreeHandlerLc2V0bachelor->SetVariables(fRunNumber,fEventID,fEventIDExt,fEventIDLong,ptGenLc2V0bachelor,d,bfield,masshypo,fPIDresp);
+            fTreeHandlerLc2V0bachelor->SetVariables(fRunNumber,fEventID,fEventIDExt,fEventIDLong,ptGenLc2V0bachelor,d,bfield,masshypo,fPIDresp,fPidHFLc);
             if (fFillJets) fTreeHandlerLc2V0bachelor->SetJetVars(aod->GetTracks(),d,d->InvMassLctoK0sP(),arrMC,partLc2V0bachelor);
             fTreeHandlerLc2V0bachelor->FillTree();
           }
@@ -3277,7 +3295,7 @@ void AliAnalysisTaskSEHFTreeCreator::ProcessBplus(TClonesArray *array2prong, Ali
                     // fill tree
                     if(!fReadMC || (issignal || isbkg || isrefl)) {
                       fTreeHandlerBplus->SetIsSelectedStd(isSelAnCuts,isSelAnTopoCuts,isSelAnPidCuts,isSelTracksAnCuts);
-                      fTreeHandlerBplus->SetVariables(fRunNumber, fEventID, fEventIDExt, fEventIDLong, ptGenBplus, &trackBplus, bfield, 0, fPIDresp);
+                      fTreeHandlerBplus->SetVariables(fRunNumber, fEventID, fEventIDExt, fEventIDLong, ptGenBplus, &trackBplus, bfield, 0, fPIDresp, fPidHFD0);
                       if (fFillJets) fTreeHandlerBplus->SetJetVars(aod->GetTracks(),&trackBplus,trackBplus.InvMass(2,pdgDgBplustoD0piUInt),arrMC,partBplus);
                       fTreeHandlerBplus->FillTree();
                     }
@@ -3594,7 +3612,7 @@ void AliAnalysisTaskSEHFTreeCreator::ProcessBs(TClonesArray *array3Prong, AliAOD
                     if(!fReadMC || (issignal || isbkg || isrefl)) {
                       fTreeHandlerBs->SetIsSelectedStd(isSelAnCuts,isSelAnTopoCuts,isSelAnPidCuts,isSelTracksAnCuts);
                       fTreeHandlerBs->SetDsBackgroundShapeType(isDsPrompt, isDsFDBplus, isDsFDB0, isDsFDLb0, isDsFDBs0);
-                      fTreeHandlerBs->SetVariables(fRunNumber, fEventID, fEventIDExt, fEventIDLong, ptGenBs, &trackBs, bfield, masshypoDs, fPIDresp);
+                      fTreeHandlerBs->SetVariables(fRunNumber, fEventID, fEventIDExt, fEventIDLong, ptGenBs, &trackBs, bfield, masshypoDs, fPIDresp, fPidHFDs);
                       if (fFillJets) fTreeHandlerBs->SetJetVars(aod->GetTracks(),&trackBs,trackBs.InvMass(2,pdgDgBstoDspiUInt),arrMC,partBs);
                       fTreeHandlerBs->FillTree();
                     }
@@ -3913,7 +3931,7 @@ void AliAnalysisTaskSEHFTreeCreator::ProcessLb(TClonesArray *array3Prong, AliAOD
                     if(!fReadMC || (issignal || isbkg || isrefl)) {
                       fTreeHandlerLb->SetIsSelectedStd(isSelAnCuts,isSelAnTopoCuts,isSelAnPidCuts,isSelTracksAnCuts);
                       fTreeHandlerLb->SetLcBackgroundShapeType(isLcPrompt, isLcFDBplus, isLcFDB0, isLcFDLb0, isLcFDBs0);
-                      fTreeHandlerLb->SetVariables(fRunNumber, fEventID, fEventIDExt, fEventIDLong, ptGenLb, &trackLb, bfield, masshypoLc, fPIDresp);
+                      fTreeHandlerLb->SetVariables(fRunNumber, fEventID, fEventIDExt, fEventIDLong, ptGenLb, &trackLb, bfield, masshypoLc, fPIDresp, fPidHFLc);
                       if (fFillJets) fTreeHandlerLb->SetJetVars(aod->GetTracks(),&trackLb,trackLb.InvMass(2,pdgDgLbtoLcpiUInt),arrMC,partLb);
                       fTreeHandlerLb->FillTree();
                     }
@@ -3945,7 +3963,7 @@ void AliAnalysisTaskSEHFTreeCreator::ProcessLb(TClonesArray *array3Prong, AliAOD
 void AliAnalysisTaskSEHFTreeCreator::ProcessInclusiveJet(AliAODEvent *aod, TClonesArray *arrMC){
   
 
-  fTreeHandlerInclusiveJet->SetVariables(fRunNumber,fEventID,fEventIDExt,fEventIDLong, 0.0, NULL, 0.0, 0, NULL);
+  fTreeHandlerInclusiveJet->SetVariables(fRunNumber,fEventID,fEventIDExt,fEventIDLong, 0.0, NULL, 0.0, 0, NULL, NULL);
   fTreeHandlerInclusiveJet->SetAndFillInclusiveJetVars(aod->GetTracks(),arrMC);
 
   return;

--- a/PWGHF/treeHF/AliHFTreeHandler.cxx
+++ b/PWGHF/treeHF/AliHFTreeHandler.cxx
@@ -834,7 +834,7 @@ void AliHFTreeHandler::SetGenJetTreeVars(AliHFJet hfjet){
 
 
 //________________________________________________________________
-bool AliHFTreeHandler::SetPidVars(AliAODTrack* prongtracks[], AliPIDResponse* pidrespo, bool usePionHypo, bool useKaonHypo, bool useProtonHypo, bool useTPC, bool useTOF) 
+bool AliHFTreeHandler::SetPidVars(AliAODTrack* prongtracks[], AliPIDResponse* pidrespo, bool usePionHypo, bool useKaonHypo, bool useProtonHypo, bool useTPC, bool useTOF, AliAODPidHF* pidhf)
 {
   if(!pidrespo) return false;
   for(unsigned int iProng=0; iProng<fNProngs; iProng++) {
@@ -859,15 +859,24 @@ bool AliHFTreeHandler::SetPidVars(AliAODTrack* prongtracks[], AliPIDResponse* pi
       for(unsigned int iPartHypo=0; iPartHypo<knMaxHypo4Pid; iPartHypo++) {
         if(useHypo[iPartHypo]) {
           if(useTPC) {
-          float nSigmaTPC = pidrespo->NumberOfSigmasTPC(prongtracks[iProng],parthypo[iPartHypo]);
-            if(fApplyNsigmaTPCDataCorr && nSigmaTPC>-990.) {
-              float sigma=1., mean=0.;
-              GetNsigmaTPCMeanSigmaData(mean, sigma, parthypo[iPartHypo], prongtracks[iProng]->GetTPCmomentum(), prongtracks[iProng]->Eta());
-              nSigmaTPC = (nSigmaTPC-mean)/sigma;
+            double nSigmaTPC = -999;
+            if(pidhf) pidhf->GetnSigmaTPC(prongtracks[iProng],parthypo[iPartHypo],nSigmaTPC);
+            else {
+              nSigmaTPC = pidrespo->NumberOfSigmasTPC(prongtracks[iProng],parthypo[iPartHypo]);
+              if(fApplyNsigmaTPCDataCorr && nSigmaTPC>-990.) {
+                float sigma=1., mean=0.;
+                GetNsigmaTPCMeanSigmaData(mean, sigma, parthypo[iPartHypo], prongtracks[iProng]->GetTPCmomentum(), prongtracks[iProng]->Eta());
+                nSigmaTPC = (nSigmaTPC-mean)/sigma;
+              }
             }
             sig[iProng][kTPC][iPartHypo] = nSigmaTPC;
           }
-          if(useTOF) sig[iProng][kTOF][iPartHypo] = pidrespo->NumberOfSigmasTOF(prongtracks[iProng],parthypo[iPartHypo]);
+          if(useTOF){
+            double nSigmaTOF = -999;
+            if(pidhf) pidhf->GetnSigmaTOF(prongtracks[iProng],parthypo[iPartHypo],nSigmaTOF);
+            else nSigmaTOF = pidrespo->NumberOfSigmasTOF(prongtracks[iProng],parthypo[iPartHypo]);
+            sig[iProng][kTOF][iPartHypo] = nSigmaTOF;
+          }
           if(((fPidOpt>=kNsigmaCombPID && fPidOpt<=kNsigmaCombPIDfloatandint) || fPidOpt==kNsigmaDetAndCombPID) && useTPC && useTOF) {
             sigComb[iProng][iPartHypo] = CombineNsigmaDiffDet(sig[iProng][kTPC][iPartHypo],sig[iProng][kTOF][iPartHypo]);
           }

--- a/PWGHF/treeHF/AliHFTreeHandler.h
+++ b/PWGHF/treeHF/AliHFTreeHandler.h
@@ -85,7 +85,7 @@ class AliHFTreeHandler : public TObject
 
     //core methods --> implemented in each derived class
     virtual TTree* BuildTree(TString name, TString title) = 0;
-    virtual bool SetVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, float ptgen, AliAODRecoDecayHF* cand, float bfield, int masshypo, AliPIDResponse* pidrespo) = 0;
+    virtual bool SetVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, float ptgen, AliAODRecoDecayHF* cand, float bfield, int masshypo, AliPIDResponse* pidrespo, AliAODPidHF* pidhf) = 0;
     //for MC gen --> common implementation
     TTree* BuildTreeMCGen(TString name, TString title);
     bool SetMCGenVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, AliAODMCParticle* mcpart);
@@ -194,7 +194,7 @@ class AliHFTreeHandler : public TObject
     void AddGenJetBranches();
     void AddPidBranches(bool usePionHypo, bool useKaonHypo, bool useProtonHypo, bool useTPC, bool useTOF);
     bool SetSingleTrackVars(AliAODTrack* prongtracks[]);
-    bool SetPidVars(AliAODTrack* prongtracks[], AliPIDResponse* pidrespo, bool usePionHypo, bool useKaonHypo, bool useProtonHypo, bool useTPC, bool useTOF);
+    bool SetPidVars(AliAODTrack* prongtracks[], AliPIDResponse* pidrespo, bool usePionHypo, bool useKaonHypo, bool useProtonHypo, bool useTPC, bool useTOF, AliAODPidHF* pidhf);
   
     //utils methods
     double CombineNsigmaDiffDet(double nsigmaTPC, double nsigmaTOF);

--- a/PWGHF/treeHF/AliHFTreeHandlerBplustoD0pi.cxx
+++ b/PWGHF/treeHF/AliHFTreeHandlerBplustoD0pi.cxx
@@ -157,7 +157,7 @@ TTree* AliHFTreeHandlerBplustoD0pi::BuildTree(TString name, TString title)
 }
 
 //________________________________________________________________
-bool AliHFTreeHandlerBplustoD0pi::SetVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, float ptgen, AliAODRecoDecayHF* cand, float bfield, int /*masshypo*/, AliPIDResponse* pidrespo)
+bool AliHFTreeHandlerBplustoD0pi::SetVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, float ptgen, AliAODRecoDecayHF* cand, float bfield, int /*masshypo*/, AliPIDResponse* pidrespo, AliAODPidHF* pidhf)
 {
   fRunNumber=runnumber;
   fEvID=eventID;
@@ -250,7 +250,7 @@ bool AliHFTreeHandlerBplustoD0pi::SetVariables(int runnumber, int eventID, int e
   //pid variables
   if(fPidOpt==kNoPID) return true;
 
-  bool setpid = SetPidVars(prongtracks,pidrespo,true,true,false,true,true);
+  bool setpid = SetPidVars(prongtracks,pidrespo,true,true,false,true,true,pidhf);
   if(!setpid) return false;
 
   return true;

--- a/PWGHF/treeHF/AliHFTreeHandlerBplustoD0pi.h
+++ b/PWGHF/treeHF/AliHFTreeHandlerBplustoD0pi.h
@@ -33,7 +33,7 @@ class AliHFTreeHandlerBplustoD0pi : public AliHFTreeHandler
     virtual ~AliHFTreeHandlerBplustoD0pi();
 
     virtual TTree* BuildTree(TString name="tree", TString title="tree");
-    virtual bool SetVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, float ptgen, AliAODRecoDecayHF* cand, float bfield, int masshypo=0, AliPIDResponse *pidrespo=0x0);
+    virtual bool SetVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, float ptgen, AliAODRecoDecayHF* cand, float bfield, int masshypo=0, AliPIDResponse *pidrespo=0x0, AliAODPidHF *pidhf=0x0);
     Int_t IsBplusPionSelected(TObject* obj, AliRDHFCutsD0toKpi* cutsD0, AliAODPidHF* fPidHFD0, AliAODEvent* aod, AliAODVertex *vtx);
 
   private:

--- a/PWGHF/treeHF/AliHFTreeHandlerBstoDspi.cxx
+++ b/PWGHF/treeHF/AliHFTreeHandlerBstoDspi.cxx
@@ -162,7 +162,7 @@ TTree* AliHFTreeHandlerBstoDspi::BuildTree(TString name, TString title)
 }
 
 //________________________________________________________________
-bool AliHFTreeHandlerBstoDspi::SetVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, float ptgen, AliAODRecoDecayHF* cand, float bfield, int masshypo/*used for Ds*/, AliPIDResponse* pidrespo)
+bool AliHFTreeHandlerBstoDspi::SetVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, float ptgen, AliAODRecoDecayHF* cand, float bfield, int masshypo/*used for Ds*/, AliPIDResponse* pidrespo, AliAODPidHF* pidhf)
 {
   fRunNumber=runnumber;
   fEvID=eventID;
@@ -247,7 +247,7 @@ bool AliHFTreeHandlerBstoDspi::SetVariables(int runnumber, int eventID, int even
   //pid variables
   if(fPidOpt==kNoPID) return true;
 
-  bool setpid = SetPidVars(prongtracks,pidrespo,true,true,false,true,true);
+  bool setpid = SetPidVars(prongtracks,pidrespo,true,true,false,true,true,pidhf);
   if(!setpid) return false;
 
   return true;

--- a/PWGHF/treeHF/AliHFTreeHandlerBstoDspi.h
+++ b/PWGHF/treeHF/AliHFTreeHandlerBstoDspi.h
@@ -40,7 +40,7 @@ class AliHFTreeHandlerBstoDspi : public AliHFTreeHandler
     virtual ~AliHFTreeHandlerBstoDspi();
 
     virtual TTree* BuildTree(TString name="tree", TString title="tree");
-    virtual bool SetVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, float ptgen, AliAODRecoDecayHF* cand, float bfield, int masshypo=0, AliPIDResponse *pidrespo=0x0);
+    virtual bool SetVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, float ptgen, AliAODRecoDecayHF* cand, float bfield, int masshypo=0, AliPIDResponse *pidrespo=0x0, AliAODPidHF *pidhf=0x0);
     Int_t IsBsPionSelected(TObject* obj, AliRDHFCutsDstoKKpi* cutsDs, AliAODPidHF* fPidHFDs, AliAODEvent* aod, AliAODVertex *vtx);
     Int_t IsBsSelected(AliAODRecoDecayHF2Prong* bs);
     void SetDsBackgroundShapeType(bool isPr, bool isFDBplus, bool isFDB0, bool isFDLb0, bool isFDBs0);

--- a/PWGHF/treeHF/AliHFTreeHandlerD0toKpi.cxx
+++ b/PWGHF/treeHF/AliHFTreeHandlerD0toKpi.cxx
@@ -107,7 +107,7 @@ TTree* AliHFTreeHandlerD0toKpi::BuildTree(TString name, TString title)
 }
 
 //________________________________________________________________
-bool AliHFTreeHandlerD0toKpi::SetVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, float ptgen, AliAODRecoDecayHF* cand, float bfield, int masshypo, AliPIDResponse *pidrespo) 
+bool AliHFTreeHandlerD0toKpi::SetVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, float ptgen, AliAODRecoDecayHF* cand, float bfield, int masshypo, AliPIDResponse *pidrespo, AliAODPidHF* pidhf)
 {
   fRunNumber=runnumber;
   fEvID=eventID;
@@ -162,7 +162,7 @@ bool AliHFTreeHandlerD0toKpi::SetVariables(int runnumber, int eventID, int event
   //pid variables
   if(fPidOpt==kNoPID) return true;
 
-  bool setpid = SetPidVars(prongtracks,pidrespo,true,true,false,true,true);
+  bool setpid = SetPidVars(prongtracks,pidrespo,true,true,false,true,true,pidhf);
   if(!setpid) return false;
 
   return true;

--- a/PWGHF/treeHF/AliHFTreeHandlerD0toKpi.h
+++ b/PWGHF/treeHF/AliHFTreeHandlerD0toKpi.h
@@ -48,7 +48,7 @@ class AliHFTreeHandlerD0toKpi : public AliHFTreeHandler
     virtual ~AliHFTreeHandlerD0toKpi();
 
     virtual TTree* BuildTree(TString name="tree", TString title="tree");
-    virtual bool SetVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, float ptgen, AliAODRecoDecayHF* cand, float bfiled, int masshypo=0, AliPIDResponse *pidrespo=nullptr);
+    virtual bool SetVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, float ptgen, AliAODRecoDecayHF* cand, float bfiled, int masshypo=0, AliPIDResponse *pidrespo=nullptr, AliAODPidHF *pidhf=nullptr);
     
     void SetIsDzeroDzeroBar(int isSel, int isSelTopo, int isSelPID, int isSelFilt, int isSelTopoFilt, int isSelPIDFilt);
 

--- a/PWGHF/treeHF/AliHFTreeHandlerDplustoKpipi.cxx
+++ b/PWGHF/treeHF/AliHFTreeHandlerDplustoKpipi.cxx
@@ -96,7 +96,7 @@ TTree* AliHFTreeHandlerDplustoKpipi::BuildTree(TString name, TString title)
 }
 
 //________________________________________________________________
-bool AliHFTreeHandlerDplustoKpipi::SetVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, float ptgen, AliAODRecoDecayHF* cand, float bfield, int /*masshypo*/, AliPIDResponse *pidrespo) 
+bool AliHFTreeHandlerDplustoKpipi::SetVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, float ptgen, AliAODRecoDecayHF* cand, float bfield, int /*masshypo*/, AliPIDResponse *pidrespo, AliAODPidHF* pidhf)
 {
   fRunNumber=runnumber;
   fEvID=eventID;
@@ -143,7 +143,7 @@ bool AliHFTreeHandlerDplustoKpipi::SetVariables(int runnumber, int eventID, int 
   //pid variables
   if(fPidOpt==kNoPID) return true;
 
-  bool setpid = SetPidVars(prongtracks,pidrespo,true,true,false,true,true);
+  bool setpid = SetPidVars(prongtracks,pidrespo,true,true,false,true,true,pidhf);
   if(!setpid) return false;
 
   return true;

--- a/PWGHF/treeHF/AliHFTreeHandlerDplustoKpipi.h
+++ b/PWGHF/treeHF/AliHFTreeHandlerDplustoKpipi.h
@@ -32,7 +32,7 @@ class AliHFTreeHandlerDplustoKpipi : public AliHFTreeHandler
     virtual ~AliHFTreeHandlerDplustoKpipi();
 
     virtual TTree* BuildTree(TString name="tree", TString title="tree");
-    virtual bool SetVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, float ptgen, AliAODRecoDecayHF* cand, float bfield, int masshypo=0, AliPIDResponse *pidrespo=nullptr);
+    virtual bool SetVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, float ptgen, AliAODRecoDecayHF* cand, float bfield, int masshypo=0, AliPIDResponse *pidrespo=nullptr, AliAODPidHF *pidhf=nullptr);
 
   private:
 

--- a/PWGHF/treeHF/AliHFTreeHandlerDstartoKpipi.cxx
+++ b/PWGHF/treeHF/AliHFTreeHandlerDstartoKpipi.cxx
@@ -121,7 +121,7 @@ TTree* AliHFTreeHandlerDstartoKpipi::BuildTree(TString name, TString title)
 }
 
 //________________________________________________________________
-bool AliHFTreeHandlerDstartoKpipi::SetVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, float ptgen, AliAODRecoDecayHF* cand, float bfield, int /*masshypo*/, AliPIDResponse *pidrespo)
+bool AliHFTreeHandlerDstartoKpipi::SetVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, float ptgen, AliAODRecoDecayHF* cand, float bfield, int /*masshypo*/, AliPIDResponse *pidrespo, AliAODPidHF* pidhf)
 {
   fIsMCGenTree=false;
   fRunNumber=runnumber;
@@ -195,7 +195,7 @@ bool AliHFTreeHandlerDstartoKpipi::SetVariables(int runnumber, int eventID, int 
   //pid variables
   if(fPidOpt==kNoPID) return true;
 
-  bool setpid = SetPidVars(prongtracks,pidrespo,true,true,false,true,true);
+  bool setpid = SetPidVars(prongtracks,pidrespo,true,true,false,true,true,pidhf);
   if(!setpid) return false;
 
   return true;

--- a/PWGHF/treeHF/AliHFTreeHandlerDstartoKpipi.h
+++ b/PWGHF/treeHF/AliHFTreeHandlerDstartoKpipi.h
@@ -32,7 +32,7 @@ class AliHFTreeHandlerDstartoKpipi : public AliHFTreeHandler
     virtual ~AliHFTreeHandlerDstartoKpipi();
 
     virtual TTree* BuildTree(TString name="tree", TString title="tree");
-    virtual bool SetVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, float ptgen, AliAODRecoDecayHF* cand, float bfield, int masshypo=0, AliPIDResponse *pidrespo=nullptr);
+    virtual bool SetVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, float ptgen, AliAODRecoDecayHF* cand, float bfield, int masshypo=0, AliPIDResponse *pidrespo=nullptr, AliAODPidHF *pidhf=nullptr);
 
   private:
 

--- a/PWGHF/treeHF/AliHFTreeHandlerDstoKKpi.cxx
+++ b/PWGHF/treeHF/AliHFTreeHandlerDstoKKpi.cxx
@@ -111,7 +111,7 @@ TTree* AliHFTreeHandlerDstoKKpi::BuildTree(TString name, TString title)
 }
 
 //________________________________________________________________
-bool AliHFTreeHandlerDstoKKpi::SetVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, float ptgen, AliAODRecoDecayHF* cand, float bfield, int masshypo, AliPIDResponse *pidrespo) 
+bool AliHFTreeHandlerDstoKKpi::SetVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, float ptgen, AliAODRecoDecayHF* cand, float bfield, int masshypo, AliPIDResponse *pidrespo, AliAODPidHF* pidhf)
 {
   fRunNumber=runnumber;
   fEvID=eventID;
@@ -169,7 +169,7 @@ bool AliHFTreeHandlerDstoKKpi::SetVariables(int runnumber, int eventID, int even
   //pid variables
   if(fPidOpt==kNoPID) return true;
 
-  bool setpid = SetPidVars(prongtracks,pidrespo,true,true,false,true,true);
+  bool setpid = SetPidVars(prongtracks,pidrespo,true,true,false,true,true,pidhf);
   if(!setpid) return false;
 
   return true;

--- a/PWGHF/treeHF/AliHFTreeHandlerDstoKKpi.h
+++ b/PWGHF/treeHF/AliHFTreeHandlerDstoKKpi.h
@@ -37,7 +37,7 @@ class AliHFTreeHandlerDstoKKpi : public AliHFTreeHandler
     virtual ~AliHFTreeHandlerDstoKKpi();
 
     virtual TTree* BuildTree(TString name="tree", TString title="tree");
-    virtual bool SetVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, float ptgen, AliAODRecoDecayHF* cand, float bfield, int masshypo=0, AliPIDResponse *pidrespo=nullptr);
+    virtual bool SetVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, float ptgen, AliAODRecoDecayHF* cand, float bfield, int masshypo=0, AliPIDResponse *pidrespo=nullptr, AliAODPidHF *pidhf=nullptr);
 
     void SetMassKKOption(int opt) {fMassKKOpt=opt;}
     void SetIsDplustoKKpi(bool isDplus) {

--- a/PWGHF/treeHF/AliHFTreeHandlerInclusiveJet.cxx
+++ b/PWGHF/treeHF/AliHFTreeHandlerInclusiveJet.cxx
@@ -57,7 +57,7 @@ TTree* AliHFTreeHandlerInclusiveJet::BuildTree(TString name, TString title)
 }
 
 //________________________________________________________________
-bool AliHFTreeHandlerInclusiveJet::SetVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, float ptgen, AliAODRecoDecayHF* cand, float bfield, int masshypo, AliPIDResponse *pidrespo) 
+bool AliHFTreeHandlerInclusiveJet::SetVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, float ptgen, AliAODRecoDecayHF* cand, float bfield, int masshypo, AliPIDResponse *pidrespo, AliAODPidHF* pidhf) 
 {
   fRunNumber=runnumber;
   fEvID=eventID;

--- a/PWGHF/treeHF/AliHFTreeHandlerInclusiveJet.h
+++ b/PWGHF/treeHF/AliHFTreeHandlerInclusiveJet.h
@@ -25,7 +25,7 @@ class AliHFTreeHandlerInclusiveJet : public AliHFTreeHandler
     virtual ~AliHFTreeHandlerInclusiveJet();
 
     virtual TTree* BuildTree(TString name="tree", TString title="tree");
-    virtual bool SetVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, float ptgen, AliAODRecoDecayHF* cand, float bfield, int masshypo, AliPIDResponse *pidrespo);
+    virtual bool SetVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, float ptgen, AliAODRecoDecayHF* cand, float bfield, int masshypo, AliPIDResponse *pidrespo, AliAODPidHF *pidhf=nullptr);
     virtual bool SetMCGenVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long);
 
 

--- a/PWGHF/treeHF/AliHFTreeHandlerLbtoLcpi.cxx
+++ b/PWGHF/treeHF/AliHFTreeHandlerLbtoLcpi.cxx
@@ -180,7 +180,7 @@ TTree* AliHFTreeHandlerLbtoLcpi::BuildTree(TString name, TString title)
 }
 
 //________________________________________________________________
-bool AliHFTreeHandlerLbtoLcpi::SetVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, float ptgen, AliAODRecoDecayHF* cand, float bfield, int masshypo/*used for Lc*/, AliPIDResponse* pidrespo)
+bool AliHFTreeHandlerLbtoLcpi::SetVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, float ptgen, AliAODRecoDecayHF* cand, float bfield, int masshypo/*used for Lc*/, AliPIDResponse* pidrespo, AliAODPidHF* pidhf)
 {
   fIsMCGenTree=false;
   fRunNumber=runnumber;
@@ -264,7 +264,7 @@ bool AliHFTreeHandlerLbtoLcpi::SetVariables(int runnumber, int eventID, int even
   //pid variables
   if(fPidOpt==kNoPID) return true;
 
-  bool setpid = SetPidVars(prongtracks,pidrespo,true,true,true,true,true);
+  bool setpid = SetPidVars(prongtracks,pidrespo,true,true,true,true,true,pidhf);
   if(!setpid) return false;
 
   return true;

--- a/PWGHF/treeHF/AliHFTreeHandlerLbtoLcpi.h
+++ b/PWGHF/treeHF/AliHFTreeHandlerLbtoLcpi.h
@@ -41,7 +41,7 @@ class AliHFTreeHandlerLbtoLcpi : public AliHFTreeHandler
     virtual ~AliHFTreeHandlerLbtoLcpi();
 
     virtual TTree* BuildTree(TString name="tree", TString title="tree");
-    virtual bool SetVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, float ptgen, AliAODRecoDecayHF* cand, float bfield, int masshypo=0, AliPIDResponse *pidrespo=0x0);
+    virtual bool SetVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, float ptgen, AliAODRecoDecayHF* cand, float bfield, int masshypo=0, AliPIDResponse *pidrespo=0x0, AliAODPidHF *pidhf=0x0);
     Int_t IsLbPionSelected(TObject* obj, AliRDHFCutsLctopKpi* cutsLc, AliAODPidHF* fPidHFLc, AliAODEvent* aod, AliAODVertex *vtx);
     Int_t IsLbSelected(AliAODRecoDecayHF2Prong* lb);
 

--- a/PWGHF/treeHF/AliHFTreeHandlerLc2V0bachelor.cxx
+++ b/PWGHF/treeHF/AliHFTreeHandlerLc2V0bachelor.cxx
@@ -121,7 +121,7 @@ TTree* AliHFTreeHandlerLc2V0bachelor::BuildTree(TString name, TString title)
 }
 
 //________________________________________________________________
-bool AliHFTreeHandlerLc2V0bachelor::SetVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, float ptgen, AliAODRecoDecayHF* cand, float bfield, int masshypo, AliPIDResponse* pidrespo) 
+bool AliHFTreeHandlerLc2V0bachelor::SetVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, float ptgen, AliAODRecoDecayHF* cand, float bfield, int masshypo, AliPIDResponse* pidrespo, AliAODPidHF* pidhf)
 {
   fRunNumber=runnumber;
   fEvID=eventID;
@@ -213,7 +213,7 @@ bool AliHFTreeHandlerLc2V0bachelor::SetVariables(int runnumber, int eventID, int
   //pid variables
   if(fPidOpt == kNoPID) return true;
 
-  bool setpid = SetPidVars(prongtracks, pidrespo, true, true, true, true, true);
+  bool setpid = SetPidVars(prongtracks, pidrespo, true, true, true, true, true, pidhf);
   if(!setpid) return false;
 
   return true;

--- a/PWGHF/treeHF/AliHFTreeHandlerLc2V0bachelor.h
+++ b/PWGHF/treeHF/AliHFTreeHandlerLc2V0bachelor.h
@@ -32,7 +32,7 @@ class AliHFTreeHandlerLc2V0bachelor : public AliHFTreeHandler
     virtual ~AliHFTreeHandlerLc2V0bachelor();
 
     virtual TTree* BuildTree(TString name = "tree", TString title = "tree");
-    virtual bool SetVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, float ptgen, AliAODRecoDecayHF* cand, float bfield, int masshypo = 0, AliPIDResponse* pidrespo = nullptr);
+    virtual bool SetVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, float ptgen, AliAODRecoDecayHF* cand, float bfield, int masshypo = 0, AliPIDResponse* pidrespo = nullptr, AliAODPidHF *pidhf=nullptr);
 
     void SetCalcSecoVtx(int opt) {fCalcSecoVtx=opt;}
 

--- a/PWGHF/treeHF/AliHFTreeHandlerLctopKpi.cxx
+++ b/PWGHF/treeHF/AliHFTreeHandlerLctopKpi.cxx
@@ -115,7 +115,7 @@ TTree* AliHFTreeHandlerLctopKpi::BuildTree(TString name, TString title)
 }
 
 //________________________________________________________________
-bool AliHFTreeHandlerLctopKpi::SetVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, float ptgen, AliAODRecoDecayHF* cand, float bfield, int masshypo, AliPIDResponse *pidrespo)
+bool AliHFTreeHandlerLctopKpi::SetVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, float ptgen, AliAODRecoDecayHF* cand, float bfield, int masshypo, AliPIDResponse *pidrespo, AliAODPidHF* pidhf)
 {
   fRunNumber=runnumber;
   fEvID=eventID;
@@ -168,7 +168,7 @@ bool AliHFTreeHandlerLctopKpi::SetVariables(int runnumber, int eventID, int even
   //pid variables
   if(fPidOpt==kNoPID) return true;
 
-  bool setpid = SetPidVars(prongtracks,pidrespo,true,true,true,true,true);
+  bool setpid = SetPidVars(prongtracks,pidrespo,true,true,true,true,true,pidhf);
   if(!setpid) return false;
 
   return true;

--- a/PWGHF/treeHF/AliHFTreeHandlerLctopKpi.h
+++ b/PWGHF/treeHF/AliHFTreeHandlerLctopKpi.h
@@ -40,7 +40,7 @@ class AliHFTreeHandlerLctopKpi : public AliHFTreeHandler
     virtual ~AliHFTreeHandlerLctopKpi();
 
     virtual TTree* BuildTree(TString name="tree", TString title="tree");
-    virtual bool SetVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, float ptgen, AliAODRecoDecayHF* cand, float bfield, int masshypo=0, AliPIDResponse *pidrespo=0x0);
+    virtual bool SetVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, float ptgen, AliAODRecoDecayHF* cand, float bfield, int masshypo=0, AliPIDResponse *pidrespo=0x0, AliAODPidHF *pidhf=0x0);
     void SetVariableResonantDecay(int restype) {fResonantDecayType = restype;}
     void SetMCGenVariableResonantDecay(int restype) {fResonantDecayTypeMC = restype;}
     void AddBranchResonantDecay(TTree *t);


### PR DESCRIPTION
Fix for extracted nsigma TOF stored in TTrees. There are two methods:
 * `AliAODPidHF::GetnSigmaTOF()`
 * `AliPIDResponse::NumberOfSigmasTOF()`

First one is adding a TOF mismatch cut (default 0.01) as extra condition for flagging bad TOF-PID tracks (standard procedure in HF). Second option isn't, leading to random nsigma TOF values in a huge range, which were given as input to the ML training. These candidates should have been flagged with nsigmaTOF = -999 (and therefore masked in the training) instead.

Switched now from 2nd to 1st method, fixing the issue