### PR TITLE
PWGHF: Downsampling methods to reduce output size PbPb

### DIFF
--- a/PWGHF/vertexingHF/vHFML/AliAnalysisTaskSEHFTreeCreatorApply.cxx
+++ b/PWGHF/vertexingHF/vHFML/AliAnalysisTaskSEHFTreeCreatorApply.cxx
@@ -190,9 +190,13 @@ fITSUpgradePreSelect(0),
 fEnableNsigmaTPCDataCorr(false),
 fSystemForNsigmaTPCDataCorr(AliAODPidHF::kNone),
 fApplyPhysicsSelOnline(false),
+fApplyEventSelOnline(false),
 fEnableEventDownsampling(false),
 fFracToKeepEventDownsampling(1.1),
 fSeedEventDownsampling(0),
+fEnableCandDownsampling(false),
+fFracToKeepCandDownsampling(1.1),
+fMaxPtCandDownsampling(999.),
 fConfigPath(""),
 fMLResponse(0x0),
 fReducePbPbBranches(false),
@@ -764,13 +768,16 @@ void AliAnalysisTaskSEHFTreeCreatorApply::UserExec(Option_t */*option*/){
                         TESTBIT(triggerBits, inputV0A->GetIndexCTP() - 1)) : -1;
   
   fTreeEvChar->Fill();
+  if(fFillMCGenTrees && fReadMC) ProcessMCGen(mcArray,mcHeader);
   
+  //reduce output size by continuing only with selected events to reco TTrees
+  if(!isEvSel && fApplyEventSelOnline) return;
+
   //get PID response
   if(!fPIDresp) fPIDresp = ((AliInputEventHandler*)(AliAnalysisManager::GetAnalysisManager()->GetInputEventHandler()))->GetPIDResponse();
   
   if(fWriteVariableTreeDs) Process3Prong(array3Prong,aod,mcArray,aod->GetMagneticField(),mcHeader);
   if(fWriteVariableTreeLc2V0bachelor) ProcessCasc(arrayCasc,aod,mcArray,aod->GetMagneticField(),mcHeader);
-  if(fFillMCGenTrees && fReadMC) ProcessMCGen(mcArray,mcHeader);
   
   // Post the data
   PostData(1,fNentries);
@@ -871,6 +878,12 @@ void AliAnalysisTaskSEHFTreeCreatorApply::Process3Prong(TClonesArray *array3Pron
       nFilteredDs++;
       if((vHF->FillRecoCand(aod,ds))) {////Fill the data members of the candidate only if they are empty.
         
+        if(fEnableCandDownsampling){
+          Double_t ptCand = ds->Pt();
+          Double_t pseudoRand = ptCand * 1000. - (long)(ptCand * 1000);
+          if (pseudoRand > fFracToKeepCandDownsampling && ptCand < fMaxPtCandDownsampling) continue;
+        }
+
         Int_t isSelectedFilt=fFiltCutsDstoKKpi->IsSelected(ds,AliRDHFCuts::kAll,aod);
         Int_t isKKpi=isSelectedFilt&1;
         Int_t ispiKK=isSelectedFilt&2;
@@ -1135,6 +1148,12 @@ void AliAnalysisTaskSEHFTreeCreatorApply::ProcessCasc(TClonesArray *arrayCasc, A
         //Remember to run also CleanUpTask!
         if(d->GetIsFilled()==1 && fLc2V0bachelorCalcSecoVtx) vHF->RecoSecondaryVertexForCascades(aod, d);
         
+        if(fEnableCandDownsampling){
+          Double_t ptCand = d->Pt();
+          Double_t pseudoRand = ptCand * 1000. - (long)(ptCand * 1000);
+          if (pseudoRand > fFracToKeepCandDownsampling && ptCand < fMaxPtCandDownsampling) continue;
+        }
+
         Int_t isSelectedFilt = fFiltCutsLc2V0bachelor->IsSelected(d,AliRDHFCuts::kAll,aod); //selected
         
         if(isSelectedFilt > 0){

--- a/PWGHF/vertexingHF/vHFML/AliAnalysisTaskSEHFTreeCreatorApply.h
+++ b/PWGHF/vertexingHF/vHFML/AliAnalysisTaskSEHFTreeCreatorApply.h
@@ -121,6 +121,8 @@ public:
 
   void ApplyPhysicsSelectionOnline(bool apply=true) { fApplyPhysicsSelOnline = apply; }
   Bool_t GetApplyPhysicsSelOnline() const { return fApplyPhysicsSelOnline; }
+  void ApplyEventSelectionOnline(bool apply=true) { fApplyEventSelOnline = apply; }
+  Bool_t GetApplyEventSelOnline() const { return fApplyEventSelOnline; }
   void EnableEventDownsampling(float fractokeep, unsigned long seed) {
     fEnableEventDownsampling = true;
     fFracToKeepEventDownsampling = fractokeep;
@@ -129,6 +131,15 @@ public:
   Bool_t GetEnableEventDownsampling() const { return fEnableEventDownsampling; }
   Float_t GetFracToKeepEventDownsampling() const { return fFracToKeepEventDownsampling; }
   unsigned long GetSeedEventDownsampling() const { return fSeedEventDownsampling; }
+  void EnableCandDownsampling(float fractokeep, float maxptsampling) {
+    fEnableCandDownsampling = true;
+    fFracToKeepCandDownsampling = fractokeep;
+    fMaxPtCandDownsampling = maxptsampling;
+  }
+  Bool_t GetEnableCandDownsampling() const { return fEnableCandDownsampling; }
+  Float_t GetFracToKeepCandDownsampling() const { return fFracToKeepCandDownsampling; }
+  Float_t GetMaxPtCandDownsampling() const { return fMaxPtCandDownsampling; }
+
   void SetMLConfigFile(TString path = ""){fConfigPath = path;}
   TString GetMLConfigFile() const { return fConfigPath; }
 
@@ -265,9 +276,13 @@ private:
   Int_t fSystemForNsigmaTPCDataCorr;                             /// system for data-driven NsigmaTPC correction
 
   Bool_t fApplyPhysicsSelOnline;                                 /// flag to apply physics selection in the task
+  Bool_t fApplyEventSelOnline;                                   /// flag to fill reco TTrees only with selected events
   Bool_t fEnableEventDownsampling;                               /// flag to apply event downsampling
   Float_t fFracToKeepEventDownsampling;                          /// fraction of events to be kept by event downsampling
   unsigned long fSeedEventDownsampling;                          /// seed for event downsampling
+  Bool_t fEnableCandDownsampling;                                /// flag to apply cand downsampling
+  Float_t fFracToKeepCandDownsampling;                           /// fraction of cands to be kept by cand downsampling
+  Float_t fMaxPtCandDownsampling;                                /// max pT used for cand downsampling
 
   TString fConfigPath;                                           /// path to ML config file
   AliHFMLResponse* fMLResponse;                                  //!<! object to handle ML response
@@ -275,7 +290,7 @@ private:
   Bool_t fSaveSTDSelection;                                      /// variable to store candidates that pass std cuts as well, even when ML < MLcut
 
   /// \cond CLASSIMP
-  ClassDef(AliAnalysisTaskSEHFTreeCreatorApply,5);
+  ClassDef(AliAnalysisTaskSEHFTreeCreatorApply,6);
   /// \endcond
 };
 


### PR DESCRIPTION
Two additional methods:
 * Only fill reconstructed TTrees with selected events
 * Pseudorandom candidate rejection factor (as defined for other HF studies), to store less low pT candidates when creating sample for training only