### PR TITLE
Add option to select events in a certain pt-hard range

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.h
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.h
@@ -603,6 +603,8 @@ class AliAnalysisTaskEmcal : public AliAnalysisTaskSE {
    */
   void                        SetVzRange(Double_t min, Double_t max)                { fMinVz             = min  ; fMaxVz   = max          ; }
   void                        SetMinVertexContrib(Int_t min)                        { fMinVertexContrib = min                             ; }
+  void                        SetMinPtHard(double minpthard)                        { fMinPtHard         = minpthard                      ; }
+  void                        SetMaxPtHard(double maxpthard)                        { fMaxPtHard         = maxpthard                      ; }
   void                        SetUseSPDTrackletVsClusterBG(Bool_t b)                { fTklVsClusSPDCut   = b                              ; }
   void                        SetEMCalTriggerMode(EMCalTriggerMode_t m)             { fEMCalTriggerMode  = m                              ; }
   void                        SetUseNewCentralityEstimation(Bool_t b)               { fUseNewCentralityEstimation = b                     ; }
@@ -1279,6 +1281,8 @@ class AliAnalysisTaskEmcal : public AliAnalysisTaskSE {
   Double_t                    fEventPlaneVsEmcal;          ///< select events which have a certain event plane wrt the emcal
   Double_t                    fMinEventPlane;              ///< minimum event plane value
   Double_t                    fMaxEventPlane;              ///< maximum event plane value
+  Double_t                    fMinPtHard;                  ///< minimum pt-hard value
+  Double_t                    fMaxPtHard;                  ///< maximum pt-hard value
   TString                     fCentEst;                    ///< name of V0 centrality estimator
   Bool_t                      fIsEmbedded;                 ///< trigger, embedded signal
   Bool_t                      fIsPythia;                   ///< trigger, if it is a PYTHIA production

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetEnergyScale.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetEnergyScale.cxx
@@ -143,7 +143,7 @@ void AliAnalysisTaskEmcalJetEnergyScale::UserCreateOutputObjects(){
 
   // Debugging the JES
   std::array<double, 17> ptbins = {0., 10., 20., 30., 40., 50., 60., 80., 100., 120., 140., 160., 180., 200., 240., 280., 320.};
-  for(int iptbin = 0; iptbin < ptbins.size() -1; iptbin++){
+  for(std::size_t iptbin = 0; iptbin < ptbins.size() -1; iptbin++){
     int ptbminI = ptbins[iptbin],
         ptbmaxI = ptbins[iptbin+1];
     fHistos->CreateTH2(Form("hJESVsNEFdet_%d_%d", ptbminI, ptbmaxI), Form("JES vs. NEF_{det} for jets with %d GeV/c < p_{t,part} < %d GeV/c", ptbminI, ptbmaxI), 100, 0.,  1., 200, -1., 1.);


### PR DESCRIPTION
Option is in particular of relevance when combining min. bias and pt-hard events, in order to remove events with pt-hard values in ranges where the jet-jet MC is used, in order to avoid double counting. 