### PR TITLE
Exception handling for ZDC in LHC16qrst

### DIFF
--- a/OADB/COMMON/MULTIPLICITY/AliMultSelectionTask.cxx
+++ b/OADB/COMMON/MULTIPLICITY/AliMultSelectionTask.cxx
@@ -1633,14 +1633,26 @@ void AliMultSelectionTask::UserExec(Option_t *)
             Int_t detCh_ZNC = lESDZDC->GetZNCTDCChannel();
             Int_t detCh_ZPA = lESDZDC->GetZPATDCChannel();
             Int_t detCh_ZPC = lESDZDC->GetZPCTDCChannel();
-            
+          
+            //Exception check: periods LHC16qrst
+            Bool_t l2016Override = kFALSE;
+            TString lPeriod = GetPeriodNameByRunNumber();
+            if(lPeriod.Contains("LHC16q")||lPeriod.Contains("LHC16r")||lPeriod.Contains("LHC16s")||lPeriod.Contains("LHC16t")) l2016Override = kTRUE;
+
+            if( l2016Override ){
+              detCh_ZNA = 14;
+              detCh_ZNC = 12;
+              detCh_ZPA = 15;
+              detCh_ZPC = 13;
+            }
+          
             for (Int_t j = 0; j < 4; ++j) {
                 if (lESDZDC->GetZDCTDCData(detCh_ZNA,j) != 0)      fZnaFired -> SetValueInteger(1);
                 if (lESDZDC->GetZDCTDCData(detCh_ZNC,j) != 0)      fZncFired -> SetValueInteger(1);
                 if (lESDZDC->GetZDCTDCData(detCh_ZPA,j) != 0)      fZpaFired -> SetValueInteger(1);
                 if (lESDZDC->GetZDCTDCData(detCh_ZPC,j) != 0)      fZpcFired -> SetValueInteger(1);
             }
-            
+          
             const Double_t *ZNAtower = lESDZDC->GetZNATowerEnergy();
             const Double_t *ZNCtower = lESDZDC->GetZNCTowerEnergy();
             const Double_t *ZPAtower = lESDZDC->GetZPATowerEnergy();


### PR DESCRIPTION
At the request of @coppedis, @valzacc (in the context of having ZNA, ZNC fully available in LHC16qrst)