### PR TITLE
Fixed Terminate method in several FLOW tasks.

### DIFF
--- a/PWG/FLOW/Tasks/AliAnalysisTaskForStudents.cxx
+++ b/PWG/FLOW/Tasks/AliAnalysisTaskForStudents.cxx
@@ -200,11 +200,6 @@ void AliAnalysisTaskForStudents::Terminate(Option_t *)
 
  // ... your code for offline calculations ...
 
- // Update the output file with new results:
- TFile *f = new TFile("AnalysisResults.root","RECREATE");
- fHistList->Write(fHistList->GetName(),TObject::kSingleKey);
-
- delete f;
 
 } // end of void AliAnalysisTaskForStudents::Terminate(Option_t *)
 

--- a/PWG/FLOW/Tasks/AliAnalysisTaskMultiparticleFemtoscopy.cxx
+++ b/PWG/FLOW/Tasks/AliAnalysisTaskMultiparticleFemtoscopy.cxx
@@ -683,10 +683,6 @@ void AliAnalysisTaskMultiparticleFemtoscopy::Terminate(Option_t *)
  // e) Dump the results:
  //TDirectoryFile *df = new TDirectoryFile("outputMPFanalysis","");
  //df->Add(fHistList);
- TFile *f = new TFile("AnalysisResults.root","RECREATE");
- fHistList->Write(fHistList->GetName(),TObject::kSingleKey);
-
- delete f;
 
 } // end of void AliAnalysisTaskMultiparticleFemtoscopy::Terminate(Option_t *)
 

--- a/PWG/FLOW/Tasks/AliAnalysisTaskNBodyFemtoscopy.cxx
+++ b/PWG/FLOW/Tasks/AliAnalysisTaskNBodyFemtoscopy.cxx
@@ -755,12 +755,6 @@ void AliAnalysisTaskNBodyFemtoscopy::Terminate(Option_t *)
 
  // ... your code for offline calculations ...
 
- // Update the output file with new results:
- TFile *f = new TFile("AnalysisResults.root","RECREATE");
- fHistList->Write(fHistList->GetName(),TObject::kSingleKey);
-
- delete f;
-
 } // end of void AliAnalysisTaskNBodyFemtoscopy::Terminate(Option_t *)
 
 //================================================================================================================

--- a/PWG/FLOW/Tasks/AliAnalysisTaskStudentsCM.cxx
+++ b/PWG/FLOW/Tasks/AliAnalysisTaskStudentsCM.cxx
@@ -245,11 +245,6 @@ void AliAnalysisTaskStudentsCM::Terminate(Option_t *)
  // ...
 
 
- TFile *f = new TFile("AnalysisResults.root","RECREATE");		// {Name of the output file}
- fHistList->Write(fHistList->GetName(),TObject::kSingleKey);	// {Writing of the main TList in the output file}
-
- delete f;
-
 } // end of void AliAnalysisTaskStudentsCM::Terminate(Option_t *)
 
 //================================================================================================================

--- a/PWG/FLOW/Tasks/AliAnalysisTaskStudentsML.cxx
+++ b/PWG/FLOW/Tasks/AliAnalysisTaskStudentsML.cxx
@@ -861,10 +861,6 @@ void AliAnalysisTaskStudentsML::Terminate(Option_t *)
  // Do some calculation in offline mode here:
  // ...
 
- TFile *f = new TFile("AnalysisResults.root","RECREATE");
- fHistList->Write(fHistList->GetName(),TObject::kSingleKey);
-
- delete f;
 
 } // end of void AliAnalysisTaskStudentsML::Terminate(Option_t *)
 

--- a/PWG/FLOW/Tasks/AliAnalysisTaskStudentsMW.cxx
+++ b/PWG/FLOW/Tasks/AliAnalysisTaskStudentsMW.cxx
@@ -389,11 +389,6 @@ void AliAnalysisTaskStudentsMW::Terminate(Option_t *)
  // Do some calculation in offline mode here:
  // ...
 
- TFile *f = new TFile("AnalysisResults.root","RECREATE");
- fHistList->Write(fHistList->GetName(),TObject::kSingleKey);
-
- delete f;
-
 } // end of void AliAnalysisTaskStudentsMW::Terminate(Option_t *)
 
 //================================================================================================================

--- a/PWG/FLOW/Tasks/AliAnalysisTaskTwoMultiCorrelations.cxx
+++ b/PWG/FLOW/Tasks/AliAnalysisTaskTwoMultiCorrelations.cxx
@@ -317,11 +317,6 @@ void AliAnalysisTaskTwoMultiCorrelations::Terminate(Option_t *)
   fMainList = (TList*)GetOutputData(1);
   if (!fMainList) {Fatal(sMethod.Data(), "ERROR: fMainList not found.");}
 
-// 2. Create the output file and save inside the mother list.
-  TFile *outputFile = new TFile("AnalysisResults.root", "RECREATE");
-  fMainList->Write(fMainList->GetName(), TObject::kSingleKey);
-  delete outputFile;
-
 } // End: void Terminate(Option_t *).
 
 /* ========================================================================================== /


### PR DESCRIPTION
The output file was manually opened, overwriting the existing file with the same name. This creates problems in the final merging phase in train mode.