### PR TITLE
Add option for requiring a cluster with a min. energy for run3 trigge…

### DIFF
--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetEnergySpectrum.h
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetEnergySpectrum.h
@@ -74,7 +74,8 @@ public:
   void SetEnergyScaleShfit(Double_t scaleshift)    { fScaleShift = scaleshift; } 
   void SetUseStandardOutlierRejection(bool doUse)  { fUseStandardOutlierRejection = doUse; }
   void SetJetTypeOutlierCut(EJetTypeOutliers_t jtype) { fJetTypeOutliers = jtype; }
-
+  void SetEMCALClusterBias(double minE)            { fEMCALClusterBias = minE; }
+  void SetTimeRangeEMCALCusterBias(Double_t mintime, Double_t maxtime) { fMinTimeClusterBias = mintime; fMaxTimeClusterBias = maxtime; }
 
   void ConfigureMCPtHard(MCProductionType_t mcprodtype, const TArrayI &pthardbinning, Bool_t doMCFilter, Double_t jetptcut);
   void ConfigureMCMinBias(MCProductionType_t mcprodtype);
@@ -121,6 +122,9 @@ private:
   Bool_t                        fUseStandardOutlierRejection;   ///< Use standard outlier rejection
   EJetTypeOutliers_t            fJetTypeOutliers;               ///< Jet type used for outlier detection
   Double_t                      fScaleShift;                    ///< Artificial jet energy scale shift
+  Double_t                      fEMCALClusterBias;              ///< Requirement of a min. cluster energy in EMCAL
+  Double_t                      fMinTimeClusterBias;            ///< Min. time cut for cluster bias
+  Double_t                      fMaxTimeClusterBias;            ///< Max. time cut for cluster bias
   TString                       fCentralityEstimator;           ///< Centrality estimator
   TArrayD                       fUserPtBinning;                 ///< User-defined pt-binning
 


### PR DESCRIPTION
…r studies

Run3 trigger in hardware expected to be similar to the L0 trigger
which can be mimiced with adding a requirement of a cluster with min.
energy (non-lin corr) in event. Existing cluster containers are used
(if available), however the cluster selection is implemented by hand as
the cluster container will use had. corr energy in case of full jets.