### PR TITLE
fix(PWGCF): changing counter type to double

### DIFF
--- a/PWGCF/Correlations/Base/AliUEHist.cxx
+++ b/PWGCF/Correlations/Base/AliUEHist.cxx
@@ -1044,7 +1044,7 @@ TH2* AliUEHist::GetSumOfRatios2(AliUEHist* mixed, AliUEHist::CFStep step, AliUEH
   TH2* eventMixedAll = 0;
   TH2* eventMixedAllStep6 = 0;
   
-  Long64_t totalEvents = 0;
+  Double_t totalEvents = 0; // a counter that takes into account non-unitary weights, thus it is a double
   Int_t nCorrelationFunctions = 0;
   
   GetHistsZVtxMult(step, region, ptLeadMin, ptLeadMax, &trackSameAll, &eventSameAll);

--- a/PWGCF/Correlations/Base/AliUEHist.cxx
+++ b/PWGCF/Correlations/Base/AliUEHist.cxx
@@ -1297,7 +1297,7 @@ TH2* AliUEHist::GetSumOfRatios2(AliUEHist* mixed, AliUEHist::CFStep step, AliUEH
     
     if (normalizePerTrigger)
     {
-      Printf("Dividing %f tracks by %lld events (%d correlation function(s)) (error %f)", totalTracks->Integral(), totalEvents, nCorrelationFunctions, errors[0]);
+      Printf("Dividing %f tracks by %f events (%d correlation function(s)) (error %f)", totalTracks->Integral(), totalEvents, nCorrelationFunctions, errors[0]);
       if (totalEvents > 0)
 	totalTracks->Scale(1.0 / totalEvents);
     }


### PR DESCRIPTION
This fix allows to sum entries with non-unitary weights, which may happen depending on what exactly a user asks for.