### PR TITLE
PWG/EMCAL: Adjusted cross talk module grouping

### DIFF
--- a/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
+++ b/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
@@ -121,23 +121,23 @@ CellEmulateCrosstalk:                               # Component to emulate cross
     inducedEnergyLossFraction:                      # Fraction of energy lost by max energy cell in one of T-Card cells
         enabled: true                               # Enable setting these values
        #values: {"all" : [0.02, 0.02, 0.02, 0]}     # Values are energy lost in [ upper/lower cell in same column, upper/lower cell in left or right, left or right cell in same row, 2nd row upper/lower cells]
-        values: {0 : [0.80e-02, 0.80e-02, 0.80e-02, 0], 
+        values: {0 : [1.15e-02, 1.15e-02, 1.15e-02, 0], 
                  1 : [1.20e-02, 1.20e-02, 1.20e-02, 0], 
                  2 : [1.15e-02, 1.15e-02, 1.15e-02, 0], 
                  3 : [1.20e-02, 1.20e-02, 1.20e-02, 0], 
-                 4 : [0.80e-02, 0.80e-02, 0.80e-02, 0], 
-                 5 : [0.80e-02, 0.80e-02, 0.80e-02, 0], 
-                 6 : [0.80e-02, 0.80e-02, 0.80e-02, 0], 
+                 4 : [1.15e-02, 1.15e-02, 1.15e-02, 0], 
+                 5 : [1.15e-02, 1.15e-02, 1.15e-02, 0], 
+                 6 : [1.15e-02, 1.15e-02, 1.15e-02, 0], 
                  7 : [1.20e-02, 1.20e-02, 1.20e-02, 0], 
                  8 : [0.80e-02, 0.80e-02, 0.80e-02, 0],  
                  9 : [0.80e-02, 0.80e-02, 0.80e-02, 0], 
                  10: [1.20e-02, 1.20e-02, 1.20e-02, 0], 
-                 11: [1.20e-02, 1.20e-02, 1.20e-02, 0], 
-                 12: [0.80e-02, 0.80e-02, 0.80e-02, 0], 
-                 13: [0.80e-02, 0.80e-02, 0.80e-02, 0], 
+                 11: [1.15e-02, 1.15e-02, 1.15e-02, 0], 
+                 12: [1.15e-02, 1.15e-02, 1.15e-02, 0], 
+                 13: [1.15e-02, 1.15e-02, 1.15e-02, 0], 
                  14: [0.80e-02, 0.80e-02, 0.80e-02, 0], 
                  15: [0.80e-02, 0.80e-02, 0.80e-02, 0], 
-                 16: [0.80e-02, 0.80e-02, 0.80e-02, 0], 
+                 16: [1.15e-02, 1.15e-02, 1.15e-02, 0], 
                  17: [0.80e-02, 0.80e-02, 0.80e-02, 0], 
                  18: [0.80e-02, 0.80e-02, 0.80e-02, 0], 
                  19: [0.80e-02, 0.80e-02, 0.80e-02, 0], 
@@ -151,8 +151,8 @@ CellEmulateCrosstalk:                               # Component to emulate cross
         values: {"all" : [5.0e-03,5.0e-03,5.0e-03, 0]}        # Values are energy lost in [ upper/lower cell in same column, upper/lower cell in left or right, left or right cell in same row, ??]
     inducedEnergyLossMinimumFraction:               # Minimum induced energy fraction when linear dependency is set
         enabled: true                               # Enable setting these values
-        values: {0 : [3.5e-3], 1 : [5.0e-3], 2 : [4.5e-3], 3 : [6.0e-3], 4 : [3.5e-3], 5 : [3.5e-3], 6 : [3.5e-3], 7 : [6.0e-3], 8 : [3.5e-3], 9 : [3.5e-3], 
-                 10: [5.0e-3], 11: [5.0e-3], 12: [3.5e-3], 13: [3.5e-3], 14: [3.5e-3], 15: [3.5e-3], 16: [3.5e-3], 17: [3.5e-3], 18: [3.5e-3], 19: [3.5e-3], 
+        values: {0 : [4.5e-3], 1 : [5.0e-3], 2 : [4.5e-3], 3 : [6.0e-3], 4 : [4.5e-3], 5 : [4.5e-3], 6 : [4.5e-3], 7 : [6.0e-3], 8 : [3.5e-3], 9 : [3.5e-3], 
+                 10: [5.0e-3], 11: [4.5e-3], 12: [4.5e-3], 13: [4.5e-3], 14: [3.5e-3], 15: [3.5e-3], 16: [4.5e-3], 17: [3.5e-3], 18: [3.5e-3], 19: [3.5e-3], 
                  20: [3.5e-3], 21: [3.5e-3]} 
        #values: {"all" : [0.008]}                   # Values are [minimum fraction]
     inducedEnergyLossMaximumFraction:               # Maximum induced energy fraction when linear dependency is set


### PR DESCRIPTION
Modified the cross talk parameter grouping from the old version:
group 1: SM 3, 7
group 2: 1, 10, 11
group 3: 2
group 4: rest
to the new grouping:
group 1: SM 3, 7
group 2: 1, 10
group 3: 2, 11, 0, 6, 5, 4, 13, 16, 12
group 4: rest

For questions, please ask @FriederikeBock and @gconesab .