### PR TITLE
chore(PWGCF): code clean-up in AliAnalysisTaskPhiCorrelations class

### DIFF
--- a/PWGCF/Correlations/DPhi/AliAnalysisTaskPhiCorrelations.cxx
+++ b/PWGCF/Correlations/DPhi/AliAnalysisTaskPhiCorrelations.cxx
@@ -77,23 +77,23 @@
 // This class needs input AODs.
 // The output is a list of analysis-specific containers.
 //
-// The AOD can be either connected to the InputEventHandler  
-// for a chain of AOD files 
-// or 
+// The AOD can be either connected to the InputEventHandler
+// for a chain of AOD files
+// or
 // to the OutputEventHandler
 // for a chain of ESD files,
 // in this case the class should be in the train after the jet-finder
 //
 //    Authors:
 //    Jan Fiete Grosse-Oetringhaus
-// 
+//
 ////////////////////////////////////////////////////////////////////////
 
 
 ClassImp( AliAnalysisTaskPhiCorrelations )
 
 //____________________________________________________________________
-AliAnalysisTaskPhiCorrelations:: AliAnalysisTaskPhiCorrelations(const char* name):
+AliAnalysisTaskPhiCorrelations::AliAnalysisTaskPhiCorrelations(const char* name):
 AliAnalysisTask(name,""),
 // general configuration
 fDebug(0),
@@ -133,9 +133,9 @@ fMcEvent(0x0),
 fMcHandler(0x0),
 fPoolMgr(0x0),
 // histogram settings
-fListOfHistos(0x0), 
+fListOfHistos(0x0),
 // event QA
-fnTracksVertex(1),  // QA tracks pointing to principal vertex (= 3 default) 
+fnTracksVertex(1),  // QA tracks pointing to principal vertex (= 3 default)
 fZVertex(7.),
 fAcceptOnlyMuEvents(kFALSE),
 fCentralityMethod("V0M"),
@@ -217,10 +217,10 @@ fCheckEventNumberInMixedEvent(kFALSE)
   DefineOutput(0, TList::Class());
 }
 
-AliAnalysisTaskPhiCorrelations::~AliAnalysisTaskPhiCorrelations() 
-{ 
+AliAnalysisTaskPhiCorrelations::~AliAnalysisTaskPhiCorrelations()
+{
   // destructor
-  
+
   if (fListOfHistos  && !AliAnalysisManager::GetAnalysisManager()->IsProofMode()) 
     delete fListOfHistos;
 }
@@ -228,43 +228,43 @@ AliAnalysisTaskPhiCorrelations::~AliAnalysisTaskPhiCorrelations()
 //____________________________________________________________________
 void AliAnalysisTaskPhiCorrelations::ConnectInputData(Option_t* /*option*/)
 {
-  
-  // Connect the input data  
+
+  // Connect the input data
   if (fDebug > 1) AliInfo("ConnectInputData() ");
-  
+
   // Since AODs can either be connected to the InputEventHandler
   // or to the OutputEventHandler ( the AOD is created by a previus task in the train )
   // we need to get the pointer to the AODEvent correctly.
-  
+
   // Delta AODs are also accepted.
-  
+
   TObject* handler = AliAnalysisManager::GetAnalysisManager()->GetInputEventHandler();
-  
-  if( handler && handler->InheritsFrom("AliAODInputHandler") ) 
+
+  if ( handler && handler->InheritsFrom("AliAODInputHandler") )
   { // input AOD
     fAOD = ((AliAODInputHandler*)handler)->GetEvent();
     if (fDebug > 1) AliInfo(" ==== Tracks and Jets from AliAODInputHandler");
-  } 
-  else 
+  }
+  else
   {  //output AOD
     handler = AliAnalysisManager::GetAnalysisManager()->GetOutputEventHandler();
-    if (handler && handler->InheritsFrom("AliAODHandler") ) 
+    if (handler && handler->InheritsFrom("AliAODHandler") )
     {
       fAOD = ((AliAODHandler*)handler)->GetAOD();
       if (fDebug > 1) AliInfo(" ==== Tracks and Jets from AliAODHandler");
-    } 
-    else 
+    }
+    else
     {  // no AOD
       AliWarning("I can't get any AOD Event Handler");
     }
   }
-  
-  if (handler && handler->InheritsFrom("AliESDInputHandler") ) 
+
+  if (handler && handler->InheritsFrom("AliESDInputHandler") )
   { // input ESD
     // pointer received per event in ::Exec
     if (fDebug > 1) AliInfo(" ==== Tracks and Jets from AliESDInputHandler");
-  } 
-  
+  }
+
   // Initialize common pointers
   Initialize();
 }
@@ -273,10 +273,10 @@ void AliAnalysisTaskPhiCorrelations::ConnectInputData(Option_t* /*option*/)
 void  AliAnalysisTaskPhiCorrelations::CreateOutputObjects()
 {
   // Create the output container
-  
+
   if (fDebug > 1) AliInfo("CreateOutputObjects()");
-   
-  // Initialize class with main algorithms, event and track selection. 
+
+  // Initialize class with main algorithms, event and track selection.
   fAnalyseUE = new AliAnalyseLeadingTrackUE();
   fAnalyseUE->SetParticleSelectionCriteria(fFilterBit, fUseChargeHadrons, fTrackEtaCut, fTrackEtaCutMin, fPtMin);
   fAnalyseUE->SetDCAXYCut(fDCAXYCut);
@@ -285,26 +285,26 @@ void  AliAnalysisTaskPhiCorrelations::CreateOutputObjects()
   fAnalyseUE->SetFoundFractionCut(fFoundFractionCut);
   fAnalyseUE->SetTrackStatus(fTrackStatus);
   fAnalyseUE->SetCheckMotherPDG(fCheckMotherPDG);
-  fAnalyseUE->SetDebug(fDebug); 
+  fAnalyseUE->SetDebug(fDebug);
   fAnalyseUE->DefineESDCuts(fFilterBit);
   fAnalyseUE->SetEventSelection(fSelectBit);
   fAnalyseUE->SetHelperPID(fHelperPID);
-  if(fTrackPhiCutEvPlMax > 0.0001)
+  if (fTrackPhiCutEvPlMax > 0.0001)
     fAnalyseUE->SetParticlePhiCutEventPlane(fTrackPhiCutEvPlMin,fTrackPhiCutEvPlMax);
   if ((fParticleSpeciesTrigger != -1 || fParticleSpeciesAssociated != -1) && !fHelperPID)
     AliFatal("HelperPID object should be set in the steering macro");
 
   // Initialize output list of containers
-  if (fListOfHistos != NULL){
-	delete fListOfHistos;
-        fListOfHistos = NULL;
-  	}
-  if (!fListOfHistos){
-  	fListOfHistos = new TList();
-  	fListOfHistos->SetOwner(kTRUE); 
-  	}
+  if (fListOfHistos != NULL) {
+    delete fListOfHistos;
+    fListOfHistos = NULL;
+  }
+  if (!fListOfHistos) {
+    fListOfHistos = new TList();
+    fListOfHistos->SetOwner(kTRUE);
+  }
 
-  // Initialize class to handle histograms 
+  // Initialize class to handle histograms
   TString histType = "4R";
   if (fUseVtxAxis == 1)
     histType = "5R";
@@ -323,75 +323,73 @@ void  AliAnalysisTaskPhiCorrelations::CreateOutputObjects()
 
   fHistos->SetSelectCharge(fSelectCharge);
   fHistosMixed->SetSelectCharge(fSelectCharge);
-  
+
   fHistos->SetSelectTriggerCharge(fTriggerSelectCharge);
   fHistosMixed->SetSelectTriggerCharge(fTriggerSelectCharge);
-  
+
   fHistos->SetSelectAssociatedCharge(fAssociatedSelectCharge);
   fHistosMixed->SetSelectAssociatedCharge(fAssociatedSelectCharge);
 
   fHistos->SetTriggerRestrictEta(fTriggerRestrictEta);
   fHistosMixed->SetTriggerRestrictEta(fTriggerRestrictEta);
-  
+
   fHistos->SetOnlyOneEtaSide(fOnlyOneEtaSide);
   fHistosMixed->SetOnlyOneEtaSide(fOnlyOneEtaSide);
-  
+
   fHistos->SetOnlyOneAssocEtaSide(fOnlyOneAssocEtaSide);
   fHistosMixed->SetOnlyOneAssocEtaSide(fOnlyOneAssocEtaSide);
-  
+
   fHistos->SetEtaOrdering(fEtaOrdering);
   fHistosMixed->SetEtaOrdering(fEtaOrdering);
 
   fHistos->SetPairCuts(fCutConversionsV, fCutResonancesV);
   fHistosMixed->SetPairCuts(fCutConversionsV, fCutResonancesV);
-  
+
   fHistos->SetCustomCut(fCutOnCustomMass, fCutOnCustomFirst, fCutOnCustomSecond, fCutOnCustomV);
   fHistosMixed->SetCustomCut(fCutOnCustomMass, fCutOnCustomFirst, fCutOnCustomSecond, fCutOnCustomV);
 
   fHistos->SetCutOnPhi(fCutOnPhi);
   fHistosMixed->SetCutOnPhi(fCutOnPhi);
-  
+
   fHistos->SetCutOnPhi(fCutOnPhiV);
   fHistosMixed->SetCutOnPhi(fCutOnPhiV);
-  
+
   fHistos->SetCutOnRho(fCutOnRho);
   fHistosMixed->SetCutOnRho(fCutOnRho);
-  
+
   fHistos->SetCutOnRho(fCutOnRhoV);
   fHistosMixed->SetCutOnRho(fCutOnRhoV);
-  
+
   fHistos->SetCutOnK0s(fCutOnK0sV);
   fHistosMixed->SetCutOnK0s(fCutOnK0sV);
-  
+
   fHistos->SetCutOnLambda(fCutOnLambdaV);
   fHistosMixed->SetCutOnLambda(fCutOnLambdaV);
-  
+
   fHistos->SetRejectResonanceDaughters(fRejectResonanceDaughters);
   fHistosMixed->SetRejectResonanceDaughters(fRejectResonanceDaughters);
-  
+
   fHistos->SetTrackEtaCut(fTrackEtaCut);
   fHistosMixed->SetTrackEtaCut(fTrackEtaCut);
-  
+
   fHistos->SetWeightPerEvent(fWeightPerEvent);
   fHistosMixed->SetWeightPerEvent(fWeightPerEvent);
-  
+
   fHistos->SetPtOrder(fPtOrder);
   fHistosMixed->SetPtOrder(fPtOrder);
-  
+
   fHistos->SetTwoTrackCutMinRadius(fTwoTrackCutMinRadius);
   fHistosMixed->SetTwoTrackCutMinRadius(fTwoTrackCutMinRadius);
-  
-  if (fEfficiencyCorrectionTriggers)
-   {
+
+  if (fEfficiencyCorrectionTriggers) {
     fHistos->SetEfficiencyCorrectionTriggers(fEfficiencyCorrectionTriggers);
     fHistosMixed->SetEfficiencyCorrectionTriggers((THnF*) fEfficiencyCorrectionTriggers->Clone());
-   }
-  if (fEfficiencyCorrectionAssociated)
-  {
+  }
+  if (fEfficiencyCorrectionAssociated) {
     fHistos->SetEfficiencyCorrectionAssociated(fEfficiencyCorrectionAssociated);
     fHistosMixed->SetEfficiencyCorrectionAssociated((THnF*) fEfficiencyCorrectionAssociated->Clone());
   }
-  
+
   // add histograms to list
   fListOfHistos->Add(fHistos);
   fListOfHistos->Add(fHistosMixed);
@@ -401,14 +399,13 @@ void  AliAnalysisTaskPhiCorrelations::CreateOutputObjects()
   // add TMap to list
   if (fMap)
     fListOfHistos->Add(fMap);
-  
+
   fListOfHistos->Add(new TH2F("processIDs", ";#Delta#phi;process id", 100, -0.5 * TMath::Pi(), 1.5 * TMath::Pi(), kPNoProcess + 1, -0.5, kPNoProcess + 0.5));
   fListOfHistos->Add(new TH1F("eventStat", ";;events", 4, -0.5, 3.5));
   fListOfHistos->Add(new TH2F("mixedDist", ";centrality;tracks;events", 101, 0, 101, 200, 0, fMixingTracks * 1.5));
   fListOfHistos->Add(new TH2F("mixedDist2", ";centrality;events;events", 101, 0, 101, 100, -0.5, 99.5));
   fListOfHistos->Add(new TH2F("referenceMultiplicity", ";centrality;tracks;events", 101, 0, 101, 200, -0.5, 199.5));
-  if (fCentralityMethod == "V0A_MANUAL")
-  {
+  if (fCentralityMethod == "V0A_MANUAL") {
     fListOfHistos->Add(new TH2F("V0AMult", "V0A multiplicity;V0A multiplicity;V0A multiplicity (scaled)", 1000, -.5, 999.5, 1000, -.5, 999.5));
     fListOfHistos->Add(new TH2F("V0AMultCorrelation", "V0A multiplicity;V0A multiplicity;SPD tracklets", 1000, -.5, 999.5, 1000, -.5, 999.5));
   }
@@ -418,37 +415,34 @@ void  AliAnalysisTaskPhiCorrelations::CreateOutputObjects()
     fListOfHistos->Add(new TH1F("DphiTrklets", "tracklets Dphi;#Delta#phi,trklets (mrad);entries", 100, -100, 100));
   if (fCheckCertainSpecies > 0)
     fListOfHistos->Add(new TH2F("checkSpecies", ";eta;pt;particles", 20, -1, 1, 40, 0, 10));
-  
+
   if (fCentralityMethod == "ZNAC")
     fListOfHistos->Add(new TH1D("ZNA+C_energy", "ZNA+C_energy", 4100, -100, 4000));
   if (fCentralityMethod == "MCGen_V0M")
     fListOfHistos->Add(new TH2D("Mult_MCGen_V0M", "Mult_MCGen_V0M", 1010, -9.5, 1000.5, 1010, -9.5, 1000.5));
   if (fCentralityMethod == "MCGen_CL1")
     fListOfHistos->Add(new TH2D("Mult_MCGen_CL1", "Mult_MCGen_CL1", 1010, -9.5, 1000.5, 1010, -9.5, 1000.5));
-  if (fV0CL1PileUp)
-  {
+  if (fV0CL1PileUp) {
     fListOfHistos->Add(new TH2I("fHistGlobalvsV0BeforePileUpCuts", "fHistGlobalvsV0BeforePileUpCuts;V0;CL1", 100, 0, 100, 100, 0, 100));
     fListOfHistos->Add(new TH2I("fHistGlobalvsV0AfterPileUpCuts", "fHistGlobalvsV0AfterPileUpCuts;V0;CL1", 100, 0, 100, 100, 0, 100));
   }
-  if (fESDTPCTrackPileUp)
-  {
+  if (fESDTPCTrackPileUp) {
     fListOfHistos->Add(new TH2I("fHistGlobalvsESDBeforePileUpCuts", "fHistGlobalvsESDBeforePileUpCuts;nTracks;multESD", 100, 0, 30000, 100, 0, 30000));
     fListOfHistos->Add(new TH2I("fHistGlobalvsESDAfterPileUpCuts", "fHistGlobalvsESDAfterPileUpCuts;nTracks;multESD", 100, 0, 30000, 100, 0, 30000));
   }
-  if (fTPCITSTOFPileUp)
-  {
+  if (fTPCITSTOFPileUp) {
     fListOfHistos->Add(new TH2I("fHistV0MvsTPCoutBeforePileUpCuts", "fHistV0MvsTPCoutBeforePileUpCuts;ntrkTPCout;multVZERO", 100, 0, 40000, 100, 0, 40000));
     fListOfHistos->Add(new TH2I("fHistV0MvsTPCoutAfterPileUpCuts", "fHistV0MvsTPCoutAfterPileUpCuts;ntrkTPCout;multVZERO", 100, 0, 40000, 100, 0, 40000));
   }
-  Int_t nCentralityBins  = fHistos->GetUEHist(2)->GetEventHist()->GetNBins(1);
+  Int_t nCentralityBins = fHistos->GetUEHist(2)->GetEventHist()->GetNBins(1);
   Double_t* centralityBins = (Double_t*) fHistos->GetUEHist(2)->GetEventHist()->GetAxis(1, 0)->GetXbins()->GetArray();
-  
+
   if (fFillYieldRapidity) {
     const Int_t nPtBins = 200;
     Double_t ptBins[nPtBins+1];
     for (int i=0; i<=nPtBins; i++)
       ptBins[i] = 20.0 / nPtBins * i;
-    
+
     const Int_t nyBins = 200;
     Double_t yBins[nyBins+1];
     for (int i=0; i<=nyBins; i++)
@@ -458,61 +452,57 @@ void  AliAnalysisTaskPhiCorrelations::CreateOutputObjects()
   }
 
   PostData(0,fListOfHistos);
-  
-  // Add task configuration to output list 
+
+  // Add task configuration to output list
   AddSettingsTree();
 
   // event mixing
-  Int_t poolsize   = -1;  // Maximum number of events, -1 means no limit
-   
-  const Int_t kNZvtxBins  = 10+(1+10)*4;
-  // bins for further buffers are shifted by 100 cm
-  Double_t vertexBins[kNZvtxBins+1] = { -10,   -8,  -6,  -4,  -2,   0,   2,   4,   6,   8,  10, 
-				       90,  92,  94,  96,  98, 100, 102, 104, 106, 108, 110, 
-				      190, 192, 194, 196, 198, 200, 202, 204, 206, 208, 210, 
-				      290, 292, 294, 296, 298, 300, 302, 304, 306, 308, 310, 
-				      390, 392, 394, 396, 398, 400, 402, 404, 406, 408, 410 };
+  Int_t poolsize = -1; // Maximum number of events, -1 means no limit
 
-  Int_t nZvtxBins  = kNZvtxBins;
+  const Int_t kNZvtxBins = 10+(1+10)*4;
+  // bins for further buffers are shifted by 100 cm
+  Double_t vertexBins[kNZvtxBins+1] = {-10, -8,  -6,  -4,  -2,   0,   2,   4,   6,   8,   10, 
+                                        90,  92,  94,  96,  98,  100, 102, 104, 106, 108, 110, 
+                                        190, 192, 194, 196, 198, 200, 202, 204, 206, 208, 210, 
+                                        290, 292, 294, 296, 298, 300, 302, 304, 306, 308, 310, 
+                                        390, 392, 394, 396, 398, 400, 402, 404, 406, 408, 410 };
+
+  Int_t nZvtxBins = kNZvtxBins;
   Double_t* zvtxbin = vertexBins;
 
-  if (fMode == 0 && fHistos->GetUEHist(2)->GetEventHist()->GetNVar() > 2)
-  {
+  if (fMode == 0 && fHistos->GetUEHist(2)->GetEventHist()->GetNVar() > 2) {
     nZvtxBins = fHistos->GetUEHist(2)->GetEventHist()->GetNBins(2);
     zvtxbin = (Double_t*) fHistos->GetUEHist(2)->GetEventHist()->GetAxis(2, 0)->GetXbins()->GetArray();
   }
 
   Int_t nPsiBins = 1;
   Double_t psibins[2] = {-999.,999.};
-  
+
   Int_t nPtBins = 1;
   Double_t defaultPtBins[2] = {-9999., 9999.};
   Double_t* ptbins = defaultPtBins;
 
   // Retrieve event pool pt binning only if pool should be devided in bins of pt
-  if(fUsePtBinnedEventPool)
-    if (fHistos->GetUEHist(2)->GetTrackHist(AliUEHist::kToward)->GetNBins(1))
-    {
+  if (fUsePtBinnedEventPool)
+    if (fHistos->GetUEHist(2)->GetTrackHist(AliUEHist::kToward)->GetNBins(1)) {
       nPtBins  = fHistos->GetUEHist(2)->GetTrackHist(AliUEHist::kToward)->GetNBins(1);
       ptbins = (Double_t*) fHistos->GetUEHist(2)->GetTrackHist(AliUEHist::kToward)->GetAxis(1, 0)->GetXbins()->GetArray();
     }
 
   // Create default event pool in case no external pool is given
-  if(!fPoolMgr)
-  {
+  if (!fPoolMgr) {
     fPoolMgr = new AliEventPoolManager(poolsize, fMixingTracks, nCentralityBins, centralityBins, nZvtxBins, zvtxbin, nPsiBins, psibins, nPtBins, ptbins);
     fPoolMgr->SetTargetValues(fMixingTracks, 0.1, 5);
   }
 
   // Check binning of pool manager (basic dimensional check for the time being)
-  if( (fPoolMgr->GetNumberOfMultBins() != nCentralityBins) || (fPoolMgr->GetNumberOfZVtxBins() != nZvtxBins) || (fPoolMgr->GetNumberOfPtBins() != nPtBins) )
+  if ( (fPoolMgr->GetNumberOfMultBins() != nCentralityBins) || (fPoolMgr->GetNumberOfZVtxBins() != nZvtxBins) || (fPoolMgr->GetNumberOfPtBins() != nPtBins) )
     AliFatal("Binning of given pool manager not compatible with binning of correlation task!");
 
   // If some bins of the pool should be saved, fEventPoolOutputList must be given
   // using AddEventPoolToOutput()
   // Note that this is in principle also possible, if an external poolmanager was given
-  for(UInt_t i = 0; i < fEventPoolOutputList.size(); i++)
-  {
+  for (UInt_t i = 0; i < fEventPoolOutputList.size(); i++) {
     Double_t minCent = fEventPoolOutputList[i][0];
     Double_t maxCent = fEventPoolOutputList[i][1];
     Double_t minZvtx = fEventPoolOutputList[i][2];
@@ -527,7 +517,7 @@ void  AliAnalysisTaskPhiCorrelations::CreateOutputObjects()
   fPoolMgr->Validate();
 
   // save to output if requested
-  if(fEventPoolOutputList.size())
+  if (fEventPoolOutputList.size())
     fListOfHistos->Add(fPoolMgr);
 }
 
@@ -538,28 +528,25 @@ void  AliAnalysisTaskPhiCorrelations::Exec(Option_t */*option*/)
   fAnalyseUE->NextEvent();
 
   // receive ESD pointer if we are not running AOD analysis
-  if (!fAOD)
-  {
+  if (!fAOD) {
     AliVEventHandler* handler = AliAnalysisManager::GetAnalysisManager()->GetInputEventHandler();
     if (handler && handler->InheritsFrom("AliESDInputHandler"))
       fESD = (AliESDEvent*)((AliESDInputHandler*)handler)->GetEvent();
   }
 
-  if (fMode)
-  {
+  if (fMode) {
     // correction mode
-    
+
     if (fMcHandler)
       fMcEvent = fMcHandler->MCEvent();
 
-    if (fAOD)
-    {
+    if (fAOD) {
       // array of MC particles
       fArrayMC = dynamic_cast<TClonesArray*>(fAOD->FindListObject(AliAODMCParticle::StdBranchName()));
       if (!fArrayMC)
-	AliFatal("No array of MC particles found !!!");
+        AliFatal("No array of MC particles found !!!");
     }
-    
+
     AnalyseCorrectionMode();
   }
   else AnalyseDataMode();
@@ -571,7 +558,7 @@ void  AliAnalysisTaskPhiCorrelations::Exec(Option_t */*option*/)
 void  AliAnalysisTaskPhiCorrelations::AddSettingsTree()
 {
   //Write settings to output list
-  TTree *settingsTree   = new TTree("UEAnalysisSettings","Analysis Settings in UE estimation");
+  TTree *settingsTree = new TTree("UEAnalysisSettings","Analysis Settings in UE estimation");
   settingsTree->Branch("fnTracksVertex", &fnTracksVertex,"nTracksVertex/I");
   settingsTree->Branch("fZVertex", &fZVertex,"ZVertex/D");
   settingsTree->Branch("fAcceptOnlyMuEvents", &fAcceptOnlyMuEvents,"AcceptOnlyMuEvents/O");
@@ -633,21 +620,22 @@ void  AliAnalysisTaskPhiCorrelations::AddSettingsTree()
   settingsTree->Branch("fUseNewCentralityFramework", &fUseNewCentralityFramework,"fUseNewCentralityFramework/O");
   settingsTree->Branch("fTwoTrackEfficiencyCut", &fTwoTrackEfficiencyCut,"TwoTrackEfficiencyCut/D");
   settingsTree->Branch("fTwoTrackCutMinRadius", &fTwoTrackCutMinRadius,"TwoTrackCutMinRadius/D");
-  
+
   //fCustomBinning
-  
+
   settingsTree->Fill();
   fListOfHistos->Add(settingsTree);
-}  
+}
 
 //____________________________________________________________________
 void  AliAnalysisTaskPhiCorrelations::AnalyseCorrectionMode()
 {
   // Run the analysis on MC to get the correction maps
   //
- 
-  if ( fDebug > 3 ) AliInfo( " Processing event in Corrections mode ..." );
-  
+
+  if ( fDebug > 3 )
+    AliInfo( " Processing event in Corrections mode ..." );
+
   TObject* mc = fArrayMC;
   if (!mc)
     mc = fMcEvent;
@@ -658,18 +646,17 @@ void  AliAnalysisTaskPhiCorrelations::AnalyseCorrectionMode()
     inputEvent = fESD;
 
   Double_t centrality = GetCentrality(inputEvent, mc);
-  
+
   Float_t bSign = 0;
-  
-  if (inputEvent)
-  {
+
+  if (inputEvent) {
     fHistos->SetRunNumber(inputEvent->GetRunNumber());
     bSign = (inputEvent->GetMagneticField() > 0) ? 1 : -1;
   }
-  
+
   // count all events
   fHistos->FillEvent(centrality, -1);
-  
+
   if (centrality < 0)
     return;
 
@@ -677,10 +664,10 @@ void  AliAnalysisTaskPhiCorrelations::AnalyseCorrectionMode()
   TObject* vertexSupplier = fMcEvent;
   if (fAOD) // AOD
     vertexSupplier = fAOD->FindListObject(AliAODMCHeader::StdBranchName());
-    
-  if (!fAnalyseUE->VertexSelection(vertexSupplier, 0, fZVertex)) 
+
+  if (!fAnalyseUE->VertexSelection(vertexSupplier, 0, fZVertex))
     return;
-    
+
   Float_t zVtx = 0;
   if (fAOD)
     zVtx = ((AliAODMCHeader*) vertexSupplier)->GetVtxZ();
@@ -691,70 +678,62 @@ void  AliAnalysisTaskPhiCorrelations::AnalyseCorrectionMode()
     weight = -1;
 
   Double_t evtPlanePhi = -999.; //A value outside [-pi/2,pi/2] will be ignored
-  if(fTrackPhiCutEvPlMax > 0.0001)
-    if(!InitiateEventPlane(evtPlanePhi, inputEvent)) return; //Reject event if plane is not available
- 
+  if (fTrackPhiCutEvPlMax > 0.0001)
+    if (!InitiateEventPlane(evtPlanePhi, inputEvent)) return; //Reject event if plane is not available
+
   // For productions with injected signals, figure out above which label to skip particles/tracks
   Int_t skipParticlesAbove = 0;
-  if (fInjectedSignals)
-  {
+  if (fInjectedSignals) {
     AliGenEventHeader* eventHeader = 0;
     Int_t headers = 0;
 
-    if (fMcEvent)
-    {
+    if (fMcEvent) {
       // ESD
       AliHeader* header = (AliHeader*) fMcEvent->Header();
       if (!header)
-	AliFatal("fInjectedSignals set but no MC header found");
-	
+        AliFatal("fInjectedSignals set but no MC header found");
+
       AliGenCocktailEventHeader* cocktailHeader = dynamic_cast<AliGenCocktailEventHeader*> (header->GenEventHeader());
-      if (!cocktailHeader)
-      {
-	header->Dump();
-	AliFatal("fInjectedSignals set but no MC cocktail header found");
+      if (!cocktailHeader) {
+        header->Dump();
+        AliFatal("fInjectedSignals set but no MC cocktail header found");
       }
 
       headers = cocktailHeader->GetHeaders()->GetEntries();
       eventHeader = dynamic_cast<AliGenEventHeader*> (cocktailHeader->GetHeaders()->First());
-      
-      if (fDebug > 4)
-      {
-	for (Int_t i=0; i<cocktailHeader->GetHeaders()->GetEntries(); i++)
-	{
-	  AliGenEventHeader* headerTmp = dynamic_cast<AliGenEventHeader*> (cocktailHeader->GetHeaders()->At(i));
-	  if (headerTmp)
-	    Printf("%d particles in header:", headerTmp->NProduced());
-	  cocktailHeader->GetHeaders()->At(i)->Dump();
-	}
+
+      if (fDebug > 4) {
+        for (Int_t i=0; i<cocktailHeader->GetHeaders()->GetEntries(); i++) {
+          AliGenEventHeader* headerTmp = dynamic_cast<AliGenEventHeader*> (cocktailHeader->GetHeaders()->At(i));
+          if (headerTmp)
+            Printf("%d particles in header:", headerTmp->NProduced());
+          cocktailHeader->GetHeaders()->At(i)->Dump();
+        }
       }
     }
-    else
-    {
+    else {
       // AOD
       AliAODMCHeader* header = (AliAODMCHeader*) fAOD->GetList()->FindObject(AliAODMCHeader::StdBranchName());
       if (!header)
-	AliFatal("fInjectedSignals set but no MC header found");
-      
+        AliFatal("fInjectedSignals set but no MC header found");
+
       headers = header->GetNCocktailHeaders();
       eventHeader = header->GetCocktailHeader(0);
     }
-    
-    if (!eventHeader)
-    {
+
+    if (!eventHeader) {
       // We avoid AliFatal here, because the AOD productions sometimes have events where the MC header is missing 
       // (due to unreadable Kinematics) and we don't want to loose the whole job because of a few events
       AliError("First event header not found. Skipping this event.");
       fHistos->FillEvent(centrality, AliUEHist::kCFStepAnaTopology);
       return;
     }
-    
+
     skipParticlesAbove = eventHeader->NProduced();
     AliInfo(Form("Injected signals in this event (%d headers). Keeping particles/tracks of %s. Will skip particles/tracks above %d.", headers, eventHeader->ClassName(), skipParticlesAbove));
   }
-  
-  if (fCentralityWeights && !AcceptEventCentralityWeight(centrality))
-  {
+
+  if (fCentralityWeights && !AcceptEventCentralityWeight(centrality)) {
     AliInfo(Form("Rejecting event because of centrality weighting: %f", centrality));
     fHistos->FillEvent(centrality, AliUEHist::kCFStepAnaTopology);
     return;
@@ -767,14 +746,14 @@ void  AliAnalysisTaskPhiCorrelations::AnalyseCorrectionMode()
     for (Int_t i=0; i<tmpList->GetEntriesFast(); i++) {
       AliMCParticle* particle = dynamic_cast<AliMCParticle*> (tmpList->UncheckedAt(i));
       if (!particle)
-	continue;
+        continue;
       if (TMath::Abs(particle->PdgCode()) != fCheckCertainSpecies)
-	continue;
+        continue;
       ((TH2F*) fListOfHistos->FindObject("checkSpecies"))->Fill(particle->Eta(), particle->Pt());
     }
     delete tmpList;
   }
-  
+
   // Get MC primaries
   // triggers
   TObjArray* tmpList = fAnalyseUE->GetAcceptedParticles(mc, 0, kTRUE, fParticleSpeciesTrigger, kTRUE, kTRUE, evtPlanePhi);
@@ -783,25 +762,23 @@ void  AliAnalysisTaskPhiCorrelations::AnalyseCorrectionMode()
     for (Int_t i=0; i<tmpList->GetEntriesFast(); i++) {
       AliVParticle* particle = dynamic_cast<AliVParticle*> (tmpList->UncheckedAt(i));
       if (!particle)
-	continue;
+        continue;
       ((TH3F*) fListOfHistos->FindObject("yieldsRapidity"))->Fill(centrality, particle->Pt(), particle->Y());
     }
   }
   TObjArray* tracksMC = CloneAndReduceTrackList(tmpList);
   delete tmpList;
-  
+
   // associated
   TObjArray* tracksCorrelateMC = tracksMC;
-  if (fParticleSpeciesAssociated != fParticleSpeciesTrigger || fTrackPhiCutEvPlMax > 0.0001)
-  {
+  if (fParticleSpeciesAssociated != fParticleSpeciesTrigger || fTrackPhiCutEvPlMax > 0.0001) {
     tmpList = fAnalyseUE->GetAcceptedParticles(mc, 0, kTRUE, fParticleSpeciesAssociated, kTRUE);
     CleanUp(tmpList, mc, skipParticlesAbove);
     tracksCorrelateMC = CloneAndReduceTrackList(tmpList);
     delete tmpList;
   }
-  
-  if (fRandomizeReactionPlane)
-  {
+
+  if (fRandomizeReactionPlane) {
     Double_t centralityDigits = centrality*1000. - (Int_t)(centrality*1000.);
     Double_t angle = TMath::TwoPi() * centralityDigits;
     AliInfo(Form("Shifting phi of all tracks by %f (digits %f)", angle, centralityDigits));
@@ -809,13 +786,12 @@ void  AliAnalysisTaskPhiCorrelations::AnalyseCorrectionMode()
     if (tracksCorrelateMC != tracksMC)
       ShiftTracks(tracksCorrelateMC, angle);
   }
-  
+
   if (fFillOnlyStep0)
     zVtx = 0;
-  
+
   // Event selection based on number of number of MC particles
-  if (fRejectZeroTrackEvents && tracksMC->GetEntriesFast() == 0)
-  {
+  if (fRejectZeroTrackEvents && tracksMC->GetEntriesFast() == 0) {
     AliInfo(Form("Rejecting event due to kinematic selection: %f %d", centrality, tracksMC->GetEntriesFast()));
     fHistos->FillEvent(centrality, AliUEHist::kCFStepAnaTopology);
     if (tracksMC != tracksCorrelateMC)
@@ -823,90 +799,83 @@ void  AliAnalysisTaskPhiCorrelations::AnalyseCorrectionMode()
     delete tracksMC;
     return;
   }
-  
+
   // (MC-true all particles)
   // STEP 0
   fHistos->FillCorrelations(centrality, zVtx, AliUEHist::kCFStepAll, tracksMC, tracksCorrelateMC, weight);
-  
+
   // mixed event
-  if (fFillMixed)
-  {
-    for(Int_t iPool=0; iPool<fPoolMgr->GetNumberOfPtBins(); iPool++)
-    {
+  if (fFillMixed) {
+    for (Int_t iPool=0; iPool<fPoolMgr->GetNumberOfPtBins(); iPool++) {
       AliEventPool* pool = fPoolMgr->GetEventPool(centrality, zVtx, 0., iPool);
       if (fFillOnlyStep0) {
         ((TH2F*) fListOfHistos->FindObject("mixedDist"))->Fill(centrality, pool->NTracksInPool());
         ((TH2F*) fListOfHistos->FindObject("mixedDist2"))->Fill(centrality, pool->GetCurrentNEvents());
       }
       if (pool->IsReady())
-        for (Int_t jMix=0; jMix<pool->GetCurrentNEvents(); jMix++) 
-	  fHistosMixed->FillCorrelations(centrality, zVtx, AliUEHist::kCFStepAll, tracksMC, pool->GetEvent(jMix), 1.0 / pool->GetCurrentNEvents(), (jMix == 0));
+        for (Int_t jMix=0; jMix<pool->GetCurrentNEvents(); jMix++)
+          fHistosMixed->FillCorrelations(centrality, zVtx, AliUEHist::kCFStepAll, tracksMC, pool->GetEvent(jMix), 1.0 / pool->GetCurrentNEvents(), (jMix == 0));
       pool->UpdatePool(CloneAndReduceTrackList(tracksCorrelateMC, pool->GetPtMin(), pool->GetPtMax()));
     }
   }
-  
+
 //   Printf("trigger: %d", ((AliInputEventHandler*)fInputHandler)->IsEventSelected());
-  
+
   // Trigger selection ************************************************
-  if (!fFillOnlyStep0 && (fSkipTrigger || fAnalyseUE->TriggerSelection(fInputHandler)))
-  {  
+  if (!fFillOnlyStep0 && (fSkipTrigger || fAnalyseUE->TriggerSelection(fInputHandler))) {
     // (MC-true all particles)
     // STEP 1
     if (!fReduceMemoryFootprint)
       fHistos->FillCorrelations(centrality, zVtx, AliUEHist::kCFStepTriggered, tracksMC, tracksCorrelateMC, weight);
     else
       fHistos->FillEvent(centrality, AliUEHist::kCFStepTriggered);
-      
+
     if (!inputEvent) {
       AliFatal("UNEXPECTED: inputEvent is 0. Trigger selection should have failed");
       return;
     }
-    
+
     // Vertex selection *************************************************
-    if (fAnalyseUE->VertexSelection(inputEvent, fnTracksVertex, fZVertex))
-    {
+    if (fAnalyseUE->VertexSelection(inputEvent, fnTracksVertex, fZVertex)) {
       // fill here for tracking efficiency
       // loop over particle species
-      
-      for (Int_t particleSpecies = 0; particleSpecies < 4; particleSpecies++)
-      {
+
+      for (Int_t particleSpecies = 0; particleSpecies < 4; particleSpecies++) {
         TObjArray* primMCParticles = fAnalyseUE->GetAcceptedParticles(mc, 0x0, kTRUE, particleSpecies, kTRUE, kTRUE, evtPlanePhi);
         TObjArray* primRecoTracksMatched = fAnalyseUE->GetAcceptedParticles(inputEvent, mc, kTRUE, particleSpecies, kTRUE, kFALSE, evtPlanePhi);
         TObjArray* allRecoTracksMatched  = fAnalyseUE->GetAcceptedParticles(inputEvent, mc, kFALSE, particleSpecies, kTRUE, kFALSE, evtPlanePhi);
         TObjArray* primRecoTracksMatchedPID = 0;
         TObjArray* allRecoTracksMatchedPID  = 0;
-	
-	if (fHelperPID)
-	{
-	  primRecoTracksMatchedPID = fAnalyseUE->GetAcceptedParticles(inputEvent, mc, kTRUE, particleSpecies, kTRUE, kTRUE, evtPlanePhi);
-	  allRecoTracksMatchedPID  = fAnalyseUE->GetAcceptedParticles(inputEvent, mc, kFALSE, particleSpecies, kTRUE, kTRUE, evtPlanePhi);
-	}
-	
-	CleanUp(primMCParticles, mc, skipParticlesAbove);
-	CleanUp(primRecoTracksMatched, mc, skipParticlesAbove);
-	CleanUp(allRecoTracksMatched, mc, skipParticlesAbove);
-	CleanUp(primRecoTracksMatchedPID, mc, skipParticlesAbove);
-	CleanUp(allRecoTracksMatchedPID, mc, skipParticlesAbove);
-	
-	// select charges
-	if (fTriggerSelectCharge != 0)
-	{
-	  SelectCharge(primMCParticles);
-	  SelectCharge(primRecoTracksMatched);
-	  SelectCharge(allRecoTracksMatched);
-	  SelectCharge(primRecoTracksMatchedPID);
-	  SelectCharge(allRecoTracksMatchedPID);
-	}
-      
-        fHistos->FillTrackingEfficiency(primMCParticles, primRecoTracksMatched, allRecoTracksMatched, primRecoTracksMatchedPID, allRecoTracksMatchedPID, 0, particleSpecies, centrality, zVtx);
-        
-// 	Printf("%d --> %d %d %d", particleSpecies, primMCParticles->GetEntries(), primRecoTracksMatched->GetEntries(), allRecoTracksMatched->GetEntries());
 
-	delete primMCParticles;
+        if (fHelperPID) {
+          primRecoTracksMatchedPID = fAnalyseUE->GetAcceptedParticles(inputEvent, mc, kTRUE, particleSpecies, kTRUE, kTRUE, evtPlanePhi);
+          allRecoTracksMatchedPID  = fAnalyseUE->GetAcceptedParticles(inputEvent, mc, kFALSE, particleSpecies, kTRUE, kTRUE, evtPlanePhi);
+        }
+
+        CleanUp(primMCParticles, mc, skipParticlesAbove);
+        CleanUp(primRecoTracksMatched, mc, skipParticlesAbove);
+        CleanUp(allRecoTracksMatched, mc, skipParticlesAbove);
+        CleanUp(primRecoTracksMatchedPID, mc, skipParticlesAbove);
+        CleanUp(allRecoTracksMatchedPID, mc, skipParticlesAbove);
+
+        // select charges
+        if (fTriggerSelectCharge != 0) {
+          SelectCharge(primMCParticles);
+          SelectCharge(primRecoTracksMatched);
+          SelectCharge(allRecoTracksMatched);
+          SelectCharge(primRecoTracksMatchedPID);
+          SelectCharge(allRecoTracksMatchedPID);
+        }
+
+        fHistos->FillTrackingEfficiency(primMCParticles, primRecoTracksMatched, allRecoTracksMatched, primRecoTracksMatchedPID, allRecoTracksMatchedPID, 0, particleSpecies, centrality, zVtx);
+
+//      Printf("%d --> %d %d %d", particleSpecies, primMCParticles->GetEntries(), primRecoTracksMatched->GetEntries(), allRecoTracksMatched->GetEntries());
+
+        delete primMCParticles;
         delete primRecoTracksMatched;
         delete allRecoTracksMatched;
       }
-      
+
       TObjArray* fakeParticles = fAnalyseUE->GetFakeParticles(inputEvent, mc, kFALSE, -1, kTRUE);
       CleanUp((TObjArray*) fakeParticles->At(0), mc, skipParticlesAbove);
       CleanUp((TObjArray*) fakeParticles->At(1), mc, skipParticlesAbove);
@@ -915,29 +884,28 @@ void  AliAnalysisTaskPhiCorrelations::AnalyseCorrectionMode()
       fHistos->FillFakePt(fakeParticles, centrality);
 //       Printf(">>>>> %d %d %d fakes", ((TObjArray*) fakeParticles->At(0))->GetEntriesFast(), ((TObjArray*) fakeParticles->At(1))->GetEntriesFast(), ((TObjArray*) fakeParticles->At(2))->GetEntriesFast());
       delete fakeParticles;
-    
+
       // (MC-true all particles)
       // STEP 2
       if (!fReduceMemoryFootprint)
-	fHistos->FillCorrelations(centrality, zVtx, AliUEHist::kCFStepVertex, tracksMC, tracksCorrelateMC, weight);
+        fHistos->FillCorrelations(centrality, zVtx, AliUEHist::kCFStepVertex, tracksMC, tracksCorrelateMC, weight);
       else
-	fHistos->FillEvent(centrality, AliUEHist::kCFStepVertex);
-      
+        fHistos->FillEvent(centrality, AliUEHist::kCFStepVertex);
+
       // Get MC primaries that match reconstructed track
       // triggers
       tmpList = fAnalyseUE->GetAcceptedParticles(inputEvent, mc, kTRUE, fParticleSpeciesTrigger, kTRUE, kTRUE, evtPlanePhi);
       CleanUp(tmpList, mc, skipParticlesAbove);
       TObjArray* tracksRecoMatchedPrim = CloneAndReduceTrackList(tmpList);
       delete tmpList;
-      
+
       // associated
       TObjArray* tracksCorrelateRecoMatchedPrim = tracksRecoMatchedPrim;
-      if (fParticleSpeciesAssociated != fParticleSpeciesTrigger || fTrackPhiCutEvPlMax > 0.0001)
-      {
-	tmpList = fAnalyseUE->GetAcceptedParticles(inputEvent, mc, kTRUE, fParticleSpeciesAssociated, kTRUE);
-	CleanUp(tmpList, mc, skipParticlesAbove);
-	tracksCorrelateRecoMatchedPrim = CloneAndReduceTrackList(tmpList);
-	delete tmpList;
+      if (fParticleSpeciesAssociated != fParticleSpeciesTrigger || fTrackPhiCutEvPlMax > 0.0001) {
+        tmpList = fAnalyseUE->GetAcceptedParticles(inputEvent, mc, kTRUE, fParticleSpeciesAssociated, kTRUE);
+        CleanUp(tmpList, mc, skipParticlesAbove);
+        tracksCorrelateRecoMatchedPrim = CloneAndReduceTrackList(tmpList);
+        delete tmpList;
       }
 
       // (RECO-matched (quantities from MC particle) primary particles)
@@ -945,113 +913,101 @@ void  AliAnalysisTaskPhiCorrelations::AnalyseCorrectionMode()
       fHistos->FillCorrelations(centrality, zVtx, AliUEHist::kCFStepTrackedOnlyPrim, tracksRecoMatchedPrim, tracksCorrelateRecoMatchedPrim, weight);
 
       // mixed event
-      if (fFillMixed)
-      {
-        for(Int_t iPool=0; iPool<fPoolMgr->GetNumberOfPtBins(); iPool++)
-        {
+      if (fFillMixed) {
+        for (Int_t iPool=0; iPool<fPoolMgr->GetNumberOfPtBins(); iPool++) {
           AliEventPool* pool = fPoolMgr->GetEventPool(centrality, zVtx + 200, 0., iPool);
           if (pool->IsReady())
-            for (Int_t jMix=0; jMix<pool->GetCurrentNEvents(); jMix++) 
+            for (Int_t jMix=0; jMix<pool->GetCurrentNEvents(); jMix++)
               fHistosMixed->FillCorrelations(centrality, zVtx, AliUEHist::kCFStepTrackedOnlyPrim, tracksRecoMatchedPrim, pool->GetEvent(jMix), 1.0 / pool->GetCurrentNEvents(), (jMix == 0));
           pool->UpdatePool(CloneAndReduceTrackList(tracksCorrelateRecoMatchedPrim, pool->GetPtMin(), pool->GetPtMax()));
         }
       }
-      
+
       // Get MC primaries + secondaries that match reconstructed track
       // triggers
       tmpList = fAnalyseUE->GetAcceptedParticles(inputEvent, mc, kFALSE, fParticleSpeciesTrigger, kTRUE, kTRUE, evtPlanePhi);
       CleanUp(tmpList, mc, skipParticlesAbove);
       TObjArray* tracksRecoMatchedAll = CloneAndReduceTrackList(tmpList);
       delete tmpList;
-      
+
       // associated
       TObjArray* tracksCorrelateRecoMatchedAll = tracksRecoMatchedAll;
-      if (fParticleSpeciesAssociated != fParticleSpeciesTrigger || fTrackPhiCutEvPlMax > 0.0001)
-      {
-	tmpList = fAnalyseUE->GetAcceptedParticles(inputEvent, mc, kFALSE, fParticleSpeciesAssociated, kTRUE);
-	CleanUp(tmpList, mc, skipParticlesAbove);
-	tracksCorrelateRecoMatchedAll = CloneAndReduceTrackList(tmpList);
-	delete tmpList;
+      if (fParticleSpeciesAssociated != fParticleSpeciesTrigger || fTrackPhiCutEvPlMax > 0.0001) {
+        tmpList = fAnalyseUE->GetAcceptedParticles(inputEvent, mc, kFALSE, fParticleSpeciesAssociated, kTRUE);
+        CleanUp(tmpList, mc, skipParticlesAbove);
+        tracksCorrelateRecoMatchedAll = CloneAndReduceTrackList(tmpList);
+        delete tmpList;
       }
-      
+
       // (RECO-matched (quantities from MC particle) all particles)
       // STEP 5
       fHistos->FillCorrelations(centrality, zVtx, AliUEHist::kCFStepTracked, tracksRecoMatchedAll, tracksCorrelateRecoMatchedAll, weight);
-      
+
       // mixed event
-      if (fFillMixed)
-      {
-        for(Int_t iPool=0; iPool<fPoolMgr->GetNumberOfPtBins(); iPool++)
-        {
+      if (fFillMixed) {
+        for (Int_t iPool=0; iPool<fPoolMgr->GetNumberOfPtBins(); iPool++) {
           AliEventPool* pool = fPoolMgr->GetEventPool(centrality, zVtx + 300, 0., iPool);
           if (pool->IsReady())
-            for (Int_t jMix=0; jMix<pool->GetCurrentNEvents(); jMix++) 
+            for (Int_t jMix=0; jMix<pool->GetCurrentNEvents(); jMix++)
               fHistosMixed->FillCorrelations(centrality, zVtx, AliUEHist::kCFStepTracked, tracksRecoMatchedAll, pool->GetEvent(jMix), 1.0 / pool->GetCurrentNEvents(), (jMix == 0));
           pool->UpdatePool(CloneAndReduceTrackList(tracksCorrelateRecoMatchedAll, pool->GetPtMin(), pool->GetPtMax()));
         }
       }
-      
+
       // Get RECO tracks
       // triggers
       tmpList = fAnalyseUE->GetAcceptedParticles(inputEvent, 0, kTRUE, fParticleSpeciesTrigger, kTRUE, kTRUE, evtPlanePhi);
       CleanUp(tmpList, mc, skipParticlesAbove);
       TObjArray* tracks = CloneAndReduceTrackList(tmpList);
       delete tmpList;
-      
+
       // associated
       TObjArray* tracksCorrelate = tracks;
-      if (fParticleSpeciesAssociated != fParticleSpeciesTrigger || fTrackPhiCutEvPlMax > 0.0001)
-      {
-	tmpList = fAnalyseUE->GetAcceptedParticles(inputEvent, 0, kTRUE, fParticleSpeciesAssociated, kTRUE);
-	CleanUp(tmpList, mc, skipParticlesAbove);
-	tracksCorrelate = CloneAndReduceTrackList(tmpList);
-	delete tmpList;
+      if (fParticleSpeciesAssociated != fParticleSpeciesTrigger || fTrackPhiCutEvPlMax > 0.0001) {
+        tmpList = fAnalyseUE->GetAcceptedParticles(inputEvent, 0, kTRUE, fParticleSpeciesAssociated, kTRUE);
+        CleanUp(tmpList, mc, skipParticlesAbove);
+        tracksCorrelate = CloneAndReduceTrackList(tmpList);
+        delete tmpList;
       }
-     
+
       // (RECO all tracks)
       // STEP 6
       if (!fSkipStep6)
-	fHistos->FillCorrelations(centrality, zVtx, AliUEHist::kCFStepReconstructed, tracks, tracksCorrelate, weight);
-      
+        fHistos->FillCorrelations(centrality, zVtx, AliUEHist::kCFStepReconstructed, tracks, tracksCorrelate, weight);
+
       // two track cut, STEP 8
       if (fTwoTrackEfficiencyCut > 0)
-	fHistos->FillCorrelations(centrality, zVtx, AliUEHist::kCFStepBiasStudy, tracks, tracksCorrelate, weight, kTRUE, kTRUE, bSign, fTwoTrackEfficiencyCut);
+        fHistos->FillCorrelations(centrality, zVtx, AliUEHist::kCFStepBiasStudy, tracks, tracksCorrelate, weight, kTRUE, kTRUE, bSign, fTwoTrackEfficiencyCut);
 
       // apply correction efficiency, STEP 10
-      if (fEfficiencyCorrectionTriggers || fEfficiencyCorrectionAssociated)
-      {
-	  // with or without two track efficiency depending on if fTwoTrackEfficiencyCut is set
-	Bool_t twoTrackCut = (fTwoTrackEfficiencyCut > 0);
-	
-	fHistos->FillCorrelations(centrality, zVtx, AliUEHist::kCFStepCorrected, tracks, tracksCorrelate, weight, kTRUE, twoTrackCut, bSign, fTwoTrackEfficiencyCut, kTRUE);
+      if (fEfficiencyCorrectionTriggers || fEfficiencyCorrectionAssociated) {
+        // with or without two track efficiency depending on if fTwoTrackEfficiencyCut is set
+        Bool_t twoTrackCut = (fTwoTrackEfficiencyCut > 0);
+
+        fHistos->FillCorrelations(centrality, zVtx, AliUEHist::kCFStepCorrected, tracks, tracksCorrelate, weight, kTRUE, twoTrackCut, bSign, fTwoTrackEfficiencyCut, kTRUE);
       }
-      
+
       // mixed event
-      if (fFillMixed)
-      {
-        for(Int_t iPool=0; iPool<fPoolMgr->GetNumberOfPtBins(); iPool++)
-        {
+      if (fFillMixed) {
+        for (Int_t iPool=0; iPool<fPoolMgr->GetNumberOfPtBins(); iPool++) {
           AliEventPool* pool2 = fPoolMgr->GetEventPool(centrality, zVtx + 100, 0., iPool);
           ((TH2F*) fListOfHistos->FindObject("mixedDist"))->Fill(centrality, pool2->NTracksInPool());
           ((TH2F*) fListOfHistos->FindObject("mixedDist2"))->Fill(centrality, pool2->GetCurrentNEvents());
-          if (pool2->IsReady())
-          {
-            for (Int_t jMix=0; jMix<pool2->GetCurrentNEvents(); jMix++)
-            {
+          if (pool2->IsReady()) {
+            for (Int_t jMix=0; jMix<pool2->GetCurrentNEvents(); jMix++) {
               // STEP 6
               if (!fSkipStep6)
                 fHistosMixed->FillCorrelations(centrality, zVtx, AliUEHist::kCFStepReconstructed, tracks, pool2->GetEvent(jMix), 1.0 / pool2->GetCurrentNEvents(), (jMix == 0));
-              
+
               // two track cut, STEP 8
               if (fTwoTrackEfficiencyCut > 0)
                 fHistosMixed->FillCorrelations(centrality, zVtx, AliUEHist::kCFStepBiasStudy, tracks, pool2->GetEvent(jMix), 1.0 / pool2->GetCurrentNEvents(), (jMix == 0), kTRUE, bSign, fTwoTrackEfficiencyCut);
-              
+
               // apply correction efficiency, STEP 10
-              if (fEfficiencyCorrectionTriggers || fEfficiencyCorrectionAssociated)
-              {
+              if (fEfficiencyCorrectionTriggers || fEfficiencyCorrectionAssociated) {
                 // with or without two track efficiency depending on if fTwoTrackEfficiencyCut is set
                 Bool_t twoTrackCut = (fTwoTrackEfficiencyCut > 0);
-                
+
                 fHistosMixed->FillCorrelations(centrality, zVtx, AliUEHist::kCFStepCorrected, tracks, pool2->GetEvent(jMix), 1.0 / pool2->GetCurrentNEvents(), (jMix == 0), twoTrackCut, bSign, fTwoTrackEfficiencyCut, kTRUE);
               }
             }
@@ -1059,71 +1015,68 @@ void  AliAnalysisTaskPhiCorrelations::AnalyseCorrectionMode()
           pool2->UpdatePool(CloneAndReduceTrackList(tracksCorrelate, pool2->GetPtMin(), pool2->GetPtMax()));
         }
       }
-      
-      if (0 && !fReduceMemoryFootprint)
-      {
+
+      if (0 && !fReduceMemoryFootprint) {
         // make list of secondaries (matched with MC)
         TObjArray* tracksRecoMatchedSecondaries = new TObjArray;
         for (Int_t i=0; i<tracksRecoMatchedAll->GetEntriesFast(); i++)
           if (((AliAODMCParticle*)tracksRecoMatchedAll->At(i))->IsPhysicalPrimary() == kFALSE)
             tracksRecoMatchedSecondaries->Add(tracksRecoMatchedAll->At(i));
-      
+
         // Study: Use only secondaries as trigger particles and plot the correlation vs. all particles; store in step 9
         fHistos->FillCorrelations(centrality, zVtx, AliUEHist::kCFStepBiasStudy2, tracksRecoMatchedSecondaries, tracksRecoMatchedAll, weight);
-        
+
         // Study: Use only primaries as trigger particles and plot the correlation vs. secondaries; store in step 8
         fHistos->FillCorrelations(centrality, zVtx, AliUEHist::kCFStepBiasStudy, tracksRecoMatchedPrim, tracksRecoMatchedSecondaries, weight);
-      
+
         // plot delta phi vs process id of secondaries
         // trigger particles: primaries in 4 < pT < 10
         // associated particles: secondaries in 1 < pT < 10
-        
-        for (Int_t i=0; i<tracksRecoMatchedPrim->GetEntriesFast(); i++)
-        {
+
+        for (Int_t i=0; i<tracksRecoMatchedPrim->GetEntriesFast(); i++) {
           AliVParticle* triggerParticle = (AliVParticle*) tracksRecoMatchedPrim->At(i);
-          
+
           if (triggerParticle->Pt() < 4 || triggerParticle->Pt() > 10)
             continue;
-          
-          for (Int_t j=0; j<tracksRecoMatchedSecondaries->GetEntriesFast(); j++)
-          {
+
+          for (Int_t j=0; j<tracksRecoMatchedSecondaries->GetEntriesFast(); j++) {
             AliAODMCParticle* particle = (AliAODMCParticle*) tracksRecoMatchedSecondaries->At(j);
-            
+
             if (particle->Pt() < 1 || particle->Pt() > 10)
               continue;
-            
+
             if (particle->Pt() > triggerParticle->Pt())
               continue;
-              
+
             Double_t deltaPhi = triggerParticle->Phi() - particle->Phi();
-            if (deltaPhi > 1.5 * TMath::Pi()) 
+            if (deltaPhi > 1.5 * TMath::Pi())
               deltaPhi -= TMath::TwoPi();
             if (deltaPhi < -0.5 * TMath::Pi())
               deltaPhi += TMath::TwoPi();
-              
+
             Int_t processID = fMcEvent->Stack()->Particle(particle->GetLabel())->GetUniqueID();
-              
+
             ((TH2F*) fListOfHistos->FindObject("processIDs"))->Fill(deltaPhi, processID);
           }
         }
-        
+
         delete tracksRecoMatchedSecondaries;
       }
-  
+
       if (tracksCorrelateRecoMatchedPrim != tracksRecoMatchedPrim)
-	delete tracksCorrelateRecoMatchedPrim;
+        delete tracksCorrelateRecoMatchedPrim;
       delete tracksRecoMatchedPrim;
 
       if (tracksCorrelateRecoMatchedAll != tracksRecoMatchedAll)
-	delete tracksCorrelateRecoMatchedAll;
+        delete tracksCorrelateRecoMatchedAll;
       delete tracksRecoMatchedAll;
-      
+
       if (tracksCorrelate != tracks)
-	delete tracksCorrelate;
+        delete tracksCorrelate;
       delete tracks;
     }
   }
-  
+
   if (tracksMC != tracksCorrelateMC)
     delete tracksCorrelateMC;
   delete tracksMC;
@@ -1133,52 +1086,51 @@ void  AliAnalysisTaskPhiCorrelations::AnalyseCorrectionMode()
 AliGenEventHeader* AliAnalysisTaskPhiCorrelations::GetFirstHeader()
 {
   // get first MC header from either ESD/AOD (including cocktail header if available)
-  
-  if (fMcEvent)
-  {
+
+  if (fMcEvent) {
     // ESD
     AliHeader* header = (AliHeader*) fMcEvent->Header();
     if (!header)
       return 0;
-      
+
     AliGenCocktailEventHeader* cocktailHeader = dynamic_cast<AliGenCocktailEventHeader*> (header->GenEventHeader());
     if (cocktailHeader)
       return dynamic_cast<AliGenEventHeader*> (cocktailHeader->GetHeaders()->First());
 
     return dynamic_cast<AliGenEventHeader*> (header->GenEventHeader());
   }
-  else
-  {
+  else {
     // AOD
     AliAODMCHeader* header = (AliAODMCHeader*) fAOD->GetList()->FindObject(AliAODMCHeader::StdBranchName());
     if (!header)
       return 0;
-    
+
     return header->GetCocktailHeader(0);
   }
 }
 
 //____________________________________________________________________
-void  AliAnalysisTaskPhiCorrelations::AnalyseDataMode()
+void AliAnalysisTaskPhiCorrelations::AnalyseDataMode()
 {
 
   // Run the analysis on DATA or MC to get raw distributions
- 
-  if ( fDebug > 3 ) AliInfo( " Processing event in Data mode ..." );
+
+  if ( fDebug > 3 )
+    AliInfo( " Processing event in Data mode ..." );
 
   ((TH1F*) fListOfHistos->FindObject("eventStat"))->Fill(0);
 
   if (!fInputHandler)
     return;
-    
+
   // skip not selected events here (the AOD is not updated for those)
   if (!fSkipTrigger && !(fInputHandler->IsEventSelected() & fSelectBit))
     return;
-  
+
   // skip fast cluster events here if requested
   if (fSkipFastCluster && (fInputHandler->IsEventSelected() & AliVEvent::kFastOnly))
     return;
- 
+
   // Support for ESD and AOD based analysis
   AliVEvent* inputEvent = fAOD;
   if (!inputEvent)
@@ -1189,27 +1141,25 @@ void  AliAnalysisTaskPhiCorrelations::AnalyseDataMode()
   Float_t bSign = (inputEvent->GetMagneticField() > 0) ? 1 : -1;
 
   fHistos->SetRunNumber(inputEvent->GetRunNumber());
-  
+
   // Fill the "event-counting-container", it is needed to get the number of events remaining after each event-selection cut
   fHistos->FillEvent(centrality, AliUEHist::kCFStepAll);
-  
+
   // Trigger selection ************************************************
   if (!fSkipTrigger && !fAnalyseUE->TriggerSelection(fInputHandler)) return;
 
   // Fill the "event-counting-container", it is needed to get the number of events remaining after each event-selection cut
   fHistos->FillEvent(centrality, AliUEHist::kCFStepTriggered);
-  
+
   // Pileup selection ************************************************
-  if (fAnalysisUtils && fAnalysisUtils->IsPileUpEvent(inputEvent))
-  {
+  if (fAnalysisUtils && fAnalysisUtils->IsPileUpEvent(inputEvent)) {
     // count the removed events
     fHistos->FillEvent(centrality, AliUEHist::kCFStepAnaTopology);
 
     return;
   }
-  
-  if (fV0CL1PileUp)
-  {
+
+  if (fV0CL1PileUp) {
     AliMultSelection *multSelection = (AliMultSelection*) inputEvent->FindListObject("MultSelection");
     ((TH2I*)fListOfHistos->FindObject("fHistGlobalvsV0BeforePileUpCuts"))->Fill(multSelection->GetMultiplicityPercentile("V0M"),multSelection->GetMultiplicityPercentile("CL1"));
     if (TMath::Abs(multSelection->GetMultiplicityPercentile("V0M") - multSelection->GetMultiplicityPercentile("CL1")) > 7.5) {
@@ -1219,8 +1169,7 @@ void  AliAnalysisTaskPhiCorrelations::AnalyseDataMode()
     ((TH2I*)fListOfHistos->FindObject("fHistGlobalvsV0AfterPileUpCuts"))->Fill(multSelection->GetMultiplicityPercentile("V0M"),multSelection->GetMultiplicityPercentile("CL1"));
   }
 
-  if (fESDTPCTrackPileUp)
-  {
+  if (fESDTPCTrackPileUp) {
     const Int_t nTracks = inputEvent->GetNumberOfTracks();
     Int_t multEsd = ((AliAODHeader*)inputEvent->GetHeader())->GetNumberOfESDTracks();
     ((TH2D*)fListOfHistos->FindObject("fHistGlobalvsESDBeforePileUpCuts"))->Fill(nTracks,multEsd);
@@ -1232,34 +1181,32 @@ void  AliAnalysisTaskPhiCorrelations::AnalyseDataMode()
     } // end of for (Int_t it = 0; it < nTracks; it++)
     double fPileupLHC15oSlope = 3.38;
     double fPileupLHC15oOffset = 15000;
-    if ((multEsd - fPileupLHC15oSlope*multTPC) > fPileupLHC15oOffset)
-    {
+    if ((multEsd - fPileupLHC15oSlope*multTPC) > fPileupLHC15oOffset) {
       fHistos->FillEvent(centrality, AliUEHist::kCFStepAnaTopology);
       return;
     }
     ((TH2I*)fListOfHistos->FindObject("fHistGlobalvsESDAfterPileUpCuts"))->Fill(nTracks,multEsd);
   }
 
-  if (fTPCITSTOFPileUp)
-  {
+  if (fTPCITSTOFPileUp) {
     Int_t ntrkTPCout = 0;
     for (int it = 0; it < inputEvent->GetNumberOfTracks(); it++) {
       AliAODTrack* AODTrk = (AliAODTrack*)inputEvent->GetTrack(it);
       if ((AODTrk->GetStatus() & AliAODTrack::kTPCout) && AODTrk->GetID() > 0)
         ntrkTPCout++;
     }
-  
-    Double_t multVZERO =0; 
+
+    Double_t multVZERO =0;
     AliVVZERO *vzero = (AliVVZERO*)inputEvent->GetVZEROData();
-    if(vzero) {
-      for(int ich=0; ich < 64; ich++)
+    if (vzero) {
+      for (int ich=0; ich < 64; ich++)
         multVZERO += vzero->GetMultiplicity(ich);
     }
-  
-  
+
+
     ((TH2I*)fListOfHistos->FindObject("fHistV0MvsTPCoutBeforePileUpCuts"))->Fill(ntrkTPCout, multVZERO);
-  
-    if (multVZERO < (-2200 + 2.5*ntrkTPCout + 1.2e-5*ntrkTPCout*ntrkTPCout))  {
+
+    if (multVZERO < (-2200 + 2.5*ntrkTPCout + 1.2e-5*ntrkTPCout*ntrkTPCout)) {
       fHistos->FillEvent(centrality, AliUEHist::kCFStepAnaTopology);
       return;
     }
@@ -1267,22 +1214,23 @@ void  AliAnalysisTaskPhiCorrelations::AnalyseDataMode()
   }
 
   // Reject events without a muon in the muon arm ************************************************
-  if(fAcceptOnlyMuEvents && !IsMuEvent())return;
-  
+  if (fAcceptOnlyMuEvents && !IsMuEvent())
+    return;
+
   // Vertex selection *************************************************
-  if(!fAnalyseUE->VertexSelection(inputEvent, fnTracksVertex, fZVertex)) return;
-  
+  if (!fAnalyseUE->VertexSelection(inputEvent, fnTracksVertex, fZVertex))
+    return;
+
   // Fill the "event-counting-container", it is needed to get the number of events remaining after each event-selection cut
   fHistos->FillEvent(centrality, AliUEHist::kCFStepVertex);
- 
+
   // fill V0 control histograms
-  if (fCentralityMethod == "V0A_MANUAL")
-  {
+  if (fCentralityMethod == "V0A_MANUAL") {
     ((TH2F*) fListOfHistos->FindObject("V0AMult"))->Fill(inputEvent->GetVZEROData()->GetMTotV0A(), centrality);
     if (fAOD)
       ((TH2F*) fListOfHistos->FindObject("V0AMultCorrelation"))->Fill(inputEvent->GetVZEROData()->GetMTotV0A(), fAOD->GetTracklets()->GetNumberOfTracklets());
   }
- 
+
   // optimization
   if (centrality < 0)
     return;
@@ -1290,8 +1238,8 @@ void  AliAnalysisTaskPhiCorrelations::AnalyseDataMode()
   TObjArray* tracks = 0;
 
   Double_t evtPlanePhi = -999.; //A value outside [-pi/2,pi/2] will be ignored
-  if(fTrackPhiCutEvPlMax > 0.0001)
-    if(!InitiateEventPlane(evtPlanePhi, inputEvent)) return; //Reject event if plane is not available
+  if (fTrackPhiCutEvPlMax > 0.0001)
+    if (!InitiateEventPlane(evtPlanePhi, inputEvent)) return; //Reject event if plane is not available
 
   if (fTriggersFromDetector == 0)
     tracks = fAnalyseUE->GetAcceptedParticles(inputEvent, 0, kTRUE, fParticleSpeciesTrigger, kTRUE, kTRUE, evtPlanePhi);
@@ -1299,13 +1247,12 @@ void  AliAnalysisTaskPhiCorrelations::AnalyseDataMode()
     tracks=GetParticlesFromDetector(inputEvent,fTriggersFromDetector);
   else
     AliFatal(Form("Invalid setting for fTriggersFromDetector: %d", fTriggersFromDetector));
-  
+
   //Printf("Accepted %d tracks", tracks->GetEntries());
-  
+
   // check for outlier in centrality vs number of tracks (rough constants extracted from correlation histgram)
   Bool_t reject = kFALSE;
-  if (fRejectCentralityOutliers)
-  {
+  if (fRejectCentralityOutliers) {
     if (centrality > 40 && centrality <= 50 && tracks->GetEntriesFast() > 1160)
       reject = kTRUE;
     if (centrality > 50 && centrality <= 60 && tracks->GetEntriesFast() > 650)
@@ -1319,25 +1266,22 @@ void  AliAnalysisTaskPhiCorrelations::AnalyseDataMode()
     if (centrality > 90 && tracks->GetEntriesFast() > 75)
       reject = kTRUE;
   }
-  
-  if (reject)
-  {
+
+  if (reject) {
     AliInfo(Form("Rejecting event due to centrality vs tracks correlation: %f %d", centrality, tracks->GetEntriesFast()));
     fHistos->FillEvent(centrality, AliUEHist::kCFStepAnaTopology);
     delete tracks;
     return;
   }
-  
-  if (fRejectZeroTrackEvents && tracks->GetEntriesFast() == 0)
-  {
+
+  if (fRejectZeroTrackEvents && tracks->GetEntriesFast() == 0) {
     AliInfo(Form("Rejecting event because it has no tracks: %f %d", centrality, tracks->GetEntriesFast()));
     fHistos->FillEvent(centrality, AliUEHist::kCFStepAnaTopology);
     delete tracks;
     return;
   }
-  
-  if (fCentralityWeights && !AcceptEventCentralityWeight(centrality))
-  {
+
+  if (fCentralityWeights && !AcceptEventCentralityWeight(centrality)) {
     AliInfo(Form("Rejecting event because of centrality weighting: %f", centrality));
     fHistos->FillEvent(centrality, AliUEHist::kCFStepAnaTopology);
     delete tracks;
@@ -1346,17 +1290,17 @@ void  AliAnalysisTaskPhiCorrelations::AnalyseDataMode()
 
   // correlate particles with...
   TObjArray* tracksCorrelate = 0;
-  if(fAssociatedFromDetector==0){
+  if (fAssociatedFromDetector==0) {
     if (fParticleSpeciesAssociated != fParticleSpeciesTrigger || fTriggersFromDetector > 0 || fTrackPhiCutEvPlMax > 0.0001)
       tracksCorrelate = fAnalyseUE->GetAcceptedParticles(inputEvent, 0, kTRUE, fParticleSpeciesAssociated, kTRUE);
   }
-  else if (fAssociatedFromDetector <= 7){
-    if(fAssociatedFromDetector != fTriggersFromDetector)
+  else if (fAssociatedFromDetector <= 7) {
+    if (fAssociatedFromDetector != fTriggersFromDetector)
       tracksCorrelate = GetParticlesFromDetector(inputEvent,fAssociatedFromDetector);
   }
   else
     AliFatal(Form("Invalid setting for fAssociatedFromDetector: %d", fAssociatedFromDetector));
-  
+
   // reference multiplicity
   Int_t referenceMultiplicity = -1;
   if (fESD)
@@ -1366,22 +1310,21 @@ void  AliAnalysisTaskPhiCorrelations::AnalyseDataMode()
 //    referenceMultiplicity = ((AliVAODHeader*)fAOD->GetHeader())->GetRefMultiplicityComb05();
 
   ((TH2F*) fListOfHistos->FindObject("referenceMultiplicity"))->Fill(centrality, referenceMultiplicity);
-  
+
   const AliVVertex* vertex = inputEvent->GetPrimaryVertex();
   Double_t zVtx = vertex->GetZ();
-  
+
   Float_t weight = 1;
   if (fFillpT)
     weight = -1;
 
   // Fill containers at STEP 6 (reconstructed)
-  if (centrality >= 0)
-  {
+  if (centrality >= 0) {
     if (!fSkipStep6)
       fHistos->FillCorrelations(centrality, zVtx, AliUEHist::kCFStepReconstructed, tracks, tracksCorrelate, weight, kTRUE, kFALSE, 0, 0.02, kTRUE);
-    
+
     ((TH1F*) fListOfHistos->FindObject("eventStat"))->Fill(1);
-    
+
     if (fTwoTrackEfficiencyCut > 0)
       fHistos->FillCorrelations(centrality, zVtx, AliUEHist::kCFStepBiasStudy, tracks, tracksCorrelate, weight, kTRUE, kTRUE, bSign, fTwoTrackEfficiencyCut, kTRUE);
   }
@@ -1389,11 +1332,10 @@ void  AliAnalysisTaskPhiCorrelations::AnalyseDataMode()
   // create a list of reduced objects. This speeds up processing and reduces memory consumption for the event pool
   TObjArray* tracksClone = CloneAndReduceTrackList(tracks);
   delete tracks;
-  
-  if (fFillMixed)
-  {
+
+  if (fFillMixed) {
     // event mixing
-    
+
     // 1. First get an event pool corresponding in mult (cent) and
     //    zvertex to the current event. Once initialized, the pool
     //    should contain nMix (reduced) events. This routine does not
@@ -1410,30 +1352,27 @@ void  AliAnalysisTaskPhiCorrelations::AnalyseDataMode()
     //    FillCorrelations(). Also nMix should be passed in, so a weight
     //    of 1./nMix can be applied.
 
-    for(Int_t iPool=0; iPool<fPoolMgr->GetNumberOfPtBins(); iPool++)
-    {
+    for (Int_t iPool=0; iPool<fPoolMgr->GetNumberOfPtBins(); iPool++) {
       AliEventPool* pool = fPoolMgr->GetEventPool(centrality, zVtx, 0., iPool);
-      
+
       if (!pool)
         AliFatal(Form("No pool found for centrality = %f, zVtx = %f", centrality, zVtx));
-      
+
   //     pool->SetDebug(1);
-       
-      if (pool->IsReady()) 
-      {
+
+      if (pool->IsReady()) {
         Int_t nMix = pool->GetCurrentNEvents();
   //       cout << "nMix = " << nMix << " tracks in pool = " << pool->NTracksInPool() << endl;
-        
+
         ((TH1F*) fListOfHistos->FindObject("eventStat"))->Fill(2);
         ((TH1F*) fListOfHistos->FindObject("eventStat"))->Fill(3, nMix);
         ((TH2F*) fListOfHistos->FindObject("mixedDist"))->Fill(centrality, pool->NTracksInPool());
         ((TH2F*) fListOfHistos->FindObject("mixedDist2"))->Fill(centrality, nMix);
-      
-        // Fill mixed-event histos here  
-        for (Int_t jMix=0; jMix<nMix; jMix++) 
-        {
+
+        // Fill mixed-event histos here
+        for (Int_t jMix=0; jMix<nMix; jMix++) {
           TObjArray* bgTracks = pool->GetEvent(jMix);
-        
+
           if (!fSkipStep6)
             fHistosMixed->FillCorrelations(centrality, zVtx, AliUEHist::kCFStepReconstructed, tracksClone, bgTracks, 1.0 / nMix, (jMix == 0), kFALSE, 0, 0.02, kTRUE);
 
@@ -1441,15 +1380,14 @@ void  AliAnalysisTaskPhiCorrelations::AnalyseDataMode()
             fHistosMixed->FillCorrelations(centrality, zVtx, AliUEHist::kCFStepBiasStudy, tracksClone, bgTracks, 1.0 / nMix, (jMix == 0), kTRUE, bSign, fTwoTrackEfficiencyCut, kTRUE);
         }
       }
-      
-      if (!pool->GetLockFlag())
-      {
+
+      if (!pool->GetLockFlag()) {
         TObjArray* storeInMixed = 0;
         if (tracksCorrelate)
           storeInMixed = CloneAndReduceTrackList(tracksCorrelate, pool->GetPtMin(), pool->GetPtMax());
         else
           storeInMixed = CloneAndReduceTrackList(tracksClone, pool->GetPtMin(), pool->GetPtMax());
-        
+
         // ownership is with the pool now
         pool->UpdatePool(storeInMixed);
       }
@@ -1465,58 +1403,58 @@ void  AliAnalysisTaskPhiCorrelations::AnalyseDataMode()
 Double_t AliAnalysisTaskPhiCorrelations::GetCentrality(AliVEvent* inputEvent, TObject* mc)
 {
   // return centrality
-  
+
   if (fCentralityMethod.Length() == 0)
     return 0;
-  
+
   Double_t centrality = 0;
-  
-  if (fUseNewCentralityFramework) 
-  {
+
+  if (fUseNewCentralityFramework)  {
     AliMultSelection *multSelection = (AliMultSelection*) inputEvent->FindListObject("MultSelection");
     if (!multSelection)
       AliFatal("MultSelection not found in input event");
-      
+
     if (fUseUncheckedCentrality)
       centrality = multSelection->GetMultiplicityPercentile(fCentralityMethod, kFALSE);
     else
       centrality = multSelection->GetMultiplicityPercentile(fCentralityMethod, kTRUE);
-    
+
     // error handling
     if (centrality > 100)
       centrality = -1;
   }
-  else 
-  {
+  else {
     AliCentrality *centralityObj = 0;
 
-    if (fCentralityMethod == "ZNA_MANUAL")
-    {
+    if (fCentralityMethod == "ZNA_MANUAL") {
       Bool_t zna = kFALSE;
-      for(Int_t j = 0; j < 4; ++j) {
+      for (Int_t j = 0; j < 4; ++j) {
         if (fESD->GetZDCData()->GetZDCTDCData(12,j) != 0) {
           zna = kTRUE;
         }
       }
 
 //       Printf("%d %f", zna, fZNAtower[0]);
-      if (zna)
-      {
+      if (zna) {
         // code from Chiara O (23.10.12)
         const Double_t *fZNAtower = fESD->GetZDCData()->GetZN2TowerEnergy();
         Float_t znacut[4] = {681., 563., 413., 191.};
-        
-        if(fZNAtower[0]>znacut[0]) centrality = 1;
-        else if(fZNAtower[0]>znacut[1]) centrality = 21;
-        else if(fZNAtower[0]>znacut[2]) centrality = 41;
-        else if(fZNAtower[0]>znacut[3]) centrality = 61;
-        else centrality = 81;
+
+        if (fZNAtower[0]>znacut[0])
+          centrality = 1;
+        else if (fZNAtower[0]>znacut[1])
+          centrality = 21;
+        else if (fZNAtower[0]>znacut[2])
+          centrality = 41;
+        else if (fZNAtower[0]>znacut[3])
+          centrality = 61;
+        else
+          centrality = 81;
       }
       else
         centrality = -1;
     }
-    else if (fCentralityMethod == "ZNAC") // pp
-    {
+    else if (fCentralityMethod == "ZNAC") { // pp
       // values from Cvetan
       const Double_t *towZNA = fAOD->GetZDCData()->GetZNATowerEnergy();
       const Double_t *towZNC = fAOD->GetZDCData()->GetZNCTowerEnergy();
@@ -1526,20 +1464,27 @@ Double_t AliAnalysisTaskPhiCorrelations::GetCentrality(AliVEvent* inputEvent, TO
       Double_t enZN = enZNA + enZNC;
 
       Float_t znaccut[8] = {1e9, 797.743, 526.879, 238.595, 107.325, 39.214, 7.633, -100};
-      
-      if(enZN > znaccut[1] && enZN < znaccut[0]) centrality = 96;
-      else if(enZN > znaccut[2]) centrality = 91;
-      else if(enZN > znaccut[3]) centrality = 81;
-      else if(enZN > znaccut[4]) centrality = 71;
-      else if(enZN > znaccut[5]) centrality = 61;
-      else if(enZN > znaccut[6]) centrality = 51;
-      else if(enZN > znaccut[7]) centrality = 1;
-      else centrality = -1;
 
-    ((TH1D*) fListOfHistos->FindObject("ZNA+C_energy"))->Fill(enZN);
+      if (enZN > znaccut[1] && enZN < znaccut[0])
+        centrality = 96;
+      else if (enZN > znaccut[2])
+        centrality = 91;
+      else if (enZN > znaccut[3])
+        centrality = 81;
+      else if (enZN > znaccut[4])
+        centrality = 71;
+      else if (enZN > znaccut[5])
+        centrality = 61;
+      else if (enZN > znaccut[6])
+        centrality = 51;
+      else if (enZN > znaccut[7])
+        centrality = 1;
+      else
+        centrality = -1;
+
+      ((TH1D*) fListOfHistos->FindObject("ZNA+C_energy"))->Fill(enZN);
     }
-    else if (fCentralityMethod == "TRACKS_MANUAL")
-    {
+    else if (fCentralityMethod == "TRACKS_MANUAL") {
       // for pp
       TObjArray* tracks = fAnalyseUE->GetAcceptedParticles(inputEvent, 0, kTRUE, -1, kTRUE);
       centrality = tracks->GetEntriesFast();
@@ -1548,70 +1493,63 @@ Double_t AliAnalysisTaskPhiCorrelations::GetCentrality(AliVEvent* inputEvent, TO
 //       Printf("%d %f", tracks->GetEntriesFast(), centrality);
       delete tracks;
     }
-    else if (fCentralityMethod == "V0A_MANUAL")
-    {
+    else if (fCentralityMethod == "V0A_MANUAL") {
       // for pp
-      
+
       //Total multiplicity in the VZERO A detector
       Float_t MV0A=inputEvent->GetVZEROData()->GetMTotV0A();
       Float_t MV0AScaled=0.;
-      if (fMap){
+      if (fMap) {
         TParameter<float>* sf=(TParameter<float>*)fMap->GetValue(Form("%d",inputEvent->GetRunNumber()));
-        if(sf)MV0AScaled=MV0A*sf->GetVal();
+        if (sf)
+          MV0AScaled=MV0A*sf->GetVal();
       }
-      
+
       if (MV0AScaled > 0)
         centrality = MV0AScaled;
       else
         centrality = -1;
     }
-    else if (fCentralityMethod == "nano")
-    {
+    else if (fCentralityMethod == "nano") {
       centrality = ((AliNanoAODHeader*) fAOD->GetHeader())->GetCentrality();
     }
-    else if (fCentralityMethod.BeginsWith("Nano."))
-    {
+    else if (fCentralityMethod.BeginsWith("Nano.")) {
       AliNanoAODHeader* nanoHeader = dynamic_cast<AliNanoAODHeader*>(fAOD->GetHeader());
       if (!nanoHeader)
         AliFatal("Nano Header not found");
-      
+
       static TString nanoField = fCentralityMethod(5, fCentralityMethod.Length());
       static const Int_t kField = nanoHeader->GetVarIndex(nanoField);
 
       centrality = nanoHeader->GetVar(kField);
     }
-    else if (fCentralityMethod == "PPVsMultUtils")
-    {
+    else if (fCentralityMethod == "PPVsMultUtils") {
       if (fAnalysisUtils) centrality = fAnalysisUtils->GetMultiplicityPercentile(inputEvent);
       else centrality = -1;
     }
-    else if (fCentralityMethod == "MC_b")
-    {
+    else if (fCentralityMethod == "MC_b") {
       AliGenEventHeader* eventHeader = GetFirstHeader();
-      if (!eventHeader)
-      {
+      if (!eventHeader) {
         // We avoid AliFatal here, because the AOD productions sometimes have events where the MC header is missing 
         // (due to unreadable Kinematics) and we don't want to loose the whole job because of a few events
         AliError("Event header not found. Skipping this event.");
         fHistos->FillEvent(0, AliUEHist::kCFStepAnaTopology);
         return -1;
       }
-      
+
       AliCollisionGeometry* collGeometry = dynamic_cast<AliCollisionGeometry*> (eventHeader);
       AliGenHepMCEventHeader* hepMCHeader = dynamic_cast<AliGenHepMCEventHeader*> (eventHeader);
-      if (!collGeometry && !hepMCHeader)
-      {
+      if (!collGeometry && !hepMCHeader) {
         eventHeader->Dump();
         AliFatal("Asking for MC_b centrality, but event header has no collision geometry information");
       }
-      
+
       if (collGeometry)
         centrality = collGeometry->ImpactParameter();
       else if (hepMCHeader)
         centrality = hepMCHeader->impact_parameter();
-    }    
-    else if (fCentralityMethod == "MCGen_V0M")
-    {
+    }
+    else if (fCentralityMethod == "MCGen_V0M") {
 //      TObjArray* tmpList = fAnalyseUE->GetAcceptedParticles(mc, 0, kTRUE, -1, kFALSE, kFALSE, -999.,kTRUE);
       TObjArray* tmpList = fAnalyseUE->GetAcceptedParticles(mc, 0, kFALSE, -1, kFALSE, kFALSE, -999.,kTRUE);
       Float_t MultV0M=0.;
@@ -1622,24 +1560,33 @@ Double_t AliAnalysisTaskPhiCorrelations::GetCentrality(AliVEvent* inputEvent, TO
         if (!particle)
           continue;
         Int_t pdgabs=TMath::Abs(particle->PdgCode());
-        if(pdgabs==9902210)return -1; //no diffractive protons
-        if(pdgabs!=211 && pdgabs!=321 && pdgabs!=2212)continue; //only charged pi+K+p
-	if(!(((AliMCEvent*)mc)->IsPhysicalPrimary(particle->GetLabel()))) continue; // only primaries (probably not necessary)
-        if( particle->Pt() < 0.001 || particle->Pt() > 50. )continue;
+        if (pdgabs==9902210)
+          return -1; //no diffractive protons
+        if (pdgabs!=211 && pdgabs!=321 && pdgabs!=2212)
+          continue; //only charged pi+K+p
+        if (!(((AliMCEvent*)mc)->IsPhysicalPrimary(particle->GetLabel())))
+          continue; // only primaries (probably not necessary)
+        if ( particle->Pt() < 0.001 || particle->Pt() > 50. )
+          continue;
         Float_t eta=particle->Eta();
-        if((eta > 2.8 && eta < 5.1) || (eta > -3.7 && eta < -1.7)) MultV0M += 1.;
-	if(eta < 0.5 && eta > -0.5) dNchdeta += 1.;
-	if(eta < 1. && eta > -1.) INEL0 += 1.;
+        if ((eta > 2.8 && eta < 5.1) || (eta > -3.7 && eta < -1.7))
+          MultV0M += 1.;
+        if (eta < 0.5 && eta > -0.5)
+          dNchdeta += 1.;
+        if (eta < 1. && eta > -1.)
+          INEL0 += 1.;
       }
-      if(INEL0 < 0.5) centrality = -1.; // INEL>0 cut
-      else{
-	((TH2D*)fListOfHistos->FindObject("Mult_MCGen_V0M"))->Fill(MultV0M,dNchdeta);
-	if(fCentralityMCGen_V0M)centrality = fCentralityMCGen_V0M->GetBinContent(fCentralityMCGen_V0M->GetXaxis()->FindBin(MultV0M));
-	else centrality=-1.;
+      if (INEL0 < 0.5)
+        centrality = -1.; // INEL>0 cut
+      else {
+        ((TH2D*)fListOfHistos->FindObject("Mult_MCGen_V0M"))->Fill(MultV0M,dNchdeta);
+        if (fCentralityMCGen_V0M)
+          centrality = fCentralityMCGen_V0M->GetBinContent(fCentralityMCGen_V0M->GetXaxis()->FindBin(MultV0M));
+        else
+          centrality=-1.;
       }
     }
-    else if (fCentralityMethod == "MCGen_CL1")
-    {
+    else if (fCentralityMethod == "MCGen_CL1") {
 //      TObjArray* tmpList = fAnalyseUE->GetAcceptedParticles(mc, 0, kTRUE, -1, kFALSE, kFALSE, -999.,kTRUE);
       TObjArray* tmpList = fAnalyseUE->GetAcceptedParticles(mc, 0, kFALSE, -1, kFALSE, kFALSE, -999.,kTRUE);
       Float_t MultCL1=0.;
@@ -1649,32 +1596,40 @@ Double_t AliAnalysisTaskPhiCorrelations::GetCentrality(AliVEvent* inputEvent, TO
         AliMCParticle* particle = dynamic_cast<AliMCParticle*> (tmpList->UncheckedAt(i));
         if (!particle)
           continue;
-        Int_t pdgabs=TMath::Abs(particle->PdgCode());
-        if(pdgabs==9902210)return -1; //no diffractive protons
-        if(pdgabs!=211 && pdgabs!=321 && pdgabs!=2212)continue; //only charged pi+K+p
-	if(!(((AliMCEvent*)mc)->IsPhysicalPrimary(particle->GetLabel()))) continue; // only primaries (probably not necessary)
-        if( particle->Pt() < 0.001 || particle->Pt() > 50. )continue;
-        Float_t eta=particle->Eta();
-        if(eta < 1.4 && eta > -1.4) MultCL1 += 1.;
-	if(eta < 0.5 && eta > -0.5) dNchdeta += 1.;
-	if(eta < 1. && eta > -1.) INEL0 += 1.;
+        Int_t pdgabs = TMath::Abs(particle->PdgCode());
+        if (pdgabs==9902210)
+          return -1; //no diffractive protons
+        if (pdgabs!=211 && pdgabs!=321 && pdgabs!=2212)
+          continue; //only charged pi+K+p
+        if (!(((AliMCEvent*)mc)->IsPhysicalPrimary(particle->GetLabel())))
+          continue; // only primaries (probably not necessary)
+        if ( particle->Pt() < 0.001 || particle->Pt() > 50. )
+          continue;
+        Float_t eta = particle->Eta();
+        if (eta < 1.4 && eta > -1.4)
+          MultCL1 += 1.;
+        if (eta < 0.5 && eta > -0.5)
+          dNchdeta += 1.;
+        if (eta < 1. && eta > -1.)
+          INEL0 += 1.;
       }
-      if(INEL0 < 0.5) centrality = -1.; // INEL>0 cut
-      else{
-	((TH2D*)fListOfHistos->FindObject("Mult_MCGen_CL1"))->Fill(MultCL1,dNchdeta);
-	if(fCentralityMCGen_CL1)centrality = fCentralityMCGen_CL1->GetBinContent(fCentralityMCGen_CL1->GetXaxis()->FindBin(MultCL1));
-	else centrality=-1.;
+      if (INEL0 < 0.5)
+        centrality = -1.; // INEL>0 cut
+      else {
+        ((TH2D*)fListOfHistos->FindObject("Mult_MCGen_CL1"))->Fill(MultCL1,dNchdeta);
+        if (fCentralityMCGen_CL1)
+          centrality = fCentralityMCGen_CL1->GetBinContent(fCentralityMCGen_CL1->GetXaxis()->FindBin(MultCL1));
+        else
+          centrality=-1.;
       }
     }
-    else
-    {
+    else {
       if (fAOD)
         centralityObj = fAOD->GetCentrality();
       else if (fESD)
         centralityObj = fESD->GetCentrality();
-      
-      if (centralityObj)
-      {
+
+      if (centralityObj) {
         if (fUseUncheckedCentrality)
           centrality = centralityObj->GetCentralityPercentileUnchecked(fCentralityMethod);
         else
@@ -1682,19 +1637,15 @@ Double_t AliAnalysisTaskPhiCorrelations::GetCentrality(AliVEvent* inputEvent, TO
       }
       else
         centrality = -1;
-      
-      if (fAOD)
-      {
+
+      if (fAOD) {
         // remove outliers
-        if (centrality == 0)
-        {
-          if (fAOD->GetVZEROData())
-          {
+        if (centrality == 0) {
+          if (fAOD->GetVZEROData()) {
             Float_t multV0 = 0;
             for (Int_t i=0; i<64; i++)
               multV0 += fAOD->GetVZEROData()->GetMultiplicity(i);
-            if (multV0 < 19500)
-            {
+            if (multV0 < 19500) {
               centrality = -1;
               AliInfo("Rejecting event due to too small V0 multiplicity");
             }
@@ -1704,7 +1655,7 @@ Double_t AliAnalysisTaskPhiCorrelations::GetCentrality(AliVEvent* inputEvent, TO
     }
   }
   AliInfo(Form("Centrality is %f", centrality));
-  
+
   return centrality;
 }
 
@@ -1716,15 +1667,14 @@ TObjArray* AliAnalysisTaskPhiCorrelations::CloneAndReduceTrackList(TObjArray* tr
 
   // Check if we already have a reduced track list. In that case a simple Clone is enough
   // Only possible for inclusive pt
-  if(maxPt-minPt < 0)
+  if (maxPt-minPt < 0)
     if (tracks->GetEntriesFast() == 0 || tracks->UncheckedAt(0)->InheritsFrom("AliBasicParticle"))
       return (TObjArray*) tracks->Clone();
-  
+
   TObjArray* tracksClone = new TObjArray;
   tracksClone->SetOwner(kTRUE);
 
-  for (Int_t i=0; i<tracks->GetEntriesFast(); i++)
-  {
+  for (Int_t i=0; i<tracks->GetEntriesFast(); i++) {
     AliVParticle* particle = (AliVParticle*) tracks->UncheckedAt(i);
     AliBasicParticle* copy = 0;
 
@@ -1739,12 +1689,12 @@ TObjArray* AliAnalysisTaskPhiCorrelations::CloneAndReduceTrackList(TObjArray* tr
 
     // Set unique event index if input tracks are AliBasicParticles
     AliBasicParticle* particleBasic = dynamic_cast<AliBasicParticle*>(particle);
-    if(particleBasic)
+    if (particleBasic)
       copy->SetEventIndex(particleBasic->GetEventIndex());
 
     tracksClone->Add(copy);
   }
-  
+
   return tracksClone;
 }
 
@@ -1753,7 +1703,7 @@ void  AliAnalysisTaskPhiCorrelations::Initialize()
 {
   // input handler
   fInputHandler = (AliInputEventHandler*)
-         ((AliAnalysisManager::GetAnalysisManager())->GetInputEventHandler());
+    ((AliAnalysisManager::GetAnalysisManager())->GetInputEventHandler());
   // MC handler
   fMcHandler = dynamic_cast<AliInputEventHandler*> (AliAnalysisManager::GetAnalysisManager()->GetMCtruthEventHandler());
 }
@@ -1762,41 +1712,38 @@ void  AliAnalysisTaskPhiCorrelations::Initialize()
 void AliAnalysisTaskPhiCorrelations::RemoveDuplicates(TObjArray* tracks)
 {
   // remove particles with the same label
-  
+
   Int_t before = tracks->GetEntriesFast();
 
-  for (Int_t i=0; i<before; ++i) 
-  {
+  for (Int_t i=0; i<before; ++i) {
     AliVParticle* part = (AliVParticle*) tracks->At(i);
-    
-    for (Int_t j=i+1; j<before; ++j) 
-    {
+
+    for (Int_t j=i+1; j<before; ++j) {
       AliVParticle* part2 = (AliVParticle*) tracks->At(j);
-      
-      if (part->GetLabel() == part2->GetLabel())
-      {
-	Printf("Removing %d with label %d (duplicated in %d)", i, part->GetLabel(), j); part->Dump(); part2->Dump();
-	TObject* object = tracks->RemoveAt(i);
-	if (tracks->IsOwner())
-	  delete object;
-	break;
+
+      if (part->GetLabel() == part2->GetLabel()) {
+        Printf("Removing %d with label %d (duplicated in %d)", i, part->GetLabel(), j); part->Dump(); part2->Dump();
+        TObject* object = tracks->RemoveAt(i);
+        if (tracks->IsOwner())
+          delete object;
+        break;
       }
     }
   }
- 
+
   tracks->Compress();
-  
+
   if (before > tracks->GetEntriesFast())
-    AliInfo(Form("Reduced from %d to %d", before, tracks->GetEntriesFast())); 
+    AliInfo(Form("Reduced from %d to %d", before, tracks->GetEntriesFast()));
 }
 
 void AliAnalysisTaskPhiCorrelations::CleanUp(TObjArray* tracks, TObject* mcObj, Int_t maxLabel)
 {
   // calls RemoveInjectedSignals, RemoveWeakDecays and RemoveDuplicates
-  
+
   if (!tracks)
     return;
-  
+
   if (fInjectedSignals)
     fAnalyseUE->RemoveInjectedSignals(tracks, mcObj, maxLabel);
   if (fRemoveWeakDecays)
@@ -1810,87 +1757,84 @@ void AliAnalysisTaskPhiCorrelations::CleanUp(TObjArray* tracks, TObject* mcObj, 
 void AliAnalysisTaskPhiCorrelations::RemoveWeakDecaysInMC(TObjArray* tracks, TObject* mcObj)
 {
   // Exclude weak decay products (if not done by IsPhysicalPrimary)
-  // In order to prevent analyzing daughters from weak decays 
+  // In order to prevent analyzing daughters from weak decays
   // - AMPT does not only strong decays, so IsPhysicalPrimary does not catch it
-  
+
   const Int_t kNWeakParticles = 7;
   const Int_t kWeakParticles[kNWeakParticles] = { 3322, 3312, 3222, // Xi0 Xi+- Sigma-+
-						  3122, 3112, // Lambda0 Sigma+-
-						  130, 310 // K_L0 K_S0
-  };
+                                                  3122, 3112, // Lambda0 Sigma+-
+                                                  130, 310 }; // K_L0 K_S0
 
   AliMCEvent* mcEvent = dynamic_cast<AliMCEvent*>(mcObj);
   if (!mcEvent)
     return;
-  
+
   Int_t before = tracks->GetEntriesFast();
 
   for (Int_t i=0; i<before; ++i) {
     AliMCParticle* mcParticle = dynamic_cast<AliMCParticle*> (tracks->UncheckedAt(i));
     if (!mcParticle)
       continue;
-    
+
     TParticle *particle = mcParticle->Particle();
-    if (!particle) 
+    if (!particle)
       continue;
-  
+
     Int_t motherIndex = particle->GetMother(0);
     if (motherIndex == -1)
       continue;
-    
+
     AliMCParticle* motherTrack = dynamic_cast<AliMCParticle *>(mcEvent->GetTrack(motherIndex));
-    if (!motherTrack) 
+    if (!motherTrack)
       continue;
 
     TParticle *motherParticle = motherTrack->Particle();
     if (!motherParticle)
       continue;
-    
+
     Int_t pdgcode = TMath::Abs(motherParticle->GetPdgCode());
-    
+
     for (Int_t j=0; j != kNWeakParticles; ++j) {
       if (kWeakParticles[j] == pdgcode) {
-	AliDebug(1, Form("Removing particle %d (pdg code %d; mother %d)", i, particle->GetPdgCode(), motherParticle->GetPdgCode()));
-	TObject* object = tracks->RemoveAt(i);
-	if (tracks->IsOwner())
-	  delete object;
-	break;
+        AliDebug(1, Form("Removing particle %d (pdg code %d; mother %d)", i, particle->GetPdgCode(), motherParticle->GetPdgCode()));
+        TObject* object = tracks->RemoveAt(i);
+        if (tracks->IsOwner())
+          delete object;
+        break;
       }
     }
   }
-  
-  tracks->Compress();  
+
+  tracks->Compress();
   if (before > tracks->GetEntriesFast())
-    AliInfo(Form("Reduced from %d to %d", before, tracks->GetEntriesFast())); 
+    AliInfo(Form("Reduced from %d to %d", before, tracks->GetEntriesFast()));
 }
 
 //____________________________________________________________________
 void AliAnalysisTaskPhiCorrelations::SelectCharge(TObjArray* tracks)
 {
   // remove particles with charge not selected (depending on fTriggerSelectCharge)
-  
+
   if (!tracks)
     return;
-  
+
   Int_t before = tracks->GetEntriesFast();
 
-  for (Int_t i=0; i<before; ++i) 
-  {
+  for (Int_t i=0; i<before; ++i) {
     AliVParticle* part = (AliVParticle*) tracks->At(i);
-    
-    if (part->Charge() * fTriggerSelectCharge < -1)
-    {
+
+    if (part->Charge() * fTriggerSelectCharge < -1) {
 //       Printf("Removing %d with charge %d", i, part->Charge());
       TObject* object = tracks->RemoveAt(i);
       if (tracks->IsOwner())
-	delete object;
+        delete object;
     }
   }
- 
+
   tracks->Compress();
-  
+
   if (before > tracks->GetEntriesFast())
-    AliInfo(Form("Reduced from %d to %d", before, tracks->GetEntriesFast())); 
+    AliInfo(Form("Reduced from %d to %d", before, tracks->GetEntriesFast()));
 }
 
 //____________________________________________________________________
@@ -1900,16 +1844,16 @@ Bool_t AliAnalysisTaskPhiCorrelations::AcceptEventCentralityWeight(Double_t cent
   // uses fCentralityWeights histogram
 
   // TODO code taken and adapted from AliRDHFCuts; waiting for general class AliCentralityFlattening
-  
+
   Double_t weight = fCentralityWeights->GetBinContent(fCentralityWeights->FindBin(centrality));
   Double_t centralityDigits = centrality*100. - (Int_t)(centrality*100.);
-  
+
   Bool_t result = kFALSE;
-  if (centralityDigits < weight) 
+  if (centralityDigits < weight)
     result = kTRUE;
-  
+
   AliInfo(Form("Centrality: %f; Digits: %f; Weight: %f; Result: %d", centrality, centralityDigits, weight, result));
-  
+
   return result;
 }
 
@@ -1918,14 +1862,13 @@ void AliAnalysisTaskPhiCorrelations::ShiftTracks(TObjArray* tracks, Double_t ang
 {
   // shifts the phi angle of all tracks by angle
   // 0 <= angle <= 2pi
-  
-  for (Int_t i=0; i<tracks->GetEntriesFast(); ++i) 
-  {
+
+  for (Int_t i=0; i<tracks->GetEntriesFast(); ++i) {
     AliBasicParticle* part = (AliBasicParticle*) tracks->At(i);
-    Double_t newAngle = part->Phi() + angle; 
+    Double_t newAngle = part->Phi() + angle;
     if (newAngle >= TMath::TwoPi())
       newAngle -= TMath::TwoPi();
-    
+
     part->SetPhi(newAngle);
   }
 }
@@ -1938,191 +1881,186 @@ TObjArray* AliAnalysisTaskPhiCorrelations::GetParticlesFromDetector(AliVEvent* i
   //6 = custom particles A; 7 = custom particles B
   TObjArray* obj = new TObjArray;
   obj->SetOwner(kTRUE);
-  
+
   if (idet == 0 || idet > 9)
     AliFatal("Value of idet causes problem with uniqueID to avoid double counting");
-  
-  if (idet == 1 || idet == 2)
-  {
+
+  if (idet == 1 || idet == 2) {
     AliVVZERO* vZero = inputEvent->GetVZEROData();
-    
+
     const Int_t vZeroStart = (idet == 1) ? 32 : 0;
-    
+
     TH1F* singleCells = (TH1F*) fListOfHistos->FindObject("V0SingleCells");
-    for (Int_t i=vZeroStart; i<vZeroStart+32; i++)
-      {
-	Float_t weight = vZero->GetMultiplicity(i);
-	singleCells->Fill(weight);
-	
-	// rough estimate of multiplicity
-	for (Int_t j=0; j<TMath::Nint(weight); j++)
-	  {
-	    AliBasicParticle* particle = new AliBasicParticle((AliVVZERO::GetVZEROEtaMax(i) + AliVVZERO::GetVZEROEtaMin(i)) / 2, AliVVZERO::GetVZEROAvgPhi(i), 1.1, 0); // fix pT = 1.1 and charge = 0
-	    particle->SetUniqueID((fAnalyseUE->GetEventCounter() * 50000 + j + i * 1000) * 10 + idet);
-	    particle->SetEventIndex(GetUniqueEventID(inputEvent));
-	    
-	    obj->Add(particle);
-	  }
-      }    
-  }
-  else if (idet == 3)
-    {
-      if(!fAOD)
-	AliFatal("Tracklets only available on AOD");
-      AliAODTracklets* trklets=(AliAODTracklets*)fAOD->GetTracklets();
-      if(!trklets)
-	AliFatal("AliAODTracklets not found");
-      for(Int_t itrklets=0;itrklets<trklets->GetNumberOfTracklets();itrklets++)
-	{
-	  Float_t eta=-TMath::Log(TMath::Tan(trklets->GetTheta(itrklets)/2));
-	  if(TMath::Abs(eta)>fTrackEtaCut)continue;
-	  Float_t pT=1000*TMath::Abs(trklets->GetDeltaPhi(itrklets));//in mrad
-	  if(pT>fTrackletDphiCut)continue;
-	  TH1F* DphiTrklets = (TH1F*)fListOfHistos->FindObject("DphiTrklets");
-	  DphiTrklets->Fill(1000*trklets->GetDeltaPhi(itrklets)); //in mrad
-	  Float_t phi=trklets->GetPhi(itrklets);
-	  phi+=trklets->GetDeltaPhi(itrklets)*39./34.; //correction dphi*39./34. (Dphi in rad)
-	  if (phi<0) phi+=TMath::TwoPi();
-	  if (phi>TMath::TwoPi()) phi-=TMath::TwoPi();
-	  
-	  AliBasicParticle* particle = new AliBasicParticle(eta,phi, pT, 0); // pT = TMath::Abs(trklets->GetDeltaPhi(itrklets)) in mrad and charge = 0
-	  particle->SetUniqueID((fAnalyseUE->GetEventCounter() * 50000 + itrklets) * 10 + idet);
-	  particle->SetEventIndex(GetUniqueEventID(inputEvent));
-	  
-	  obj->Add(particle);
-       	}      
-    }
-  else if (idet == 4)
-    {
-      if(!fAOD)
-	AliFatal("Muon selection only implemented on AOD");//FIXME to be implemented also for ESDs as in AliAnalyseLeadingTrackUE::GetAcceptedPArticles
-      for (Int_t iTrack = 0; iTrack < fAOD->GetNumberOfTracks(); iTrack++) {
-	AliAODTrack* track = dynamic_cast<AliAODTrack*>(fAOD->GetTrack(iTrack));
-	if(!track) AliFatal("Not a standard AOD");
-	if (!track->IsMuonTrack()) continue;
-	//Float_t dca    = track->DCA();
-	//Float_t chi2   = track->Chi2perNDF();
-	Float_t rabs   = track->GetRAtAbsorberEnd();
-	Float_t eta    = track->Eta();
-	Int_t   matching   = track->GetMatchTrigger();
-	if (rabs < 17.6 || rabs > 89.5) continue;
-	if (eta < -4 || eta > -2.5) continue;
-	if (matching < 2) continue;
-	
-	AliBasicParticle* particle = new AliBasicParticle(eta,track->Phi(), track->Pt(), track->Charge()); 
-	particle->SetUniqueID((fAnalyseUE->GetEventCounter() * 50000 + iTrack) * 10 + idet);
-	particle->SetEventIndex(GetUniqueEventID(inputEvent));
-	
-	obj->Add(particle);
-      }
-    }      
-  else if (idet == 5)
-    {
-      if(!fAOD)
-        AliFatal("Cannot access jets without AOD");
+    for (Int_t i=vZeroStart; i<vZeroStart+32; i++) {
+      Float_t weight = vZero->GetMultiplicity(i);
+      singleCells->Fill(weight);
 
-      // retrieve jet array
-      TClonesArray *jetArray = 0x0;
-      if (fJetBranchName.Length() > 0) {
-        jetArray = dynamic_cast<TClonesArray*> (fAOD->FindListObject(fJetBranchName));
-        if (!jetArray) {
-          fAOD->Print();
-          AliFatal(Form("Cannot access jet branch <%s>", fJetBranchName.Data()));
-        }
-      }
-
-      const Int_t nJets = jetArray ? jetArray->GetEntries() : 0;
-      const Int_t nTracks = fAOD->GetNumberOfTracks();
-
-      for (Int_t iTrack = 0; iTrack < nTracks; ++iTrack) {
-        AliAODTrack *track = dynamic_cast<AliAODTrack*> (fAOD->GetTrack(iTrack));
-
-        if (!track)
-          AliFatal("Not a standard AOD");
-
-        // track cuts
-        if (!track->IsHybridGlobalConstrainedGlobal() ||
-            (TMath::Abs(track->Eta()) > fTrackEtaMax))
-          continue;
-
-        // check if track is part of a jet
-        Bool_t rejectTrack = kFALSE;
-        for (Int_t iJet = 0; iJet < nJets; ++iJet) {
-          AliEmcalJet *jet = dynamic_cast<AliEmcalJet*> (jetArray->At(iJet));
-
-          // skip jets outside of acceptance and too low pt
-          if ((TMath::Abs(jet->Eta()) > fJetEtaMax) ||
-              (jet->Pt() < fJetPtMin) ||
-              (jet->GetNumberOfConstituents() < fJetConstMin))
-            continue;
-
-          Float_t dEta = track->Eta() - jet->Eta();
-          Float_t dPhi = TVector2::Phi_mpi_pi(track->Phi() - jet->Phi());
-          Bool_t trackInCone = (TMath::Power(dPhi, 2.) + TMath::Power(dEta, 2.)) < TMath::Power(fExclusionRadius, 2.);
-          Bool_t trackInJet  = jet->ContainsTrack(track, fAOD->GetTracks()) >= 0;
-
-          if (trackInJet != trackInCone)
-            AliDebug(2, Form("track %15s - %15s",
-                             trackInJet ? "in jet" : "not in jet",
-                             trackInCone ? "in cone" : "not in cone"));
-
-          // exclude track if in cone around jet or assigned to jet
-          rejectTrack = fExclusionRadius > 0. ? trackInCone : trackInJet;
-
-          if (rejectTrack)
-            break;
-        }
-
-        // skip track if it is associated to a selected jet
-        // (either by jet finder or by cone radius)
-        if (rejectTrack)
-          continue;
-
-        // add particle to array
-        AliBasicParticle* particle =
-          new AliBasicParticle(track->Eta(), track->Phi(), track->Pt(), track->Charge());
-        // NOTE "+ idet" is missing here on purpose as the tracks are the same as in the case of idet == 0
-        particle->SetUniqueID((fAnalyseUE->GetEventCounter() * 50000 + iTrack) * 10);
+      // rough estimate of multiplicity
+      for (Int_t j=0; j<TMath::Nint(weight); j++) {
+        AliBasicParticle* particle = new AliBasicParticle((AliVVZERO::GetVZEROEtaMax(i) + AliVVZERO::GetVZEROEtaMin(i)) / 2, AliVVZERO::GetVZEROAvgPhi(i), 1.1, 0); // fix pT = 1.1 and charge = 0
+        particle->SetUniqueID((fAnalyseUE->GetEventCounter() * 50000 + j + i * 1000) * 10 + idet);
         particle->SetEventIndex(GetUniqueEventID(inputEvent));
+
         obj->Add(particle);
       }
     }
-  else if ( (idet == 6) || (idet == 7) ) // custom particle arrays
-  {
+  }
+  else if (idet == 3) {
+    if (!fAOD)
+      AliFatal("Tracklets only available on AOD");
+    AliAODTracklets* trklets=(AliAODTracklets*)fAOD->GetTracklets();
+    if (!trklets)
+      AliFatal("AliAODTracklets not found");
+    for (Int_t itrklets=0;itrklets<trklets->GetNumberOfTracklets();itrklets++) {
+      Float_t eta=-TMath::Log(TMath::Tan(trklets->GetTheta(itrklets)/2));
+      if (TMath::Abs(eta)>fTrackEtaCut)
+        continue;
+      Float_t pT=1000*TMath::Abs(trklets->GetDeltaPhi(itrklets));//in mrad
+      if (pT>fTrackletDphiCut)
+        continue;
+      TH1F* DphiTrklets = (TH1F*)fListOfHistos->FindObject("DphiTrklets");
+      DphiTrklets->Fill(1000*trklets->GetDeltaPhi(itrklets)); //in mrad
+      Float_t phi=trklets->GetPhi(itrklets);
+      phi+=trklets->GetDeltaPhi(itrklets)*39./34.; //correction dphi*39./34. (Dphi in rad)
+      if (phi<0)
+        phi+=TMath::TwoPi();
+      if (phi>TMath::TwoPi())
+        phi-=TMath::TwoPi();
+
+      AliBasicParticle* particle = new AliBasicParticle(eta,phi, pT, 0); // pT = TMath::Abs(trklets->GetDeltaPhi(itrklets)) in mrad and charge = 0
+      particle->SetUniqueID((fAnalyseUE->GetEventCounter() * 50000 + itrklets) * 10 + idet);
+      particle->SetEventIndex(GetUniqueEventID(inputEvent));
+
+      obj->Add(particle);
+    }
+  }
+  else if (idet == 4) {
+    if (!fAOD)
+      AliFatal("Muon selection only implemented on AOD");//FIXME to be implemented also for ESDs as in AliAnalyseLeadingTrackUE::GetAcceptedPArticles
+    for (Int_t iTrack = 0; iTrack < fAOD->GetNumberOfTracks(); iTrack++) {
+      AliAODTrack* track = dynamic_cast<AliAODTrack*>(fAOD->GetTrack(iTrack));
+      if (!track)
+        AliFatal("Not a standard AOD");
+      if (!track->IsMuonTrack())
+        continue;
+      //Float_t dca    = track->DCA();
+      //Float_t chi2   = track->Chi2perNDF();
+      Float_t rabs   = track->GetRAtAbsorberEnd();
+      Float_t eta    = track->Eta();
+      Int_t   matching   = track->GetMatchTrigger();
+      if (rabs < 17.6 || rabs > 89.5)
+        continue;
+      if (eta < -4 || eta > -2.5)
+        continue;
+      if (matching < 2)
+        continue;
+
+      AliBasicParticle* particle = new AliBasicParticle(eta,track->Phi(), track->Pt(), track->Charge()); 
+      particle->SetUniqueID((fAnalyseUE->GetEventCounter() * 50000 + iTrack) * 10 + idet);
+      particle->SetEventIndex(GetUniqueEventID(inputEvent));
+
+      obj->Add(particle);
+    }
+  }
+  else if (idet == 5) {
+    if (!fAOD)
+      AliFatal("Cannot access jets without AOD");
+
+    // retrieve jet array
+    TClonesArray *jetArray = 0x0;
+    if (fJetBranchName.Length() > 0) {
+      jetArray = dynamic_cast<TClonesArray*> (fAOD->FindListObject(fJetBranchName));
+      if (!jetArray) {
+        fAOD->Print();
+        AliFatal(Form("Cannot access jet branch <%s>", fJetBranchName.Data()));
+      }
+    }
+
+    const Int_t nJets = jetArray ? jetArray->GetEntries() : 0;
+    const Int_t nTracks = fAOD->GetNumberOfTracks();
+
+    for (Int_t iTrack = 0; iTrack < nTracks; ++iTrack) {
+      AliAODTrack *track = dynamic_cast<AliAODTrack*> (fAOD->GetTrack(iTrack));
+
+      if (!track)
+        AliFatal("Not a standard AOD");
+
+      // track cuts
+      if (!track->IsHybridGlobalConstrainedGlobal() ||
+          (TMath::Abs(track->Eta()) > fTrackEtaMax))
+        continue;
+
+      // check if track is part of a jet
+      Bool_t rejectTrack = kFALSE;
+      for (Int_t iJet = 0; iJet < nJets; ++iJet) {
+        AliEmcalJet *jet = dynamic_cast<AliEmcalJet*> (jetArray->At(iJet));
+
+        // skip jets outside of acceptance and too low pt
+        if ((TMath::Abs(jet->Eta()) > fJetEtaMax) ||
+            (jet->Pt() < fJetPtMin) ||
+            (jet->GetNumberOfConstituents() < fJetConstMin))
+          continue;
+
+        Float_t dEta = track->Eta() - jet->Eta();
+        Float_t dPhi = TVector2::Phi_mpi_pi(track->Phi() - jet->Phi());
+        Bool_t trackInCone = (TMath::Power(dPhi, 2.) + TMath::Power(dEta, 2.)) < TMath::Power(fExclusionRadius, 2.);
+        Bool_t trackInJet  = jet->ContainsTrack(track, fAOD->GetTracks()) >= 0;
+
+        if (trackInJet != trackInCone)
+          AliDebug(2, Form("track %15s - %15s",
+                           trackInJet ? "in jet" : "not in jet",
+                           trackInCone ? "in cone" : "not in cone"));
+
+        // exclude track if in cone around jet or assigned to jet
+        rejectTrack = fExclusionRadius > 0. ? trackInCone : trackInJet;
+
+        if (rejectTrack)
+          break;
+      }
+
+      // skip track if it is associated to a selected jet
+      // (either by jet finder or by cone radius)
+      if (rejectTrack)
+        continue;
+
+      // add particle to array
+      AliBasicParticle* particle =
+        new AliBasicParticle(track->Eta(), track->Phi(), track->Pt(), track->Charge());
+      // NOTE "+ idet" is missing here on purpose as the tracks are the same as in the case of idet == 0
+      particle->SetUniqueID((fAnalyseUE->GetEventCounter() * 50000 + iTrack) * 10);
+      particle->SetEventIndex(GetUniqueEventID(inputEvent));
+      obj->Add(particle);
+    }
+  }
+  else if ( (idet == 6) || (idet == 7) ) { // custom particle arrays
     TClonesArray* clonesArray = 0;
-    if(idet == 6)
-    {
+    if (idet == 6) {
       if (fCustomParticlesA=="")
         AliFatal("Custom particle array A demanded. Use SetCustomParticlesA() to give particle array's name");
 
       // Get custom particle array
       clonesArray = dynamic_cast<TClonesArray*> (inputEvent->FindListObject(fCustomParticlesA.Data()));
-      if (!clonesArray)
-      {
+      if (!clonesArray) {
         inputEvent->Print();
         AliFatal(Form("Cannot find custom particle array A <%s>", fCustomParticlesA.Data()));
       }
     }
-    else if(idet == 7)
-    {
+    else if (idet == 7) {
       if (fCustomParticlesB=="")
         AliFatal("Custom particle array B demanded. Use SetCustomParticlesB() to give particle array's name");
 
       // Get custom particle array
       clonesArray = dynamic_cast<TClonesArray*> (inputEvent->FindListObject(fCustomParticlesB.Data()));
-      if (!clonesArray)
-      {
+      if (!clonesArray) {
         inputEvent->Print();
         AliFatal(Form("Cannot find custom particle array B <%s>", fCustomParticlesB.Data()));
       }
     }
 
-    for (Int_t iParticle = 0; iParticle < clonesArray->GetEntries(); iParticle++)
-    {
+    for (Int_t iParticle = 0; iParticle < clonesArray->GetEntries(); iParticle++) {
       AliVParticle* customParticle = dynamic_cast<AliVParticle*> (clonesArray->At(iParticle));
 
-      if(!customParticle)
-      {
+      if (!customParticle) {
         AliError(Form("Custom particle in array %s cannot be casted to AliVParticle", ( (idet==6) ? "A" : "B" ) ));
         continue;
       }
@@ -2131,7 +2069,7 @@ TObjArray* AliAnalysisTaskPhiCorrelations::GetParticlesFromDetector(AliVEvent* i
       AliBasicParticle* particle = new AliBasicParticle(customParticle->Eta(), customParticle->Phi(), customParticle->Pt(), customParticle->Charge());
 
       // Set custom ID. Should be the same if custom particle A and B are the same
-      if(fCustomParticlesA == fCustomParticlesB)
+      if (fCustomParticlesA == fCustomParticlesB)
         particle->SetUniqueID((fAnalyseUE->GetEventCounter() * 50000 + iParticle) * 10 + 6);
       else
         particle->SetUniqueID((fAnalyseUE->GetEventCounter() * 50000 + iParticle) * 10 + idet);
@@ -2148,33 +2086,39 @@ TObjArray* AliAnalysisTaskPhiCorrelations::GetParticlesFromDetector(AliVEvent* i
 }
 
 //____________________________________________________________________
-Bool_t AliAnalysisTaskPhiCorrelations::IsMuEvent(){
-  
-  if(!fAOD)
+Bool_t AliAnalysisTaskPhiCorrelations::IsMuEvent()
+{
+  if (!fAOD)
     AliFatal("Muon selection only implemented on AOD");//FIXME to be implemented also for ESDs as in AliAnalyseLeadingTrackUE::GetAcceptedPArticles
   for (Int_t iTrack = 0; iTrack < fAOD->GetNumberOfTracks(); iTrack++) {
     AliAODTrack* track = dynamic_cast<AliAODTrack*>(fAOD->GetTrack(iTrack));
-    if(!track) AliFatal("Not a standard AOD");
-    if (!track->IsMuonTrack()) continue;
+    if (!track)
+      AliFatal("Not a standard AOD");
+    if (!track->IsMuonTrack())
+      continue;
     //Float_t dca    = track->DCA();
     //Float_t chi2   = track->Chi2perNDF();
     Float_t rabs   = track->GetRAtAbsorberEnd();
     Float_t eta    = track->Eta();
     Int_t   matching   = track->GetMatchTrigger();
-    if (rabs < 17.6 || rabs > 89.5) continue;
-    if (eta < -4 || eta > -2.5) continue;
-    if (matching < 2) continue;
+    if (rabs < 17.6 || rabs > 89.5)
+      continue;
+    if (eta < -4 || eta > -2.5)
+      continue;
+    if (matching < 2)
+      continue;
     return kTRUE;
   }
   return kFALSE;
-  
+
 }
 
 //____________________________________________________________________
-Bool_t AliAnalysisTaskPhiCorrelations::InitiateEventPlane(Double_t& evtPlanePhi, AliVEvent* inputEvent){
+Bool_t AliAnalysisTaskPhiCorrelations::InitiateEventPlane(Double_t& evtPlanePhi, AliVEvent* inputEvent)
+{
   AliEventplane* evtPlane = inputEvent->GetEventplane();
   Double_t qx = 0; Double_t qy = 0;
-  if(evtPlane) {
+  if (evtPlane) {
     evtPlanePhi = evtPlane->CalculateVZEROEventPlane(inputEvent, 10, 2, qx, qy);
     return 1;
   }
@@ -2187,7 +2131,7 @@ Long64_t AliAnalysisTaskPhiCorrelations::GetUniqueEventID(AliVEvent* inputEvent)
 {
   // Get event ID from header
   AliVHeader* eventIDHeader = inputEvent->GetHeader();
-  if(eventIDHeader)
+  if (eventIDHeader)
     return eventIDHeader->GetEventIdAsLong();
   else
     return 0;

--- a/PWGCF/Correlations/DPhi/AliAnalysisTaskPhiCorrelations.h
+++ b/PWGCF/Correlations/DPhi/AliAnalysisTaskPhiCorrelations.h
@@ -57,31 +57,31 @@ class  AliAnalysisTaskPhiCorrelations : public AliAnalysisTask
 {
 public:
   AliAnalysisTaskPhiCorrelations(const char* name="AliAnalysisTaskPhiCorrelations");
-  virtual           ~AliAnalysisTaskPhiCorrelations();
+  virtual ~AliAnalysisTaskPhiCorrelations();
 
 
   // Implementation of interace methods
-  virtual     void   ConnectInputData(Option_t *);
-  virtual     void   CreateOutputObjects();
-  virtual     void   Exec(Option_t *option);
-  virtual     void   FinishTaskOutput();
+  virtual void ConnectInputData(Option_t *);
+  virtual void CreateOutputObjects();
+  virtual void Exec(Option_t *option);
+  virtual void FinishTaskOutput();
 
   // Setters/Getters
   // general configuration
-  virtual     void    SetDebugLevel( Int_t level )  { fDebug = level; }
-  virtual     void    SetMode(Int_t mode)           { fMode  = mode;  }
-  virtual     void    SetReduceMemoryFootprint(Bool_t flag) { fReduceMemoryFootprint = flag; }
-  virtual	void	SetEventMixing(Bool_t flag) { fFillMixed = flag; }
-  virtual	void    SetMixingTracks(Int_t tracks) { fMixingTracks = tracks; }
-  virtual	void	SetTwoTrackEfficiencyStudy(Bool_t flag) { fTwoTrackEfficiencyStudy = flag; }
-  virtual	void	SetTwoTrackEfficiencyCut(Float_t value = 0.02, Float_t min = 0.8) { fTwoTrackEfficiencyCut = value; fTwoTrackCutMinRadius = min; }
-  virtual	void	SetUseVtxAxis(Int_t flag) { fUseVtxAxis = flag; }
-  virtual	void	SetCourseCentralityBinning(Bool_t flag) { fCourseCentralityBinning = flag; }
-  virtual     void    SetSkipTrigger(Bool_t flag) { fSkipTrigger = flag; }
-  virtual     void    SetInjectedSignals(Bool_t flag) { fInjectedSignals = flag; }
-  virtual     void    SetV0CL1PileUp(Bool_t flag) { fV0CL1PileUp = flag; }
-  virtual     void    SetESDTPCTrackPileUp(Bool_t flag) { fESDTPCTrackPileUp = flag; }
-  virtual     void    SetTPCITSTOFPileUp(Bool_t flag) { fTPCITSTOFPileUp = flag; }
+  virtual void SetDebugLevel(Int_t level) { fDebug = level; }
+  virtual void SetMode(Int_t mode) { fMode  = mode;  }
+  virtual void SetReduceMemoryFootprint(Bool_t flag) { fReduceMemoryFootprint = flag; }
+  virtual void SetEventMixing(Bool_t flag) { fFillMixed = flag; }
+  virtual void SetMixingTracks(Int_t tracks) { fMixingTracks = tracks; }
+  virtual void SetTwoTrackEfficiencyStudy(Bool_t flag) { fTwoTrackEfficiencyStudy = flag; }
+  virtual void SetTwoTrackEfficiencyCut(Float_t value = 0.02, Float_t min = 0.8) { fTwoTrackEfficiencyCut = value; fTwoTrackCutMinRadius = min; }
+  virtual void SetUseVtxAxis(Int_t flag) { fUseVtxAxis = flag; }
+  virtual void SetCourseCentralityBinning(Bool_t flag) { fCourseCentralityBinning = flag; }
+  virtual void SetSkipTrigger(Bool_t flag) { fSkipTrigger = flag; }
+  virtual void SetInjectedSignals(Bool_t flag) { fInjectedSignals = flag; }
+  virtual void SetV0CL1PileUp(Bool_t flag) { fV0CL1PileUp = flag; }
+  virtual void SetESDTPCTrackPileUp(Bool_t flag) { fESDTPCTrackPileUp = flag; }
+  virtual void SetTPCITSTOFPileUp(Bool_t flag) { fTPCITSTOFPileUp = flag; }
   void SetRandomizeReactionPlane(Bool_t flag) { fRandomizeReactionPlane = flag; }
 
   // histogram settings
@@ -91,75 +91,75 @@ public:
   void SetCentralityMCGen_V0M(TH1* hist) { fCentralityMCGen_V0M = hist; }
   void SetCentralityMCGen_CL1(TH1* hist) { fCentralityMCGen_CL1 = hist; }
   // for event QA
-  void   SetTracksInVertex( Int_t val ){ fnTracksVertex = val; }
-  void   SetZVertex( Double_t val )    { fZVertex = val; }
-  void   SetAcceptOnlyMuEvents( Bool_t val )    { fAcceptOnlyMuEvents = val; }
+  void SetTracksInVertex(Int_t val) { fnTracksVertex = val; }
+  void SetZVertex(Double_t val) { fZVertex = val; }
+  void SetAcceptOnlyMuEvents(Bool_t val) { fAcceptOnlyMuEvents = val; }
 
   // track cuts
-  void   SetTrackEtaCut( Double_t val )    { fTrackEtaCut = val; }
-  void   SetTrackEtaCutMin( Double_t val )    { fTrackEtaCutMin = val; }
-  void   SetOnlyOneEtaSide(Int_t flag)     { fOnlyOneEtaSide = flag; }
-  void   SetOnlyOneAssocEtaSide(Int_t flag)     { fOnlyOneAssocEtaSide = flag; }
-  void   SetTrackPhiCutEvPlMin(Double_t val)  { fTrackPhiCutEvPlMin = val; }
-  void   SetTrackPhiCutEvPlMax(Double_t val)  { fTrackPhiCutEvPlMax = val; }
-  void   SetPtMin(Double_t val)            { fPtMin = val; }
-  void   SetFilterBit( UInt_t val )        { fFilterBit = val;  }
-  void   SetDCAXYCut(TFormula* value)      { fDCAXYCut = value; }
-  void   SetSharedClusterCut(Float_t value) { fSharedClusterCut = value; }
-  void   SetCrossedRowsCut(Int_t value)    { fCrossedRowsCut = value; }
-  void   SetFoundFractionCut(Double_t value) { fFoundFractionCut = value; }
-  void   SetTrackStatus(UInt_t status)     { fTrackStatus = status; }
-  void   SetCheckMotherPDG(Bool_t checkpdg) { fCheckMotherPDG = checkpdg; }
+  void SetTrackEtaCut(Double_t val) { fTrackEtaCut = val; }
+  void SetTrackEtaCutMin(Double_t val) { fTrackEtaCutMin = val; }
+  void SetOnlyOneEtaSide(Int_t flag) { fOnlyOneEtaSide = flag; }
+  void SetOnlyOneAssocEtaSide(Int_t flag) { fOnlyOneAssocEtaSide = flag; }
+  void SetTrackPhiCutEvPlMin(Double_t val) { fTrackPhiCutEvPlMin = val; }
+  void SetTrackPhiCutEvPlMax(Double_t val) { fTrackPhiCutEvPlMax = val; }
+  void SetPtMin(Double_t val) { fPtMin = val; }
+  void SetFilterBit(UInt_t val) { fFilterBit = val;  }
+  void SetDCAXYCut(TFormula* value) { fDCAXYCut = value; }
+  void SetSharedClusterCut(Float_t value) { fSharedClusterCut = value; }
+  void SetCrossedRowsCut(Int_t value) { fCrossedRowsCut = value; }
+  void SetFoundFractionCut(Double_t value) { fFoundFractionCut = value; }
+  void SetTrackStatus(UInt_t status) { fTrackStatus = status; }
+  void SetCheckMotherPDG(Bool_t checkpdg) { fCheckMotherPDG = checkpdg; }
 
   // track cuts
-  void   SetTrackletDphiCut( Double_t val )    { fTrackletDphiCut = val; }
+  void SetTrackletDphiCut(Double_t val) { fTrackletDphiCut = val; }
 
-  void   SetEventSelectionBit( UInt_t val )        { fSelectBit = val;  }
-  void   SetUseChargeHadrons( Bool_t val ) { fUseChargeHadrons = val; }
-  void   SetSelectParticleSpecies( Int_t trigger, Int_t associated ) { fParticleSpeciesTrigger = trigger; fParticleSpeciesAssociated = associated; }
-  void   SetSelectCharge(Int_t selectCharge) { fSelectCharge = selectCharge; }
-  void   SetSelectTriggerCharge(Int_t selectCharge) { fTriggerSelectCharge = selectCharge; }
-  void   SetSelectAssociatedCharge(Int_t selectCharge) { fAssociatedSelectCharge = selectCharge; }
-  void   SetTriggerRestrictEta(Float_t eta) { fTriggerRestrictEta = eta; }
-  void   SetEtaOrdering(Bool_t flag) { fEtaOrdering = flag; }
-  void   SetPairCuts(Float_t conversions = 0.004, Float_t resonances = 0.005) { fCutConversionsV = conversions; fCutResonancesV = resonances; fCutOnLambdaV = resonances; fCutOnK0sV = resonances; }
-  void   SetCustomCut(Float_t cutOnCustomMass, Float_t cutOnCustomFirst, Float_t cutOnCustomSecond, Float_t cutOnCustomV) { fCutOnCustomMass = cutOnCustomMass; fCutOnCustomFirst = cutOnCustomFirst; fCutOnCustomSecond = cutOnCustomSecond; fCutOnCustomV = cutOnCustomV; }
-  void   SetCutOnPhi(bool cutOnPhi) { fCutOnPhi = cutOnPhi; }
-  void   SetCutOnPhi(Float_t cutOnPhi) { fCutOnPhiV = cutOnPhi; }
-  void   SetCutOnRho(bool cutOnRho) { fCutOnRho = cutOnRho; }
-  void   SetCutOnRho(Float_t cutOnRho) { fCutOnRhoV = cutOnRho; }
-  void   SetCutOnLambda(Float_t cutOnLambda) { fCutOnLambdaV = cutOnLambda; }
-  void   SetCutOnK0s(Float_t cutOnK0s) { fCutOnK0sV = cutOnK0s; }
-  void   SetRejectResonanceDaughters(Int_t value) { fRejectResonanceDaughters = value; }
-  void   SetCentralityMethod(const char* method) { fCentralityMethod = method; }
-  void   SetFillpT(Bool_t flag) { fFillpT = flag; }
-  void   SetStepsFillSkip(Bool_t step0, Bool_t step6) { fFillOnlyStep0 = step0; fSkipStep6 = step6; }
-  void   SetRejectCentralityOutliers(Bool_t flag = kTRUE) { fRejectCentralityOutliers = flag; }
-  void   SetRejectZeroTrackEvents(Bool_t flag)    { fRejectZeroTrackEvents = flag; }
-  void   SetRemoveWeakDecays(Bool_t flag = kTRUE) { fRemoveWeakDecays = flag; }
-  void   SetRemoveDuplicates(Bool_t flag = kTRUE) { fRemoveDuplicates = flag; }
-  void   SetSkipFastCluster(Bool_t flag = kTRUE)  { fSkipFastCluster = flag; }
-  void   SetWeightPerEvent(Bool_t flag = kTRUE)   { fWeightPerEvent = flag; }
-  void   SetCustomBinning(const char* binningStr) { fCustomBinning = binningStr; }
-  void   SetPtOrder(Bool_t flag) { fPtOrder = flag; }
-  void   SetTriggersFromDetector(Int_t flag) { fTriggersFromDetector = flag; }
-  void   SetAssociatedFromDetector(Int_t flag) { fAssociatedFromDetector = flag; }
-  void   SetUseUncheckedCentrality(Bool_t flag) { fUseUncheckedCentrality = flag; }
-  void   SetCheckCertainSpecies(Int_t species) { fCheckCertainSpecies = species; }
-  void   SetRemoveWeakDecaysInMC(Bool_t flag) { fRemoveWeakDecaysInMC = flag; }
-  void   SetFillYieldRapidity(Bool_t flag) { fFillYieldRapidity = flag; }
-  void   SetFillCorrelationsRapidity(Bool_t flag) { fFillCorrelationsRapidity = flag; }
-  void   SetUseDoublePrecision(Bool_t flag) { fUseDoublePrecision = flag; }
-  void   SetUseNewCentralityFramework(Bool_t flag) { fUseNewCentralityFramework = flag; }
+  void SetEventSelectionBit(UInt_t val) { fSelectBit = val;  }
+  void SetUseChargeHadrons(Bool_t val) { fUseChargeHadrons = val; }
+  void SetSelectParticleSpecies(Int_t trigger, Int_t associated) { fParticleSpeciesTrigger = trigger; fParticleSpeciesAssociated = associated; }
+  void SetSelectCharge(Int_t selectCharge) { fSelectCharge = selectCharge; }
+  void SetSelectTriggerCharge(Int_t selectCharge) { fTriggerSelectCharge = selectCharge; }
+  void SetSelectAssociatedCharge(Int_t selectCharge) { fAssociatedSelectCharge = selectCharge; }
+  void SetTriggerRestrictEta(Float_t eta) { fTriggerRestrictEta = eta; }
+  void SetEtaOrdering(Bool_t flag) { fEtaOrdering = flag; }
+  void SetPairCuts(Float_t conversions = 0.004, Float_t resonances = 0.005) { fCutConversionsV = conversions; fCutResonancesV = resonances; fCutOnLambdaV = resonances; fCutOnK0sV = resonances; }
+  void SetCustomCut(Float_t cutOnCustomMass, Float_t cutOnCustomFirst, Float_t cutOnCustomSecond, Float_t cutOnCustomV) { fCutOnCustomMass = cutOnCustomMass; fCutOnCustomFirst = cutOnCustomFirst; fCutOnCustomSecond = cutOnCustomSecond; fCutOnCustomV = cutOnCustomV; }
+  void SetCutOnPhi(bool cutOnPhi) { fCutOnPhi = cutOnPhi; }
+  void SetCutOnPhi(Float_t cutOnPhi) { fCutOnPhiV = cutOnPhi; }
+  void SetCutOnRho(bool cutOnRho) { fCutOnRho = cutOnRho; }
+  void SetCutOnRho(Float_t cutOnRho) { fCutOnRhoV = cutOnRho; }
+  void SetCutOnLambda(Float_t cutOnLambda) { fCutOnLambdaV = cutOnLambda; }
+  void SetCutOnK0s(Float_t cutOnK0s) { fCutOnK0sV = cutOnK0s; }
+  void SetRejectResonanceDaughters(Int_t value) { fRejectResonanceDaughters = value; }
+  void SetCentralityMethod(const char* method) { fCentralityMethod = method; }
+  void SetFillpT(Bool_t flag) { fFillpT = flag; }
+  void SetStepsFillSkip(Bool_t step0, Bool_t step6) { fFillOnlyStep0 = step0; fSkipStep6 = step6; }
+  void SetRejectCentralityOutliers(Bool_t flag = kTRUE) { fRejectCentralityOutliers = flag; }
+  void SetRejectZeroTrackEvents(Bool_t flag) { fRejectZeroTrackEvents = flag; }
+  void SetRemoveWeakDecays(Bool_t flag = kTRUE) { fRemoveWeakDecays = flag; }
+  void SetRemoveDuplicates(Bool_t flag = kTRUE) { fRemoveDuplicates = flag; }
+  void SetSkipFastCluster(Bool_t flag = kTRUE) { fSkipFastCluster = flag; }
+  void SetWeightPerEvent(Bool_t flag = kTRUE) { fWeightPerEvent = flag; }
+  void SetCustomBinning(const char* binningStr) { fCustomBinning = binningStr; }
+  void SetPtOrder(Bool_t flag) { fPtOrder = flag; }
+  void SetTriggersFromDetector(Int_t flag) { fTriggersFromDetector = flag; }
+  void SetAssociatedFromDetector(Int_t flag) { fAssociatedFromDetector = flag; }
+  void SetUseUncheckedCentrality(Bool_t flag) { fUseUncheckedCentrality = flag; }
+  void SetCheckCertainSpecies(Int_t species) { fCheckCertainSpecies = species; }
+  void SetRemoveWeakDecaysInMC(Bool_t flag) { fRemoveWeakDecaysInMC = flag; }
+  void SetFillYieldRapidity(Bool_t flag) { fFillYieldRapidity = flag; }
+  void SetFillCorrelationsRapidity(Bool_t flag) { fFillCorrelationsRapidity = flag; }
+  void SetUseDoublePrecision(Bool_t flag) { fUseDoublePrecision = flag; }
+  void SetUseNewCentralityFramework(Bool_t flag) { fUseNewCentralityFramework = flag; }
 
   AliHelperPID* GetHelperPID() { return fHelperPID; }
-  void   SetHelperPID(AliHelperPID* pid){ fHelperPID = pid; }
+  void SetHelperPID(AliHelperPID* pid) { fHelperPID = pid; }
 
   AliAnalysisUtils* GetAnalysisUtils() { return fAnalysisUtils; }
-  void   SetAnalysisUtils(AliAnalysisUtils* utils){ fAnalysisUtils = utils; }
+  void SetAnalysisUtils(AliAnalysisUtils* utils) { fAnalysisUtils = utils; }
 
   TMap* GetMap() { return fMap; }
-  void   SetMap(TMap* map){ fMap = map; }
+  void SetMap(TMap* map) { fMap = map; }
 
   // configuration for tracks with jets removed
   void SetJetBranchName(const char* branchName) { fJetBranchName = branchName; }
@@ -189,14 +189,14 @@ public:
   void AddEventPoolsToOutput(Double_t minCent, Double_t maxCent,  Double_t minZvtx, Double_t maxZvtx, Double_t minPt, Double_t maxPt);
 
 private:
-  AliAnalysisTaskPhiCorrelations(const  AliAnalysisTaskPhiCorrelations &det);
-  AliAnalysisTaskPhiCorrelations&   operator=(const  AliAnalysisTaskPhiCorrelations &det);
-  void            AddSettingsTree();                                  // add list of settings to output list
+  AliAnalysisTaskPhiCorrelations(const AliAnalysisTaskPhiCorrelations &det);
+  AliAnalysisTaskPhiCorrelations& operator=(const  AliAnalysisTaskPhiCorrelations &det);
+  void AddSettingsTree(); // add list of settings to output list
   // Analysis methods
-  void            AnalyseCorrectionMode();                            // main algorithm to get correction maps
-  void            AnalyseDataMode();                                  // main algorithm to get raw distributions
-  void            Initialize(); 			                // initialize some common pointer
-  Double_t        GetCentrality(AliVEvent* inputEvent, TObject* mc);
+  void AnalyseCorrectionMode(); // main algorithm to get correction maps
+  void AnalyseDataMode();       // main algorithm to get raw distributions
+  void Initialize();            // initialize some common pointer
+  Double_t GetCentrality(AliVEvent* inputEvent, TObject* mc);
   TObjArray* CloneAndReduceTrackList(TObjArray* tracks, Double_t minPt = 0., Double_t maxPt = -1.);
   void RemoveDuplicates(TObjArray* tracks);
   void CleanUp(TObjArray* tracks, TObject* mcObj, Int_t maxLabel);
@@ -211,38 +211,37 @@ private:
   Long64_t GetUniqueEventID(AliVEvent* inputEvent);
 
   // General configuration
-  Int_t               fDebug;           //  Debug flag
-  Int_t 	        fMode;            //  fMode = 0: data-like analysis
-  //  fMode = 1: corrections analysis
-  Bool_t              fReduceMemoryFootprint; // reduce memory consumption by writing less debug histograms
-  Bool_t		fFillMixed;		// enable event mixing (default: ON)
-  Int_t  		fMixingTracks;		// size of track buffer for event mixing
-  Bool_t		fTwoTrackEfficiencyStudy; // two-track efficiency study on
-  Float_t		fTwoTrackEfficiencyCut;   // enable two-track efficiency cut
-  Float_t		fTwoTrackCutMinRadius;    // minimum radius for two-track efficiency cut
-  Int_t		fUseVtxAxis;              // use z vtx as axis (needs 7-10 times more memory!)
-  Bool_t		fCourseCentralityBinning; // less centrality bins
-  Bool_t		fSkipTrigger;		  // skip trigger selection
-  Bool_t		fInjectedSignals;	  // check header to skip injected signals in MC
-  Bool_t		fRandomizeReactionPlane;  // change the orientation of the RP by a random value by shifting all tracks
-  Bool_t		fV0CL1PileUp;  // Remove pile up events according to V0 CL1 correlation
-  Bool_t		fESDTPCTrackPileUp;  // Remove pile up events according ESD tracks and number of TPC only tracks correlation
-  Bool_t		fTPCITSTOFPileUp;  // Remove pile up events according to TPC+ITS tracks (FilterBit 32) and number of tracks matched to TOF with BCid=0 correlation
+  Int_t fDebug; // Debug flag
+  Int_t fMode;  // fMode = 0: data-like analysis, fMode = 1: corrections analysis
+  Bool_t  fReduceMemoryFootprint;   // reduce memory consumption by writing less debug histograms
+  Bool_t  fFillMixed;               // enable event mixing (default: ON)
+  Int_t   fMixingTracks;            // size of track buffer for event mixing
+  Bool_t  fTwoTrackEfficiencyStudy; // two-track efficiency study on
+  Float_t fTwoTrackEfficiencyCut;   // enable two-track efficiency cut
+  Float_t fTwoTrackCutMinRadius;    // minimum radius for two-track efficiency cut
+  Int_t   fUseVtxAxis;              // use z vtx as axis (needs 7-10 times more memory!)
+  Bool_t  fCourseCentralityBinning; // less centrality bins
+  Bool_t  fSkipTrigger;             // skip trigger selection
+  Bool_t  fInjectedSignals;         // check header to skip injected signals in MC
+  Bool_t  fRandomizeReactionPlane;  // change the orientation of the RP by a random value by shifting all tracks
+  Bool_t  fV0CL1PileUp;             // Remove pile up events according to V0 CL1 correlation
+  Bool_t  fESDTPCTrackPileUp;       // Remove pile up events according ESD tracks and number of TPC only tracks correlation
+  Bool_t  fTPCITSTOFPileUp;         // Remove pile up events according to TPC+ITS tracks (FilterBit 32) and number of tracks matched to TOF with BCid=0 correlation
 
-  AliHelperPID*     fHelperPID;      // points to class for PID
-  AliAnalysisUtils*     fAnalysisUtils;      // points to class with common analysis utilities
-  TMap*     fMap;                   // points to TMap class containing scaling factors for VZERO A signal
+  AliHelperPID* fHelperPID;         // points to class for PID
+  AliAnalysisUtils* fAnalysisUtils; // points to class with common analysis utilities
+  TMap* fMap;                       // points to TMap class containing scaling factors for VZERO A signal
 
   // Pointers to external UE classes
-  AliAnalyseLeadingTrackUE*     fAnalyseUE;      //! points to class containing common analysis algorithms
-  AliUEHistograms*  fHistos;       //! points to class to handle histograms/containers
-  AliUEHistograms*  fHistosMixed;       //! points to class to handle mixed histograms/containers
+  AliAnalyseLeadingTrackUE* fAnalyseUE; //! points to class containing common analysis algorithms
+  AliUEHistograms* fHistos;             //! points to class to handle histograms/containers
+  AliUEHistograms* fHistosMixed;        //! points to class to handle mixed histograms/containers
 
-  THnF* fEfficiencyCorrectionTriggers;     // if non-0 this efficiency correction is applied on the fly to the filling for trigger particles. The factor is multiplicative, i.e. should contain 1/efficiency. Axes: eta, pT, centrality, z-vtx
-  THnF* fEfficiencyCorrectionAssociated;   // if non-0 this efficiency correction is applied on the fly to the filling for associated particles. The factor is multiplicative, i.e. should contain 1/efficiency. Axes: eta, pT, centrality, z-vtx
-  TH1* fCentralityWeights;		     // for centrality flattening
-  TH1* fCentralityMCGen_V0M;               // for centrality from generated MCGen_V0M
-  TH1* fCentralityMCGen_CL1;               // for centrality from generated MCGen_CL1
+  THnF* fEfficiencyCorrectionTriggers;   // if non-0 this efficiency correction is applied on the fly to the filling for trigger particles. The factor is multiplicative, i.e. should contain 1/efficiency. Axes: eta, pT, centrality, z-vtx
+  THnF* fEfficiencyCorrectionAssociated; // if non-0 this efficiency correction is applied on the fly to the filling for associated particles. The factor is multiplicative, i.e. should contain 1/efficiency. Axes: eta, pT, centrality, z-vtx
+  TH1* fCentralityWeights;               // for centrality flattening
+  TH1* fCentralityMCGen_V0M;             // for centrality from generated MCGen_V0M
+  TH1* fCentralityMCGen_CL1;             // for centrality from generated MCGen_CL1
 
   // Handlers and events
   AliAODEvent*             fAOD;             //! AOD Event
@@ -257,65 +256,65 @@ private:
   TList*              fListOfHistos;    //  Output list of containers
 
   // Event QA cuts
-  Int_t          	fnTracksVertex;          // QA tracks pointing to principal vertex
-  Double_t       	fZVertex;                 // Position of Vertex in Z direction
-  Bool_t       	fAcceptOnlyMuEvents;   // Only Events with at least one muon are accepted
-  TString             fCentralityMethod;      // Method to determine centrality
+  Int_t               fnTracksVertex;        // QA tracks pointing to principal vertex
+  Double_t            fZVertex;              // Position of Vertex in Z direction
+  Bool_t              fAcceptOnlyMuEvents;   // Only Events with at least one muon are accepted
+  TString             fCentralityMethod;     // Method to determine centrality
 
   // Track cuts
-  Double_t      	fTrackEtaCut;          // Maximum Eta cut on particles
-  Double_t      	fTrackEtaCutMin;          // Minimum Eta cut on particles
+  Double_t            fTrackEtaCut;          // Maximum Eta cut on particles
+  Double_t            fTrackEtaCutMin;       // Minimum Eta cut on particles
   Double_t            fTrackPhiCutEvPlMin;   // Minimum Phi cut on particles with respect to the Event Plane (values between 0 and Pi/2)
   Double_t            fTrackPhiCutEvPlMax;   // Maximum Phi cut on particles with respect to the Event Plane (values between 0 and Pi/2), if = 0, then no cut is performed
-  Int_t 		fOnlyOneEtaSide;       // decides that only trigger particle from one eta side are considered (0 = all; -1 = negative, 1 = positive)
-  Int_t 		fOnlyOneAssocEtaSide;       // decides that only associated particle from one eta side are considered (0 = all; -1 = negative, 1 = positive)
+  Int_t               fOnlyOneEtaSide;       // decides that only trigger particle from one eta side are considered (0 = all; -1 = negative, 1 = positive)
+  Int_t               fOnlyOneAssocEtaSide;  // decides that only associated particle from one eta side are considered (0 = all; -1 = negative, 1 = positive)
   Double_t            fPtMin;                // Min pT to start correlations
   TFormula*           fDCAXYCut;             // additional pt dependent cut on DCA XY (only for AOD)
-  Double_t            fSharedClusterCut;  // cut on shared clusters (only for AOD)
-  Int_t		fCrossedRowsCut;   // cut on crossed rows (only for AOD)
-  Double_t	 	fFoundFractionCut;     // cut on crossed rows/findable clusters (only for AOD)
-  UInt_t           	fFilterBit;            // Select tracks from an specific track cut
-  UInt_t         	fTrackStatus;          // if non-0, the bits set in this variable are required for each track
-  UInt_t         	fSelectBit;            // Select events according to AliAnalysisTaskJetServices bit maps
-  Bool_t         	fUseChargeHadrons;     // Only use charge hadrons
+  Double_t            fSharedClusterCut;     // cut on shared clusters (only for AOD)
+  Int_t               fCrossedRowsCut;       // cut on crossed rows (only for AOD)
+  Double_t            fFoundFractionCut;     // cut on crossed rows/findable clusters (only for AOD)
+  UInt_t              fFilterBit;            // Select tracks from an specific track cut
+  UInt_t              fTrackStatus;          // if non-0, the bits set in this variable are required for each track
+  UInt_t              fSelectBit;            // Select events according to AliAnalysisTaskJetServices bit maps
+  Bool_t              fUseChargeHadrons;     // Only use charge hadrons
   Int_t               fParticleSpeciesTrigger; // Select which particle to use for the trigger [ -1 (all, default) 0 (pions) 1 (kaons) 2 (protons) 3 (others) particles ]
   Int_t               fParticleSpeciesAssociated; // Select which particle to use for the associated [ -1 (all, default) 0 (pions) 1 (kaons) 2 (protons) 3 (others) particles ]
-  Bool_t             fCheckMotherPDG;     // Check the PDG code of mother for secondaries
+  Bool_t              fCheckMotherPDG;       // Check the PDG code of mother for secondaries
 
   // Tracklets cuts
-  Double_t      	fTrackletDphiCut;    //maximum Dphi cut on tracklets
+  Double_t            fTrackletDphiCut;      // maximum Dphi cut on tracklets
 
   Int_t fSelectCharge;           // (un)like sign selection when building correlations: 0: no selection; 1: unlike sign; 2: like sign
   Int_t fTriggerSelectCharge;    // select charge of trigger particle: 1: positive; -1 negative
   Int_t fAssociatedSelectCharge; // select charge of associated particle: 1: positive; -1 negative
   Float_t fTriggerRestrictEta;   // restrict eta range for trigger particle (default: -1 [off])
   Bool_t fEtaOrdering;           // eta ordering, see AliUEHistograms.h for documentation
-  Float_t fCutConversionsV;        // cut on conversions (inv mass)
-  Float_t fCutResonancesV;         // cut on resonances (inv mass)
-  Float_t fCutOnLambdaV;          // cut on Lambda (inv mass)
-  Float_t fCutOnK0sV;             // cut on K0s (inv mass)
-  Bool_t fCutOnPhi;               // cut on Phi
-  Float_t fCutOnPhiV;             // cut on Phi (inv mass)
-  Bool_t fCutOnRho;               // cut on Rho
-  Float_t fCutOnRhoV;             // cut on Rho (inv mass)
+  Float_t fCutConversionsV;      // cut on conversions (inv mass)
+  Float_t fCutResonancesV;       // cut on resonances (inv mass)
+  Float_t fCutOnLambdaV;         // cut on Lambda (inv mass)
+  Float_t fCutOnK0sV;            // cut on K0s (inv mass)
+  Bool_t fCutOnPhi;              // cut on Phi
+  Float_t fCutOnPhiV;            // cut on Phi (inv mass)
+  Bool_t fCutOnRho;              // cut on Rho
+  Float_t fCutOnRhoV;            // cut on Rho (inv mass)
   Float_t fCutOnCustomMass;      // user-defined inv mass value
   Float_t fCutOnCustomFirst;     // user-defined mass of the 1st particle
   Float_t fCutOnCustomSecond;    // user-defined mass of the 2nd particle
   Float_t fCutOnCustomV;         // cut on user-defined value (inv mass)
   Int_t fRejectResonanceDaughters; // reject all daughters of all resonance candidates (1: test method (cut at m_inv=0.9); 2: k0; 3: lambda)
-  Bool_t fFillOnlyStep0; 	   // fill only step 0
-  Bool_t fSkipStep6;		   // skip step 6 when filling
-  Bool_t fRejectCentralityOutliers;  // enable rejection of outliers in centrality vs no track correlation. Interferes with the event plane dependence code
-  Bool_t fRejectZeroTrackEvents;  // reject events which have no tracks (using the eta, pT cuts defined)
-  Bool_t fRemoveWeakDecays;	   // remove secondaries from weak decays from tracks and particles
+  Bool_t fFillOnlyStep0;         // fill only step 0
+  Bool_t fSkipStep6;             // skip step 6 when filling
+  Bool_t fRejectCentralityOutliers; // enable rejection of outliers in centrality vs no track correlation. Interferes with the event plane dependence code
+  Bool_t fRejectZeroTrackEvents; // reject events which have no tracks (using the eta, pT cuts defined)
+  Bool_t fRemoveWeakDecays;      // remove secondaries from weak decays from tracks and particles
   Bool_t fRemoveDuplicates;      // remove particles with the same label (double reconstruction)
-  Bool_t fSkipFastCluster;	   // skip kFastOnly flagged events (only for data)
-  Bool_t fWeightPerEvent;	   // weight with the number of trigger particles per event
-  TString fCustomBinning;	   // supersedes default binning if set, see AliUEHist::GetBinning or AliUEHistograms::AliUEHistograms for syntax and examples
-  Bool_t fPtOrder;		   // apply pT,a < pt,t condition; default: kTRUE
+  Bool_t fSkipFastCluster;       // skip kFastOnly flagged events (only for data)
+  Bool_t fWeightPerEvent;        // weight with the number of trigger particles per event
+  TString fCustomBinning;        // supersedes default binning if set, see AliUEHist::GetBinning or AliUEHistograms::AliUEHistograms for syntax and examples
+  Bool_t fPtOrder;               // apply pT,a < pt,t condition; default: kTRUE
   Int_t fTriggersFromDetector;   // 0 = tracks (default); 1 = VZERO_A; 2 = VZERO_C; 3 = SPD tracklets; 4 = forward muons; 5 = tracks w/o jets; 6, 7 = arbitrary AliVParticle-TClonesArrays (see SetCustomParticleArrayA())
-  Int_t fAssociatedFromDetector;   // 0 = tracks (default); 1 = VZERO_A; 2 = VZERO_C; 3 = SPD tracklets; 4 = forward muons; 5 = tracks w/o jets; 6,7 = arbitrary AliVParticle-TClonesArrays (see SetCustomParticleArrayB())
-  Bool_t fUseUncheckedCentrality; // use unchecked centrality; default: kFALSE
+  Int_t fAssociatedFromDetector; // 0 = tracks (default); 1 = VZERO_A; 2 = VZERO_C; 3 = SPD tracklets; 4 = forward muons; 5 = tracks w/o jets; 6,7 = arbitrary AliVParticle-TClonesArrays (see SetCustomParticleArrayB())
+  Bool_t fUseUncheckedCentrality;// use unchecked centrality; default: kFALSE
   Int_t fCheckCertainSpecies;    // make eta,pt distribution of MC particles with the label of fCheckCertainSpecies, by default switched off (value: -1)
   Bool_t fRemoveWeakDecaysInMC;  // remove weak decays which have been included by mistake as primaries in the stack (bug in AMPT)
   Bool_t fFillYieldRapidity;     // fill a control histogram centrality vs pT vs y
@@ -338,13 +337,11 @@ private:
   TString fCustomParticlesB;   // name of TClonesArray of AliVParticle-derived particles attached to fInputEvent
 
   // Event pool variables
-  vector<vector<Double_t> >   fEventPoolOutputList; // vector representing a list of pools (given by value range) that will be saved
-  Bool_t                      fUsePtBinnedEventPool; // uses event pool in pt bins
-  Bool_t                      fCheckEventNumberInMixedEvent; // check event number before correlation in mixed event
+  vector<vector<Double_t> > fEventPoolOutputList; // vector representing a list of pools (given by value range) that will be saved
+  Bool_t fUsePtBinnedEventPool;                   // uses event pool in pt bins
+  Bool_t fCheckEventNumberInMixedEvent;           // check event number before correlation in mixed event
 
   ClassDef(AliAnalysisTaskPhiCorrelations, 62); // Analysis task for delta phi correlations
 };
 
 #endif
-
-


### PR DESCRIPTION
Clean-up of .h & .cxx files for AliAnalysisTaskPhiCorrelations class:
- Fix indentation issues
- Convert all tab characters to spaces
- Remove unnecessary whitespaces
- Keep curly brackets consistent across the files
- Adjust spaces to improve readability