### PR TITLE
PWGLF/NUCLEX: Fix the size of track array

### DIFF
--- a/PWGLF/NUCLEX/Exotica/Dibaryons/AliAnalysisTaskDibaryons.cxx
+++ b/PWGLF/NUCLEX/Exotica/Dibaryons/AliAnalysisTaskDibaryons.cxx
@@ -41,6 +41,7 @@ AliAnalysisTaskDibaryons::AliAnalysisTaskDibaryons():
   fPileupCut(kTRUE),
   fOutput(0),
   fTrackArray(0),
+  fTrackBuffSize(2500),
   fProtonCandIdx(),
   fLambdaCandIdx(),
   fXiCnadIdx(),
@@ -60,6 +61,7 @@ AliAnalysisTaskDibaryons::AliAnalysisTaskDibaryons(const char *name):
   fPileupCut(kTRUE),
   fOutput(0),
   fTrackArray(0),
+  fTrackBuffSize(2500),
   fProtonCandIdx(),
   fLambdaCandIdx(),
   fXiCnadIdx(),
@@ -93,7 +95,7 @@ void AliAnalysisTaskDibaryons::UserCreateOutputObjects()
   }
   fAliEventCuts.AddQAplotsToList(fOutput);
 
-  fTrackArray = new AliAODTrack*[2000];
+  fTrackArray = new AliAODTrack*[fTrackBuffSize];
 
   TH1F *hNPartStatistics = new TH1F("hNPartStatistics","Number of candidates under certain condition",10,0.5,10.5);
   hNPartStatistics->GetXaxis()->SetBinLabel(1,"p");
@@ -389,7 +391,7 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
   if(fAnalysisType == "AOD") {
 
     // Reset global track reference
-    for(Int_t i=0; i < 2000; i++) fTrackArray[i] = 0;
+    for(Int_t i=0; i < fTrackBuffSize; i++) fTrackArray[i] = 0;
 
     // Store global track reference
     for(Int_t iTrack=0; iTrack < nTrack; iTrack++) {
@@ -402,6 +404,10 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
 
       const Int_t trackID = track->GetID();
       if(trackID < 0) continue;
+      if(trackID >= fTrackBuffSize) {
+        AliWarning(Form("Track ID too big for buffer: ID: %d, buffer %d",trackID,fTrackBuffSize));
+        continue;
+      }
 
       if (fTrackArray[trackID]) {
         if ((!track->GetFilterMap()) && (!track->GetTPCNcls())) continue;

--- a/PWGLF/NUCLEX/Exotica/Dibaryons/AliAnalysisTaskDibaryons.cxx
+++ b/PWGLF/NUCLEX/Exotica/Dibaryons/AliAnalysisTaskDibaryons.cxx
@@ -1309,11 +1309,11 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
         TLorentzVector trackProton, trackOmega, trackSum;
 
         trackProton.SetXYZM(track->Px(), track->Py(), track->Pz(), massProton);
-        trackOmega.SetXYZM(xi->Px(), xi->Py(), xi->Pz(), massXi);
+        trackOmega.SetXYZM(xi->Px(), xi->Py(), xi->Pz(), massOmega);
         trackSum = trackProton + trackOmega;
 
         Double_t mass = trackSum.M();
-        Double_t relK = 1000*relKcalc(trackProton, trackOmega); 
+        Double_t relK = 1000*relKcalc(trackProton, trackOmega);
 
         dynamic_cast<TH1F*>(fOutput->FindObject("hNPairStatistics"))->Fill(4);
         dynamic_cast<TH2F*>(fOutput->FindObject("hInvMassRelKProtonOmega"))->Fill(mass, relK);
@@ -1503,11 +1503,11 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
         TLorentzVector trackProton, trackOmega, trackSum;
 
         trackProton.SetXYZM(track->Px(), track->Py(), track->Pz(), massProton);
-        trackOmega.SetXYZM(xi->Px(), xi->Py(), xi->Pz(), massXi);
+        trackOmega.SetXYZM(xi->Px(), xi->Py(), xi->Pz(), massOmega);
         trackSum = trackProton + trackOmega;
 
         Double_t mass = trackSum.M();
-        Double_t relK = 1000*relKcalc(trackProton, trackOmega); 
+        Double_t relK = 1000*relKcalc(trackProton, trackOmega);
 
         dynamic_cast<TH1F*>(fOutput->FindObject("hNPairStatistics"))->Fill(4);
         dynamic_cast<TH2F*>(fOutput->FindObject("hInvMassRelKProtonOmega"))->Fill(mass, relK);

--- a/PWGLF/NUCLEX/Exotica/Dibaryons/AliAnalysisTaskDibaryons.h
+++ b/PWGLF/NUCLEX/Exotica/Dibaryons/AliAnalysisTaskDibaryons.h
@@ -33,6 +33,7 @@ class AliAnalysisTaskDibaryons : public AliAnalysisTaskSE {
 
     THashList              *fOutput;                  //! User output
     AliAODTrack           **fTrackArray;              //! global track info
+    const UShort_t          fTrackBuffSize;           //! size fo the above array
     std::vector<UInt_t>     fProtonCandIdx;           //! track index of proton candidate
     std::vector<UInt_t>     fLambdaCandIdx;           //! V0 index of Lambda candidate
     std::vector<UInt_t>     fXiCnadIdx;               //! cascade index of Xi candidate
@@ -41,7 +42,7 @@ class AliAnalysisTaskDibaryons : public AliAnalysisTaskSE {
     AliAnalysisTaskDibaryons(const AliAnalysisTaskDibaryons&);            // not implemented
     AliAnalysisTaskDibaryons& operator=(const AliAnalysisTaskDibaryons&); // not implemented
 
-    ClassDef(AliAnalysisTaskDibaryons, 4);
+    ClassDef(AliAnalysisTaskDibaryons, 5);
 };
 
 #endif


### PR DESCRIPTION
- The max size of track array is set larger (2000->2500) for HM event
  - The size of array is determined by new member variable
- p-Omega invariant mass calculation is fixed