### PR TITLE
PWGLF/NUCLEX: Reject other particle from proton candidates using PID info

### DIFF
--- a/PWGLF/NUCLEX/Exotica/Dibaryons/AliAnalysisTaskDibaryons.cxx
+++ b/PWGLF/NUCLEX/Exotica/Dibaryons/AliAnalysisTaskDibaryons.cxx
@@ -171,11 +171,11 @@ void AliAnalysisTaskDibaryons::UserCreateOutputObjects()
 
   // Define QA plots for topological observables
   TH2F *hProtonDCAxyDCAz = new TH2F("hProtonDCAxyDCAz","Proton DCAxy vs DCAz;DCA_{xy} (cm);DCA_{z} (cm)",500,-5,5,1000,-20,20);
-  TH1F *hLambdaDCADaughterTracks = new TH1F("hLambdaDCADaughterTracks","DCA between #Lambda daughters;DCA (cm);Counts",100,0,10);
+  TH1F *hLambdaDCADaughterTracks = new TH1F("hLambdaDCADaughterTracks","DCA between #Lambda daughters;DCA (cm);Counts",200,0,10);
   TH1F *hLambdaDCAPosDaughPrimVertex = new TH1F("hLambdaDCAPosDaughPrimVertex","DCA of proton to PV;DCA (cm);Counts",500,0,100);
   TH1F *hLambdaDCANegDaughPrimVertex = new TH1F("hLambdaDCANegDaughPrimVertex","DCA of pion to PV;DCA (cm);Counts",500,0,100);
   TH1F *hLambdaTransverseRadius = new TH1F("hLambdaTransverseRadius","Transverse radius of #Lambda decay vertex;r_{xy} (cm);Counts;",400,0,200);
-  TH1F *hLambdaCosPointingAngle = new TH1F("hLambdaCosPointingAngle","Cosine of #Lambda pointing angle;cos(PA);Counts",100,0.9,1);
+  TH1F *hLambdaCosPointingAngle = new TH1F("hLambdaCosPointingAngle","Cosine of #Lambda pointing angle;cos(PA);Counts",200,0.95,1);
   TH1F *hXiDCADaughterTracks = new TH1F("hXiDCADaughterTracks","DCA between #Xi daughters;DCA (cm);Counts",100,0,10);
   TH1F *hXiDCAV0DaughterTracks = new TH1F("hXiDCAV0DaughterTracks","DCA between #Lambda daughters, stemming from #Xi;DCA (cm);Counts",100,0,10);
   TH1F *hXiDCAV0PrimVertex = new TH1F("hXiDCAV0PrimVertex","DCA of #Lambda to PV, stemming from #Xi;DCA (cm);Counts",500,0,100);
@@ -184,18 +184,18 @@ void AliAnalysisTaskDibaryons::UserCreateOutputObjects()
   TH1F *hXiDCANegDaughPrimVertex = new TH1F("hXiDCANegDaughPrimVertex","DCA of daughter pion to PV, stemming from #Xi;DCA (cm);Counts",500,0,100);
   TH1F *hXiTransverseRadius = new TH1F("hXiTransverseRadius","Transverse radius of #Xi decay vertex;r_{xy} (cm);Counts",400,0,200);
   TH1F *hXiV0TransverseRadius = new TH1F("hXiV0TransverseRadius","Transverse rsdius of #Lambda decay vertex, stemming form #Xi;r_{xy} (cm);Counts",400,0,200);
-  TH1F *hXiCosPointingAngle = new TH1F("hXiCosPointingAngle","Cosine of #Xi pointing angle;cos(PA);Counts",100,0.9,1);
-  TH1F *hXiV0CosPointingAngle = new TH1F("hXiV0CosPointingAngle","Cosine of #Lambda pointing angle, stemming from #Xi;cos(PA);Counts",100,0.9,1);
-  TH1F *hOmegaDCADaughterTracks = new TH1F("hOmegaDCADaughterTracks","DCA between #Omega daughters;DCA (cm);Counts",100,0,10);
-  TH1F *hOmegaDCAV0DaughterTracks = new TH1F("hOmegaDCAV0DaughterTracks","DCA between #Lambda daughters, stemming from #Omega;DCA (cm);Counts",100,0,10);
+  TH1F *hXiCosPointingAngle = new TH1F("hXiCosPointingAngle","Cosine of #Xi pointing angle;cos(PA);Counts",200,0.95,1);
+  TH1F *hXiV0CosPointingAngle = new TH1F("hXiV0CosPointingAngle","Cosine of #Lambda pointing angle, stemming from #Xi;cos(PA);Counts",200,0.95,1);
+  TH1F *hOmegaDCADaughterTracks = new TH1F("hOmegaDCADaughterTracks","DCA between #Omega daughters;DCA (cm);Counts",200,0,10);
+  TH1F *hOmegaDCAV0DaughterTracks = new TH1F("hOmegaDCAV0DaughterTracks","DCA between #Lambda daughters, stemming from #Omega;DCA (cm);Counts",200,0,10);
   TH1F *hOmegaDCAV0PrimVertex = new TH1F("hOmegaDCAV0PrimVertex","DCA of #Lambda to PV, stemming from #Omega;DCA (cm);Counts",500,0,100);
   TH1F *hOmegaDCABachPrimVertex = new TH1F("hOmegaDCABachPrimVertex","DCA of bachelor kaon to PV;DCA (cm);Counts",500,0,100);
   TH1F *hOmegaDCAPosDaughPrimVertex = new TH1F("hOmegaDCAPosDaughPrimVertex","DCA of daughter proton to PV, stemming from #Omega;DCA (cm);Counts",500,0,100);
   TH1F *hOmegaDCANegDaughPrimVertex = new TH1F("hOmegaDCANegDaughPrimVertex","DCA of daughter pion to PV, stemming from #Omega;DCA (cm);Counts",500,0,100);
   TH1F *hOmegaTransverseRadius = new TH1F("hOmegaTransverseRadius","Transverse radius of #Omega decay vertex;r_{xy} (cm);Counts",400,0,200);
   TH1F *hOmegaV0TransverseRadius = new TH1F("hOmegaV0TransverseRadius","Transverse rsdius of #Lambda decay vertex, stemming form #Omega;r_{xy} (cm);Counts",400,0,200);
-  TH1F *hOmegaCosPointingAngle = new TH1F("hOmegaCosPointingAngle","Cosine of #Omega pointing angle;cos(PA);Counts",100,0.9,1);
-  TH1F *hOmegaV0CosPointingAngle = new TH1F("hOmegaV0CosPointingAngle","Cosine of #Lambda pointing angle, stemming from #Omega;cos(PA);Counts",100,0.9,1);
+  TH1F *hOmegaCosPointingAngle = new TH1F("hOmegaCosPointingAngle","Cosine of #Omega pointing angle;cos(PA);Counts",200,0.95,1);
+  TH1F *hOmegaV0CosPointingAngle = new TH1F("hOmegaV0CosPointingAngle","Cosine of #Lambda pointing angle, stemming from #Omega;cos(PA);Counts",200,0.95,1);
 
   fOutput->Add(hProtonDCAxyDCAz);
   fOutput->Add(hLambdaDCADaughterTracks);
@@ -299,15 +299,21 @@ void AliAnalysisTaskDibaryons::UserCreateOutputObjects()
   // Define PID related histograms
   TH2F *hdEdxVsP = new TH2F("hdEdxVsP","TPC dE/dx vs momentum;p (GeV/c);TPC #frac{dE}{dx} (a.u.)",1000,0,10,1000,0,1000);
   TH2F *hBetaVsP = new TH2F("hBetaVsP","TOF #beta vs momentum;p (GeV/c);TOF #beta",1000,0,5,1000,0.1,1.1);
-  TH2F *hProtonNsigmaTPC = new TH2F("hProtonNsigmaTPC","PID for protons using TPC;p (GeV/c);n_{#sigma,TPC}",1000,0,10,200,-10,10);
-  TH2F *hProtonNsigmaTOF = new TH2F("hProtonNsigmaTOF","PID for protons using TOF;p (GeV/c);n_{#sigma,TOF}",1000,0,10,200,-10,10);
-  TH2F *hProtonNsigmaTPCvsTOF = new TH2F("hProtonNsigmaTPCvsTOF","Nsigma TPC vs TOF;n_{#sigma,TPC};n_{#sigma,TOF};",1000,-10,10,1000,-10,10);
+  TH2F *hProtonNsigmaTPC = new TH2F("hProtonNsigmaTPC","Nsigma TPC vs momentum;p (GeV/c);n_{#sigma,TPC}",1000,0,10,200,-10,10);
+  TH2F *hProtonNsigmaTOF = new TH2F("hProtonNsigmaTOF","Nsigma TOF vs momentum;p (GeV/c);n_{#sigma,TOF}",1000,0,10,200,-10,10);
+  TH2F *hProtonNsigmaTPCvsTOF = new TH2F("hProtonNsigmaTPCvsTOF","Nsigma TPC vs TOF;n_{#sigma,TPC};n_{#sigma,TOF};",200,-10,10,200,-10,10);
+  TH2F *hProtonNsigmaTPCwPID = new TH2F("hProtonNsigmaTPCwPID","Nsimga TPC vs momentum after PID selection;p (GeV/c);n_{#sigma,TPC}",500,0,5,100,-5,5);
+  TH2F *hProtonNsigmaTOFwPID = new TH2F("hProtonNsigmaTOFwPID","Nsimga TOF vs momentum after PID selection;p (GeV/c);n_{#sigma,TOF}",500,0,5,100,-5,5);
+  TH2F *hProtonNsigmaTPCvsTOFwCuts = new TH2F("hProtonNsigmaTPCvsTOFwCuts","Nsigma TPC vs TOF with hypothesis cuts;n_{#sigma,TPC};n_{#sigma,TOF};",200,-10,10,200,-10,10);
 
   fOutput->Add(hdEdxVsP);
   fOutput->Add(hBetaVsP);
   fOutput->Add(hProtonNsigmaTPC);
   fOutput->Add(hProtonNsigmaTOF);
   fOutput->Add(hProtonNsigmaTPCvsTOF);
+  fOutput->Add(hProtonNsigmaTPCwPID);
+  fOutput->Add(hProtonNsigmaTOFwPID);
+  fOutput->Add(hProtonNsigmaTPCvsTOFwCuts);
 
   // Define histograms related to pair analysis
   TH1F *hNPairStatistics = new TH1F("hNPairStatistics","Number of pairs under certain condition",10,0.5,10.5);
@@ -516,8 +522,17 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
     Bool_t isthereTOF = kFALSE;
 
     Float_t nSigmaTPCproton      = -10.;
+    Float_t nSigmaTPCkaon        = -10.;
+    Float_t nSigmaTPCpion        = -10.;
+    Float_t nSigmaTPCelectron    = -10.;
     Float_t nSigmaTOFproton      = -10.;
-    Float_t nSigmaTPCTOFcombined = -10.;
+    Float_t nSigmaTOFkaon        = -10.;
+    Float_t nSigmaTOFpion        = -10.;
+    Float_t nSigmaTOFelectron    = -10.;
+    Float_t nSigmaTPCTOFproton   = -10.;
+    Float_t nSigmaTPCTOFkaon     = -10.;
+    Float_t nSigmaTPCTOFpion     = -10.;
+    Float_t nSigmaTPCTOFelectron = -10.;
 
     Float_t DCAxy = -999., DCAz = -999.;
 
@@ -552,8 +567,17 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
       if(statusTOF == AliPIDResponse::kDetPidOk) isthereTOF = kTRUE;
 
       nSigmaTPCproton      = fPIDResponse->NumberOfSigmasTPC(esdTrack,AliPID::kProton);
+      nSigmaTPCkaon        = fPIDResponse->NumberOfSigmasTPC(esdTrack,AliPID::kKaon);
+      nSigmaTPCpion        = fPIDResponse->NumberOfSigmasTPC(esdTrack,AliPID::kPion);
+      nSigmaTPCelectron    = fPIDResponse->NumberOfSigmasTPC(esdTrack,AliPID::kElectron);
       nSigmaTOFproton      = fPIDResponse->NumberOfSigmasTOF(esdTrack,AliPID::kProton);
-      nSigmaTPCTOFcombined = TMath::Sqrt(pow(nSigmaTPCproton,2.) + pow(nSigmaTOFproton,2.));
+      nSigmaTOFkaon        = fPIDResponse->NumberOfSigmasTOF(esdTrack,AliPID::kKaon);
+      nSigmaTOFpion        = fPIDResponse->NumberOfSigmasTOF(esdTrack,AliPID::kPion);
+      nSigmaTOFelectron    = fPIDResponse->NumberOfSigmasTOF(esdTrack,AliPID::kElectron);
+      nSigmaTPCTOFproton   = TMath::Sqrt(pow(nSigmaTPCproton,2.) + pow(nSigmaTOFproton,2.));
+      nSigmaTPCTOFkaon     = TMath::Sqrt(pow(nSigmaTPCkaon,2.) + pow(nSigmaTOFkaon,2.));
+      nSigmaTPCTOFpion     = TMath::Sqrt(pow(nSigmaTPCpion,2.) + pow(nSigmaTOFpion,2.));
+      nSigmaTPCTOFelectron = TMath::Sqrt(pow(nSigmaTPCelectron,2.) + pow(nSigmaTOFelectron,2.));
 
       esdTrack->GetImpactParameters(DCAxy,DCAz);
 
@@ -601,8 +625,17 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
       if(statusTOF == AliPIDResponse::kDetPidOk) isthereTOF = kTRUE;
 
       nSigmaTPCproton      = fPIDResponse->NumberOfSigmasTPC(globalTrack,AliPID::kProton);
+      nSigmaTPCkaon        = fPIDResponse->NumberOfSigmasTPC(globalTrack,AliPID::kKaon);
+      nSigmaTPCpion        = fPIDResponse->NumberOfSigmasTPC(globalTrack,AliPID::kPion);
+      nSigmaTPCelectron    = fPIDResponse->NumberOfSigmasTPC(globalTrack,AliPID::kElectron);
       nSigmaTOFproton      = fPIDResponse->NumberOfSigmasTOF(globalTrack,AliPID::kProton);
-      nSigmaTPCTOFcombined = TMath::Sqrt(pow(nSigmaTPCproton,2.) + pow(nSigmaTOFproton,2.));
+      nSigmaTOFkaon        = fPIDResponse->NumberOfSigmasTOF(globalTrack,AliPID::kKaon);
+      nSigmaTOFpion        = fPIDResponse->NumberOfSigmasTOF(globalTrack,AliPID::kPion);
+      nSigmaTOFelectron    = fPIDResponse->NumberOfSigmasTOF(globalTrack,AliPID::kElectron);
+      nSigmaTPCTOFproton   = TMath::Sqrt(pow(nSigmaTPCproton,2.) + pow(nSigmaTOFproton,2.));
+      nSigmaTPCTOFkaon     = TMath::Sqrt(pow(nSigmaTPCkaon,2.) + pow(nSigmaTOFkaon,2.));
+      nSigmaTPCTOFpion     = TMath::Sqrt(pow(nSigmaTPCpion,2.) + pow(nSigmaTOFpion,2.));
+      nSigmaTPCTOFelectron = TMath::Sqrt(pow(nSigmaTPCelectron,2.) + pow(nSigmaTOFelectron,2.));
 
       globalTrack->GetImpactParameters(DCAxy,DCAz);
 
@@ -638,10 +671,21 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
     else if(p > 0.75) { // for p > 0.75 use TPC & TOF
       if(!isthereTPC || !isthereTOF) continue;
       dynamic_cast<TH2F*>(fOutput->FindObject("hProtonNsigmaTPCvsTOF"))->Fill(nSigmaTPCproton,nSigmaTOFproton);
-      if(nSigmaTPCTOFcombined > 3.) continue;
+
+      // Reject if the other hypotheis fits better
+      if(nSigmaTPCTOFproton > nSigmaTPCTOFkaon) continue;
+      if(nSigmaTPCTOFproton > nSigmaTPCTOFpion) continue;
+      if(nSigmaTPCTOFproton > nSigmaTPCTOFelectron) continue;
+
+      dynamic_cast<TH2F*>(fOutput->FindObject("hProtonNsigmaTPCvsTOFwCuts"))->Fill(nSigmaTPCproton,nSigmaTOFproton);
+      if(nSigmaTPCTOFproton > 3.) continue;
     }
 
-    if(charge > 0.) dynamic_cast<TH2F*>(fOutput->FindObject("hProtonDCAxyDCAz"))->Fill(DCAxy,DCAz);
+    if(charge > 0.) {
+      dynamic_cast<TH2F*>(fOutput->FindObject("hProtonDCAxyDCAz"))->Fill(DCAxy,DCAz);
+      dynamic_cast<TH2F*>(fOutput->FindObject("hProtonNsigmaTPCwPID"))->Fill(p,nSigmaTPCproton);
+      if(isthereTOF) dynamic_cast<TH2F*>(fOutput->FindObject("hProtonNsigmaTOFwPID"))->Fill(p,nSigmaTOFproton);
+    }
 
     // proton selection
     if(TMath::Abs(eta) > 0.8) continue;

--- a/PWGLF/NUCLEX/Exotica/Dibaryons/AliAnalysisTaskDibaryons.cxx
+++ b/PWGLF/NUCLEX/Exotica/Dibaryons/AliAnalysisTaskDibaryons.cxx
@@ -119,6 +119,7 @@ void AliAnalysisTaskDibaryons::UserCreateOutputObjects()
     fOmegaArray  = new TClonesArray("AliAODcascade",fCascadeBuffSize);
   }
 
+  TH1F *hRefMultiplicity08 = new TH1F("hRefMultiplicity08","Reference multiplicity;Multipicity;Counts",600,0,600);
   TH1F *hNPartStatistics = new TH1F("hNPartStatistics","Number of candidates under certain condition",10,0.5,10.5);
   hNPartStatistics->GetXaxis()->SetBinLabel(1,"p");
   hNPartStatistics->GetXaxis()->SetBinLabel(2,"#bar{p}");
@@ -130,39 +131,40 @@ void AliAnalysisTaskDibaryons::UserCreateOutputObjects()
   hNPartStatistics->GetXaxis()->SetBinLabel(8,"#Omega^{+}");
   hNPartStatistics->GetYaxis()->SetTitle("Counts");
 
+  fOutput->Add(hRefMultiplicity08);
   fOutput->Add(hNPartStatistics);
 
   // Define histograms related to invariant mass for V0 and Cascade
-  TH1F *hInvMassLambdawoCuts = new TH1F("hInvMassLambdawoCuts","Invariant mass of p#pi^{-} without topological cuts;M_{p#pi} (GeV/c^{2});Counts",400,1.0,1.2);
-  TH1F *hInvMassLambdawCuts = new TH1F("hInvMassLambdawCuts","Invariant mass of p#pi^{-} with topological cuts;M_{p#pi} (GeV/c^{2});Counts",400,1.0,1.2);
-  TH1F *hInvMassAntiLambdawoCuts = new TH1F("hInvMassAntiLambdawoCuts","Invariant mass of #bar{p}#pi^{+} without topological cuts;M_{p#pi} (GeV/c^{2});Counts",400,1.0,1.2);
-  TH1F *hInvMassAntiLambdawCuts = new TH1F("hInvMassAntiLambdawCuts","Invariant mass of #bar{p}#pi^{+} with topological cuts;M_{p#pi} (GeV/c^{2});Counts",400,1.0,1.2);
+  TH2F *hInvMassLambda = new TH2F("hInvMassLambda","Invariant mass of p#pi^{-};M_{p#pi} (GeV/c^{2});p_{T} (GeV/c)",400,1.0,1.2,100,0,10);
+  TH2F *hInvMassAntiLambda = new TH2F("hInvMassAntiLambda","Invariant mass of #bar{p}#pi^{+};M_{p#pi} (GeV/c^{2});p_{T} (GeV/c)",400,1.0,1.2,100,0,10);
+  TH2F *hInvMassXim = new TH2F("hInvMassXim","Invariant mass of #pi^{-}#Lambda;M_{#pi#Lambda} (GeV/c^{2});p_{T} (GeV/c)",300,1.2,1.5,100,0,10);
+  TH2F *hInvMassXip = new TH2F("hInvMassXip","Invariant mass of #pi^{+}#bar{#Lambda};M_{#pi#Lambda} (GeV/c^{2});p_{T} (GeV/c)",300,1.2,1.5,100,0,10);
+  TH2F *hInvMassOmegam = new TH2F("hInvMassOmegam","Invariant mass of K^{-}#Lambda;M_{K#Lambda} (GeV/c^{2});p_{T} (GeV/c)",300,1.5,1.8,100,0,10);
+  TH2F *hInvMassOmegap = new TH2F("hInvMassOmegap","Invariant mass of K^{+}#bar{#Lambda};M_{K#Lambda} (GeV/c^{2});p_{T} (GeV/c)",300,1.5,1.8,100,0,10);
   TH1F *hInvMassLambdaAsCascDghter = new TH1F("hInvMassLambdaAsCascDghter","Invariant mass of p#pi stemming from cascade;M_{p#pi} (GeV/c^{2});Counts",400,1.0,1.2);
-  TH1F *hInvMassXimwoCuts = new TH1F("hInvMassXimwoCuts","Invariant mass of p#pi^{-}#pi^{-} without topological cuts;M_{#pi#Lambda} (GeV/c^{2});Counts",300,1.2,1.5);
-  TH1F *hInvMassXimwCuts = new TH1F("hInvMassXimwCuts","Invariant mass of p#pi^{-}#pi^{-} with topological cuts;M_{#pi#Lambda} (GeV/c^{2});Counts",300,1.2,1.5);
-  TH1F *hInvMassXipwoCuts = new TH1F("hInvMassXipwoCuts","Invariant mass of #bar{p}#pi^{+}#pi^{+} without topological cuts;M_{#pi#Lambda} (GeV/c^{2});Counts",300,1.2,1.5);
-  TH1F *hInvMassXipwCuts = new TH1F("hInvMassXipwCuts","Invariant mass of #bar{p}#pi^{+}#pi^{+} with topological cuts;M_{#pi#Lambda} (GeV/c^{2});Counts",300,1.2,1.5);
-  TH1F *hInvMassOmegamwoCuts = new TH1F("hInvMassOmegamwoCuts","Invariant mass of p#pi^{-}K^{-} without topological cuts;M_{K#Lambda} (GeV/c^{2});Counts",300,1.5,1.8);
-  TH1F *hInvMassOmegamwCuts = new TH1F("hInvMassOmegamwCuts","Invariant mass of p#pi^{-}K^{-} with topological cuts;M_{K#Lambda} (GeV/c^{2});Counts",300,1.5,1.8);
-  TH1F *hInvMassOmegapwoCuts = new TH1F("hInvMassOmegapwoCuts","Invariant mass of #bar{p}#pi^{+}K^{+} without topological cuts;M_{K#Lambda} (GeV/c^{2});Counts",300,1.5,1.8);
-  TH1F *hInvMassOmegapwCuts = new TH1F("hInvMassOmegapwCuts","Invariant mass of #bar{p}#pi^{+}K^{+} with topological cuts;M_{K#Lambda} (GeV/c^{2});Counts",300,1.5,1.8);
+  TH1F *hInvMassLambdawoCuts = new TH1F("hInvMassLambdawoCuts","Invariant mass of p#pi^{-} without topological cuts;M_{p#pi} (GeV/c^{2});Counts",400,1.0,1.2);
+  TH1F *hInvMassAntiLambdawoCuts = new TH1F("hInvMassAntiLambdawoCuts","Invariant mass of #bar{p}#pi^{+} without topological cuts;M_{p#pi} (GeV/c^{2});Counts",400,1.0,1.2);
+  TH1F *hInvMassXimwoCuts = new TH1F("hInvMassXimwoCuts","Invariant mass of #pi^{-}#Lambda without topological cuts;M_{#pi#Lambda} (GeV/c^{2});Counts",300,1.2,1.5);
+  TH1F *hInvMassXipwoCuts = new TH1F("hInvMassXipwoCuts","Invariant mass of #pi^{+}#bar{#Lambda} without topological cuts;M_{#pi#Lambda} (GeV/c^{2});Counts",300,1.2,1.5);
+  TH1F *hInvMassOmegamwoCuts = new TH1F("hInvMassOmegamwoCuts","Invariant mass of K^{-}#Lambda without topological cuts;M_{K#Lambda} (GeV/c^{2});Counts",300,1.5,1.8);
+  TH1F *hInvMassOmegapwoCuts = new TH1F("hInvMassOmegapwoCuts","Invariant mass of K^{+}#bar{#Lambda} without topological cuts;M_{K#Lambda} (GeV/c^{2});Counts",300,1.5,1.8);
   TH1F *hInvMassMissIDK0S = new TH1F("hInvMassMissIDK0S","Invariant mass of #pi^{+}#pi^{-} under assumption of selected #Lambda;M_{#pi#pi} (GeV/c^{2})",400,0.4,0.6);
-  TH1F *hInvMassMissIDOmegam = new TH1F("hInvMassMissIDOmegam","Invariant mass of p#pi^{-}K^{-} under assumption of selected #Xi^{-};M_{K#Lambda} (GeV/c^{2})",300,1.5,1.8);
-  TH1F *hInvMassMissIDXim = new TH1F("hInvMassMissIDXim","Invariant mass of p#pi^{-}#pi^{-} under assumption of selected #Omega^{-};M_{#pi#Lambda} (GeV/c^{2})",300,1.2,1.5);
+  TH1F *hInvMassMissIDOmegam = new TH1F("hInvMassMissIDOmegam","Invariant mass of K^{-}#Lambda under assumption of selected #Xi^{-};M_{K#Lambda} (GeV/c^{2})",300,1.5,1.8);
+  TH1F *hInvMassMissIDXim = new TH1F("hInvMassMissIDXim","Invariant mass of #pi^{-}#Lambda under assumption of selected #Omega^{-};M_{#pi#Lambda} (GeV/c^{2})",300,1.2,1.5);
 
-  fOutput->Add(hInvMassLambdawoCuts);
-  fOutput->Add(hInvMassLambdawCuts);
-  fOutput->Add(hInvMassAntiLambdawoCuts);
-  fOutput->Add(hInvMassAntiLambdawCuts);
+  fOutput->Add(hInvMassLambda);
+  fOutput->Add(hInvMassAntiLambda);
+  fOutput->Add(hInvMassXim);
+  fOutput->Add(hInvMassXip);
+  fOutput->Add(hInvMassOmegam);
+  fOutput->Add(hInvMassOmegap);
   fOutput->Add(hInvMassLambdaAsCascDghter);
+  fOutput->Add(hInvMassLambdawoCuts);
+  fOutput->Add(hInvMassAntiLambdawoCuts);
   fOutput->Add(hInvMassXimwoCuts);
-  fOutput->Add(hInvMassXimwCuts);
   fOutput->Add(hInvMassXipwoCuts);
-  fOutput->Add(hInvMassXipwCuts);
   fOutput->Add(hInvMassOmegamwoCuts);
-  fOutput->Add(hInvMassOmegamwCuts);
   fOutput->Add(hInvMassOmegapwoCuts);
-  fOutput->Add(hInvMassOmegapwCuts);
   fOutput->Add(hInvMassMissIDK0S);
   fOutput->Add(hInvMassMissIDOmegam);
   fOutput->Add(hInvMassMissIDXim);
@@ -224,53 +226,61 @@ void AliAnalysisTaskDibaryons::UserCreateOutputObjects()
 
   // Define QA plots for kinematic observables
   TH1F *hProtonPt = new TH1F("hProtonPt","Transverse momentum of proton;p_{T} (GeV/c);Counts",200,0,10);
-  TH1F *hProtonPhi = new TH1F("hProtonPhi","Phi angle of proton;#varphi (rad);Counts",200,0,TMath::TwoPi());
-  TH1F *hProtonEta = new TH1F("hProtonEta","Pseudorapidity of proton;#eta;Counts",20,-1,+1);
+  TH2F *hProtonEtaPhi = new TH2F("hProtonEtaPhi","Pseudorapidity vs azimuthal angle of proton;#eta;#varphi (rad)",200,-1,+1,200,0,TMath::TwoPi());
   TH1F *hAntiProtonPt = new TH1F("hAntiProtonPt","Transverse momentum of Anti-proton;p_{T} (GeV/c);Counts",200,0,10);
   TH1F *hLambdaPt = new TH1F("hLambdaPt","Transverse momentum of #Lambda;p_{T} (GeV/c);Counts",200,0,10);
-  TH1F *hLambdaPosDaughPt = new TH1F("hLambdaPosDaughPt","Transverse momentum of daughter proton;p_{T} (GeV/c);Counts",200,0,10);
-  TH1F *hLambdaNegDaughPt = new TH1F("hLambdaNegDaughPt","Transverse momentum of daughter pion;p_{T} (GeV/c);Counts",200,0,10);
-  TH1F *hLambdaPhi = new TH1F("hLambdaPhi","Phi angle of #Lambda;#varphi (rad);Counts",200,0,TMath::TwoPi());
-  TH1F *hLambdaEta = new TH1F("hLambdaEta","Pseudorapidity of #Lambda;#eta;Counts",20,-1,1);
+  TH1F *hLambdaPosDaughPt = new TH1F("hLambdaPosDaughPt","Transverse momentum of #Lambda daughter proton;p_{T} (GeV/c);Counts",200,0,10);
+  TH1F *hLambdaNegDaughPt = new TH1F("hLambdaNegDaughPt","Transverse momentum of #Lambda daughter pion;p_{T} (GeV/c);Counts",200,0,10);
+  TH2F *hLambdaEtaPhi = new TH2F("hLambdaEtaPhi","Pseudorapidity vs azimuthal angle of #Lambda;#eta;#varphi (rad)",200,-1,1,200,0,TMath::TwoPi());
+  TH2F *hLambdaPosDaughEtaPhi = new TH2F("hLambdaPosDaughEtaPhi","Pseudorapidity vs azimuthal angle of #Lambda daughter proton;#eta;#varphi (rad)",200,-1,1,200,0,TMath::TwoPi());
+  TH2F *hLambdaNegDaughEtaPhi = new TH2F("hLambdaNegDaughEtaPhi","Pseudorapidity vs azimuthal angle of #Lambda daughter pion;#eta;#varphi (rad)",200,-1,1,200,0,TMath::TwoPi());
   TH1F *hAntiLambdaPt = new TH1F("hAntiLambdaPt","Transverse momentum of #bar{#Lambda};p_{T} (GeV/c);Counts",200,0,10);
   TH1F *hXimPt = new TH1F("hXimPt","Transverse momentum of #Xi^{-};p_{T} (GeV/c);Counts",200,0,10);
   TH1F *hXimBachPt = new TH1F("hXimBachPt","Transverse momentum of bachelor pion;p_{T} (GeV/c);Counts",200,0,10);
   TH1F *hXimPosDaughPt = new TH1F("hXimPosDaughPt","Transverse momentum of daughter proton from #Xi;p_{T} (GeV/c);Counts",200,0,10);
   TH1F *hXimNegDaughPt = new TH1F("hXimNegDaughPt","Transverse momentum of daughter pion from #Xi;p_{T} (GeV/c);Counts",200,0,10);
-  TH1F *hXimPhi = new TH1F("hXimPhi","Phi angle of #Xi^{-};#varphi (rad);Counts",200,0,TMath::TwoPi());
-  TH1F *hXimEta = new TH1F("hXimEta","Pseudorapidity of #Xi^{-};#eta;Counts",20,-1,1);
+  TH2F *hXimEtaPhi = new TH2F("hXimEtaPhi","Pseudorapidity vs azimuthal angle of #Xi^{-};#eta;#varphi (rad)",200,-1,1,200,0,TMath::TwoPi());
+  TH2F *hXimBachEtaPhi = new TH2F("hXimBachEtaPhi","Pseudorapidity vs azimuthal angle of #Xi^{-} bachelor pion;#eta;#varphi (rad)",200,-1,1,200,0,TMath::TwoPi());
+  TH2F *hXimPosDaughEtaPhi = new TH2F("hXimPosDaughEtaPhi","Pseudorapidity vs azimuthal angle of #Xi^{-} daughter proton;#eta;#varphi (rad)",200,-1,1,200,0,TMath::TwoPi());
+  TH2F *hXimNegDaughEtaPhi = new TH2F("hXimNegDaughEtaPhi","Pseudorapidity vs azimuthal angle of #Xi^{-} daughter pion;#eta;#varphi (rad)",200,-1,1,200,0,TMath::TwoPi());
   TH1F *hXipPt = new TH1F("hXipPt","Transverse momentum of #Xi^{+};p_{T} (GeV/c);Counts",200,0,10);
   TH1F *hOmegamPt = new TH1F("hOmegamPt","Transverse momentum of #Omega^{-};p_{T} (GeV/c);Counts",200,0,10);
   TH1F *hOmegamBachPt = new TH1F("hOmegamBachPt","Transverse momentum of bachelor kaon;p_{T} (GeV/c);Counts",200,0,10);
   TH1F *hOmegamPosDaughPt = new TH1F("hOmegamPosDaughPt","Transverse momentum of daughter proton from #Omega;p_{T} (GeV/c);Counts",200,0,10);
   TH1F *hOmegamNegDaughPt = new TH1F("hOmegamNegDaughPt","Transverse momentum of daughter pion from #Omega;p_{T} (GeV/c);Counts",200,0,10);
-  TH1F *hOmegamPhi = new TH1F("hOmegamPhi","Phi angle of #Omega^{-};#varphi (rad);Counts",200,0,TMath::TwoPi());
-  TH1F *hOmegamEta = new TH1F("hOmegamEta","Pseudorapidity of #Omega^{-};#eta;Counts",20,-1,1);
+  TH2F *hOmegamEtaPhi = new TH2F("hOmegamEtaPhi","Pseudorapidity vs azimuthal angle of #Omega^{-};#eta;#varphi (rad)",200,-1,1,200,0,TMath::TwoPi());
+  TH2F *hOmegamBachEtaPhi = new TH2F("hOmegamBachEtaPhi","Pseudorapidity vs azimuthal angle of #Omega^{-} bachelor kaon;#eta;#varphi (rad)",200,-1,1,200,0,TMath::TwoPi());
+  TH2F *hOmegamPosDaughEtaPhi = new TH2F("hOmegamPosDaughEtaPhi","Pseudorapidity vs azimuthal angle of #Omega^{-} daughter proton;#eta;#varphi (rad)",200,-1,1,200,0,TMath::TwoPi());
+  TH2F *hOmegamNegDaughEtaPhi = new TH2F("hOmegamNegDaughEtaPhi","Pseudorapidity vs azimuthal angle of #Omega^{-} daughter pion;#eta;#varphi (rad)",200,-1,1,200,0,TMath::TwoPi());
   TH1F *hOmegapPt = new TH1F("hOmegapPt","Transverse momentum of #Omega^{+};p_{T} (GeV/c);Counts",200,0,10);
 
   fOutput->Add(hProtonPt);
-  fOutput->Add(hProtonPhi);
-  fOutput->Add(hProtonEta);
+  fOutput->Add(hProtonEtaPhi);
   fOutput->Add(hAntiProtonPt);
   fOutput->Add(hLambdaPt);
   fOutput->Add(hLambdaPosDaughPt);
   fOutput->Add(hLambdaNegDaughPt);
-  fOutput->Add(hLambdaPhi);
-  fOutput->Add(hLambdaEta);
+  fOutput->Add(hLambdaEtaPhi);
+  fOutput->Add(hLambdaPosDaughEtaPhi);
+  fOutput->Add(hLambdaNegDaughEtaPhi);
   fOutput->Add(hAntiLambdaPt);
   fOutput->Add(hXimPt);
   fOutput->Add(hXimBachPt);
   fOutput->Add(hXimPosDaughPt);
   fOutput->Add(hXimNegDaughPt);
-  fOutput->Add(hXimPhi);
-  fOutput->Add(hXimEta);
+  fOutput->Add(hXimEtaPhi);
+  fOutput->Add(hXimBachEtaPhi);
+  fOutput->Add(hXimPosDaughEtaPhi);
+  fOutput->Add(hXimNegDaughEtaPhi);
   fOutput->Add(hXipPt);
   fOutput->Add(hOmegamPt);
   fOutput->Add(hOmegamBachPt);
   fOutput->Add(hOmegamPosDaughPt);
   fOutput->Add(hOmegamNegDaughPt);
-  fOutput->Add(hOmegamPhi);
-  fOutput->Add(hOmegamEta);
+  fOutput->Add(hOmegamEtaPhi);
+  fOutput->Add(hOmegamBachEtaPhi);
+  fOutput->Add(hOmegamPosDaughEtaPhi);
+  fOutput->Add(hOmegamNegDaughEtaPhi);
   fOutput->Add(hOmegapPt);
 
   // Define histogrms related to TPC track info
@@ -287,15 +297,17 @@ void AliAnalysisTaskDibaryons::UserCreateOutputObjects()
   fOutput->Add(hRatioFindableCrossed);
 
   // Define PID related histograms
-  TH2F *hdEdxVsP = new TH2F("hdEdxVsP","dE/dx of all particles vs momentum;p (GeV/c);#frac{dE}{dx} (a.u.)",1000,0,10,200,0,200);
-  TH2F *hProtonNsigmaTPC = new TH2F("hProtonNsigmaTPC","PID for protons using TPC;p (GeV/c);n#sigma_{TPC}",1000,0,10,200,-10,10);
-  TH2F *hProtonNsigmaTOF = new TH2F("hProtonNsigmaTOF","PID for protons using TOF;p (GeV/c);n#sigma_{TOF}",1000,0,10,200,-10,10);
-  TH2F *hProtonNsigmaCombined = new TH2F("hProtonNsigmaCombined","PID for proton using both TPC and TOF;p (GeV/c);n#sigma_{comb}=#sqrt{n#sigma_{TPC}^{2}+n#sigma_{TOF}^{2}};",1000,0,10,100,0,10);
+  TH2F *hdEdxVsP = new TH2F("hdEdxVsP","TPC dE/dx vs momentum;p (GeV/c);TPC #frac{dE}{dx} (a.u.)",1000,0,10,1000,0,1000);
+  TH2F *hBetaVsP = new TH2F("hBetaVsP","TOF #beta vs momentum;p (GeV/c);TOF #beta",1000,0,5,1000,0.1,1.1);
+  TH2F *hProtonNsigmaTPC = new TH2F("hProtonNsigmaTPC","PID for protons using TPC;p (GeV/c);n_{#sigma,TPC}",1000,0,10,200,-10,10);
+  TH2F *hProtonNsigmaTOF = new TH2F("hProtonNsigmaTOF","PID for protons using TOF;p (GeV/c);n_{#sigma,TOF}",1000,0,10,200,-10,10);
+  TH2F *hProtonNsigmaTPCvsTOF = new TH2F("hProtonNsigmaTPCvsTOF","Nsigma TPC vs TOF;n_{#sigma,TPC};n_{#sigma,TOF};",1000,-10,10,1000,-10,10);
 
   fOutput->Add(hdEdxVsP);
+  fOutput->Add(hBetaVsP);
   fOutput->Add(hProtonNsigmaTPC);
   fOutput->Add(hProtonNsigmaTOF);
-  fOutput->Add(hProtonNsigmaCombined);
+  fOutput->Add(hProtonNsigmaTPCvsTOF);
 
   // Define histograms related to pair analysis
   TH1F *hNPairStatistics = new TH1F("hNPairStatistics","Number of pairs under certain condition",10,0.5,10.5);
@@ -311,16 +323,40 @@ void AliAnalysisTaskDibaryons::UserCreateOutputObjects()
   fOutput->Add(hNPairStatistics);
 
   // Define histograms related to invariant mass for dibaryons
-  TH2F *hInvMassRelKLambdaLambda = new TH2F("hInvMassRelKLambdaLambda","Invariant mass vs relative momentum of #Lambda-#Lambda pair;M_{#Lambda#Lambda} (GeV/c^{2});k^{*} (MeV/c)",1000,2,3,100,0,1000);
+  TH1F *hInvMassProtonLambda = new TH1F("hInvMassProtonLambda","Invariant mass of p-#Lambda pair;M_{p#Lambda} (GeV/c^{2});Counts",1000,2,2.4);
+  TH1F *hInvMassLambdaLambda = new TH1F("hInvMassLambdaLambda","Invariant mass of #Lambda-#Lambda pair;M_{#Lambda#Lambda} (GeV/c^{2});Counts",1000,2.2,2.3);
+  TH1F *hInvMassProtonXi = new TH1F("hInvMassProtonXi","Invariant mass of p-#Xi pair;M_{p#Xi} (GeV/c^{2});Counts",1000,2.25,2.35);
+  TH1F *hInvMassProtonOmega = new TH1F("hInvMassProtonOmega","Invariant mass of p-#Omega pair;M_{p#Omega} (GeV/c^{2});Counts",1000,2.6,2.7);
+  TH1F *hInvMassLambdaXi = new TH1F("hInvMassLambdaXi","Invariant mass of #Lambda-#Xi pair;M_{#Lambda#Xi} (GeV/c^{2});Counts",1000,2.55,2.65);
+  TH2F *hInvMassPtProtonLambda = new TH2F("hInvMassPtProtonLambda","Invariant mass vs transverse momentum of p-#Lambda pair;M_{p#Lambda} (GeV/c^{2});p_{T} (GeV/c)",1000,2,3,100,0,10);
+  TH2F *hInvMassPtLambdaLambda = new TH2F("hInvMassPtLambdaLambda","Invariant mass vs transverse momentum of #Lambda-#Lambda pair;M_{#Lambda#Lambda} (GeV/c^{2});p_{T} (GeV/c)",1000,2.2,3.2,100,0,10);
+  TH2F *hInvMassPtProtonXi = new TH2F("hInvMassPtProtonXi","Invariant mass vs transverse momentum of p-#Xi pair;M_{p#Xi} (GeV/c^{2});p_{T} (GeV/c)",1000,2.2,3.2,100,0,10);
+  TH2F *hInvMassPtProtonOmega = new TH2F("hInvMassPtProtonOmega","Invariant mass vs transverse momentum of p-#Omega pair;M_{p#Omega} (GeV/c^{2});p_{T} (GeV/c)",1000,2.6,3.6,100,0,10);
+  TH2F *hInvMassPtLambdaXi = new TH2F("hInvMassPtLambdaXi","Invariant mass vs transverse momentum of #Lambda-#Xi pair;M_{#Lambda#Xi} (GeV/c^{2});p_{T} (GeV/c)",1000,2.4,3.4,100,0,10);
+  TH2F *hInvMassPtXiOmega = new TH2F("hInvMassPtXiOmega","Invariant mass vs transverse momentum of #Xi-#Omega pair;M_{#Xi#Omega} (GeV/c^{2});p_{T} (GeV/c)",1000,2.9,3.9,100,0,10);
+  TH2F *hInvMassPtOmegaOmega = new TH2F("hInvMassPtOmegaOmega","Invariant mass vs transverse momentum of #Omega-#Omega pair;M_{#Omega#Omega} (GeV/c^{2});p_{T} (GeV/c)",1000,3.3,4.3,100,0,10);
   TH2F *hInvMassRelKProtonLambda = new TH2F("hInvMassRelKProtonLambda","Invariant mass vs relative momentum of p-#Lambda pair;M_{p#Lambda} (GeV/c^{2});k^{*} (MeV/c)",1000,2,3,100,0,1000);
+  TH2F *hInvMassRelKLambdaLambda = new TH2F("hInvMassRelKLambdaLambda","Invariant mass vs relative momentum of #Lambda-#Lambda pair;M_{#Lambda#Lambda} (GeV/c^{2});k^{*} (MeV/c)",1000,2.2,3.2,100,0,1000);
   TH2F *hInvMassRelKProtonXi = new TH2F("hInvMassRelKProtonXi","Invariant mass vs relative momentum of p-#Xi pair;M_{p#Xi} (GeV/c^{2});k^{*} (MeV/c)",1000,2,3,100,0,1000);
   TH2F *hInvMassRelKProtonOmega = new TH2F("hInvMassRelKProtonOmega","Invariant mass vs relative momentum of p-#Omega pair;M_{p#Omega} (GeV/c^{2});k^{*} (MeV/c)",1000,2.6,3.6,100,0,1000);
   TH2F *hInvMassRelKLambdaXi = new TH2F("hInvMassRelKLambdaXi","Invariant mass vs relative momentum of #Lambda-#Xi pair;M_{#Lambda#Xi} (GeV/c^{2});k^{*} (MeV/c)",1000,2.4,3.4,100,0,1000);
-  TH2F *hInvMassRelKXiOmega = new TH2F("hInvMassRelKXiOmega","Invariant mass vs relative momentum of #Xi-#Omega pair;M_{#Xi#Omega} (GeV/c^{2});k^{*} (MeV/c)",1000,2.8,3.8,100,0,1000);
-  TH2F *hInvMassRelKOmegaOmega = new TH2F("hInvMassRelKOmegaOmega","Invariant mass vs relative momentum of #Omega-#Omega pair;M_{#Omega#Omega} (GeV/c^{2});k^{*} (MeV/c)",1000,3,4,100,0,1000);
+  TH2F *hInvMassRelKXiOmega = new TH2F("hInvMassRelKXiOmega","Invariant mass vs relative momentum of #Xi-#Omega pair;M_{#Xi#Omega} (GeV/c^{2});k^{*} (MeV/c)",1000,2.9,3.9,100,0,1000);
+  TH2F *hInvMassRelKOmegaOmega = new TH2F("hInvMassRelKOmegaOmega","Invariant mass vs relative momentum of #Omega-#Omega pair;M_{#Omega#Omega} (GeV/c^{2});k^{*} (MeV/c)",1000,3.3,4.3,100,0,1000);
 
-  fOutput->Add(hInvMassRelKLambdaLambda);
+  fOutput->Add(hInvMassProtonLambda);
+  fOutput->Add(hInvMassLambdaLambda);
+  fOutput->Add(hInvMassProtonXi);
+  fOutput->Add(hInvMassProtonOmega);
+  fOutput->Add(hInvMassLambdaXi);
+  fOutput->Add(hInvMassPtProtonLambda);
+  fOutput->Add(hInvMassPtLambdaLambda);
+  fOutput->Add(hInvMassPtProtonXi);
+  fOutput->Add(hInvMassPtProtonOmega);
+  fOutput->Add(hInvMassPtLambdaXi);
+  fOutput->Add(hInvMassPtXiOmega);
+  fOutput->Add(hInvMassPtOmegaOmega);
   fOutput->Add(hInvMassRelKProtonLambda);
+  fOutput->Add(hInvMassRelKLambdaLambda);
   fOutput->Add(hInvMassRelKProtonXi);
   fOutput->Add(hInvMassRelKProtonOmega);
   fOutput->Add(hInvMassRelKLambdaXi);
@@ -387,6 +423,20 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
     aodVtx->GetXYZ(primaryVtxPos);
   }
 
+  // Reference multiplicity
+  Int_t refMult08 = 0;
+  if(fAnalysisType == "ESD") {
+    refMult08 = AliESDtrackCuts::GetReferenceMultiplicity(esdEvent,AliESDtrackCuts::kTrackletsITSTPC,0.8,0);
+  } else if(fAnalysisType == "AOD") {
+    AliAODHeader *header = dynamic_cast<AliAODHeader*>(aodEvent->GetHeader());
+    if(!header) {
+      AliWarning("Could not get AOD header... return!");
+      return;
+    }
+    refMult08 = header->GetRefMultiplicityComb08();
+  }
+  dynamic_cast<TH1F*>(fOutput->FindObject("hRefMultiplicity08"))->Fill(refMult08);
+
   // Magnetic field
   Double_t bz = -10.;
   if     (fAnalysisType == "ESD") bz = esdEvent->GetMagneticField();
@@ -398,11 +448,13 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
   const Double_t massXi     = TDatabasePDG::Instance()->GetParticle(3312)->Mass();
   const Double_t massOmega  = TDatabasePDG::Instance()->GetParticle(3334)->Mass();
 
+  // Speed of light
+  const Double_t c = 2.99792457999999984e-02; // cm/ps
 
   //______________________________________________________________________________
   // Loop over the reconstructed candidates
 
-  // - Track loop
+  // - Track loop for proton and anti-proton selecton
 
   Int_t nTrack = 0;
   if     (fAnalysisType == "ESD") nTrack = esdEvent->GetNumberOfTracks();
@@ -411,7 +463,7 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
   fProtonArray->Clear("C");
   Int_t countProton = 0;
 
-  if(fAnalysisType == "AOD") {
+  if(fAnalysisType == "AOD") { // set global track
 
     // Reset global track reference
     for(Int_t i=0; i < fTrackBuffSize; i++) fTrackArray[i] = 0;
@@ -440,18 +492,19 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
     }
   }
 
-  for(Int_t iTrack=0; iTrack < nTrack; iTrack++) {// This is the beginning of the track loop
+  for(Int_t iTrack=0; iTrack < nTrack; iTrack++) {
 
     AliESDtrack *esdTrack = 0x0;
     AliAODTrack *aodTrack = 0x0;
 
-    // Initialisation of the local variables that will be needed for ESD/AOD
+    // Initialisation of the local variables
     Double_t charge = 0.;
     Double_t pt     = 0.;
     Double_t eta    = 0.;
     Double_t phi    = 0.;
     Double_t p      = 0.;
     Double_t dEdx   = 0.;
+    Double_t beta   = 0.;
 
     Float_t nTPCCrossedRows  = -1.;
     UShort_t nTPCClusters    = -1;
@@ -482,6 +535,10 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
       phi    = esdTrack->Phi();
       dEdx   = esdTrack->GetTPCsignal();
       p      = esdTrack->GetTPCmomentum();
+
+      const Double_t len = esdTrack->GetIntegratedLength();
+      const Double_t tim = esdTrack->GetTOFsignal() - fPIDResponse->GetTOFResponse().GetStartTime(esdTrack->GetTPCmomentum());
+      if(tim != 0.) beta = len / (tim * c);
 
       nTPCCrossedRows = esdTrack->GetTPCCrossedRows();
       nTPCClusters    = esdTrack->GetTPCNcls();
@@ -528,6 +585,10 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
       p      = globalTrack->GetTPCmomentum();
       dEdx   = globalTrack->GetTPCsignal();
 
+      const Double_t len = globalTrack->GetIntegratedLength();
+      const Double_t tim = globalTrack->GetTOFsignal() - fPIDResponse->GetTOFResponse().GetStartTime(globalTrack->GetTPCmomentum());
+      if(tim != 0.) beta = len / (tim * c);
+
       nTPCCrossedRows = aodTrack->GetTPCCrossedRows();
       nTPCClusters    = aodTrack->GetTPCNcls();
       nTPCSharedCls   = aodTrack->GetTPCnclsS();
@@ -547,6 +608,7 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
 
     } // end of AOD treatment
 
+    // Check track quality
     dynamic_cast<TH1F*>(fOutput->FindObject("hNCrossedRows"))        ->Fill(nTPCCrossedRows);
     dynamic_cast<TH1F*>(fOutput->FindObject("hNCluster"))            ->Fill(nTPCClusters);
     dynamic_cast<TH1F*>(fOutput->FindObject("hNSharedCluster"))      ->Fill(nTPCSharedCls);
@@ -558,44 +620,41 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
     if(ratio           < 0.83) continue;
     if(nTPCSharedCls   > 0)    continue;
 
-    if(!isthereTPC) continue; // TPC signal must be there
-    dynamic_cast<TH2F*>(fOutput->FindObject("hdEdxVsP"))->Fill(p,dEdx);
-
-    // Proton PID
-    if(p < 0.75) { // for p < 0.75 use TPC only
-
+    // Fill histos related to PID
+    if(isthereTPC) {
+      dynamic_cast<TH2F*>(fOutput->FindObject("hdEdxVsP"))->Fill(p,dEdx);
       if(charge > 0.) dynamic_cast<TH2F*>(fOutput->FindObject("hProtonNsigmaTPC"))->Fill(p,nSigmaTPCproton);
+    }
+    if(isthereTOF) {
+      dynamic_cast<TH2F*>(fOutput->FindObject("hBetaVsP"))->Fill(p,beta);
+      if(charge > 0.) dynamic_cast<TH2F*>(fOutput->FindObject("hProtonNsigmaTOF"))->Fill(p,nSigmaTOFproton);
+    }
 
+    // proton PID
+    if(p < 0.75) { // for p < 0.75 use TPC only
+      if(!isthereTPC) continue;
       if(TMath::Abs(nSigmaTPCproton) > 3.) continue;
-
-    } else if(p > 0.75) { // for p > 0.75 use TPC & TOF
-
-      if(!isthereTOF) continue; // TOF signal must be there
-
-      if(charge > 0.) {
-        dynamic_cast<TH2F*>(fOutput->FindObject("hProtonNsigmaTPC"))     ->Fill(p,nSigmaTPCproton);
-        dynamic_cast<TH2F*>(fOutput->FindObject("hProtonNsigmaTOF"))     ->Fill(p,nSigmaTOFproton);
-        dynamic_cast<TH2F*>(fOutput->FindObject("hProtonNsigmaCombined"))->Fill(p,nSigmaTPCTOFcombined);
-      }
-
+    }
+    else if(p > 0.75) { // for p > 0.75 use TPC & TOF
+      if(!isthereTPC || !isthereTOF) continue;
+      dynamic_cast<TH2F*>(fOutput->FindObject("hProtonNsigmaTPCvsTOF"))->Fill(nSigmaTPCproton,nSigmaTOFproton);
       if(nSigmaTPCTOFcombined > 3.) continue;
     }
 
-    if(charge > 0.) {
-      dynamic_cast<TH2F*>(fOutput->FindObject("hProtonDCAxyDCAz"))->Fill(DCAxy,DCAz);
-    }
+    if(charge > 0.) dynamic_cast<TH2F*>(fOutput->FindObject("hProtonDCAxyDCAz"))->Fill(DCAxy,DCAz);
 
+    // proton selection
     if(TMath::Abs(eta) > 0.8) continue;
     if(pt < 0.5 || 4.05 < pt) continue;
     if(TMath::Abs(DCAz)  > 0.2) continue; 
     if(TMath::Abs(DCAxy) > 0.1) continue;
 
-    // proton
-    if(charge > 0.) {
+    // Store candidates after selection
+    if(charge > 0.) { // for proton
 
       dynamic_cast<TH1F*>(fOutput->FindObject("hProtonPt")) ->Fill(pt);
-      dynamic_cast<TH1F*>(fOutput->FindObject("hProtonPhi"))->Fill(phi);
-      dynamic_cast<TH1F*>(fOutput->FindObject("hProtonEta"))->Fill(eta);
+      dynamic_cast<TH2F*>(fOutput->FindObject("hProtonEtaPhi"))->Fill(eta,phi);
+
       dynamic_cast<TH1F*>(fOutput->FindObject("hNPartStatistics"))->Fill(1);
 
       if(fAnalysisType == "ESD") {
@@ -611,17 +670,17 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
         countProton++;
       }
     }
-    // Anti-proton
-    else if(charge < 0.) {
+    else if(charge < 0.) { // for anti-proton
 
       dynamic_cast<TH1F*>(fOutput->FindObject("hAntiProtonPt"))->Fill(pt);
+
       dynamic_cast<TH1F*>(fOutput->FindObject("hNPartStatistics"))->Fill(2);
     }
 
   }// end of track loop
 
 
-  // - V0 loop
+  // - V0 loop for Lambda selection
 
   Int_t nV0 = 0;
   if     (fAnalysisType == "ESD") nV0 = esdEvent->GetNumberOfV0s();
@@ -630,12 +689,12 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
   fLambdaArray->Clear("C");
   Int_t countLambda = 0;
   
-  for(Int_t iV0=0; iV0<nV0; iV0++) {// This is the beginning of the V0 loop
+  for(Int_t iV0=0; iV0<nV0; iV0++) {
 
     AliESDv0 *esdV0 = 0x0;
     AliAODv0 *aodV0 = 0x0;
 
-    // Initialisation of the local variables that will be needed for ESD/AOD
+    // Initialisation of the local variables
     Double_t invMassLambda     = 0.;
     Double_t invMassAntiLambda = 0.;
     Double_t invMassK0S        = 0.;
@@ -652,29 +711,22 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
     Bool_t isNegProton = kFALSE;
     Bool_t isNegPion   = kFALSE;
 
-    Double_t etaV0        = -20.;
-    Double_t phiV0        = 720.;
-    Double_t momV0X       = 0.;
-    Double_t momV0Y       = 0.;
-    Double_t momV0Z       = 0.;
-    Double_t transvMomV0  = 0.;
-    Double_t etaPos       = -20.;
-    Double_t momPosX      = 0.;
-    Double_t momPosY      = 0.;
-    Double_t momPosZ      = 0.;
-    Double_t transvMomPos = 0.;
-    Double_t etaNeg       = -20.;
-    Double_t momNegX      = 0.;
-    Double_t momNegY      = 0.;
-    Double_t momNegZ      = 0.;
-    Double_t transvMomNeg = 0.;
+    Double_t ptV0   = 0.;
+    Double_t ptPos  = 0.;
+    Double_t ptNeg  = 0.;
+    Double_t etaV0  = -20.;
+    Double_t etaPos = -20.;
+    Double_t etaNeg = -20.;
+    Double_t phiV0  = 720.;
+    Double_t phiPos = 720.;
+    Double_t phiNeg = 720.;
 
     if(fAnalysisType == "ESD") {
       
       esdV0 = (AliESDv0*)esdEvent->GetV0(iV0);
       if(!esdV0) continue;
 
-      if(esdV0->GetOnFlyStatus()) continue; // select offline v0
+      if(esdV0->GetOnFlyStatus()) continue; // select offline V0
 
       // Get the tracks for the daughters
       AliESDtrack *pTrack = esdEvent->GetTrack(esdV0->GetPindex());
@@ -688,10 +740,8 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
       // Rejection of a poor quality tracks
       if(pTrack->GetTPCNcls() < 70) continue;
       if(nTrack->GetTPCNcls() < 70) continue;
-      if(TMath::Abs(pTrack->Eta()) > 0.8) continue;
-      if(TMath::Abs(nTrack->Eta()) > 0.8) continue;
-      if(esdV0->Pt() < 0.3) continue;
 
+      // Check TPC PID status
       AliPIDResponse::EDetPidStatus statusPosTPC = fPIDResponse->CheckPIDStatus(AliPIDResponse::kTPC,pTrack);
       AliPIDResponse::EDetPidStatus statusNegTPC = fPIDResponse->CheckPIDStatus(AliPIDResponse::kTPC,nTrack);
       if(statusPosTPC != AliPIDResponse::kDetPidOk) continue;
@@ -719,16 +769,16 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
       esdV0->GetXYZ(vtxPosV0[0], vtxPosV0[1], vtxPosV0[2]);
       radius = TMath::Sqrt(vtxPosV0[0]*vtxPosV0[0] + vtxPosV0[1]*vtxPosV0[1]);
 
-      esdV0->GetPxPyPz(momV0X, momV0Y, momV0Z);
-      esdV0->GetPPxPyPz(momPosX, momPosY, momPosZ);
-      esdV0->GetNPxPyPz(momNegX, momNegY, momNegZ);
-      transvMomV0  = TMath::Sqrt(momV0X*momV0X + momV0Y*momV0Y);
-      transvMomPos = TMath::Sqrt(momPosX*momPosX + momPosY*momPosY);
-      transvMomNeg = TMath::Sqrt(momNegX*momNegX + momNegY*momNegY);
+      // Get kinematic values
+      ptV0   = esdV0->Pt();
+      ptPos  = pTrack->Pt();
+      ptNeg  = nTrack->Pt();
       etaV0  = esdV0->Eta();
       etaPos = pTrack->Eta();
       etaNeg = nTrack->Eta();
       phiV0  = esdV0->Phi();
+      phiPos = pTrack->Phi();
+      phiNeg = nTrack->Phi();
 
     } // end of ESD treatment
 
@@ -756,9 +806,6 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
       // Rejection of a poor quality tracks
       if(pTrack->GetTPCNcls() < 70) continue;
       if(nTrack->GetTPCNcls() < 70) continue;
-      if(TMath::Abs(pTrack->Eta()) > 0.8) continue;
-      if(TMath::Abs(nTrack->Eta()) > 0.8) continue;
-      if(aodV0->Pt() < 0.3) continue;
 
       // Out-of-bunch pile-up removal: require either a hit in the ITS SPD or ITS SDD, or TOF in-bunch timing
       if(fPileupCut) {
@@ -770,6 +817,7 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
            !(nTrack->GetTOFBunchCrossing() == 0)) continue;
       }
 
+      // Check TPC PID status
       AliPIDResponse::EDetPidStatus statusPosTPC = fPIDResponse->CheckPIDStatus(AliPIDResponse::kTPC,pTrack);
       AliPIDResponse::EDetPidStatus statusNegTPC = fPIDResponse->CheckPIDStatus(AliPIDResponse::kTPC,nTrack);
       if(statusPosTPC != AliPIDResponse::kDetPidOk) continue;
@@ -794,27 +842,21 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
       aodV0->GetXYZ(vtxPosV0);
       radius = TMath::Sqrt(vtxPosV0[0]*vtxPosV0[0] + vtxPosV0[1]*vtxPosV0[1]);
 
-      momV0X  = aodV0->MomV0X();
-      momV0Y  = aodV0->MomV0Y();
-      momV0Z  = aodV0->MomV0Z();
-      momPosX = aodV0->MomPosX();
-      momPosY = aodV0->MomPosY();
-      momPosZ = aodV0->MomPosZ();
-      momNegX = aodV0->MomNegX();
-      momNegY = aodV0->MomNegY();
-      momNegZ = aodV0->MomNegZ();
-      transvMomV0  = TMath::Sqrt(momV0X*momV0X + momV0Y*momV0Y);
-      transvMomPos = TMath::Sqrt(momPosX*momPosX + momPosY*momPosY);
-      transvMomNeg = TMath::Sqrt(momNegX*momNegX + momNegY*momNegY);
-      phiV0   = aodV0->Phi();
-      etaV0   = aodV0->Eta();
-      etaPos  = pTrack->Eta();
-      etaNeg  = nTrack->Eta();
+      // Get kinematic values
+      ptV0   = aodV0->Pt();
+      ptPos  = pTrack->Pt();
+      ptNeg  = nTrack->Pt();
+      etaV0  = aodV0->Eta();
+      etaPos = pTrack->Eta();
+      etaNeg = nTrack->Eta();
+      phiV0  = aodV0->Phi();
+      phiPos = pTrack->Phi();
+      phiNeg = nTrack->Phi();
 
     } // end of AOD treatment
 
     if(isPosProton && isNegPion) {
-      dynamic_cast<TH1F*>(fOutput->FindObject("hInvMassLambdawoCuts"))        ->Fill(invMassLambda);
+      dynamic_cast<TH1F*>(fOutput->FindObject("hInvMassLambdawoCuts"))->Fill(invMassLambda);
     }
     else if(isNegProton && isPosPion) {
       dynamic_cast<TH1F*>(fOutput->FindObject("hInvMassAntiLambdawoCuts"))->Fill(invMassAntiLambda);
@@ -822,7 +864,10 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
     dynamic_cast<TH1F*>(fOutput->FindObject("hInvMassMissIDK0S"))->Fill(invMassK0S);
     if(0.48 < invMassK0S && invMassK0S < 0.515) continue; // reject K0Short
 
-    // Topological cuts
+    // Lambda selection
+    if(TMath::Abs(etaPos) > 0.8) continue;
+    if(TMath::Abs(etaNeg) > 0.8) continue;
+    if(ptV0 < 0.3) continue;
     if(TMath::Abs(vtxPosV0[0]) > 100) continue;
     if(TMath::Abs(vtxPosV0[1]) > 100) continue;
     if(TMath::Abs(vtxPosV0[2]) > 100) continue;
@@ -832,12 +877,12 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
     if(dcaNegToPrimVtx < 0.05) continue;
     if(radius < 0.2 || 100 < radius) continue;
 
-    // Lambda
-    if(isPosProton && isNegPion) {
+    // Store candidates after selection
+    if(isPosProton && isNegPion) { // for Lambda
 
-      dynamic_cast<TH1F*>(fOutput->FindObject("hInvMassLambdawCuts"))->Fill(invMassLambda);
+      dynamic_cast<TH2F*>(fOutput->FindObject("hInvMassLambda"))->Fill(invMassLambda,ptV0);
 
-      if(TMath::Abs(invMassLambda - massLambda) < 0.004) {
+      if(TMath::Abs(invMassLambda - massLambda) < 0.004) { // mass window selection
 
         dynamic_cast<TH1F*>(fOutput->FindObject("hLambdaDCADaughterTracks"))    ->Fill(dcaV0Dghters);
         dynamic_cast<TH1F*>(fOutput->FindObject("hLambdaDCAPosDaughPrimVertex"))->Fill(dcaPosToPrimVtx);
@@ -845,11 +890,13 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
         dynamic_cast<TH1F*>(fOutput->FindObject("hLambdaCosPointingAngle"))     ->Fill(cosPointAngle);
         dynamic_cast<TH1F*>(fOutput->FindObject("hLambdaTransverseRadius"))     ->Fill(radius);
 
-        dynamic_cast<TH1F*>(fOutput->FindObject("hLambdaPt"))        ->Fill(transvMomV0);
-        dynamic_cast<TH1F*>(fOutput->FindObject("hLambdaPosDaughPt"))->Fill(transvMomPos);
-        dynamic_cast<TH1F*>(fOutput->FindObject("hLambdaNegDaughPt"))->Fill(transvMomNeg);
-        dynamic_cast<TH1F*>(fOutput->FindObject("hLambdaPhi"))       ->Fill(phiV0);
-        dynamic_cast<TH1F*>(fOutput->FindObject("hLambdaEta"))       ->Fill(etaV0);
+        dynamic_cast<TH1F*>(fOutput->FindObject("hLambdaPt"))            ->Fill(ptV0);
+        dynamic_cast<TH1F*>(fOutput->FindObject("hLambdaPosDaughPt"))    ->Fill(ptPos);
+        dynamic_cast<TH1F*>(fOutput->FindObject("hLambdaNegDaughPt"))    ->Fill(ptNeg);
+        dynamic_cast<TH2F*>(fOutput->FindObject("hLambdaEtaPhi"))        ->Fill(etaV0,phiV0);
+        dynamic_cast<TH2F*>(fOutput->FindObject("hLambdaPosDaughEtaPhi"))->Fill(etaPos,phiPos);
+        dynamic_cast<TH2F*>(fOutput->FindObject("hLambdaNegDaughEtaPhi"))->Fill(etaNeg,phiNeg);
+
         dynamic_cast<TH1F*>(fOutput->FindObject("hNPartStatistics")) ->Fill(3);
 
         if(fAnalysisType == "ESD") {
@@ -866,14 +913,14 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
         }
       }
     }
-    // AntiLambda
-    if(isNegProton && isPosPion) {
+    if(isNegProton && isPosPion) { // for Anti-Lambda
 
-      dynamic_cast<TH1F*>(fOutput->FindObject("hInvMassAntiLambdawCuts"))->Fill(invMassAntiLambda);
+      dynamic_cast<TH2F*>(fOutput->FindObject("hInvMassAntiLambda"))->Fill(invMassAntiLambda,ptV0);
 
-      if(TMath::Abs(invMassAntiLambda - massLambda) < 0.004) {
+      if(TMath::Abs(invMassAntiLambda - massLambda) < 0.004) { // mass window selection
 
-        dynamic_cast<TH1F*>(fOutput->FindObject("hAntiLambdaPt"))->Fill(transvMomV0);
+        dynamic_cast<TH1F*>(fOutput->FindObject("hAntiLambdaPt"))->Fill(ptV0);
+
         dynamic_cast<TH1F*>(fOutput->FindObject("hNPartStatistics"))->Fill(4);
       }
     }
@@ -881,7 +928,7 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
   }// end of V0 loop
 
 
-  // - Cascade loop
+  // - Cascade loop for Xi and Omega selection
 
   Int_t nCascade = 0;
   if     (fAnalysisType == "ESD") nCascade = esdEvent->GetNumberOfCascades();
@@ -892,12 +939,12 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
   Int_t countXi = 0;
   Int_t countOmega = 0;
 
-  for(Int_t iXi = 0; iXi < nCascade; iXi++) {// This is the beginning of the Cascade loop
+  for(Int_t iXi = 0; iXi < nCascade; iXi++) {
 
     AliESDcascade *esdXi = 0x0;
     AliAODcascade *aodXi = 0x0;
 
-    // Initialisation of the local variables that will be needed for ESD/AOD
+    // Initialisation of the local variables
     Double_t invMassXiMinus    = 0.;
     Double_t invMassXiPlus     = 0.;
     Double_t invMassOmegaMinus = 0.;
@@ -905,7 +952,6 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
     Double_t invMassLambdaAsCascDghter = 0.;
 
     Double_t dcaXiDghters     = -1.; 
-    Double_t dcaXiToPrimVtx   = -1.;
     Double_t cosPointAngleXi  = -1.;
     Double_t vtxPosXi[3]      = {-999., -999., -999.};
     Double_t radiusXi         = -999.;
@@ -919,36 +965,30 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
     Double_t dcaPosToPrimVtx  = -1.;
     Double_t dcaNegToPrimVtx  = -1.;
 
-    Bool_t isBachelorKaon   = kFALSE;
-    Bool_t isBachelorPion   = kFALSE;
-    Bool_t isPosProton      = kFALSE;
-    Bool_t isPosPion        = kFALSE;
-    Bool_t isNegProton      = kFALSE;
-    Bool_t isNegPion        = kFALSE;
+    Bool_t isBachelorKaon = kFALSE;
+    Bool_t isBachelorPion = kFALSE;
+    Bool_t isPosProton    = kFALSE;
+    Bool_t isPosPion      = kFALSE;
+    Bool_t isNegProton    = kFALSE;
+    Bool_t isNegPion      = kFALSE;
 
-    Double_t etaXi         = -20.;
-    Double_t phiXi         = 720.;
-    Double_t momXiX        = 0.;
-    Double_t momXiY        = 0.;
-    Double_t momXiZ        = 0.;
-    Double_t transvMomXi   = 0.;
-    Double_t etaBach       = -20.;
-    Double_t momBachX      = 0.;
-    Double_t momBachY      = 0.;
-    Double_t momBachZ      = 0.;
-    Double_t transvMomBach = 0.;
-    Double_t etaPos        = -20.;
-    Double_t momPosX       = 0.;
-    Double_t momPosY       = 0.;
-    Double_t momPosZ       = 0.;
-    Double_t transvMomPos  = 0.;
-    Double_t etaNeg        = -20.;
-    Double_t momNegX       = 0.;
-    Double_t momNegY       = 0.;
-    Double_t momNegZ       = 0.;
-    Double_t transvMomNeg  = 0.;
+    Double_t ptXi    = 0.;
+    Double_t ptBach  = 0.;
+    Double_t ptPos   = 0.;
+    Double_t ptNeg   = 0.;
+    Double_t etaXi   = -20.;
+    Double_t etaBach = -20.;
+    Double_t etaPos  = -20.;
+    Double_t etaNeg  = -20.;
+    Double_t phiXi   = 720.;
+    Double_t phiBach = 720.;
+    Double_t phiPos  = 720.;
+    Double_t phiNeg  = 720.;
 
     Short_t chargeXi = -2;
+
+    Bool_t standerdXi    = kTRUE;
+    Bool_t standerdOmega = kTRUE;
 
     if(fAnalysisType == "ESD") {
       
@@ -971,13 +1011,8 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
       if(bachTrack->GetTPCNcls() < 70) continue;
       if(pTrack   ->GetTPCNcls() < 70) continue;
       if(nTrack   ->GetTPCNcls() < 70) continue;
-      if(TMath::Abs(bachTrack->Eta()) > 0.8) continue;
-      if(TMath::Abs(pTrack   ->Eta()) > 0.8) continue;
-      if(TMath::Abs(nTrack   ->Eta()) > 0.8) continue;
-      if(bachTrack->Pt() < 0.3) continue;
-      if(pTrack   ->Pt() < 0.3) continue;
-      if(nTrack   ->Pt() < 0.3) continue;
 
+      // Check TPC PID status
       AliPIDResponse::EDetPidStatus statusBachTPC = fPIDResponse->CheckPIDStatus(AliPIDResponse::kTPC,bachTrack);
       AliPIDResponse::EDetPidStatus statusPosTPC  = fPIDResponse->CheckPIDStatus(AliPIDResponse::kTPC,pTrack);
       AliPIDResponse::EDetPidStatus statusNegTPC  = fPIDResponse->CheckPIDStatus(AliPIDResponse::kTPC,nTrack);
@@ -1012,7 +1047,6 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
       esdXi->GetXYZcascade(vtxPosXi[0], vtxPosXi[1], vtxPosXi[2]);
       esdXi->GetXYZ(vtxPosV0[0], vtxPosV0[1], vtxPosV0[2]);
       dcaXiDghters     = TMath::Abs(esdXi->GetDcaXiDaughters());
-      dcaXiToPrimVtx   = TMath::Abs(esdXi->GetDcascade(primaryVtxPos[0], primaryVtxPos[1], primaryVtxPos[2]));
       cosPointAngleXi  = esdXi->GetCascadeCosineOfPointingAngle(primaryVtxPos[0], primaryVtxPos[1], primaryVtxPos[2]);
       radiusXi         = TMath::Sqrt(vtxPosXi[0]*vtxPosXi[0] + vtxPosXi[1]*vtxPosXi[1]);
       dcaV0Dghters     = TMath::Abs(esdXi->GetDcaV0Daughters());
@@ -1023,19 +1057,19 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
       dcaPosToPrimVtx  = TMath::Abs(pTrack->GetD(primaryVtxPos[0], primaryVtxPos[1], bz));
       dcaNegToPrimVtx  = TMath::Abs(nTrack->GetD(primaryVtxPos[0], primaryVtxPos[1], bz));
 
-      esdXi->GetPxPyPz(momXiX, momXiY, momXiZ);
-      esdXi->GetBPxPyPz(momBachX, momBachY, momBachZ);
-      esdXi->GetPPxPyPz(momPosX, momPosY, momPosZ);
-      esdXi->GetNPxPyPz(momNegX, momNegY, momNegZ);
-      transvMomXi   = TMath::Sqrt(momXiX*momXiX + momXiY*momXiY);
-      transvMomBach = TMath::Sqrt(momBachX*momBachX + momBachY*momBachY);
-      transvMomPos  = TMath::Sqrt(momPosX*momPosX + momPosY*momPosY);
-      transvMomNeg  = TMath::Sqrt(momNegX*momNegX + momNegY*momNegY);
-      phiXi   = esdXi->Phi();
+      // Get kinematic values
+      ptXi    = esdXi->Pt();
+      ptBach  = bachTrack->Pt();
+      ptPos   = pTrack->Pt();
+      ptNeg   = nTrack->Pt();
       etaXi   = esdXi->Eta();
       etaBach = bachTrack->Eta();
       etaPos  = pTrack->Eta();
       etaNeg  = nTrack->Eta();
+      phiXi   = esdXi->Phi();
+      phiBach = bachTrack->Phi();
+      phiPos  = pTrack->Phi();
+      phiNeg  = nTrack->Phi();
 
     } // end of ESD treatment
     
@@ -1060,12 +1094,6 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
       if(bachTrack->GetTPCNcls() < 70) continue;
       if(pTrack   ->GetTPCNcls() < 70) continue;
       if(nTrack   ->GetTPCNcls() < 70) continue;
-      if(TMath::Abs(bachTrack->Eta()) > 0.8) continue;
-      if(TMath::Abs(pTrack   ->Eta()) > 0.8) continue;
-      if(TMath::Abs(nTrack   ->Eta()) > 0.8) continue;
-      if(bachTrack->Pt() < 0.3) continue;
-      if(pTrack   ->Pt() < 0.3) continue;
-      if(nTrack   ->Pt() < 0.3) continue;
 
       // Out-of-bunch pile-up removal: require either a hit in the ITS SPD or ITS SDD, or TOF in-bunch timing
       if(fPileupCut) {
@@ -1080,6 +1108,7 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
            !(nTrack->GetTOFBunchCrossing() == 0)) continue;
       }
 
+      // Check TPC PID status
       AliPIDResponse::EDetPidStatus statusBachTPC = fPIDResponse->CheckPIDStatus(AliPIDResponse::kTPC,bachTrack);
       AliPIDResponse::EDetPidStatus statusPosTPC  = fPIDResponse->CheckPIDStatus(AliPIDResponse::kTPC,pTrack);
       AliPIDResponse::EDetPidStatus statusNegTPC  = fPIDResponse->CheckPIDStatus(AliPIDResponse::kTPC,nTrack);
@@ -1115,7 +1144,6 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
       vtxPosV0[1] = aodXi->DecayVertexV0Y();
       vtxPosV0[2] = aodXi->DecayVertexV0Z();
       dcaXiDghters     = TMath::Abs(aodXi->DcaXiDaughters());
-      dcaXiToPrimVtx   = TMath::Abs(aodXi->DcaXiToPrimVertex());
       cosPointAngleXi  = aodXi->CosPointingAngleXi(primaryVtxPos[0], primaryVtxPos[1], primaryVtxPos[2]);
       radiusXi         = TMath::Sqrt(vtxPosXi[0]*vtxPosXi[0] + vtxPosXi[1]*vtxPosXi[1]);
       dcaV0Dghters     = TMath::Abs(aodXi->DcaV0Daughters());
@@ -1126,27 +1154,19 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
       dcaPosToPrimVtx  = TMath::Abs(aodXi->DcaPosToPrimVertex());
       dcaNegToPrimVtx  = TMath::Abs(aodXi->DcaNegToPrimVertex());
 
-      momXiX = aodXi->MomXiX();
-      momXiY = aodXi->MomXiY();
-      momXiZ = aodXi->MomXiZ();
-      momBachX = aodXi->MomBachX();
-      momBachY = aodXi->MomBachY();
-      momBachZ = aodXi->MomBachZ();
-      momPosX = aodXi->MomPosX();
-      momPosY = aodXi->MomPosY();
-      momPosZ = aodXi->MomPosZ();
-      momNegX = aodXi->MomNegX();
-      momNegY = aodXi->MomNegY();
-      momNegZ = aodXi->MomNegZ();
-      transvMomXi   = TMath::Sqrt(momXiX*momXiX + momXiY*momXiY);
-      transvMomBach = TMath::Sqrt(momBachX*momBachX + momBachY*momBachY);
-      transvMomPos  = TMath::Sqrt(momPosX*momPosX + momPosY*momPosY);
-      transvMomNeg  = TMath::Sqrt(momNegX*momNegX + momNegY*momNegY);
-      phiXi   = aodXi->Phi();
+      // Get kinematic values
+      ptXi    = aodXi->Pt();
+      ptBach  = bachTrack->Pt();
+      ptPos   = pTrack->Pt();
+      ptNeg   = nTrack->Pt();
       etaXi   = aodXi->Eta();
       etaBach = bachTrack->Eta();
       etaPos  = pTrack->Eta();
       etaNeg  = nTrack->Eta();
+      phiXi   = aodXi->Phi();
+      phiBach = bachTrack->Phi();
+      phiPos  = pTrack->Phi();
+      phiNeg  = nTrack->Phi();
 
     } // end of AOD treatment
 
@@ -1165,8 +1185,13 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
       dynamic_cast<TH1F*>(fOutput->FindObject("hInvMassOmegapwoCuts"))->Fill(invMassOmegaPlus);
     }
 
-    Bool_t standerdXi    = kTRUE;
-    Bool_t standerdOmega = kTRUE;
+    // Kinematic cuts for Xi and Omega
+    if(TMath::Abs(etaBach) > 0.8) continue;
+    if(TMath::Abs(etaPos)  > 0.8) continue;
+    if(TMath::Abs(etaNeg) > 0.8) continue;
+    if(ptBach < 0.3) continue;
+    if(ptPos  < 0.3) continue;
+    if(ptNeg  < 0.3) continue;
 
     // Topological cuts for Xi
     if(dcaXiDghters > 1.6)      standerdXi = kFALSE;
@@ -1184,12 +1209,13 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
     if(dcaXiDghters > 0.8)      standerdOmega = kFALSE;
     if(dcaV0Dghters > 1.2)      standerdOmega = kFALSE;
     if(dcaV0ToPrimVtx < 0.06)   standerdOmega = kFALSE;
-    if(dcaBachToPrimVtx < 0.03) standerdOmega = kFALSE;
-    if(dcaPosToPrimVtx < 0.02)  standerdOmega = kFALSE;
-    if(dcaNegToPrimVtx < 0.02)  standerdOmega = kFALSE;
+    if(dcaBachToPrimVtx < 0.05) standerdOmega = kFALSE;
+    if(dcaPosToPrimVtx < 0.05)  standerdOmega = kFALSE;
+    if(dcaNegToPrimVtx < 0.05)  standerdOmega = kFALSE;
     if(cosPointAngleXi < 0.995) standerdOmega = kFALSE;
     if(cosPointAngleV0 < 0.97)  standerdOmega = kFALSE;
-    if(radiusV0 < 1.0)          standerdOmega = kFALSE;
+    if(radiusXi < 0.2 || 200 < radiusXi) standerdOmega = kFALSE;
+    if(radiusV0 < 1.0 || 200 < radiusV0) standerdOmega = kFALSE;
 
     dynamic_cast<TH1F*>(fOutput->FindObject("hInvMassLambdaAsCascDghter"))->Fill(invMassLambdaAsCascDghter);
 
@@ -1199,15 +1225,16 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
       standerdOmega = kFALSE;
     }
 
-    if(standerdXi) { // select Xi candidates
+    // Store candidates after selection
+    if(standerdXi) {
 
       if((chargeXi<0) && // for Xi-
-         (isBachelorPion && isPosProton && isNegPion) && // PID info
+         (isBachelorPion && isPosProton && isNegPion) && // TPC PID info
          (invMassOmegaMinus < 1.667 || 1.677 < invMassOmegaMinus)) { // reject Omega-
 
-        dynamic_cast<TH1F*>(fOutput->FindObject("hInvMassXimwCuts"))->Fill(invMassXiMinus);
+        dynamic_cast<TH2F*>(fOutput->FindObject("hInvMassXim"))->Fill(invMassXiMinus,ptXi);
 
-        if(TMath::Abs(invMassXiMinus - massXi) < 0.005) { // mass window cut for Xi-
+        if(TMath::Abs(invMassXiMinus - massXi) < 0.005) { // mass window selection
 
           dynamic_cast<TH1F*>(fOutput->FindObject("hXiDCADaughterTracks"))    ->Fill(dcaXiDghters);
           dynamic_cast<TH1F*>(fOutput->FindObject("hXiDCAV0DaughterTracks"))  ->Fill(dcaV0Dghters);
@@ -1220,12 +1247,15 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
           dynamic_cast<TH1F*>(fOutput->FindObject("hXiTransverseRadius"))     ->Fill(radiusXi);
           dynamic_cast<TH1F*>(fOutput->FindObject("hXiV0TransverseRadius"))   ->Fill(radiusV0);
 
-          dynamic_cast<TH1F*>(fOutput->FindObject("hXimPt"))        ->Fill(transvMomXi);
-          dynamic_cast<TH1F*>(fOutput->FindObject("hXimBachPt"))    ->Fill(transvMomBach);
-          dynamic_cast<TH1F*>(fOutput->FindObject("hXimPosDaughPt"))->Fill(transvMomPos);
-          dynamic_cast<TH1F*>(fOutput->FindObject("hXimNegDaughPt"))->Fill(transvMomNeg);
-          dynamic_cast<TH1F*>(fOutput->FindObject("hXimPhi"))       ->Fill(phiXi);
-          dynamic_cast<TH1F*>(fOutput->FindObject("hXimEta"))       ->Fill(etaXi);
+          dynamic_cast<TH1F*>(fOutput->FindObject("hXimPt"))            ->Fill(ptXi);
+          dynamic_cast<TH1F*>(fOutput->FindObject("hXimBachPt"))        ->Fill(ptBach);
+          dynamic_cast<TH1F*>(fOutput->FindObject("hXimPosDaughPt"))    ->Fill(ptPos);
+          dynamic_cast<TH1F*>(fOutput->FindObject("hXimNegDaughPt"))    ->Fill(ptNeg);
+          dynamic_cast<TH2F*>(fOutput->FindObject("hXimEtaPhi"))        ->Fill(etaXi,phiXi);
+          dynamic_cast<TH2F*>(fOutput->FindObject("hXimBachEtaPhi"))    ->Fill(etaBach,phiBach);
+          dynamic_cast<TH2F*>(fOutput->FindObject("hXimPosDaughEtaPhi"))->Fill(etaPos,phiPos);
+          dynamic_cast<TH2F*>(fOutput->FindObject("hXimNegDaughEtaPhi"))->Fill(etaNeg,phiNeg);
+
           dynamic_cast<TH1F*>(fOutput->FindObject("hNPartStatistics"))->Fill(5);
 
           if(fAnalysisType == "ESD") {
@@ -1243,28 +1273,29 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
         }
       }
       if((chargeXi>0) && // for Xi+
-         (isBachelorPion && isNegProton && isPosPion) && // PID info
+         (isBachelorPion && isNegProton && isPosPion) && // TOC PID info
          (invMassOmegaPlus < 1.667 || 1.677 < invMassOmegaPlus)) { // reject Omega+
 
-        dynamic_cast<TH1F*>(fOutput->FindObject("hInvMassXipwCuts"))->Fill(invMassXiPlus);
+        dynamic_cast<TH2F*>(fOutput->FindObject("hInvMassXip"))->Fill(invMassXiPlus,ptXi);
 
-        if(TMath::Abs(invMassXiPlus - massXi) < 0.005) { // mass window cut for Xi+
+        if(TMath::Abs(invMassXiPlus - massXi) < 0.005) { // mass window selection
 
-          dynamic_cast<TH1F*>(fOutput->FindObject("hXipPt"))->Fill(transvMomXi);
+          dynamic_cast<TH1F*>(fOutput->FindObject("hXipPt"))->Fill(ptXi);
+
           dynamic_cast<TH1F*>(fOutput->FindObject("hNPartStatistics"))->Fill(6);
         }
       }
     }
 
-    if(standerdOmega) { // select Omega candidates
+    if(standerdOmega) {
 
       if((chargeXi<0) && // for Omega-
-         (isBachelorKaon && isPosProton && isNegPion) && // PID info
+         (isBachelorKaon && isPosProton && isNegPion) && // TPC PID info
          (invMassXiMinus < 1.317 || 1.327 < invMassXiMinus)) { // reject Xi-
 
-        dynamic_cast<TH1F*>(fOutput->FindObject("hInvMassOmegamwCuts"))->Fill(invMassOmegaMinus);
+        dynamic_cast<TH2F*>(fOutput->FindObject("hInvMassOmegam"))->Fill(invMassOmegaMinus,ptXi);
 
-        if(TMath::Abs(invMassOmegaMinus - massOmega) < 0.005) { // mass window cut for Omega-
+        if(TMath::Abs(invMassOmegaMinus - massOmega) < 0.005) { // mass window selection
 
           dynamic_cast<TH1F*>(fOutput->FindObject("hOmegaDCADaughterTracks"))    ->Fill(dcaXiDghters);
           dynamic_cast<TH1F*>(fOutput->FindObject("hOmegaDCAV0DaughterTracks"))  ->Fill(dcaV0Dghters);
@@ -1277,12 +1308,15 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
           dynamic_cast<TH1F*>(fOutput->FindObject("hOmegaTransverseRadius"))     ->Fill(radiusXi);
           dynamic_cast<TH1F*>(fOutput->FindObject("hOmegaV0TransverseRadius"))   ->Fill(radiusV0);
 
-          dynamic_cast<TH1F*>(fOutput->FindObject("hOmegamPt"))        ->Fill(transvMomXi);
-          dynamic_cast<TH1F*>(fOutput->FindObject("hOmegamBachPt"))    ->Fill(transvMomBach);
-          dynamic_cast<TH1F*>(fOutput->FindObject("hOmegamPosDaughPt"))->Fill(transvMomPos);
-          dynamic_cast<TH1F*>(fOutput->FindObject("hOmegamNegDaughPt"))->Fill(transvMomNeg);
-          dynamic_cast<TH1F*>(fOutput->FindObject("hOmegamPhi"))       ->Fill(phiXi);
-          dynamic_cast<TH1F*>(fOutput->FindObject("hOmegamEta"))       ->Fill(etaXi);
+          dynamic_cast<TH1F*>(fOutput->FindObject("hOmegamPt"))            ->Fill(ptXi);
+          dynamic_cast<TH1F*>(fOutput->FindObject("hOmegamBachPt"))        ->Fill(ptBach);
+          dynamic_cast<TH1F*>(fOutput->FindObject("hOmegamPosDaughPt"))    ->Fill(ptPos);
+          dynamic_cast<TH1F*>(fOutput->FindObject("hOmegamNegDaughPt"))    ->Fill(ptNeg);
+          dynamic_cast<TH2F*>(fOutput->FindObject("hOmegamEtaPhi"))        ->Fill(etaXi,phiXi);
+          dynamic_cast<TH2F*>(fOutput->FindObject("hOmegamBachEtaPhi"))    ->Fill(etaBach,phiBach);
+          dynamic_cast<TH2F*>(fOutput->FindObject("hOmegamPosDaughEtaPhi"))->Fill(etaPos,phiPos);
+          dynamic_cast<TH2F*>(fOutput->FindObject("hOmegamNegDaughEtaPhi"))->Fill(etaNeg,phiNeg);
+
           dynamic_cast<TH1F*>(fOutput->FindObject("hNPartStatistics"))->Fill(7);
 
           if(fAnalysisType == "ESD") {
@@ -1300,14 +1334,15 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
         }
       }
       if((chargeXi>0) && // for Omega+
-         (isBachelorKaon && isNegProton && isPosPion) && // PID info
+         (isBachelorKaon && isNegProton && isPosPion) && // TPC PID info
          (invMassXiPlus < 1.317 || 1.327 < invMassXiPlus)) { // reject Xi+
 
-        dynamic_cast<TH1F*>(fOutput->FindObject("hInvMassOmegapwCuts"))->Fill(invMassOmegaPlus);
+        dynamic_cast<TH2F*>(fOutput->FindObject("hInvMassOmegap"))->Fill(invMassOmegaPlus,ptXi);
 
-        if(TMath::Abs(invMassOmegaPlus - massOmega) < 0.005) { // mass window cut for Omega+
+        if(TMath::Abs(invMassOmegaPlus - massOmega) < 0.005) { // mass window selection
 
-          dynamic_cast<TH1F*>(fOutput->FindObject("hOmegapPt"))->Fill(transvMomXi);
+          dynamic_cast<TH1F*>(fOutput->FindObject("hOmegapPt"))->Fill(ptXi);
+
           dynamic_cast<TH1F*>(fOutput->FindObject("hNPartStatistics"))->Fill(8);
         }
       }
@@ -1342,15 +1377,18 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
 
         TLorentzVector trackProton, trackLambda, trackSum;
 
-        trackProton.SetXYZM(track->Px(), track->Py(), track->Pz(), massProton);
-        trackLambda.SetXYZM(v0->Px(), v0->Py(), v0->Pz(), massLambda);
+        trackProton.SetXYZM(track->Px(),track->Py(),track->Pz(),massProton);
+        trackLambda.SetXYZM(v0->Px(),v0->Py(),v0->Pz(),massLambda);
         trackSum = trackProton + trackLambda;
 
         Double_t mass = trackSum.M();
-        Double_t relK = 1000*relKcalc(trackProton, trackLambda); 
+        Double_t pt   = trackSum.Pt();
+        Double_t relK = 1000*relKcalc(trackProton,trackLambda);
 
         dynamic_cast<TH1F*>(fOutput->FindObject("hNPairStatistics"))->Fill(1);
-        dynamic_cast<TH2F*>(fOutput->FindObject("hInvMassRelKProtonLambda"))->Fill(mass, relK);
+        dynamic_cast<TH1F*>(fOutput->FindObject("hInvMassProtonLambda"))->Fill(mass);
+        dynamic_cast<TH2F*>(fOutput->FindObject("hInvMassPtProtonLambda"))->Fill(mass,pt);
+        dynamic_cast<TH2F*>(fOutput->FindObject("hInvMassRelKProtonLambda"))->Fill(mass,relK);
       }
     }
 
@@ -1370,15 +1408,18 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
 
         TLorentzVector trackLambda1, trackLambda2, trackSum;
 
-        trackLambda1.SetXYZM(v01->Px(), v01->Py(), v01->Pz(), massLambda);
-        trackLambda2.SetXYZM(v02->Px(), v02->Py(), v02->Pz(), massLambda);
+        trackLambda1.SetXYZM(v01->Px(),v01->Py(),v01->Pz(),massLambda);
+        trackLambda2.SetXYZM(v02->Px(),v02->Py(),v02->Pz(),massLambda);
         trackSum = trackLambda1 + trackLambda2;
 
         Double_t mass = trackSum.M();
-        Double_t relK = 1000*relKcalc(trackLambda1, trackLambda2); 
+        Double_t pt   = trackSum.Pt();
+        Double_t relK = 1000*relKcalc(trackLambda1,trackLambda2);
 
         dynamic_cast<TH1F*>(fOutput->FindObject("hNPairStatistics"))->Fill(2);
-        dynamic_cast<TH2F*>(fOutput->FindObject("hInvMassRelKLambdaLambda"))->Fill(mass, relK);
+        dynamic_cast<TH1F*>(fOutput->FindObject("hInvMassLambdaLambda"))->Fill(mass);
+        dynamic_cast<TH2F*>(fOutput->FindObject("hInvMassPtLambdaLambda"))->Fill(mass,pt);
+        dynamic_cast<TH2F*>(fOutput->FindObject("hInvMassRelKLambdaLambda"))->Fill(mass,relK);
       }
     }
 
@@ -1399,15 +1440,18 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
 
         TLorentzVector trackProton, trackXi, trackSum;
 
-        trackProton.SetXYZM(track->Px(), track->Py(), track->Pz(), massProton);
-        trackXi.SetXYZM(xi->Px(), xi->Py(), xi->Pz(), massXi);
+        trackProton.SetXYZM(track->Px(),track->Py(),track->Pz(),massProton);
+        trackXi.SetXYZM(xi->Px(),xi->Py(),xi->Pz(),massXi);
         trackSum = trackProton + trackXi;
 
         Double_t mass = trackSum.M();
-        Double_t relK = 1000*relKcalc(trackProton, trackXi); 
+        Double_t pt   = trackSum.Pt();
+        Double_t relK = 1000*relKcalc(trackProton,trackXi);
 
         dynamic_cast<TH1F*>(fOutput->FindObject("hNPairStatistics"))->Fill(3);
-        dynamic_cast<TH2F*>(fOutput->FindObject("hInvMassRelKProtonXi"))->Fill(mass, relK);
+        dynamic_cast<TH1F*>(fOutput->FindObject("hInvMassProtonXi"))->Fill(mass);
+        dynamic_cast<TH2F*>(fOutput->FindObject("hInvMassPtProtonXi"))->Fill(mass,pt);
+        dynamic_cast<TH2F*>(fOutput->FindObject("hInvMassRelKProtonXi"))->Fill(mass,relK);
       }
     }
 
@@ -1428,15 +1472,18 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
 
         TLorentzVector trackProton, trackOmega, trackSum;
 
-        trackProton.SetXYZM(track->Px(), track->Py(), track->Pz(), massProton);
-        trackOmega.SetXYZM(xi->Px(), xi->Py(), xi->Pz(), massOmega);
+        trackProton.SetXYZM(track->Px(),track->Py(),track->Pz(),massProton);
+        trackOmega.SetXYZM(xi->Px(),xi->Py(),xi->Pz(),massOmega);
         trackSum = trackProton + trackOmega;
 
         Double_t mass = trackSum.M();
+        Double_t pt   = trackSum.Pt();
         Double_t relK = 1000*relKcalc(trackProton, trackOmega);
 
         dynamic_cast<TH1F*>(fOutput->FindObject("hNPairStatistics"))->Fill(4);
-        dynamic_cast<TH2F*>(fOutput->FindObject("hInvMassRelKProtonOmega"))->Fill(mass, relK);
+        dynamic_cast<TH1F*>(fOutput->FindObject("hInvMassProtonOmega"))->Fill(mass);
+        dynamic_cast<TH2F*>(fOutput->FindObject("hInvMassPtProtonOmega"))->Fill(mass,pt);
+        dynamic_cast<TH2F*>(fOutput->FindObject("hInvMassRelKProtonOmega"))->Fill(mass,relK);
       }
     }
 
@@ -1457,15 +1504,18 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
 
         TLorentzVector trackLambda, trackXi, trackSum;
 
-        trackLambda.SetXYZM(v0->Px(), v0->Py(), v0->Pz(), massLambda);
-        trackXi.SetXYZM(xi->Px(), xi->Py(), xi->Pz(), massXi);
+        trackLambda.SetXYZM(v0->Px(),v0->Py(),v0->Pz(),massLambda);
+        trackXi.SetXYZM(xi->Px(),xi->Py(),xi->Pz(),massXi);
         trackSum = trackLambda + trackXi;
 
         Double_t mass = trackSum.M();
-        Double_t relK = 1000*relKcalc(trackLambda, trackXi); 
+        Double_t pt   = trackSum.Pt();
+        Double_t relK = 1000*relKcalc(trackLambda,trackXi);
 
         dynamic_cast<TH1F*>(fOutput->FindObject("hNPairStatistics"))->Fill(5);
-        dynamic_cast<TH2F*>(fOutput->FindObject("hInvMassRelKLambdaXi"))->Fill(mass, relK);
+        dynamic_cast<TH1F*>(fOutput->FindObject("hInvMassLambdaXi"))->Fill(mass);
+        dynamic_cast<TH2F*>(fOutput->FindObject("hInvMassPtLambdaXi"))->Fill(mass,pt);
+        dynamic_cast<TH2F*>(fOutput->FindObject("hInvMassRelKLambdaXi"))->Fill(mass,relK);
       }
     }
 
@@ -1487,15 +1537,17 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
 
         TLorentzVector trackXi, trackOmega, trackSum;
 
-        trackXi.SetXYZM(xi1->Px(), xi1->Py(), xi1->Pz(), massXi);
-        trackOmega.SetXYZM(xi2->Px(), xi2->Py(), xi2->Pz(), massOmega);
+        trackXi.SetXYZM(xi1->Px(),xi1->Py(),xi1->Pz(),massXi);
+        trackOmega.SetXYZM(xi2->Px(),xi2->Py(),xi2->Pz(),massOmega);
         trackSum = trackXi + trackOmega;
 
         Double_t mass = trackSum.M();
-        Double_t relK = 1000*relKcalc(trackXi, trackOmega); 
+        Double_t pt   = trackSum.Pt();
+        Double_t relK = 1000*relKcalc(trackXi,trackOmega);
 
         dynamic_cast<TH1F*>(fOutput->FindObject("hNPairStatistics"))->Fill(6);
-        dynamic_cast<TH2F*>(fOutput->FindObject("hInvMassRelKXiOmega"))->Fill(mass, relK);
+        dynamic_cast<TH2F*>(fOutput->FindObject("hInvMassPtXiOmega"))->Fill(mass,pt);
+        dynamic_cast<TH2F*>(fOutput->FindObject("hInvMassRelKXiOmega"))->Fill(mass,relK);
       }
     }
 
@@ -1517,15 +1569,17 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
 
         TLorentzVector trackOmega1, trackOmega2, trackSum;
 
-        trackOmega1.SetXYZM(xi1->Px(), xi1->Py(), xi1->Pz(), massOmega);
-        trackOmega2.SetXYZM(xi2->Px(), xi2->Py(), xi2->Pz(), massOmega);
+        trackOmega1.SetXYZM(xi1->Px(),xi1->Py(),xi1->Pz(),massOmega);
+        trackOmega2.SetXYZM(xi2->Px(),xi2->Py(),xi2->Pz(),massOmega);
         trackSum = trackOmega1 + trackOmega2;
 
         Double_t mass = trackSum.M();
-        Double_t relK = 1000*relKcalc(trackOmega1, trackOmega2); 
+        Double_t pt   = trackSum.Pt();
+        Double_t relK = 1000*relKcalc(trackOmega1,trackOmega2);
 
         dynamic_cast<TH1F*>(fOutput->FindObject("hNPairStatistics"))->Fill(7);
-        dynamic_cast<TH2F*>(fOutput->FindObject("hInvMassRelKOmegaOmega"))->Fill(mass, relK);
+        dynamic_cast<TH2F*>(fOutput->FindObject("hInvMassPtOmegaOmega"))->Fill(mass,pt);
+        dynamic_cast<TH2F*>(fOutput->FindObject("hInvMassRelKOmegaOmega"))->Fill(mass,relK);
       }
     }
 
@@ -1552,15 +1606,18 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
 
         TLorentzVector trackProton, trackLambda, trackSum;
 
-        trackProton.SetXYZM(track->Px(), track->Py(), track->Pz(), massProton);
-        trackLambda.SetXYZM(v0->Px(), v0->Py(), v0->Pz(), massLambda);
+        trackProton.SetXYZM(track->Px(),track->Py(),track->Pz(),massProton);
+        trackLambda.SetXYZM(v0->Px(),v0->Py(),v0->Pz(),massLambda);
         trackSum = trackProton + trackLambda;
 
         Double_t mass = trackSum.M();
-        Double_t relK = 1000*relKcalc(trackProton, trackLambda); 
+        Double_t pt   = trackSum.Pt();
+        Double_t relK = 1000*relKcalc(trackProton, trackLambda);
 
         dynamic_cast<TH1F*>(fOutput->FindObject("hNPairStatistics"))->Fill(1);
-        dynamic_cast<TH2F*>(fOutput->FindObject("hInvMassRelKProtonLambda"))->Fill(mass, relK);
+        dynamic_cast<TH1F*>(fOutput->FindObject("hInvMassProtonLambda"))->Fill(mass);
+        dynamic_cast<TH2F*>(fOutput->FindObject("hInvMassPtProtonLambda"))->Fill(mass,pt);
+        dynamic_cast<TH2F*>(fOutput->FindObject("hInvMassRelKProtonLambda"))->Fill(mass,relK);
       }
     }
 
@@ -1580,15 +1637,18 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
 
         TLorentzVector trackLambda1, trackLambda2, trackSum;
 
-        trackLambda1.SetXYZM(v01->Px(), v01->Py(), v01->Pz(), massLambda);
-        trackLambda2.SetXYZM(v02->Px(), v02->Py(), v02->Pz(), massLambda);
+        trackLambda1.SetXYZM(v01->Px(),v01->Py(),v01->Pz(),massLambda);
+        trackLambda2.SetXYZM(v02->Px(),v02->Py(),v02->Pz(),massLambda);
         trackSum = trackLambda1 + trackLambda2;
 
         Double_t mass = trackSum.M();
-        Double_t relK = 1000*relKcalc(trackLambda1, trackLambda2); 
+        Double_t pt   = trackSum.Pt();
+        Double_t relK = 1000*relKcalc(trackLambda1,trackLambda2);
 
         dynamic_cast<TH1F*>(fOutput->FindObject("hNPairStatistics"))->Fill(2);
-        dynamic_cast<TH2F*>(fOutput->FindObject("hInvMassRelKLambdaLambda"))->Fill(mass, relK);
+        dynamic_cast<TH1F*>(fOutput->FindObject("hInvMassLambdaLambda"))->Fill(mass);
+        dynamic_cast<TH2F*>(fOutput->FindObject("hInvMassPtLambdaLambda"))->Fill(mass,pt);
+        dynamic_cast<TH2F*>(fOutput->FindObject("hInvMassRelKLambdaLambda"))->Fill(mass,relK);
       }
     }
 
@@ -1612,15 +1672,18 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
 
         TLorentzVector trackProton, trackXi, trackSum;
 
-        trackProton.SetXYZM(track->Px(), track->Py(), track->Pz(), massProton);
-        trackXi.SetXYZM(xi->Px(), xi->Py(), xi->Pz(), massXi);
+        trackProton.SetXYZM(track->Px(),track->Py(),track->Pz(),massProton);
+        trackXi.SetXYZM(xi->Px(),xi->Py(),xi->Pz(),massXi);
         trackSum = trackProton + trackXi;
 
         Double_t mass = trackSum.M();
-        Double_t relK = 1000*relKcalc(trackProton, trackXi); 
+        Double_t pt   = trackSum.Pt();
+        Double_t relK = 1000*relKcalc(trackProton,trackXi);
 
         dynamic_cast<TH1F*>(fOutput->FindObject("hNPairStatistics"))->Fill(3);
-        dynamic_cast<TH2F*>(fOutput->FindObject("hInvMassRelKProtonXi"))->Fill(mass, relK);
+        dynamic_cast<TH1F*>(fOutput->FindObject("hInvMassProtonXi"))->Fill(mass);
+        dynamic_cast<TH2F*>(fOutput->FindObject("hInvMassPtProtonXi"))->Fill(mass,pt);
+        dynamic_cast<TH2F*>(fOutput->FindObject("hInvMassRelKProtonXi"))->Fill(mass,relK);
       }
     }
 
@@ -1644,15 +1707,18 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
 
         TLorentzVector trackProton, trackOmega, trackSum;
 
-        trackProton.SetXYZM(track->Px(), track->Py(), track->Pz(), massProton);
-        trackOmega.SetXYZM(xi->Px(), xi->Py(), xi->Pz(), massOmega);
+        trackProton.SetXYZM(track->Px(),track->Py(),track->Pz(),massProton);
+        trackOmega.SetXYZM(xi->Px(),xi->Py(),xi->Pz(),massOmega);
         trackSum = trackProton + trackOmega;
 
         Double_t mass = trackSum.M();
-        Double_t relK = 1000*relKcalc(trackProton, trackOmega);
+        Double_t pt   = trackSum.Pt();
+        Double_t relK = 1000*relKcalc(trackProton,trackOmega);
 
         dynamic_cast<TH1F*>(fOutput->FindObject("hNPairStatistics"))->Fill(4);
-        dynamic_cast<TH2F*>(fOutput->FindObject("hInvMassRelKProtonOmega"))->Fill(mass, relK);
+        dynamic_cast<TH1F*>(fOutput->FindObject("hInvMassProtonOmega"))->Fill(mass);
+        dynamic_cast<TH2F*>(fOutput->FindObject("hInvMassPtProtonOmega"))->Fill(mass,pt);
+        dynamic_cast<TH2F*>(fOutput->FindObject("hInvMassRelKProtonOmega"))->Fill(mass,relK);
       }
     }
 
@@ -1673,15 +1739,18 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
 
         TLorentzVector trackLambda, trackXi, trackSum;
 
-        trackLambda.SetXYZM(v0->Px(), v0->Py(), v0->Pz(), massLambda);
-        trackXi.SetXYZM(xi->Px(), xi->Py(), xi->Pz(), massXi);
+        trackLambda.SetXYZM(v0->Px(),v0->Py(),v0->Pz(),massLambda);
+        trackXi.SetXYZM(xi->Px(),xi->Py(),xi->Pz(),massXi);
         trackSum = trackLambda + trackXi;
 
         Double_t mass = trackSum.M();
-        Double_t relK = 1000*relKcalc(trackLambda, trackXi); 
+        Double_t pt   = trackSum.Pt();
+        Double_t relK = 1000*relKcalc(trackLambda,trackXi);
 
         dynamic_cast<TH1F*>(fOutput->FindObject("hNPairStatistics"))->Fill(5);
-        dynamic_cast<TH2F*>(fOutput->FindObject("hInvMassRelKLambdaXi"))->Fill(mass, relK);
+        dynamic_cast<TH1F*>(fOutput->FindObject("hInvMassLambdaXi"))->Fill(mass);
+        dynamic_cast<TH2F*>(fOutput->FindObject("hInvMassPtLambdaXi"))->Fill(mass,pt);
+        dynamic_cast<TH2F*>(fOutput->FindObject("hInvMassRelKLambdaXi"))->Fill(mass,relK);
       }
     }
 
@@ -1703,15 +1772,17 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
 
         TLorentzVector trackXi, trackOmega, trackSum;
 
-        trackXi.SetXYZM(xi1->Px(), xi1->Py(), xi1->Pz(), massXi);
-        trackOmega.SetXYZM(xi2->Px(), xi2->Py(), xi2->Pz(), massOmega);
+        trackXi.SetXYZM(xi1->Px(),xi1->Py(),xi1->Pz(),massXi);
+        trackOmega.SetXYZM(xi2->Px(),xi2->Py(),xi2->Pz(),massOmega);
         trackSum = trackXi + trackOmega;
 
         Double_t mass = trackSum.M();
-        Double_t relK = 1000*relKcalc(trackXi, trackOmega); 
+        Double_t pt   = trackSum.Pt();
+        Double_t relK = 1000*relKcalc(trackXi,trackOmega);
 
         dynamic_cast<TH1F*>(fOutput->FindObject("hNPairStatistics"))->Fill(6);
-        dynamic_cast<TH2F*>(fOutput->FindObject("hInvMassRelKXiOmega"))->Fill(mass, relK);
+        dynamic_cast<TH2F*>(fOutput->FindObject("hInvMassPtXiOmega"))->Fill(mass,pt);
+        dynamic_cast<TH2F*>(fOutput->FindObject("hInvMassRelKXiOmega"))->Fill(mass,relK);
       }
     }
 
@@ -1733,15 +1804,17 @@ void AliAnalysisTaskDibaryons::UserExec(Option_t *option)
 
         TLorentzVector trackOmega1, trackOmega2, trackSum;
 
-        trackOmega1.SetXYZM(xi1->Px(), xi1->Py(), xi1->Pz(), massOmega);
-        trackOmega2.SetXYZM(xi2->Px(), xi2->Py(), xi2->Pz(), massOmega);
+        trackOmega1.SetXYZM(xi1->Px(),xi1->Py(),xi1->Pz(),massOmega);
+        trackOmega2.SetXYZM(xi2->Px(),xi2->Py(),xi2->Pz(),massOmega);
         trackSum = trackOmega1 + trackOmega2;
 
         Double_t mass = trackSum.M();
-        Double_t relK = 1000*relKcalc(trackOmega1, trackOmega2); 
+        Double_t pt   = trackSum.Pt();
+        Double_t relK = 1000*relKcalc(trackOmega1,trackOmega2);
 
         dynamic_cast<TH1F*>(fOutput->FindObject("hNPairStatistics"))->Fill(7);
-        dynamic_cast<TH2F*>(fOutput->FindObject("hInvMassRelKOmegaOmega"))->Fill(mass, relK);
+        dynamic_cast<TH2F*>(fOutput->FindObject("hInvMassPtOmegaOmega"))->Fill(mass,pt);
+        dynamic_cast<TH2F*>(fOutput->FindObject("hInvMassRelKOmegaOmega"))->Fill(mass,relK);
       }
     }
 


### PR DESCRIPTION
- The nσ is computed assuming different particle hypotheses (kaons, electrons and pions).
  -  if the nσ value found to be smaller,  the track is rejected from proton candidates.
- New histograms (multiplicity, TOF β, etc...) are added.