### PR TITLE
Update AliAnalysisTaskSpectraINEL0

### DIFF
--- a/PWGLF/SPECTRA/CMakeLists.txt
+++ b/PWGLF/SPECTRA/CMakeLists.txt
@@ -65,6 +65,7 @@ set(SRCS
   ChargedHadrons/dNdPt/Framework/AliAnalysisTaskEffContStudy.cxx
   ChargedHadrons/dNdPt/Framework/AliAnalysisTaskUEStudy.cxx
   ChargedHadrons/dNdPt/Framework/AliAnalysisTaskSpectra.cxx
+  ChargedHadrons/dNdPt/Framework/AliAnalysisTaskSpectraINEL0.cxx
   ChargedHadrons/dNdPt/Framework/AliAnalysisTaskSpectraV0M.cxx
   ChargedHadrons/dNdPt/Framework/AliAnalysisTaskFilterEventTPCdEdx.cxx
   ChargedHadrons/dNdPt/AlidNdPtTrackDumpTask.cxx

--- a/PWGLF/SPECTRA/ChargedHadrons/dNdPt/Framework/AliAnalysisTaskDCArStudy.cxx
+++ b/PWGLF/SPECTRA/ChargedHadrons/dNdPt/Framework/AliAnalysisTaskDCArStudy.cxx
@@ -25,7 +25,7 @@ ClassImp(AliAnalysisTaskDCArStudy)
 
 //_____________________________________________________________________________
 
-AliAnalysisTaskDCArStudy::AliAnalysisTaskDCArStudy() 
+AliAnalysisTaskDCArStudy::AliAnalysisTaskDCArStudy()
     : AliAnalysisTaskMKBase()
     , fHistDCA(0)
     , fHistDCATPC(0)
@@ -36,13 +36,13 @@ AliAnalysisTaskDCArStudy::AliAnalysisTaskDCArStudy()
 
 //_____________________________________________________________________________
 
-AliAnalysisTaskDCArStudy::AliAnalysisTaskDCArStudy(const char* name) 
+AliAnalysisTaskDCArStudy::AliAnalysisTaskDCArStudy(const char* name)
     : AliAnalysisTaskMKBase(name)
-    , fHistDCA(0)    
+    , fHistDCA(0)
     , fHistDCATPC(0)
 {
     // constructor
-    
+
 }
 
 //_____________________________________________________________________________
@@ -55,25 +55,27 @@ AliAnalysisTaskDCArStudy::~AliAnalysisTaskDCArStudy()
 //_____________________________________________________________________________
 
 void AliAnalysisTaskDCArStudy::AddOutput()
-{    
-    //dcar:pt:mult:mcinfo
+{
+    //dcar:pt:mult:cent:mcinfo
     AddAxis("DCAxy",5000,-1,1);
-    AddAxis("pt");    
+    AddAxis("pt");
     AddAxis("nTracks","mult6kcoarse");
+    AddAxis("cent");
     AddAxis("MCinfo",4,-1.5,2.5); // 0=prim, 1=decay 2=material -1=data
     fHistDCA = CreateHist("fHistDCA");
     fOutputList->Add(fHistDCA);
-    
-    //dcar:pt:mult:mcinfo
-    AddAxis("DCAxy",5000,-20,20); 
-    AddAxis("TPCpt","pt");    
+
+    //dcar:pt:mult:cent:mcinfo
+    AddAxis("DCAxy",5000,-20,20);
+    AddAxis("TPCpt","pt");
     AddAxis("nTracks","mult6kcoarse");
+    AddAxis("cent");
     AddAxis("MCinfo",4,-1.5,2.5); // 0=prim, 1=decay 2=material -1=data
     fHistDCATPC = CreateHist("fHistDCATPC");
     fOutputList->Add(fHistDCATPC);
-    
+
      //dcar:pt:mult:mcinfo
-  
+
 }
 
 //_____________________________________________________________________________
@@ -95,22 +97,22 @@ void AliAnalysisTaskDCArStudy::AnaEvent()
 
 void AliAnalysisTaskDCArStudy::AnaTrackMC(Int_t flag)
 {
-    if (fAcceptTrack[0]) { FillHist(fHistDCATPC, fDCArTPC, fPtInnerTPC, fNTracksAcc, fMCPrimSec); }
-    if (fAcceptTrack[1]) { FillHist(fHistDCA, fDCAr, fPt, fNTracksAcc, fMCPrimSec); }
+    if (fAcceptTrack[0]) { FillHist(fHistDCATPC, fDCArTPC, fPtInnerTPC, fNTracksAcc, fMultPercentileV0M, fMCPrimSec); }
+    if (fAcceptTrack[1]) { FillHist(fHistDCA, fDCAr, fPt, fNTracksAcc, fMultPercentileV0M, fMCPrimSec); }
 }
 
 //_____________________________________________________________________________
 
 void AliAnalysisTaskDCArStudy::AnaTrackDATA(Int_t flag)
 {
-    if (fAcceptTrack[0]) { FillHist(fHistDCATPC, fDCArTPC, fPtInnerTPC, fNTracksAcc, -1); }
-    if (fAcceptTrack[1]) { FillHist(fHistDCA, fDCAr, fPt, fNTracksAcc, -1); }
+    if (fAcceptTrack[0]) { FillHist(fHistDCATPC, fDCArTPC, fPtInnerTPC, fNTracksAcc, fMultPercentileV0M, -1); }
+    if (fAcceptTrack[1]) { FillHist(fHistDCA, fDCAr, fPt, fNTracksAcc, fMultPercentileV0M, -1); }
 }
 
 
 //_____________________________________________________________________________
 
-AliAnalysisTaskDCArStudy* AliAnalysisTaskDCArStudy::AddTaskDCArStudy(const char* name, const char* outfile) 
+AliAnalysisTaskDCArStudy* AliAnalysisTaskDCArStudy::AddTaskDCArStudy(const char* name, const char* outfile)
 {
     AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
     if (!mgr) {
@@ -124,27 +126,27 @@ AliAnalysisTaskDCArStudy* AliAnalysisTaskDCArStudy::AddTaskDCArStudy(const char*
         ::Error("AddTaskDCArStudy", "This task requires an input event handler");
         return NULL;
     }
-    
+
     // Setup output file
     //===========================================================================
-    TString fileName = AliAnalysisManager::GetCommonFileName();        
+    TString fileName = AliAnalysisManager::GetCommonFileName();
     fileName += ":";
     fileName += name;  // create a subfolder in the file
     if (outfile) { // if a finename is given, use that one
-        fileName = TString(outfile);        
+        fileName = TString(outfile);
     }
 
     // create the task
     //===========================================================================
-    AliAnalysisTaskDCArStudy *task = new AliAnalysisTaskDCArStudy(name);  
+    AliAnalysisTaskDCArStudy *task = new AliAnalysisTaskDCArStudy(name);
     if (!task) { return 0; }
-    
+
     // configure the task
     //===========================================================================
-    task->SelectCollisionCandidates(AliVEvent::kAnyINT);    
+    task->SelectCollisionCandidates(AliVEvent::kAnyINT);
     task->SetESDtrackCutsM(AlidNdPtTools::CreateESDtrackCuts("defaultEta08"));
-    task->SetESDtrackCuts(0,AlidNdPtTools::CreateESDtrackCuts("TPCgeoNoDCArEta08"));    
-    task->SetESDtrackCuts(1,AlidNdPtTools::CreateESDtrackCuts("TPCITSforDCArStudyEta08"));    
+    task->SetESDtrackCuts(0,AlidNdPtTools::CreateESDtrackCuts("TPCgeoNoDCArEta08"));
+    task->SetESDtrackCuts(1,AlidNdPtTools::CreateESDtrackCuts("TPCITSforDCArStudyEta08"));
     task->SetNeedEventMult(kTRUE);
     task->SetNeedEventVertex(kTRUE);
     task->SetNeedTrackTPC(kTRUE);
@@ -154,6 +156,6 @@ AliAnalysisTaskDCArStudy* AliAnalysisTaskDCArStudy::AddTaskDCArStudy(const char*
     mgr->AddTask(task);
     mgr->ConnectInput(task,0,mgr->GetCommonInputContainer());
     mgr->ConnectOutput(task,1,mgr->CreateContainer(name, TList::Class(), AliAnalysisManager::kOutputContainer, fileName.Data()));
-    
+
   return task;
 }

--- a/PWGLF/SPECTRA/ChargedHadrons/dNdPt/Framework/AliAnalysisTaskSpectra.cxx
+++ b/PWGLF/SPECTRA/ChargedHadrons/dNdPt/Framework/AliAnalysisTaskSpectra.cxx
@@ -28,26 +28,26 @@ ClassImp(AliAnalysisTaskSpectra)
 /// \endcond
 //_____________________________________________________________________________
 
-AliAnalysisTaskSpectra::AliAnalysisTaskSpectra() 
+AliAnalysisTaskSpectra::AliAnalysisTaskSpectra()
     : AliAnalysisTaskMKBase()
     , fHistEffCont(0)
-    , fHistTrack(0)   
+    , fHistTrack(0)
     , fHistEvent(0)
 {
     // default contructor
- 
+    AliAnalysisTaskMKBase::fNeedEventVertex = kTRUE;
 }
 
 //_____________________________________________________________________________
 
-AliAnalysisTaskSpectra::AliAnalysisTaskSpectra(const char* name) 
+AliAnalysisTaskSpectra::AliAnalysisTaskSpectra(const char* name)
     : AliAnalysisTaskMKBase(name)
     , fHistEffCont(0)
     , fHistTrack(0)
     , fHistEvent(0)
 {
     // constructor
-
+    AliAnalysisTaskMKBase::fNeedEventVertex = kTRUE;
 }
 
 //_____________________________________________________________________________
@@ -60,29 +60,29 @@ AliAnalysisTaskSpectra::~AliAnalysisTaskSpectra()
 //_____________________________________________________________________________
 
 void AliAnalysisTaskSpectra::AddOutput()
-{        
+{
     AddAxis("cent");
     AddAxis("nAcc","mult6kcoarse");
     AddAxis("MCpT","pt");
-    AddAxis("MCQ",3,-1.5,1.5);        
+    AddAxis("MCQ",3,-1.5,1.5);
     AddAxis("MCpid",10,-0.5,9.5);  // 0=e, 1=mu, 2=pi, 3=K, 4=p, 6=sigmaP, 7=sigmaM, 8=xi, 9=omega, 5=other
-    AddAxis("MCinfo",4,-0.5,3.5);  // 0=prim, 1=decay 2=material, 3=genprim    
+    AddAxis("MCinfo",4,-0.5,3.5);  // 0=prim, 1=decay 2=material, 3=genprim
     fHistEffCont = CreateHist("fHistEffCont");
     fOutputList->Add(fHistEffCont);
-    
+
     AddAxis("cent");
-    AddAxis("nAcc","mult6kcoarse"); 
-    AddAxis("pt");         
-    AddAxis("Q",3,-1.5,1.5);        
+    AddAxis("nAcc","mult6kcoarse");
+    AddAxis("pt");
+    AddAxis("Q",3,-1.5,1.5);
     fHistTrack = CreateHist("fHistTrack");
     fOutputList->Add(fHistTrack);
-        
-    AddAxis("cent");    
+
+    AddAxis("cent");
     AddAxis("nAcc","mult6kfine");
     AddAxis("zV",8,-20,20);
     fHistEvent = CreateHist("fHistEvent");
-    fOutputList->Add(fHistEvent);    
-    
+    fOutputList->Add(fHistEvent);
+
 }
 
 //_____________________________________________________________________________
@@ -96,12 +96,12 @@ Bool_t AliAnalysisTaskSpectra::IsEventSelected()
 
 void AliAnalysisTaskSpectra::AnaEvent()
 {
-   
+
    LoopOverAllTracks();
    if (fIsMC) LoopOverAllParticles();
-   
+
    FillHist(fHistEvent, fMultPercentileV0M, fNTracksAcc, fZv);
-   
+
 }
 
 //_____________________________________________________________________________
@@ -109,7 +109,7 @@ void AliAnalysisTaskSpectra::AnaEvent()
 void AliAnalysisTaskSpectra::AnaTrack(Int_t flag)
 {
     if (!fAcceptTrackM) return;
-    
+
     FillHist(fHistTrack, fMultPercentileV0M, fNTracksAcc, fPt, fChargeSign);
 }
 
@@ -117,33 +117,36 @@ void AliAnalysisTaskSpectra::AnaTrack(Int_t flag)
 
 void AliAnalysisTaskSpectra::AnaTrackMC(Int_t flag)
 {
+    if(fMCPileUpTrack) return; // reject pileup tracks
     if (!fAcceptTrackM) return;
-     
+
     if (fMCParticleType==AlidNdPtTools::kOther) { Log("RecTrack.PDG.",fMCPDGCode); }
     if (TMath::Abs(fMCQ > 1)) { Log("RecTrack.Q>1.PDG.",fMCPDGCode); }
-    
-    FillHist(fHistEffCont, fMultPercentileV0M, fNTracksAcc, fMCPt, fMCChargeSign, fMCParticleType, fMCProdcutionType); 
+
+    FillHist(fHistEffCont, fMultPercentileV0M, fNTracksAcc, fMCPt, fMCChargeSign, fMCParticleType, fMCProdcutionType);
 
 }
 
 //_____________________________________________________________________________
 
 void AliAnalysisTaskSpectra::AnaParticleMC(Int_t flag)
-{            
-    if (!fMCisPrim) return;    
-    if (!fMCIsCharged) return;    
-    if (TMath::Abs(fMCEta) > 0.8) return;    
-    
+{
+    if(fMCPileUpTrack) return; // reject pileup tracks
+
+    if (!fMCisPrim) return;
+    if (!fMCIsCharged) return;
+    if (TMath::Abs(fMCEta) > 0.8) return;
+
     if (fMCParticleType==AlidNdPtTools::kOther) { Log("GenPrim.PDG.",fMCPDGCode); }
     if (TMath::Abs(fMCQ > 1)) { Log("GenPrim.Q>1.PDG.",fMCPDGCode); }
-    
-    FillHist(fHistEffCont, fMultPercentileV0M, fNTracksAcc, fMCPt, fMCChargeSign, fMCParticleType, 3);     
+
+    FillHist(fHistEffCont, fMultPercentileV0M, fNTracksAcc, fMCPt, fMCChargeSign, fMCParticleType, 3);
 
 }
 
 //_____________________________________________________________________________
 
-AliAnalysisTaskSpectra* AliAnalysisTaskSpectra::AddTaskSpectra(const char* name, const char* outfile) 
+AliAnalysisTaskSpectra* AliAnalysisTaskSpectra::AddTaskSpectra(const char* name, const char* outfile)
 {
     AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
     if (!mgr) {
@@ -157,25 +160,25 @@ AliAnalysisTaskSpectra* AliAnalysisTaskSpectra::AddTaskSpectra(const char* name,
         ::Error("AddTaskSpectra", "This task requires an input event handler");
         return NULL;
     }
-    
+
     // Setup output file
     //===========================================================================
-    TString fileName = AliAnalysisManager::GetCommonFileName();        
+    TString fileName = AliAnalysisManager::GetCommonFileName();
     fileName += ":";
     fileName += name;  // create a subfolder in the file
     if (outfile) { // if a finename is given, use that one
-        fileName = TString(outfile);        
+        fileName = TString(outfile);
     }
-    
+
 
     // create the task
     //===========================================================================
-    AliAnalysisTaskSpectra *task = new AliAnalysisTaskSpectra(name);  
+    AliAnalysisTaskSpectra *task = new AliAnalysisTaskSpectra(name);
     if (!task) { return 0; }
-    
+
     // configure the task
     //===========================================================================
-    task->SelectCollisionCandidates(AliVEvent::kAnyINT);    
+    task->SelectCollisionCandidates(AliVEvent::kAnyINT);
     task->SetESDtrackCutsM(AlidNdPtTools::CreateESDtrackCuts("defaultEta08"));
 //     task->SetESDtrackCuts(0,AlidNdPtTools::CreateESDtrackCuts("defaultEta08"));
     task->SetNeedEventMult(kTRUE);
@@ -186,6 +189,6 @@ AliAnalysisTaskSpectra* AliAnalysisTaskSpectra::AddTaskSpectra(const char* name,
     mgr->AddTask(task);
     mgr->ConnectInput(task,0,mgr->GetCommonInputContainer());
     mgr->ConnectOutput(task,1,mgr->CreateContainer(name, TList::Class(), AliAnalysisManager::kOutputContainer, fileName.Data()));
-    
+
   return task;
 }

--- a/PWGLF/SPECTRA/ChargedHadrons/dNdPt/Framework/AliAnalysisTaskSpectraINEL0.cxx
+++ b/PWGLF/SPECTRA/ChargedHadrons/dNdPt/Framework/AliAnalysisTaskSpectraINEL0.cxx
@@ -22,7 +22,10 @@
 #include "AliAnalysisTaskSpectraINEL0.h"
 class AliAnalysisTaskSpectraINEL0;
 
+namespace {
+using namespace Hist;
 using namespace std;
+} // namespace
 
 /// \cond CLASSIMP
 ClassImp(AliAnalysisTaskSpectraINEL0)
@@ -31,26 +34,32 @@ ClassImp(AliAnalysisTaskSpectraINEL0)
 
 AliAnalysisTaskSpectraINEL0::AliAnalysisTaskSpectraINEL0()
     : AliAnalysisTaskMKBase()
-    , fHistEffCont(0)
-    , fHistTrack(0)
-    , fHistEvent(0)
-    , fHistVtxInfo(0)
-    , fHistTrackINEL0(0)
+    , fHistEffCont{}
+    , fHistTrack{}
+    , fHistEvent{}
+    , fHistVtxInfo{}
+    , fHistTrackINEL0{}
 {
     // default contructor
+    AliAnalysisTaskMKBase::fUseBaseOutput = kTRUE;
+    AliAnalysisTaskMKBase::fNeedEventVertex = kTRUE;
+    AliAnalysisTaskMKBase::fNeedEventMult = kTRUE;
 }
 
 //_____________________________________________________________________________
 
 AliAnalysisTaskSpectraINEL0::AliAnalysisTaskSpectraINEL0(const char* name)
     : AliAnalysisTaskMKBase(name)
-    , fHistEffCont(0)
-    , fHistTrack(0)
-    , fHistEvent(0)
-    , fHistVtxInfo(0)
-    , fHistTrackINEL0(0)
+    , fHistEffCont{}
+    , fHistTrack{}
+    , fHistEvent{}
+    , fHistVtxInfo{}
+    , fHistTrackINEL0{}
 {
     // constructor
+    AliAnalysisTaskMKBase::fUseBaseOutput = kTRUE;
+    AliAnalysisTaskMKBase::fNeedEventVertex = kTRUE;
+    AliAnalysisTaskMKBase::fNeedEventMult = kTRUE;
 }
 
 //_____________________________________________________________________________
@@ -64,40 +73,92 @@ AliAnalysisTaskSpectraINEL0::~AliAnalysisTaskSpectraINEL0()
 
 void AliAnalysisTaskSpectraINEL0::AddOutput()
 {
-    AddAxis("cent");
-    AddAxis("nAcc","mult6kcoarse");
-    AddAxis("MCpT","pt");
-    AddAxis("MCQ",3,-1.5,1.5);
-    AddAxis("MCpid",10,-0.5,9.5);  // 0=e, 1=mu, 2=pi, 3=K, 4=p, 6=sigmaP, 7=sigmaM, 8=xi, 9=omega, 5=other
-    AddAxis("MCinfo",4,-0.5,3.5);  // 0=prim, 1=decay 2=material, 3=genprim
-    fHistEffCont = CreateHist("fHistEffCont");
-    fOutputList->Add(fHistEffCont);
+    std::vector<double> ptbins = { 0.0,  0.05,  0.1,   0.15,  0.2,   0.25,  0.3,   0.35,  0.4,   0.45, 0.5,  0.55,
+                                0.6,  0.65,  0.7,   0.75,  0.8,   0.85,  0.9,   0.95,  1.0,   1.1,  1.2,  1.3,
+                                1.4,  1.5,   1.6,   1.7,   1.8,   1.9,   2.0,   2.2,   2.4,   2.6,  2.8,  3.0,
+                                3.2,  3.4,   3.6,   3.8,   4.0,   4.5,   5.0,   5.5,   6.0,   6.5,  7.0,  8.0,
+                                9.0,  10.0,  11.0,  12.0,  13.0,  14.0,  15.0,  16.0,  18.0,  20.0, 22.0, 24.0,
+                                26.0, 28.0,  30.0,  32.0,  34.0,  36.0,  40.0,  45.0,  50.0,  60.0, 70.0, 80.0,
+                                90.0, 100.0, 110.0, 120.0, 130.0, 140.0, 150.0, 160.0, 180.0, 200.0 };
+    std::vector<double> inverseptbins;
+    inverseptbins.push_back(0.0);
+    for(int i = ptbins.size() - 1; i > 0 ; i--){
+      inverseptbins.push_back(1./ptbins[i]);
+    }
 
-    AddAxis("cent");
-    AddAxis("nAcc","mult6kcoarse");
-    AddAxis("pt");
-    AddAxis("Q",3,-1.5,1.5);
-    fHistTrack = CreateHist("fHistTrack");
-    fOutputList->Add(fHistTrack);
+    std::vector<double> centBins = {0., 5., 10., 20., 30., 40., 50., 60., 70., 80., 90., 100. };
 
-    AddAxis("cent");
-    AddAxis("nAcc","mult6kfine");
-    AddAxis("zV",8,-20,20);
-    fHistEvent = CreateHist("fHistEvent");
-    fOutputList->Add(fHistEvent);
+    const Int_t nmultbins = 241;
+    std::vector<double> multBins;
+    multBins.reserve(nmultbins + 1);
+    multBins.push_back(-0.5);
+    {
+        int i = 0;
+        for (; i <= 100; i++) {
+            multBins.push_back(multBins.back() + 1.);
+        }
+        for (; i <= 100 + 90; i++) {
+            multBins.push_back(multBins.back() + 10.);
+        }
+        for (; i <= 10 + 90 + 50; i++) {
+            multBins.push_back(multBins.back() + 100.);
+        }
+    }
 
-    AddAxis("VtxInfo", 2, -0.5, 1.5); // 0 == with Vertex; 1== without Vertex
-    AddAxis("nAcc","mult6kfine");
-    AddAxis("zV",8,-30,30);
-    fHistVtxInfo = CreateHist("fHistVtxInfo");
-    fOutputList->Add(fHistVtxInfo);
+    Axis centAxis = {"cent", "centrality", centBins};
+    Axis multAxis = {"mult", "#it{N}_{ch}", multBins};
+    Axis zVrtAxis = {"zV", "vertex_{Z}", {-20, 20}, 8};
+    Axis ptAxis = {"pt", "#it{p}_{T} (GeV/c)", ptbins};
+    Axis QAxis = {"Q", "Q", {-1.5,1.5}, 3};
+    Axis relResoAxis = {"rel. Reso", "#sigma(#it{p}_{T}) / #it{p}_{T}", {0.0,0.3}, 300};
+    Axis Sigma1ptAxis = {"Sigma1ptAxis", "#sigma(1/#it{p}_{T})", {0.0,0.3}, 300};
+    Axis inverseptAxis = {"1/pt", "1/#it{p}_{T} (GeV/c)", inverseptbins};
+    Axis MCpidAxis = {"MCpid", "MCpid", {-0.5, 9.5}, 10}; // 0=e, 1=mu, 2=pi, 3=K, 4=p, 6=sigmaP, 7=sigmaM, 8=xi, 9=omega, 5=other
+    Axis MCinfoAxis = {"MCinfo", "MCinfo", {-0.5,3.5}, 4}; // 0=prim, 1=decay 2=material, 3=genprim
+    Axis MCQAxis = {"MCQ", "MCQ", {-1.5,1.5}, 3};
+    Axis MCptAxis = {"MCpt", "#it{p}_{T} (GeV/c)", ptbins};
+    Axis EvtSelectionAxis = {"EvtSele", "EvtSele", {-0.5,1.5}, 2}; // 0 == No Selection; 1 == with selection
+    Axis VtxInfoAxis = {"VtxInfo", "VtxInfo", {-0.5,1.5}, 2}; // 0 == with Vertex; 1== without Vertex
 
-    AddAxis("cent");
-    AddAxis("nAcc","mult6kcoarse");
-    AddAxis("MCpT","pt");
-    AddAxis("EventSelection", 2, -0.5, 1.5); // 0 == No Selection; 1 == with selection
-    fHistTrackINEL0 = CreateHist("fHistTrackINEL0");
-    fOutputList->Add(fHistTrackINEL0);
+
+    fHistEffCont.AddAxis(centAxis);
+    fHistEffCont.AddAxis(multAxis);
+    fHistEffCont.AddAxis(MCptAxis);
+    fHistEffCont.AddAxis(MCQAxis);
+    fHistEffCont.AddAxis(MCpidAxis); // 0=e, 1=mu, 2=pi, 3=K, 4=p, 6=sigmaP, 7=sigmaM, 8=xi, 9=omega, 5=other
+    fHistEffCont.AddAxis(MCinfoAxis); // 0=prim, 1=decay 2=material, 3=genprim
+    fOutputList->Add(fHistEffCont.GenerateHist("fHistEffCont"));
+
+    fHistTrack.AddAxis(centAxis);
+    fHistTrack.AddAxis(multAxis);
+    fHistTrack.AddAxis(ptAxis);
+    fHistTrack.AddAxis(QAxis);
+    fOutputList->Add(fHistTrack.GenerateHist("fHistTrack"));
+
+    fHistTrackINEL0.AddAxis(centAxis);
+    fHistTrackINEL0.AddAxis(multAxis);
+    fHistTrackINEL0.AddAxis(MCptAxis);
+    fHistTrackINEL0.AddAxis(EvtSelectionAxis);
+    fOutputList->Add(fHistTrackINEL0.GenerateHist("fHistTrackINEL0"));
+
+    fHistRelResoFromCov.AddAxis(ptAxis);
+    fHistRelResoFromCov.AddAxis(relResoAxis);
+    fOutputList->Add(fHistRelResoFromCov.GenerateHist("fHistRelResoFromCov"));
+
+    fHistSigma1pt.AddAxis(inverseptAxis);
+    fHistSigma1pt.AddAxis(Sigma1ptAxis);
+    fOutputList->Add(fHistSigma1pt.GenerateHist("fHistSigma1pt"));
+
+    fHistEvent.AddAxis(centAxis);
+    fHistEvent.AddAxis(multAxis);
+    fHistEvent.AddAxis(zVrtAxis);
+    fOutputList->Add(fHistEvent.GenerateHist("fHistEvent"));
+
+    fHistVtxInfo.AddAxis(VtxInfoAxis);// 0 == with Vertex; 1== without Vertex
+    fHistVtxInfo.AddAxis(multAxis);
+    fHistVtxInfo.AddAxis(zVrtAxis);
+    fOutputList->Add(fHistVtxInfo.GenerateHist("fHistVtxInfo"));
+
 
 }
 
@@ -106,12 +167,6 @@ void AliAnalysisTaskSpectraINEL0::AddOutput()
 Bool_t AliAnalysisTaskSpectraINEL0::IsEventSelected()
 {
   return fIsAcceptedAliEventCuts;
-  //return oldEventCuts();
-}
-
-Bool_t AliAnalysisTaskSpectraINEL0::oldEventCuts()
-{
-  return kFALSE;
 }
 
 //_____________________________________________________________________________
@@ -121,12 +176,12 @@ void AliAnalysisTaskSpectraINEL0::FillDefaultHistograms(Int_t step) {
     AliAnalysisTaskMKBase::FillDefaultHistograms(step);
 
     if(step==0){
-        if(fVtxStatus) FillHist(fHistVtxInfo, 0, fNTracksAcc, fZv);
-        else FillHist(fHistVtxInfo, 1, fNTracksAcc, fZv);
+        if(fVtxStatus) fHistVtxInfo.Fill(0, fNTracksAcc, fZv);
+        else fHistVtxInfo.Fill(1, fNTracksAcc, fZv);
     }
     if(step==1){
         LoopOverAllTracks(step);
-        FillHist(fHistEvent, fMultPercentileV0M, fNTracksAcc, fZv);
+        fHistEvent.Fill(fMultPercentileV0M, fNTracksAcc, fZv);
     }
 
 
@@ -140,13 +195,16 @@ void AliAnalysisTaskSpectraINEL0::AnaTrack(Int_t flag)
     if(0==flag) return; // data only after event selection
     if (!fAcceptTrackM) return;
 
-    FillHist(fHistTrack, fMultPercentileV0M, fNTracksAcc, fPt, fChargeSign);
+    fHistTrack.Fill(fMultPercentileV0M, fNTracksAcc, fPt, fChargeSign);
+    fHistRelResoFromCov.Fill(fPt, fSigma1Pt*fPt);
+    fHistSigma1pt.Fill(f1Pt, fSigma1Pt);
 }
 
 //_____________________________________________________________________________
 
 void AliAnalysisTaskSpectraINEL0::AnaTrackMC(Int_t flag)
 {
+    if(fMCPileUpTrack) return; // reject pileup tracks
     if (!fAcceptTrackM) return;
 
     if (fMCParticleType==AlidNdPtTools::kOther) { Log("RecTrack.PDG.",fMCPDGCode); }
@@ -156,7 +214,7 @@ void AliAnalysisTaskSpectraINEL0::AnaTrackMC(Int_t flag)
 
     } else if (flag == 1) {
 
-        FillHist(fHistEffCont, fMultPercentileV0M, fNTracksAcc, fMCPt, fMCChargeSign, fMCParticleType, fMCProdcutionType);
+        fHistEffCont.Fill(fMultPercentileV0M, fNTracksAcc, fMCPt, fMCChargeSign, fMCParticleType, fMCProdcutionType);
     } else {
         Err("AliAnalysisTaskMKBase::FillDefaultHistograms:InvalidStep");
     }
@@ -166,6 +224,8 @@ void AliAnalysisTaskSpectraINEL0::AnaTrackMC(Int_t flag)
 
 void AliAnalysisTaskSpectraINEL0::AnaParticleMC(Int_t flag)
 {
+    if(fMCPileUpTrack) return; // reject pileup tracks
+
     if (!fMCisPrim) return;
     if (!fMCIsCharged) return;
     if (TMath::Abs(fMCEta) > 0.8) return;
@@ -174,11 +234,11 @@ void AliAnalysisTaskSpectraINEL0::AnaParticleMC(Int_t flag)
     if (TMath::Abs(fMCQ > 1)) { Log("GenPrim.Q>1.PDG.",fMCPDGCode); }
 
     if (flag == 0) {
-        if(fZv < 10. && fZv > -10.) FillHist(fHistTrackINEL0, fMultPercentileV0M, fNTracksAcc, fMCPt, 0);
+        if(fZv < 10. && fZv > -10.) fHistTrackINEL0.Fill(fMultPercentileV0M, fNTracksAcc, fMCPt, 0);
     } else if (flag == 1) {
-        FillHist(fHistTrackINEL0, fMultPercentileV0M, fNTracksAcc, fMCPt, 1);
+        fHistTrackINEL0.Fill(fMultPercentileV0M, fNTracksAcc, fMCPt, 1);
 
-        FillHist(fHistEffCont, fMultPercentileV0M, fNTracksAcc, fMCPt, fMCChargeSign, fMCParticleType, 3);
+        fHistEffCont.Fill(fMultPercentileV0M, fNTracksAcc, fMCPt, fMCChargeSign, fMCParticleType, 3);
     } else {
         Err("AliAnalysisTaskMKBase::FillDefaultHistograms:InvalidStep");
     }

--- a/PWGLF/SPECTRA/ChargedHadrons/dNdPt/Framework/AliAnalysisTaskSpectraINEL0.h
+++ b/PWGLF/SPECTRA/ChargedHadrons/dNdPt/Framework/AliAnalysisTaskSpectraINEL0.h
@@ -8,6 +8,8 @@
 #define AliAnalysisTaskSpectraINEL0_H
 
 #include "AliAnalysisTaskMKBase.h"
+#include "AliAnalysisHelpersHist.h"
+
 
 class AliESDtrackCuts;
 class AliVEvent;
@@ -29,7 +31,6 @@ class AliAnalysisTaskSpectraINEL0 : public AliAnalysisTaskMKBase
 
         virtual void            AddOutput();                     //called at the beginning
         virtual Bool_t          IsEventSelected();               //called for each event
-        virtual Bool_t          oldEventCuts();               //it tests, whether old event cuts are fullfilled
         virtual void            FillDefaultHistograms(Int_t step); // called twice for each event
         virtual void            AnaTrack(Int_t flag = 0);        //called once for every track in DATA+MC event
         virtual void            AnaTrackMC(Int_t flag = 0);      //called once for every track in DATA event
@@ -38,11 +39,13 @@ class AliAnalysisTaskSpectraINEL0 : public AliAnalysisTaskMKBase
         static AliAnalysisTaskSpectraINEL0* AddTaskSpectraINEL0(const char* name = "TaskSpectra", const char* outfile = 0);
 
     protected:
-        THnSparseF*             fHistEffCont;         //-> efficiency/contamination histogram
-        THnSparseF*             fHistTrack;           //-> histogram of pt spectra vs. mult and cent
-        THnSparseF*             fHistEvent;           //-> histogram of event numbers etc.
-        THnSparseF*             fHistTrackINEL0;      //-> histogram for INEL0 study
-        THnSparseF*             fHistVtxInfo;      //-> vertex reconstruction efficiency histogram
+        Hist::Hist<THnF>           fHistEffCont;         //-> efficiency/contamination histogram
+        Hist::Hist<THnF>           fHistTrack;           //-> histogram of pt spectra vs. mult and cent
+        Hist::Hist<THnF>           fHistEvent;           //-> histogram of event numbers etc.
+        Hist::Hist<THnF>           fHistTrackINEL0;      //-> histogram for INEL0 study
+        Hist::Hist<THnF>           fHistVtxInfo;      //-> vertex reconstruction efficiency histogram
+        Hist::Hist<TH2F>           fHistRelResoFromCov;      //-> histogram for relative pt resolution (sigma(pt)/pt as function of pt)
+        Hist::Hist<TH2F>           fHistSigma1pt;      //-> vertex reconstruction efficiency histogram (sigma(1/pt) as function of 1/pt)
 
 
     private:

--- a/PWGLF/SPECTRA/ChargedHadrons/dNdPt/macros/AddTaskSpectraINEL0.C
+++ b/PWGLF/SPECTRA/ChargedHadrons/dNdPt/macros/AddTaskSpectraINEL0.C
@@ -1,0 +1,7 @@
+#if defined(__CLING__)
+#include "AliAnalysisTaskSpectraINEL0.h"
+#endif
+
+AliAnalysisTaskSpectraINEL0* AddTaskSpectraINEL0(const char* name = "TaskSpectraINEL0", const char* outfile = 0) {
+  return AliAnalysisTaskSpectraINEL0::AddTaskSpectraINEL0(name, outfile);
+}

--- a/PWGLF/SPECTRA/PWGLFspectraLinkDef.h
+++ b/PWGLF/SPECTRA/PWGLFspectraLinkDef.h
@@ -32,6 +32,7 @@
 #pragma link C++ class AliAnalysisTaskUEStudy+;
 #pragma link C++ class AliAnalysisTaskSpectraTPCRun3+;
 #pragma link C++ class AliAnalysisTaskSpectra+;
+#pragma link C++ class AliAnalysisTaskSpectraINEL0+;
 #pragma link C++ class AliAnalysisTaskSpectraV0M+;
 #pragma link C++ class AliAnalysisTaskFilterEventTPCdEdx+;
 


### PR DESCRIPTION
Detailed description: 
Add new histograms to AliAnalysisTaskSpectraINEL0 needed to calculate certain corrections (vtx. eff., rel. reso.) of a spectra analysis. Add AddTaskSpectraINEL0.C.
Reject pile-up in MC in both classes AliAnalysisTaskSpectra and AliAnalysisTaskSpectraINEL0. Set booleans to true in these clases in order to be able to fill
certain histograms (changes in the base class caused issues in this regard).
Add centrality axis to the histograms of AliAnalysisTaskDCArStudy.