### PR TITLE
remove MC gen pileup particles from track tree

### DIFF
--- a/PWGHF/treeHF/AliAnalysisTaskSEHFTreeCreator.cxx
+++ b/PWGHF/treeHF/AliAnalysisTaskSEHFTreeCreator.cxx
@@ -1114,7 +1114,7 @@ void AliAnalysisTaskSEHFTreeCreator::UserCreateOutputObjects()
 }
 
 //________________________________________________________________________
-void AliAnalysisTaskSEHFTreeCreator::FillJetTree() {
+void AliAnalysisTaskSEHFTreeCreator::FillJetTree(AliAODMCHeader* mcHeader) {
   
   // If it is the first event, then execute ExecOnce()
   if (!fLocalInitialized){
@@ -1131,6 +1131,7 @@ void AliAnalysisTaskSEHFTreeCreator::FillJetTree() {
     fTreeHandlerParticle->FillTree(fRunNumber, fEventID, fEventIDExt, fEventIDLong);
     
     if (fTreeHandlerGenParticle) {
+      fTreeHandlerGenParticle->SetMCHeader(mcHeader);
       fTreeHandlerGenParticle->FillTree(fRunNumber, fEventID, fEventIDExt, fEventIDLong);
     }
     
@@ -1608,7 +1609,7 @@ void AliAnalysisTaskSEHFTreeCreator::UserExec(Option_t */*option*/)
   
   // Fill the jet tree
   if (fWriteNJetTrees > 0 || fFillParticleTree) {
-    FillJetTree();
+    FillJetTree(mcHeader);
   }
   if (fFillTrackletTree){
     fTreeHandlerTracklet->SetTrackletContainer(aod->GetTracklets());

--- a/PWGHF/treeHF/AliAnalysisTaskSEHFTreeCreator.h
+++ b/PWGHF/treeHF/AliAnalysisTaskSEHFTreeCreator.h
@@ -232,7 +232,7 @@ public:
     AliJetContainer* AddJetContainer(AliJetContainer::EJetType_t jetType, AliJetContainer::EJetAlgo_t jetAlgo, AliJetContainer::ERecoScheme_t recoScheme, Double_t radius, UInt_t accType, AliParticleContainer* partCont, AliClusterContainer* clusCont, TString tag = "Jet");
     AliJetContainer* AddJetContainer(const char *n, UInt_t accType, Float_t jetRadius);
     AliJetContainer* GetJetContainer(Int_t i=0) const;
-    void FillJetTree();
+    void FillJetTree(AliAODMCHeader* mcHeader);
   
     
     unsigned int GetEvID();

--- a/PWGHF/treeHF/AliParticleTreeHandler.h
+++ b/PWGHF/treeHF/AliParticleTreeHandler.h
@@ -39,6 +39,7 @@
 #include "TTree.h"
 
 #include "AliParticleContainer.h"
+#include "AliAODMCHeader.h"
 
 //________________________________________________________________
 //****************************************************************
@@ -55,6 +56,7 @@ class AliParticleTreeHandler : public TObject
   
     // Setters
     void SetParticleContainer(AliParticleContainer* partCont) { fParticleContainer = partCont; }
+    void SetMCHeader(AliAODMCHeader* MCHeader) { fMCHeader = MCHeader; }
 
   protected:
   
@@ -66,7 +68,8 @@ class AliParticleTreeHandler : public TObject
     // Each tree structure is completely flat -- the branches are all primitive types.
   
     TTree*                       fTreeParticle;            ///< Tree with particle variables
-  
+    bool                         fIsMCGen;                 //!<! Flag for whether tree is for MC gen particles
+    AliAODMCHeader*              fMCHeader;                //!<! MC header (only used in case is_mc_gen=true)
     AliParticleContainer*        fParticleContainer;       //!<! Particle container for this tree
   
     // Track quantities.
@@ -81,7 +84,7 @@ class AliParticleTreeHandler : public TObject
     Long64_t                     fEventIDLong;                 //!<! event ID (unique identifier when run number is fixed), full 64 bits of fEventIDLong
 
   /// \cond CLASSIMP
-  ClassDef(AliParticleTreeHandler,1); ///
+  ClassDef(AliParticleTreeHandler,2); ///
   /// \endcond
 };
 


### PR DESCRIPTION
Implement [rejection of pileup particles at generator level](https://twiki.cern.ch/twiki/bin/view/ALICE/AliDPGtoolsPileup#Pileup_in_Monte_Carlo_simulation) in track tree 
(not actually needed for jet-jet productions, but may be useful for other productions)

FYI @nzardosh (shouldn't affect you, just FYI)