### PR TITLE
Add settable threshold for EMCAL cell level compression

### DIFF
--- a/RUN3/AliAnalysisTaskAO2Dconverter.cxx
+++ b/RUN3/AliAnalysisTaskAO2Dconverter.cxx
@@ -1218,6 +1218,8 @@ void AliAnalysisTaskAO2Dconverter::FillEventInTF()
     
     cells->GetCell(ice, cellNumber, amplitude, time, mclabel, efrac);
     calo.fCellNumber = cellNumber;
+    // Mimic run3 compression: Store only cells with energy larger than the threshold
+    if(amplitude < fEMCALAmplitudeThreshold) continue;
     calo.fAmplitude = AliMathBase::TruncateFloatFraction(amplitude, mCaloAmp);
     calo.fTime = AliMathBase::TruncateFloatFraction(time * kSecToNanoSec, mCaloAmp);
     calo.fCaloType = cells->GetType(); // common for all cells

--- a/RUN3/AliAnalysisTaskAO2Dconverter.h
+++ b/RUN3/AliAnalysisTaskAO2Dconverter.h
@@ -43,6 +43,7 @@ public:
   virtual void SetTruncation(Bool_t trunc=kTRUE) {fTruncate = trunc;}
   virtual void SetCompression(UInt_t compress=101) {fCompress = compress; }
   virtual void SetMaxBytes(ULong_t nbytes = 100000000) {fMaxBytes = nbytes;}
+  void SetEMCALAmplitudeThreshold(Double_t threshold) { fEMCALAmplitudeThreshold = threshold; }
 
   static AliAnalysisTaskAO2Dconverter* AddTask(TString suffix = "");
   enum TreeIndex { // Index of the output trees
@@ -492,6 +493,7 @@ private:
   TH1F *fCentralityHist = nullptr; ///! Centrality histogram
   TH1F *fCentralityINT7 = nullptr; ///! Centrality histogram for the INT7 triggers
   TH1I *fHistPileupEvents = nullptr; ///! Counter histogram for pileup events
+  Double_t fEMCALAmplitudeThreshold = 0.1; ///< EMCAL amplitude threshold (for compression - default: 100 MeV := cluster cell threshold)
 
   /// Byte counter
   ULong_t fBytes = 0; ///! Number of bytes stored in all trees
@@ -501,7 +503,7 @@ private:
   TFile * fOutputFile = 0x0; ///! Pointer to the output file
   TDirectory * fOutputDir = 0x0; ///! Pointer to the output Root subdirectory
   
-  ClassDef(AliAnalysisTaskAO2Dconverter, 13);
+  ClassDef(AliAnalysisTaskAO2Dconverter, 14);
 };
 
 #endif


### PR DESCRIPTION
Mimic run3 cell level compression type 1 and 2 (only amplitude
above threshold, no pre-clusterization)