### PR TITLE
 Including TPC calibrations on 2017 and 2018 data for high pT analysis

### DIFF
--- a/PWGDQ/dielectron/core/AliAnalysisTask_JPsi_EMCal.h
+++ b/PWGDQ/dielectron/core/AliAnalysisTask_JPsi_EMCal.h
@@ -14,6 +14,7 @@
 //        Authors                                                     //
 //                                                                    //
 //        Cristiane Jahnke        (cristiane.jahnke@cern.ch)          //
+//        22 January, 2021 -> TPC calibrations for 2017 and 2018 data //
 //                                                                    //
 ////////////////////////////////////////////////////////////////////////
 
@@ -78,6 +79,8 @@ class AliAnalysisTask_JPsi_EMCal : public AliAnalysisTaskSE
     void Set_Fill_ESparseTPC() {fFill_ESparseTPC=kTRUE;};
     void Set_Fill_MSparse() {fFill_MSparse=kTRUE;};
     
+    void Set_TPCCalibration(){fIs_TPC_calibration=kTRUE;};
+    
     //to select events with high energy cluster (to mimic the trigger)
     void Set_Select_trigger_events2() {fSelect_trigger_events2=kTRUE;};
     void Set_Select_trigger_events1() {fSelect_trigger_events1=kTRUE;};
@@ -112,6 +115,8 @@ class AliAnalysisTask_JPsi_EMCal : public AliAnalysisTaskSE
         //}
     }
     Double_t         GetTrackletsMeanCorrection(TProfile2D* estimatorAvg, Double_t uncorrectedNacc, Double_t vtxZ, Double_t refMult, Int_t run_number); /*const*/
+    
+    Double_t GetTPCCalibration(Int_t runNo, Double_t TPCnsigma0);/*const*/
     
     //V0 correction
     void SetMultiProfileV0(TProfile2D * hprofV0){
@@ -155,6 +160,7 @@ class AliAnalysisTask_JPsi_EMCal : public AliAnalysisTaskSE
     Bool_t              fFill_ESparse;
     Bool_t              fFill_ESparseTPC;
     Bool_t              fFill_MSparse;
+    Bool_t              fIs_TPC_calibration;
     Bool_t              fSelect_trigger_events1;
     Bool_t              fSelect_trigger_events2;
     
@@ -291,11 +297,16 @@ class AliAnalysisTask_JPsi_EMCal : public AliAnalysisTaskSE
     
 	TH2F				**fEoverP_pt;
 	TH2F				**fTPC_p;
+    
 	TH2F				**fTPCnsigma_p;
+    TH2F                *fTPCnsigma_p_beforeCalibration;
+    TH2F                *fTPCnsigma_p_afterCalibration;
+    
     TH2F                **fTOF_p;
     TH2F                **fTOFnsigma_p;
 	
-		
+   
+    
 	
 	TH2F				**fTPCnsigma_EoverP;
 	TH1F				**fECluster;

--- a/PWGDQ/dielectron/macrosJPSI/AddTask_JPsi_EMCal.C
+++ b/PWGDQ/dielectron/macrosJPSI/AddTask_JPsi_EMCal.C
@@ -1,3 +1,10 @@
+///*******************************************************
+/// AddTask
+/// January 22, 2021 - Cristiane Jahnke
+/// cristiane.jahnke@cern.ch
+/// TPC calibrations for 2017 and 2018 data
+///*******************************************************
+
 AliAnalysisTask_JPsi_EMCal *AddTask_JPsi_EMCal(
 
 			Bool_t 	isMC 			= kFALSE, 
@@ -18,7 +25,8 @@ AliAnalysisTask_JPsi_EMCal *AddTask_JPsi_EMCal(
             Bool_t is_EventsEG1 = kFALSE,
             Bool_t is_EventsEG2 = kTRUE,
             Bool_t isMultiAnalysis = kFALSE,
-            Bool_t is_MSparse = kFALSE
+            Bool_t is_MSparse = kFALSE,
+            Bool_t is_TPCcalibration = kFALSE
 			
 )
 {
@@ -79,7 +87,7 @@ AliAnalysisTask_JPsi_EMCal *AddTask_JPsi_EMCal(
 
   
 	//gROOT->LoadMacro("Config_JPsi_EMCal.C");
-	AliAnalysisTask_JPsi_EMCal *task = Config_JPsi_EMCal(isMC,isAOD, period,trigger_index, config, isTender, is_ESparse, is_ESparseTPC, is_EventsEG1, is_EventsEG2, isMultiAnalysis, is_MSparse);
+	AliAnalysisTask_JPsi_EMCal *task = Config_JPsi_EMCal(isMC,isAOD, period,trigger_index, config, isTender, is_ESparse, is_ESparseTPC, is_EventsEG1, is_EventsEG2, isMultiAnalysis, is_MSparse, is_TPCcalibration);
 	
 	//_______________________
 	//Trigger

--- a/PWGDQ/dielectron/macrosJPSI/Config_JPsi_EMCal.C
+++ b/PWGDQ/dielectron/macrosJPSI/Config_JPsi_EMCal.C
@@ -1,9 +1,11 @@
 ///*******************************************************
-///Config Description
-/// January 15, 2021 - Cristiane Jahnke
+/// Config Description
+/// January 22, 2021 - Cristiane Jahnke
 /// cristiane.jahnke@cern.ch
-/// fixed order of parameters!
+/// TPC calibrations for 2017 and 2018 data
 ///*******************************************************
+
+//isMC,isAOD, period,trigger_index, config, isTender, is_ESparse, is_ESparseTPC, is_EventsEG1, is_EventsEG2, isMultiAnalysis, is_MSparse, is_TPCcalibration
 
 AliAnalysisTask_JPsi_EMCal* Config_JPsi_EMCal(
 											
@@ -18,7 +20,8 @@ Bool_t is_ESparseTPC,
 Bool_t is_EventsEG1,
 Bool_t is_EventsEG2,
 Bool_t isMultiAnalysis,
-Bool_t is_MSparse  //changed on January 08, 2021... bug on the order of the parameters...
+Bool_t is_MSparse,
+Bool_t is_TPCcalibration
                                             
 )
 
@@ -40,6 +43,8 @@ Bool_t is_MSparse  //changed on January 08, 2021... bug on the order of the para
     if(is_ESparse)task->Set_Fill_ESparse();
     if(is_ESparseTPC)task->Set_Fill_ESparseTPC();
     if(is_MSparse)task->Set_Fill_MSparse();
+    
+    if(is_TPCcalibration)task->Set_TPCCalibration();
     
     if(is_EventsEG1)task->Set_Select_trigger_events1();
     if(is_EventsEG2)task->Set_Select_trigger_events2();


### PR DESCRIPTION
Added a data-driven calibration on TPCnsigma, due to the missing splines at high pT for 2017 data and part of the 2018 periods.