### PR TITLE
Force TOF tune on data for vertexingHF analyses

### DIFF
--- a/PWGHF/vertexingHF/AliAODPidHF.cxx
+++ b/PWGHF/vertexingHF/AliAODPidHF.cxx
@@ -966,6 +966,7 @@ Int_t AliAODPidHF::GetnSigmaTOF(AliAODTrack *track,Int_t species, Double_t &nsig
   if(!CheckTOFPIDStatus(track)) return -1;
   
   if(fPidResponse){
+    track->SetTOFsignalTunedOnData(100000); // force tune-on-data to have latest development of tail parametrisation in old AODs
     nsigma = fPidResponse->NumberOfSigmasTOF(track,(AliPID::EParticleType)species);
     return 1;
   }else{

--- a/PWGHF/vertexingHF/AliAnalysisTaskSEHFSystPID.cxx
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSEHFSystPID.cxx
@@ -636,6 +636,7 @@ void AliAnalysisTaskSEHFSystPID::UserExec(Option_t */*option*/)
     }
 
     //PID
+    track->SetTOFsignalTunedOnData(100000); // force tune-on-data to have latest development of tail parametrisation in old AODs
     bool isDetOk[kNMaxDet] = {false,false,false};
     if (fPIDresp->CheckPIDStatus(AliPIDResponse::kITS,track) == AliPIDResponse::kDetPidOk) {
       fTrackInfoMap &= ~kHasNoITS;


### PR DESCRIPTION
Forcing the TOF the improvement in the TOF response with tune on data introduced in https://github.com/alisw/AliRoot/pull/1305 can be available also for already produced AODs