### PR TITLE
Possibility to make THnSparses lighter when exploring PID possibilities

### DIFF
--- a/PWGHF/vertexingHF/AliAnalysisTaskSEXicTopKpi.cxx
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSEXicTopKpi.cxx
@@ -204,6 +204,7 @@ AliAnalysisTaskSEXicTopKpi::AliAnalysisTaskSEXicTopKpi():
   ,fCandCounter_onTheFly(0x0)
   ,fNSigmaPreFilterPID(3.)
   ,fApplyEvSel(kTRUE)
+  ,fNoStdPIDcases(kFALSE)
 {
   /// Default constructor
 
@@ -326,6 +327,7 @@ AliAnalysisTaskSEXicTopKpi::AliAnalysisTaskSEXicTopKpi(const char *name,AliRDHFC
   ,fCandCounter_onTheFly(0x0)
   ,fNSigmaPreFilterPID(3.)
   ,fApplyEvSel(kTRUE)
+  ,fNoStdPIDcases(kFALSE)
 {
   /// Default constructor
 
@@ -1713,9 +1715,17 @@ void AliAnalysisTaskSEXicTopKpi::UserExec(Option_t */*option*/)
 		      if(arrayPIDpkpi[i]){
 			if(fReadMC && (converted_isTrueLcXic==2 || converted_isTrueLcXic==6 || converted_isTrueLcXic==8 || converted_isTrueLcXic==11 || converted_isTrueLcXic==15 || converted_isTrueLcXic==17)) {
 			  point[0]=part->Pt();
-			  fhSparseAnalysis->Fill(point);
+        if(fNoStdPIDcases){
+          if(i==0 || i==11) fhSparseAnalysis->Fill(point);  // avoid to fill the cases with STD PID
+        }
+        else  fhSparseAnalysis->Fill(point);
 			}
-			if(!fReadMC || (fReadMC&&fIsXicUpgradeAnalysis&&fIsKeepOnlyBkgXicUpgradeAnalysis) )  fhSparseAnalysis->Fill(point);
+			if(!fReadMC || (fReadMC&&fIsXicUpgradeAnalysis&&fIsKeepOnlyBkgXicUpgradeAnalysis) ){
+        if(fNoStdPIDcases){
+          if(i==0 || i==11) fhSparseAnalysis->Fill(point);  // avoid to fill the cases with STD PID
+        }
+        else  fhSparseAnalysis->Fill(point);
+      }
 		      }
 	      }
 	    }	    	   
@@ -1742,9 +1752,17 @@ void AliAnalysisTaskSEXicTopKpi::UserExec(Option_t */*option*/)
 		if(arrayPIDpikp[i]){
 		  if(fReadMC && (converted_isTrueLcXic==3 || converted_isTrueLcXic==7 || converted_isTrueLcXic==9 || converted_isTrueLcXic==12 || converted_isTrueLcXic==16 || converted_isTrueLcXic==18))  {
 		    point[0]=part->Pt();
-		    fhSparseAnalysis->Fill(point);
+		    if(fNoStdPIDcases){
+          if(i==0 || i==11) fhSparseAnalysis->Fill(point);  // avoid to fill the cases with STD PID
+        }
+        else  fhSparseAnalysis->Fill(point);
 		  }
-		  if(!fReadMC || (fReadMC&&fIsXicUpgradeAnalysis&&fIsKeepOnlyBkgXicUpgradeAnalysis) )  fhSparseAnalysis->Fill(point);
+		  if(!fReadMC || (fReadMC&&fIsXicUpgradeAnalysis&&fIsKeepOnlyBkgXicUpgradeAnalysis) ){
+        if(fNoStdPIDcases){
+          if(i==0 || i==11) fhSparseAnalysis->Fill(point);  // avoid to fill the cases with STD PID
+        }
+        else  fhSparseAnalysis->Fill(point);
+      }
 		}
 	      }
 	    }	  

--- a/PWGHF/vertexingHF/AliAnalysisTaskSEXicTopKpi.h
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSEXicTopKpi.h
@@ -117,9 +117,10 @@ class AliAnalysisTaskSEXicTopKpi : public AliAnalysisTaskSE
   // dirty solution: flag to reduce the axes in the reco sparses ---> make the merging easier (mfaggin)
   void SetOnlyBayesPIDbin_recoSparse(Bool_t flag) {fOnlyBayesPIDbin=flag;}
   /// include the PID selection with Bayes approach only for proton
-  void SetExplPID_BayesOnlyProt(Bool_t flag){
+  void SetExplPID_BayesOnlyProt(Bool_t flag, Bool_t rejectStdPIDcases=kFALSE){
     if(!fExplore_PIDstdCuts)  SetExplorePIDstd(flag);
     fExplPID_BayesOnlyProt = flag;
+    fNoStdPIDcases = rejectStdPIDcases;
   }
 
   void SetLcMassWindowForSigmaC(Double_t massrange){fLcMassWindowForSigmaC=massrange;}
@@ -396,8 +397,11 @@ class AliAnalysisTaskSEXicTopKpi : public AliAnalysisTaskSE
   // bool to remove ev. selection (useful to run on ITS2-ITS3 upgrade MC)
   Bool_t fApplyEvSel;
 
+  // bool to keep only the Bayes PID- based PID selections
+  Bool_t fNoStdPIDcases;
+
   /// \cond CLASSIMP
-  ClassDef(AliAnalysisTaskSEXicTopKpi,17); /// AliAnalysisTaskSE for Xic->pKpi
+  ClassDef(AliAnalysisTaskSEXicTopKpi,18); /// AliAnalysisTaskSE for Xic->pKpi
   /// \endcond
 };
 


### PR DESCRIPTION
Possibility to avoid the THnSparses to be filled with standard PID selections when the case with Bayes PID is checked only for proton.