### PR TITLE
Nowa wiolata rz

### DIFF
--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoESDTrackCut.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoESDTrackCut.cxx
@@ -832,12 +832,12 @@ bool AliFemtoESDTrackCut::IsDeuteronTPCdEdx(float mom, float dEdx)
     if (dEdx < a4*mom+b4) return false;
   }
   
-  if (fNsigmaTPConly && fNsigmaMass==-1) {
+  if (fNsigmaTPConly && fNsigmaMass == -1) {
     // for selection with only the TPC detector
     // cutting the tip of the signal (~1.5 GeV/c) 
-    // that is dominated by missidentified particles
+    // that is dominated by wrongly identified particles
 
-    // to avoid this constrain, set fNsigmaMass i.e. on 0, SetNsigmaMass(0)  
+    // to avoid this constraint, set fNsigmaMass i.e. on 0, SetNsigmaMass(0)  
     if (dEdx < a5*mom+b5) return false;
   }
 

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoESDTrackCut.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoESDTrackCut.cxx
@@ -330,27 +330,6 @@ bool AliFemtoESDTrackCut::Pass(const AliFemtoTrack* track)
           imost = 4;
         }
       }
-      else if (fMostProbable == 13) {
-        if (IsDeuteronNSigma(track->P().Mag(),track->MassTOF(), fNsigmaMass, track->NSigmaTPCD(), track->NSigmaTOFD()))
-          imost = 13;
-        if ((track->P().Mag() < 3) &&!(IsDeuteronTPCdEdx(track->P().Mag(), track->TPCsignal())))
-          imost = 0;
-      }
-      else if (fMostProbable == 14) {
-          if (IsTritonNSigma(track->P().Mag(), track->NSigmaTPCT(), track->NSigmaTOFT())){
-          imost = 14;
-        }
-      }
-      else if (fMostProbable == 15) {
-        if ( IsHe3NSigma(track->P().Mag(), track->NSigmaTPCH(), track->NSigmaTOFH())
-      )
-          imost = 15;
-      }
-      else if (fMostProbable == 16) {
-        if ( IsAlphaNSigma(track->P().Mag(), track->NSigmaTPCA(), track->NSigmaTOFA())
-      )
-          imost = 16;
-      }
       else if (fMostProbable == 5) { // no-protons
         if ( !IsProtonNSigma(track->P().Mag(), track->NSigmaTPCP(), track->NSigmaTOFP()) )
           imost = 5;
@@ -401,6 +380,27 @@ bool AliFemtoESDTrackCut::Pass(const AliFemtoTrack* track)
       else if (fMostProbable == 12) { //cut on Nsigma in pT not p
         if ( IsProtonNSigma(track->Pt(), track->NSigmaTPCP(), track->NSigmaTOFP()) )
           imost = 12;
+      }
+      else if (fMostProbable == 13) {
+        if (IsDeuteronNSigma(track->P().Mag(), track->MassTOF(), track->NSigmaTPCD(), track->NSigmaTOFD()))
+          imost = 13;
+        if ((track->P().Mag() < 3) && !(IsDeuteronTPCdEdx(track->P().Mag(), track->TPCsignal())))
+          imost = 0;
+      }
+      else if (fMostProbable == 14) {
+          if (IsTritonNSigma(track->P().Mag(), track->NSigmaTPCT(), track->NSigmaTOFT())){
+          imost = 14;
+        }
+      }
+      else if (fMostProbable == 15) {
+        if ( IsHe3NSigma(track->P().Mag(), track->NSigmaTPCH(), track->NSigmaTOFH())
+      )
+          imost = 15;
+      }
+      else if (fMostProbable == 16) {
+        if ( IsAlphaNSigma(track->P().Mag(), track->NSigmaTPCA(), track->NSigmaTOFA())
+      )
+          imost = 16;
       }
     }
 
@@ -517,13 +517,10 @@ bool AliFemtoESDTrackCut::Pass(const AliFemtoTrack* track)
           }
         }
       }
-
-
-      /**********************************/
-    else if (fMostProbable == 13) {
+      else if (fMostProbable == 13) {
         //       if (imost == 3) {
         // Using the TPC to reject non-deuterons
-        if (track->P().Mag() < 2) {
+        if (track->P().Mag() < 3) {
           if (!(IsDeuteronTPCdEdx(track->P().Mag(), track->TPCsignal()))) {
             imost = 0;
           } else {
@@ -531,7 +528,7 @@ bool AliFemtoESDTrackCut::Pass(const AliFemtoTrack* track)
           }
         }
       }
-      /*************************************/
+
 
     }
 
@@ -815,13 +812,12 @@ bool AliFemtoESDTrackCut::IsKaonTPCdEdx(float mom, float dEdx)
 bool AliFemtoESDTrackCut::IsDeuteronTPCdEdx(float mom, float dEdx)
 {
 
-
   double a1 = -250.0,  b1 = 400.0;
   double a2 = -135.0,  b2 = 270.0;
   double a3 = -80,   b3 = 190.0;
   double a4 = 0.0,   b4 = 20.0;
 
-  double a5 = 125.0,   b5 = -100.0;
+  double a5 = 125.0,   b5 = -100.0; 
 
   if (mom < 1.1) {
     if (dEdx < a1*mom+b1) return false;
@@ -832,18 +828,17 @@ bool AliFemtoESDTrackCut::IsDeuteronTPCdEdx(float mom, float dEdx)
   else if (mom < 2) {
     if (dEdx < a3*mom+b3) return false;
   }
-  else if (mom >= 2) {
+  else if (mom <3 ) {
     if (dEdx < a4*mom+b4) return false;
   }
+  
+  if (fNsigmaTPConly && fNsigmaMass==-1) {
+    // for selection with only the TPC detector
+    // cutting the tip of the signal (~1.5 GeV/c) 
+    // that is dominated by missidentified particles
 
-
-  if (!fNsigmaTPCTOF && (fNsigmaMass == -1)) {
-    //for selection with only the TPC detector, to remove visible contamination
+    // to avoid this constrain, set fNsigmaMass i.e. on 0, SetNsigmaMass(0)  
     if (dEdx < a5*mom+b5) return false;
-  }
-  else if(fNsigmaTPCTOF && (fNsigmaMass == -1)) {
-    //for selection with tpc/tof to finish sample before the region with contamination
-    if (mom > 2.2) return false;
   }
 
   return true;
@@ -1106,53 +1101,36 @@ bool AliFemtoESDTrackCut::IsProtonNSigma(float mom, float nsigmaTPCP, float nsig
 }
 
 
-/***********************************************************************/
-
-bool AliFemtoESDTrackCut::IsDeuteronNSigma(float mom, float massTOFPDG,float sigmaMass, float nsigmaTPCD, float nsigmaTOFD)
+bool AliFemtoESDTrackCut::IsDeuteronNSigma(float mom, float massTOFPDG, float nsigmaTPCD, float nsigmaTOFD)
 {
   double massPDGD=1.8756;
   if (fNsigmaTPCTOF) {
-    if (mom > 1.4) {  //if TOF avaliable: && (nsigmaTOFD != -1000) --> always TOF
-      if ((TMath::Abs(nsigmaTPCD) < fNsigma) && (TMath::Abs(nsigmaTOFD) < 2))
+    if (mom > 1.4){
+      if ((TMath::Abs(nsigmaTPCD) < fNsigma) && (TMath::Abs(nsigmaTOFD) < fNsigma))
         return true;
     }
-    else {
+    else{ 
       if (TMath::Abs(nsigmaTPCD) < fNsigma)
         return true;
     }
   }
-  else{
-    if(sigmaMass < 0){
+  else if (fNsigmaTPConly)
       if (TMath::Abs(nsigmaTPCD) < fNsigma)
 	return true;
-    }
-    else if(sigmaMass > 0){
+  else {
+    // p dependent mass cut, TPC & TOF
+    // The method should provide similar resluts to the case
+    // with fNsigmaTPCTOF=true and fNsigma=2
 
-      //p dependent mass cut 
-      double l1, l2;
-      if(sigmaMass > 2){
-         //left band (4 sigmas)
-         l1 = 2.897 - 0.558*mom + 0.177*mom*mom - 0.026*mom*mom*mom;  
-         l2 = 3.77 - 0.487*mom + 0.126*mom*mom - 0.014*mom*mom*mom;
-      }
-      else if(sigmaMass > 1){
-         //right band (4 sigmas)
-         l1 = 4.5 - 0.42*mom + 0.1*mom*mom;
-         l2 = 6.602 -0.981*mom + 0.303*mom*mom;
-      }
-      else{
-         //signal (dist under the mass peak -- 2 sigmas)
-         l1 = 4.002 - 0.627*mom + 0.184*mom*mom - 0.02*mom*mom*mom;
-         l2 = 4.35 - 0.399*mom + 0.09*mom*mom;
-      }
+    double l1 = 4.002 - 0.627*mom + 0.184*mom*mom - 0.02*mom*mom*mom;
+    double l2 = 4.35 - 0.399*mom + 0.09*mom*mom;
 
-      if ((TMath::Abs(nsigmaTPCD) < fNsigma) && (massTOFPDG > l1) && (massTOFPDG < l2))
-	 return true;
-
-    }
+    if ( mom < 1.3 && (TMath::Abs(nsigmaTPCD) < fNsigma) ) 
+       return true;
+    else if ( mom >= 1.3 && (TMath::Abs(nsigmaTPCD) < fNsigma) && (massTOFPDG > l1) && (massTOFPDG < l2))
+       return true;
 
   }
-
   return false;
 }
 
@@ -1191,11 +1169,6 @@ bool AliFemtoESDTrackCut::IsAlphaNSigma(float mom, float nsigmaTPCA, float nsigm
 }
 
 
-
-
-
-//
-/*********************************************************************/
 
 
 void AliFemtoESDTrackCut::SetPIDMethod(ReadPIDMethodType newMethod)

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoESDTrackCut.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoESDTrackCut.h
@@ -210,7 +210,7 @@ protected:   // here are the quantities I want to cut on...
   bool IsProtonNSigma(float mom, float nsigmaTPC, float nsigmaTOF);
   bool IsElectron(float nsigmaTPCE, float nsigmaTPCPi,float nsigmaTPCK, float nsigmaTPCP);
   //
-  bool IsDeuteronNSigma(float mom,float massTOFDPG, float sigmaMass, float nsigmaTPC, float nsigmaTOF);
+  bool IsDeuteronNSigma(float mom,float massTOFDPG, float nsigmaTPC, float nsigmaTOF);
   bool IsTritonNSigma(float mom, float nsigmaTPC, float nsigmaTOF);
   bool IsHe3NSigma(float mom, float nsigmaTPC, float nsigmaTOF);
   bool IsAlphaNSigma(float mom, float nsigmaTPC, float nsigmaTOF);

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoWRzTrackCut.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoWRzTrackCut.cxx
@@ -2,15 +2,14 @@
 
 
 AliFemtoWRzTrackCut::AliFemtoWRzTrackCut():
-  AliFemtoMJTrackCut()
+  AliFemtoESDTrackCut()
   {
-     fDCA_ptdependence[0]=2.4; fDCA_ptdependence[4]=3.2;
-     fDCA_ptdependence[1]=2.4; fDCA_ptdependence[5]=3.2;
-     fDCA_ptdependence[2]=2.4; fDCA_ptdependence[6]=3.2;
-     fDCA_ptdependence[3]=2.4; fDCA_ptdependence[7]=3.2;
+     fdEdxcut = true ;
+     fNsigmaRejection = 3.0;
+     fNSigmaMass = -1;
   }
 
-AliFemtoWRzTrackCut::AliFemtoWRzTrackCut(const AliFemtoWRzTrackCut &aCut) : AliFemtoMJTrackCut(aCut)
+AliFemtoWRzTrackCut::AliFemtoWRzTrackCut(const AliFemtoWRzTrackCut &aCut) : AliFemtoESDTrackCut(aCut)
 {
     //copy constructor 
 }
@@ -27,48 +26,364 @@ AliFemtoWRzTrackCut& AliFemtoWRzTrackCut::operator=(const AliFemtoWRzTrackCut& a
   if (this == &aCut)
     return *this;
 
-  AliFemtoMJTrackCut::operator=(aCut);
+  AliFemtoESDTrackCut::operator=(aCut);
  
   return *this;
 }
 
-
-void AliFemtoWRzTrackCut::SetDCAcutPtDependence(const float &DCAxy1,const float &DCAxy2, const float &DCAxy3, const float &DCAxy4, const float &DCAz1, const float &DCAz2, const float &DCAz3, const float &DCAz4)
-{
-  fDCA_ptdependence[0]=DCAxy1;
-  fDCA_ptdependence[1]=DCAxy2;
-  fDCA_ptdependence[2]=DCAxy3;
-  fDCA_ptdependence[3]=DCAxy4;
-  fDCA_ptdependence[4]=DCAz1;
-  fDCA_ptdependence[5]=DCAz2;
-  fDCA_ptdependence[6]=DCAz3;
-  fDCA_ptdependence[7]=DCAz4;
-}
-
-
 bool AliFemtoWRzTrackCut::Pass( const AliFemtoTrack* track)
 {
-    AliFemtoMJTrackCut::Pass(track);
+  // almost the same function as in AliFemtoESDTrackCut. Differences in *N Sigma Method* and *Countur Method*
 
-    float tPt = ::sqrt((track->P().x())*(track->P().x())+(track->P().y())*(track->P().y()));
+  // test the particle and return
+  // true if it meets all the criteria
+  // false if it doesn't meet at least one of the criteria
+
+  if (fStatus && (track->Flags() & fStatus) != fStatus) {
+    return false;
+  }
+  if (fRemoveKinks && (track->KinkIndex(0) || track->KinkIndex(1) || track->KinkIndex(2))) {
+    return false;
+  }
+  if (fRemoveITSFake && track->ITSncls() < 0) {
+    return false;
+  }
+  if (fminTPCclsF > track->TPCnclsF()) {
+    return false;
+  }
+  if (fminTPCncls > track->TPCncls()) {
+    return false;
+  }
+  if (fminITScls > track->ITSncls()) {
+    return false;
+  }
+
+  if (fMaxImpactXY < TMath::Abs(track->ImpactD())) {
+    return false;
+  }
+  if (fMinImpactXY > TMath::Abs(track->ImpactD())) {
+    return false;
+  }
+  if (fMaxImpactZ < TMath::Abs(track->ImpactZ())) {
+    return false;
+  }
+  if (fMaxSigmaToVertex < track->SigmaToVertex()) {
+    return false;
+  }
+
+  if (track->ITSncls() > 0 && (track->ITSchi2() / track->ITSncls()) > fMaxITSchiNdof) {
+    return false;
+  }
+
+  if (track->TPCchi2perNDF() > fMaxTPCchiNdof) {
+    return false;
+  }
+
+  // ITS cluster requirenments
+  for (Int_t i = 0; i < 3; i++) {
+    if (!CheckITSClusterRequirement(fCutClusterRequirementITS[i], track->HasPointOnITSLayer(i * 2), track->HasPointOnITSLayer(i*2+1))) {
+      return false;
+    }
+  }
+
+  if (fLabel) {
+    if (track->Label() < 0) {
+      fNTracksFailed++;
+      return false;
+    }
+  }
+  if (fCharge != 0 && (track->Charge() != fCharge)) {
+    fNTracksFailed++;
+    return false;
+  }
 
 
-    if (tPt > 0.5 && tPt < 1.0){
-       if( (TMath::Abs(track->ImpactD()) > fDCA_ptdependence[0]) || (TMath::Abs(track->ImpactZ()) > fDCA_ptdependence[4]))
-          return false;
+  Bool_t tTPCPidIn = (track->Flags() & AliFemtoTrack::kTPCpid) > 0;
+  Bool_t tITSPidIn = (track->Flags() & AliFemtoTrack::kITSpid) > 0;
+  Bool_t tTOFPidIn = (track->Flags() & AliFemtoTrack::kTOFpid) > 0;
+
+  const double momentum = track->P().Mag();
+
+  if (fMinPforTOFpid > 0
+      && fMinPforTOFpid < momentum && momentum < fMaxPforTOFpid
+      && !tTOFPidIn) {
+    fNTracksFailed++;
+    return false;
+  }
+
+  if (fMinPforTPCpid > 0
+      && fMinPforTPCpid < momentum && momentum < fMaxPforTPCpid
+      && !tTPCPidIn) {
+    fNTracksFailed++;
+    return false;
+  }
+
+  if (fMinPforITSpid > 0
+      && fMinPforITSpid < momentum && momentum < fMaxPforITSpid
+      && !tITSPidIn) {
+    fNTracksFailed++;
+    return false;
+  }
+
+
+  float tEnergy = ::sqrt(track->P().Mag2() + fMass * fMass);
+  float tRapidity = 0;
+  if (tEnergy-track->P().z() != 0 && (tEnergy + track->P().z()) / (tEnergy-track->P().z()) > 0)
+    tRapidity = 0.5 * ::log((tEnergy + track->P().z())/(tEnergy-track->P().z()));
+  float tPt = track->P().Perp();
+  float tEta = track->P().PseudoRapidity();
+
+  if (fMaxImpactXYPtOff < 999.0) {
+    if ((fMaxImpactXYPtOff + fMaxImpactXYPtNrm*TMath::Power(tPt, fMaxImpactXYPtPow)) < TMath::Abs(track->ImpactD())) {
+      fNTracksFailed++;
+      return false;
     }
-    else if (tPt >= 1.0 && tPt < 1.5){
-       if( (TMath::Abs(track->ImpactD()) > fDCA_ptdependence[1]) || (TMath::Abs(track->ImpactZ()) > fDCA_ptdependence[5]))
-          return false;
+  }
+
+  if ((tRapidity < fRapidity[0]) || (tRapidity > fRapidity[1])) {
+    fNTracksFailed++;
+    return false;
+  }
+  if ((tEta < fEta[0]) || (tEta > fEta[1])) {
+    fNTracksFailed++;
+    return false;
+  }
+  if ((tPt < fPt[0]) || (tPt > fPt[1])) {
+    fNTracksFailed++;
+    return false;
+  }
+
+
+  if ((track->PidProbElectron() < fPidProbElectron[0]) || (track->PidProbElectron() > fPidProbElectron[1])) {
+    fNTracksFailed++;
+    return false;
+  }
+  if ((track->PidProbPion() < fPidProbPion[0]) || (track->PidProbPion() > fPidProbPion[1])) {
+    fNTracksFailed++;
+    return false;
+  }
+  if ((track->PidProbKaon() < fPidProbKaon[0]) || (track->PidProbKaon() > fPidProbKaon[1])) {
+    fNTracksFailed++;
+    return false;
+  }
+  if ((track->PidProbProton() < fPidProbProton[0]) || (track->PidProbProton() > fPidProbProton[1])) {
+    fNTracksFailed++;
+    return false;
+  }
+  if ((track->PidProbMuon() < fPidProbMuon[0]) || (track->PidProbMuon() > fPidProbMuon[1])) {
+    fNTracksFailed++;
+    return false;
+  }
+
+
+  //****N Sigma Method -- electron rejection****
+  if (fElectronRejection)
+    if (!IsElectron(track->NSigmaTPCE(),track->NSigmaTPCPi(),track->NSigmaTPCK(), track->NSigmaTPCP()))
+      return false;
+
+
+  if (fMostProbable) {
+    int imost=0;
+
+    float ipidmax = 0.0;
+    //****N Sigma Method****
+    if (fPIDMethod==0) {
+      // Looking for pions
+      if (fMostProbable == 2) {
+        if (IsPionNSigma(track->P().Mag(), track->NSigmaTPCPi(), track->NSigmaTOFPi())) {
+          imost = 2;
+        }
+      }
+      else if (fMostProbable == 3) {
+        if (IsKaonNSigma(track->P().Mag(), track->NSigmaTPCK(), track->NSigmaTOFK())){
+          imost = 3;
+        }
+      }
+      else if (fMostProbable == 4) { // proton nsigma-PID required contour adjusting (in LHC10h)
+        if (IsProtonNSigma(track->P().Mag(), track->NSigmaTPCP(), track->NSigmaTOFP()) ) {
+          imost = 4;
+        }
+      }
+      if (fMostProbable == 10) {//cut on Nsigma in pT not p
+        if (IsPionNSigma(track->Pt(), track->NSigmaTPCPi(), track->NSigmaTOFPi()))
+          imost = 10;
+      }
+      else if (fMostProbable == 11) {//cut on Nsigma in pT not p
+        if (IsKaonNSigma(track->Pt(), track->NSigmaTPCK(), track->NSigmaTOFK())){
+          imost = 11;
+        }
+      }
+      else if (fMostProbable == 12) { //cut on Nsigma in pT not p
+        if ( IsProtonNSigma(track->Pt(), track->NSigmaTPCP(), track->NSigmaTOFP()) )
+          imost = 12;
+      }
+      else if (fMostProbable == 13) { //cut on Nsigma deuteron
+        if (IsDeuteronNSigma(track->P().Mag(),track->MassTOF(), fNsigmaMass, track->NSigmaTPCD(), track->NSigmaTOFD()) )
+          imost = 13;
+        if ( fdEdxcut && (track->P().Mag() < 3) && !IsDeuteronTPCdEdx(track->P().Mag(), track->TPCsignal(), 4) )
+          imost = 0;
+      }
+      else if (fMostProbable == 14) { //cut on Nsigma, EXCLUSIVE PID -- deuteron 
+        if ( IsDeuteronNSigma(track->P().Mag(),track->MassTOF(), fNsigmaMass, track->NSigmaTPCD(), track->NSigmaTOFD()) && !IsPionNSigmaRejection(track->P().Mag(),track->NSigmaTPCPi(), track->NSigmaTOFPi()) && !IsKaonNSigmaRejection(track->P().Mag(),track->NSigmaTPCK(), track->NSigmaTOFK()) && !IsProtonNSigmaRejection(track->P().Mag(),track->NSigmaTPCP(), track->NSigmaTOFP()) && !IsElectronNSigmaRejection(track->P().Mag(),track->NSigmaTPCE()) )
+          imost = 14;
+        if ( fdEdxcut && (track->P().Mag() < 3) && !IsDeuteronTPCdEdx(track->P().Mag(), track->TPCsignal(), 4) )
+          imost = 0;
+      }
     }
-    else if (tPt >= 1.5 && tPt < 2.0){
-       if( (TMath::Abs(track->ImpactD()) > fDCA_ptdependence[2]) || (TMath::Abs(track->ImpactZ()) > fDCA_ptdependence[6]))
-          return false;
+
+    //****Contour Method****
+    if (fPIDMethod==1) {
+       if (fMostProbable == 13 || fMostProbable == 14) {
+        // Using the TPC dEdx to reject non-deuterons
+         if (track->P().Mag() < 2) {
+           if ( !(IsDeuteronTPCdEdx(track->P().Mag(), track->TPCsignal(),4)) )
+             imost = 0;
+           else 
+             imost = 13;  
+         }
+       }
+
     }
-    else if (tPt >= 2.0 && tPt < 4.0){
-       if( (TMath::Abs(track->ImpactD()) > fDCA_ptdependence[3]) || (TMath::Abs(track->ImpactZ()) > fDCA_ptdependence[7]))
-          return false;
+
+    if (imost != fMostProbable) {
+      return false;
     }
+  }
+  fNTracksPassed++ ;
+  return true;
 
 
 }
+
+bool AliFemtoWRzTrackCut::IsDeuteronTPCdEdx(float mom, float dEdx, float maxmom)
+{
+
+  double a1 = -250.0,  b1 = 400.0;
+  double a2 = -135.0,  b2 = 270.0;
+  double a3 = -80,   b3 = 190.0;
+  double a4 = 0.0,   b4 = 20.0;
+
+  double a5 = 125.0,   b5 = -100.0; 
+
+  if (mom < 1.1) {
+    if (dEdx < a1*mom+b1) return false;
+  }
+  else if (mom < 1.4) {
+    if (dEdx < a2*mom+b2) return false;
+  }
+  else if (mom < 2) {
+    if (dEdx < a3*mom+b3) return false;
+  }
+  else if (mom >= 2) {
+    if (dEdx < a4*mom+b4) return false;
+  }
+
+  if (mom > maxmom) return false;
+  
+  if (fNsigmaTPConly) {
+    // for selection with only the TPC detector
+    // cutting out the final part of the signal (~1.5 GeV) 
+    // that is dominated by missidentified particles  
+    if (dEdx < a5*mom+b5) return false;
+  }
+
+  return true;
+
+}
+
+bool AliFemtoWRzTrackCut::IsDeuteronNSigma(float mom, float massTOFPDG,float sigmaMass, float nsigmaTPCD, float nsigmaTOFD)
+{
+  double massPDGD=1.8756;
+  if (fNsigmaTPCTOF) {
+    //Identyfication with only TPC for mom<1.4 and TPC&TOF for mom>1.4
+    if (mom > 1.4) 
+      if ((TMath::Abs(nsigmaTPCD) < fNsigma) && (TMath::Abs(nsigmaTOFD) < fNsigma))
+        return true;
+    else 
+      if (TMath::Abs(nsigmaTPCD) < fNsigma)
+        return true;
+  }
+  else if (fNsigmaTPConly)
+      if (TMath::Abs(nsigmaTPCD) < fNsigma)
+	return true;
+  else{// p dependent mass cut 
+       // The default setting of sigmaMass (= -1) should provides similar 
+       // resluts to the case with fNsigmaTPCTOF=true and fNsigma=2
+
+      double l1, l2;
+      if(sigmaMass > 2){//for sideband analysis -- left band (4 sigmas)
+         l1 = 2.897 - 0.558*mom + 0.177*mom*mom - 0.026*mom*mom*mom;  
+         l2 = 3.77 - 0.487*mom + 0.126*mom*mom - 0.014*mom*mom*mom;
+      }
+      else if(sigmaMass > 1){//for sideband analysis -- right band (4 sigmas)
+         l1 = 4.5 - 0.42*mom + 0.1*mom*mom;
+         l2 = 6.602 -0.981*mom + 0.303*mom*mom;
+      }
+      else{//signal (dist under the mass peak -- 2 sigmas)
+         l1 = 4.002 - 0.627*mom + 0.184*mom*mom - 0.02*mom*mom*mom;
+         l2 = 4.35 - 0.399*mom + 0.09*mom*mom;
+      }
+
+      if ((TMath::Abs(nsigmaTPCD) < fNsigma) && (massTOFPDG > l1) && (massTOFPDG < l2))
+	 return true;
+
+  }
+  return false;
+}
+
+
+//rejection methods
+bool AliFemtoWRzTrackCut::IsPionNSigmaRejection(float mom, float nsigmaTPCPi, float nsigmaTOFPi)
+{
+  if(fNsigmaTPConly){
+    if(TMath::Abs(nsigmaTPCPi) < fNsigmaRejection)
+      return true;
+  }
+  else{
+    if(TMath::Hypot( nsigmaTOFPi, nsigmaTPCPi ) < fNsigmaRejection)
+      return true;
+  }
+
+  return false;
+}
+
+
+bool AliFemtoWRzTrackCut::IsKaonNSigmaRejection(float mom, float nsigmaTPCK, float nsigmaTOFK)
+{
+  if(fNsigmaTPConly){
+    if(TMath::Abs(nsigmaTPCK) < fNsigmaRejection)
+      return true;
+  }
+  else{
+    if(TMath::Hypot( nsigmaTOFK, nsigmaTPCK ) < fNsigmaRejection)
+      return true;
+  }
+
+  return false;
+}
+
+bool AliFemtoWRzTrackCut::IsProtonNSigmaRejection(float mom, float nsigmaTPCP, float nsigmaTOFP)
+{
+  if(fNsigmaTPConly){
+    if(TMath::Abs(nsigmaTPCP) < fNsigmaRejection)
+      return true;
+  }
+  else{
+    if(TMath::Hypot( nsigmaTOFP, nsigmaTPCP ) < fNsigmaRejection)
+      return true;
+  }
+ 
+  return false;
+}
+
+bool AliFemtoWRzTrackCut::IsElectronNSigmaRejection(float mom, float nsigmaTPCE)
+{
+  if(TMath::Abs(nsigmaTPCE) < fNsigmaRejection)
+    return true;
+ 
+
+  return false;
+}
+
+
+

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoWRzTrackCut.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoWRzTrackCut.cxx
@@ -307,7 +307,7 @@ bool AliFemtoWRzTrackCut::IsDeuteronNSigma(float mom, float massTOFPDG,float sig
       if (TMath::Abs(nsigmaTPCD) < fNsigma)
 	return true;
   else{// p dependent mass cut 
-       // The default setting of sigmaMass (= -1) should provides similar 
+       // The default setting of sigmaMass (= -1) should provide similar 
        // resluts to the case with fNsigmaTPCTOF=true and fNsigma=2
 
       double l1, l2;

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoWRzTrackCut.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoWRzTrackCut.h
@@ -1,16 +1,18 @@
 ///////////////////////////////////////////////////////////////////////////
+// wioleta.rzesa@cern.ch                                                 //
+// AliFemtoWRzTrackCut: An extension to AliFemtoESDTrackCut              //
+// dedicated to analysis with deuterons in PbPb                          //
 //                                                                       //
-// AliFemtoWRzTrackCut: An extension to AliFemtoMJTrackCut               //
-// The method allows you to set different cut on DCA for different pt ranges //
+//UWAGA!This class has not been tested on the whole stat. This information//
+//will be deleted with the next commit (after the final check)           //
 ///////////////////////////////////////////////////////////////////////////
 
 #ifndef AliFemtoWRzTrackCut_hh
 #define AliFemtoWRzTrackCut_hh
 
+#include "AliFemtoESDTrackCut.h"
 
-#include "AliFemtoMJTrackCut.h"
-
-class AliFemtoWRzTrackCut : public AliFemtoMJTrackCut{
+class AliFemtoWRzTrackCut : public AliFemtoESDTrackCut{
 
 public:
    AliFemtoWRzTrackCut();
@@ -19,13 +21,31 @@ public:
    AliFemtoWRzTrackCut& operator =(const AliFemtoWRzTrackCut &aCut);
    virtual bool Pass(const AliFemtoTrack* aTrack);
 
-   void SetDCAcutPtDependence(const float &DCAxy1,const float &DCAxy2,const float &DCAxy3,const float &DCAxy4, const float &DCAz1, const float &DCAz2, const float &DCAz3, const float &DCAz4);
-   
+   void SetdEdxcut(bool coumet = true);
+   void SetMaxmom(float maxm = 4.0);
+   void SetMostProbableDeuteron();
+   void SetNsigmaRejection(float SetNsigmaRejection = 3.0);
+   void SetfNSigmaMass(float SetNsigmass = -1);
 private:
-   float fDCA_ptdependence[8]; //DCA values (cm) in XY and Z plane for given ranges of pt 
+   bool  fdEdxcut;        // true - if nsigma selection plus the Contour Method 
+   float maxmom;        // max momentum - for dEdx cut
+   float fNsigmaRejection; // nSigmafor the EXCLUSIVE PID cut
+   float fNSigmaMass;
+
+   bool IsKaonNSigmaRejection(float mom, float nsigmaTPC, float nsigmaTOF);
+   bool IsPionNSigmaRejection(float mom, float nsigmaTPC, float nsigmaTOF);
+   bool IsProtonNSigmaRejection(float mom, float nsigmaTPC, float nsigmaTOF);
+   bool IsElectronNSigmaRejection(float mom, float nsigmaTPE);
+
+   bool IsDeuteronTPCdEdx(float mom, float dEdx, float maxmom);
+   bool IsDeuteronNSigma(float mom, float massTOFPDG,float sigmaMass, float nsigmaTPCD, float nsigmaTOFD);
+
 };
 
-
+inline void AliFemtoWRzTrackCut::SetdEdxcut(bool coumet) { fdEdxcut = coumet; }
+inline void AliFemtoWRzTrackCut::SetMaxmom(float maxm) { maxmom = maxm; }
+inline void AliFemtoWRzTrackCut::SetMostProbableDeuteron() { fMostProbable = 13; }
+inline void AliFemtoWRzTrackCut::SetNsigmaRejection(float SetNsigmaRejection) { fNsigmaRejection = SetNsigmaRejection; }
+inline void AliFemtoWRzTrackCut::SetfNSigmaMass(float SetNsigmass) { fNSigmaMass = SetNsigmass; }
 
 #endif
-


### PR DESCRIPTION
Changes in AliFemtoESDTrackCut: cleaning up a little messy code for deuterons implemented in the past by me. Removing temporary options of method and some specific cases used for tests. Functions and options for deuterons that I have left in this class are sufficient for performing basic analysis with deuterons. I added/moved more specific features to AliFemtoWRzTrackCut.

Changes in  AliFemtoWRzTrackCut: this class I have created in the past but over time, become unnecessary. I decided to adapt it mainly for deuterons that I use in femto analysis. This class in comparison to  AliFemtoESDTrackCut contains some additional features: a base for the sideband analysis, a dEdx cut more apt to my future checks, and an exclusive n sigma selection. This class is under development and testing. 