### PR TITLE
[PWGGA/CaloTrackCorr] Make sure in case of tracks in cone no cluster contribution 

### DIFF
--- a/PWG/CaloTrackCorrBase/AliIsolationCut.cxx
+++ b/PWG/CaloTrackCorrBase/AliIsolationCut.cxx
@@ -3037,7 +3037,8 @@ void  AliIsolationCut::MakeIsolationCut
     if ( fICMethod == kSumBkgSubIC )
     {
       coneptsumBkgTrk = perpPtSumTrack;
-      coneptsumBkgCls = perpPtSumTrack*GetNeutralOverChargedRatio(centrality); 
+      if ( fPartInCone == kNeutralAndCharged || fPartInCone == kOnlyNeutral )
+        coneptsumBkgCls = perpPtSumTrack*GetNeutralOverChargedRatio(centrality);
       //printf("centrality %f, neutral/charged %f\n",centrality,GetNeutralOverChargedRatio(centrality));
       
       // Add to candidate object

--- a/PWGGA/CaloTrackCorrelations/AliAnaParticleIsolation.cxx
+++ b/PWGGA/CaloTrackCorrelations/AliAnaParticleIsolation.cxx
@@ -4605,13 +4605,25 @@ void  AliAnaParticleIsolation::MakeAnalysisFillHistograms()
     Float_t coneptLeadTrack   = aod->GetChargedLeadPtInCone();
     Float_t coneptsumTrack    = aod->GetChargedPtSumInCone();
     Float_t coneptsum         = coneptsumTrack + coneptsumCluster;
+
+    if ( partInCone == AliIsolationCut::kOnlyCharged )
+      coneptsum  = coneptsumTrack;
+    if ( partInCone == AliIsolationCut::kOnlyNeutral)
+      coneptsum  = coneptsumCluster;
     
     Float_t coneptLead = coneptLeadTrack;
-    if ( coneptLeadCluster > coneptLeadTrack ) 
+    if ( partInCone == AliIsolationCut::kNeutralAndCharged )
+    {
+      if ( coneptLeadCluster > coneptLeadTrack )
+        coneptLead = coneptLeadCluster;
+    }
+    else if ( partInCone == AliIsolationCut::kOnlyNeutral )
+    {
       coneptLead = coneptLeadCluster;
+    }
     
     AliDebug(1,Form("Particle %d Energy Sum in Isolation Cone %2.2f, Leading pT in cone %2.2f",
-                    iaod, coneptsumTrack+coneptsumCluster, coneptLead));
+                    iaod, coneptsum, coneptLead));
      
     Bool_t narrow       = kFALSE;
     Bool_t inM02Windows = kTRUE;


### PR DESCRIPTION
is considered for UE in perperdicular cone