### PR TITLE
AliFlowEventSimpleMakerOnTheFly.cxx memory leak fix and optimization

### DIFF
--- a/PWG/FLOW/Base/AliFlowEventSimpleMakerOnTheFly.cxx
+++ b/PWG/FLOW/Base/AliFlowEventSimpleMakerOnTheFly.cxx
@@ -216,19 +216,19 @@ AliFlowEventSimple* AliFlowEventSimpleMakerOnTheFly::CreateEventOnTheFly(AliFlow
     fPhiDistribution->SetParameter(2,fV2vsPtMax)
    );
   } // end of if(fPtDependentV2)  
-  pTrack->SetPhi(fPhiDistribution->GetRandom());
-  pTrack->SetEta(gRandom->Uniform(-1.,1.));
-  pTrack->SetCharge((gRandom->Integer(2)>0.5 ? 1 : -1));
-  // Check uniform acceptance:
-  if(!fUniformAcceptance && !this->AcceptPhi(pTrack)){
-    delete pTrack;
-    continue;
-  }
   // Check pT efficiency:
   if(!fUniformEfficiency && !this->AcceptPt(pTrack)){
     delete pTrack;
     continue;
   }
+  pTrack->SetPhi(fPhiDistribution->GetRandom());
+  // Check uniform acceptance:
+  if(!fUniformAcceptance && !this->AcceptPhi(pTrack)){
+    delete pTrack;
+    continue;
+  }
+  pTrack->SetEta(gRandom->Uniform(-1.,1.));
+  pTrack->SetCharge((gRandom->Integer(2)>0.5 ? 1 : -1));
   // Checking the RP cuts:  	 
   if(cutsRP->PassesCuts(pTrack))
   {

--- a/PWG/FLOW/Base/AliFlowEventSimpleMakerOnTheFly.cxx
+++ b/PWG/FLOW/Base/AliFlowEventSimpleMakerOnTheFly.cxx
@@ -220,9 +220,15 @@ AliFlowEventSimple* AliFlowEventSimpleMakerOnTheFly::CreateEventOnTheFly(AliFlow
   pTrack->SetEta(gRandom->Uniform(-1.,1.));
   pTrack->SetCharge((gRandom->Integer(2)>0.5 ? 1 : -1));
   // Check uniform acceptance:
-  if(!fUniformAcceptance && !this->AcceptPhi(pTrack)){continue;}
+  if(!fUniformAcceptance && !this->AcceptPhi(pTrack)){
+    delete pTrack;
+    continue;
+  }
   // Check pT efficiency:
-  if(!fUniformEfficiency && !this->AcceptPt(pTrack)){continue;}
+  if(!fUniformEfficiency && !this->AcceptPt(pTrack)){
+    delete pTrack;
+    continue;
+  }
   // Checking the RP cuts:  	 
   if(cutsRP->PassesCuts(pTrack))
   {


### PR DESCRIPTION
**Memory Leaks**
When pTracks are rejected from the sample, the pointer was not deleted. Especially for a low mean acceptance, this causes OOM issues when scaling to many collisions. This has been addressed.

**Optimization**
When pTracks are checked for acceptance, it is more efficient to do this straight after the relevant properties are set. In simulations performed with a low mean acceptance rate for some ranges of properties, this reduced execution time by orders of magnitude (e.g. ~1e5 seconds to ~2e3 seconds). Re-ordering some of the operations addresses this.