### PR TITLE
Modifications to initialize TF1 from string and TVectorD

### DIFF
--- a/PWGPP/TPC/macros/PIDCalib/MakeTPCPIDResponseOADB.C
+++ b/PWGPP/TPC/macros/PIDCalib/MakeTPCPIDResponseOADB.C
@@ -463,18 +463,28 @@ Bool_t AddOADBObjectFromSplineFile(const TString fileName,
       Error("AddOADBObjectFromSplineFile", "Could not open '%s' to extract the TF1 sigma parametrization", resolution.Data());
     } else {
       TObject* tf1Sigma = f->Get("SigmaParametrization");
+      TObject* tf1SigmaParams = f->Get("SigmaParametrizationParams");
+      TObject* multEstimator = f->Get("MultiplicityNormalization");
+
       if (!tf1Sigma) {
         Fatal("AddOADBObjectFromSplineFile", "Could not get TF1 function with name 'SigmaParametrization' from file '%s'", resolution.Data());
-      } else {
-        arrTPCPIDResponse->Add(tf1Sigma);
       }
 
-      TObject* multEstimator = f->Get("MultiplicityNormalization");
+      if (!tf1SigmaParams) {
+        Fatal("AddOADBObjectFromSplineFile", "Could not get TF1 function with name 'SigmaParametrization' from file '%s'", resolution.Data());
+      }
+
       if (!multEstimator) {
         Fatal("AddOADBObjectFromSplineFile", "Could not get 'MultiplicityNormalization' from file '%s'", resolution.Data());
-      } else {
-        arrTPCPIDResponse->Add(multEstimator);
       }
+
+      TObjArray* arrSigmaParam = new TObjArray;
+      arrSigmaParam->SetName("SigmaParametrization");
+      arrSigmaParam->Add(tf1Sigma);
+      arrSigmaParam->Add(tf1SigmaParams);
+      arrSigmaParam->Add(multEstimator);
+
+      arrTPCPIDResponse->Add(arrSigmaParam);
     }
   } else {
     if (contFromFile) {


### PR DESCRIPTION
To allow for forward and backward compatibility between root 5 and root
6, the sigma parametrization function is initialized now from a string
for the function definition and a TVectorD for the fit parameters.
As input, the parameters are expected to be provided in a root file,
e.g.
```
 TFile*         /tmp/TF1_SigmaPar.root
  KEY: TNamed   SigmaParametrization;1
sqrt(([0]**2)*x[0]+(([1]**2)*(x[5]*[5])*(x[0]/sqrt(1+x[1]**2))**[2])+x[5]*AliTPCPIDResponse::sigmadEdxPt(x[2],x[3],[3])**2+([4]*x[4])**2
+((x[6]*[6])**2)+(x[6]*(x[0]/sqrt(1+x[1]**2))*[7])**2)
  KEY: TVectorT<double> SigmaParametrizationParams;1
  KEY: TNamed   MultiplicityNormalization;1     10000
```