### PR TITLE
PWGHF: Add setter for cvmfs path suffix in improver task

### DIFF
--- a/PWGHF/vertexingHF/AliAnalysisTaskSEImproveITSCVMFS.h
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSEImproveITSCVMFS.h
@@ -43,6 +43,7 @@ public:
   void SetMimicData(Bool_t opt=kFALSE){fMimicData=opt;}
   void SetAOD(Bool_t flag=kTRUE) { fIsAOD=flag; return; }
   void SetSmearOnlySignal(Bool_t opt=kTRUE) {fSmearOnlySignal=opt;}
+  void SetImproverSuffix(TString suffix="central") {fImproverSuffix=suffix;}
 
 private:
   AliAnalysisTaskSEImproveITSCVMFS(const AliAnalysisTaskSEImproveITSCVMFS&);


### PR DESCRIPTION
- Useful setter to configure improver with alternative input files for a given data sample @cterrevo 