### PR TITLE
Remove offline trigger selection call in default function

### DIFF
--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalClustersRef.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalClustersRef.cxx
@@ -53,7 +53,6 @@
 #include "AliEmcalTriggerDecision.h"
 #include "AliEmcalTriggerDecisionContainer.h"
 #include "AliEmcalTriggerSelectionCuts.h"
-#include "AliEmcalTriggerOfflineSelection.h"
 #include "AliEmcalTriggerStringDecoder.h"
 #include "AliESDEvent.h"
 #include "AliInputEventHandler.h"
@@ -699,18 +698,6 @@ AliAnalysisTaskEmcalClustersRef *AliAnalysisTaskEmcalClustersRef::AddTaskEmcalCl
   TString clusName(nClusters == "usedefault" ? AliEmcalAnalysisFactory::ClusterContainerNameFactory(mgr->GetInputEventHandler()->InheritsFrom("AliAODInputHandler")) : nClusters);
   task->AddClusterContainer(clusName.Data());
   task->SetClusterContainer(clusName.Data());
-
-  // Set Energy thresholds for additional patch selection:
-  // These are events with offline patches of a given type where the trigger reached already the plateau
-  // These numers are determined as:
-  // EMC7: 3.5 GeV
-  // EG1:  14 GeV
-  // EG2:  8 GeV
-  // EJ1:  22 GeV
-  // EJ2:  12 GeV
-  task->SetOfflineTriggerSelection(
-      EMCalTriggerPtAnalysis::AliEmcalAnalysisFactory::TriggerSelectionFactory(5, 14, 8, 22, 12)
-  );
 
   TString outfile(mgr->GetCommonFileName());
   outfile += ":ClusterQA";


### PR DESCRIPTION
Even though no longer used better remove the hard coded
settings for pPb 2013 in order to avoid unforced errors.