### PR TITLE
Fixes for OSX Big Sur

### DIFF
--- a/PWGGA/NtuplizerTask/GJNtuples/half.cpp
+++ b/PWGGA/NtuplizerTask/GJNtuples/half.cpp
@@ -94,9 +94,9 @@ half::convert (int i)
     // of float and half (127 versus 15).
     //
 
-    register int s =  (i >> 16) & 0x00008000;
-    register int e = ((i >> 23) & 0x000000ff) - (127 - 15);
-    register int m =   i        & 0x007fffff;
+    int s =  (i >> 16) & 0x00008000;
+    int e = ((i >> 23) & 0x000000ff) - (127 - 15);
+    int m =   i        & 0x007fffff;
 
     //
     // Now reassemble s, e and m into a half:

--- a/PWGGA/NtuplizerTask/GJNtuples/half.h
+++ b/PWGGA/NtuplizerTask/GJNtuples/half.h
@@ -459,7 +459,7 @@ half::half (float f)
 	// to do the float-to-half conversion.
 	//
 
-	register int e = (x.i >> 23) & 0x000001ff;
+	int e = (x.i >> 23) & 0x000001ff;
 
 	e = _eLut[e];
 
@@ -470,7 +470,7 @@ half::half (float f)
 	    // bits and combine it with the sign and exponent.
 	    //
 
-	    register int m = x.i & 0x007fffff;
+	    int m = x.i & 0x007fffff;
 	    _h = e + ((m + 0x00000fff + ((m >> 13) & 1)) >> 13);
 	}
 	else


### PR DESCRIPTION
Replace deprecated random_shuffle by shuffle to be able to use C++17.
Do not use register in the declarations (deprecated).