### PR TITLE
ATMeanPtV2Corr: added eta cut in eff. production (got lost when addin…

### DIFF
--- a/PWGCF/FLOW/GF/AliAnalysisTaskMeanPtV2Corr.cxx
+++ b/PWGCF/FLOW/GF/AliAnalysisTaskMeanPtV2Corr.cxx
@@ -924,6 +924,7 @@ void AliAnalysisTaskMeanPtV2Corr::ProduceEfficiencies(AliAODEvent *fAOD, const D
     if (index < 0) continue;
     lPart = (AliAODMCParticle*)tca->At(index);//fMCEvent->Particle(index);
     if(!lPart) continue;
+    if (TMath::Abs(lPart->Eta()) > fEta) continue;
     Int_t pdgcode = lPart->GetPdgCode();
     Int_t pidind = GetPIDIndex(pdgcode);
     Double_t lpt = lTrack->Pt();


### PR DESCRIPTION
…g AliGFWCuts). Not a big issue, but better to have it consistent