### PR TITLE
PWGGA/GammaConv: AliCaloTrackmatcher implemented new mode 7

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskGammaIsoTree.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaIsoTree.h
@@ -261,6 +261,9 @@ class AliAnalysisTaskGammaIsoTree : public AliAnalysisTaskSE{
     void SetGenPtCut(Double_t pt){
       fGenPtCut = pt;
     }
+    void SetDebugFlag(Int_t debug = 1){
+      fDebug = debug;
+    }
   protected:
     AliVEvent*                  fInputEvent;                //!<!
     AliMCEvent*                 fMCEvent;                   //!<!
@@ -787,7 +790,7 @@ class AliAnalysisTaskGammaIsoTree : public AliAnalysisTaskSE{
     Int_t GetProperLabel(AliAODMCParticle* mcpart);
     AliAnalysisTaskGammaIsoTree(const AliAnalysisTaskGammaIsoTree&); // Prevent copy-construction
     AliAnalysisTaskGammaIsoTree& operator=(const AliAnalysisTaskGammaIsoTree&); // Prevent assignment  
-    ClassDef(AliAnalysisTaskGammaIsoTree, 34);
+    ClassDef(AliAnalysisTaskGammaIsoTree, 35);
 
 };
 

--- a/PWGGA/GammaConv/macros/AddTask_GammaIsoTree.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaIsoTree.C
@@ -29,6 +29,8 @@ void AddTask_GammaIsoTree(
   AliCutHandlerPCM cuts(13); // only for tokenize
   TString addTaskName = "AddTask_GammaIsoTree";
 
+  Int_t debugFlag = 0;
+
   // Default
   TString   TaskEventCutnumber                = "00010113";
   TString   TaskClusterCutnumberEMC           = "1111100010022700000";
@@ -46,7 +48,7 @@ void AddTask_GammaIsoTree(
   vector<Double_t> neutralIsoE = {0.5,1.5,2.5};
   Double_t minSignalM02 = 0.1;
   Double_t maxSignalM02 = 0.5;
-  Int_t trackMatcherRunningMode = 0; // CaloTrackMatcher running mode
+  Int_t trackMatcherRunningMode = 7; // CaloTrackMatcher running mode
   Bool_t backgroundTrackMatching = kFALSE; // obsolete
   Bool_t doNeutralIso            = kTRUE;
   Bool_t doChargedIso            = kTRUE;
@@ -744,6 +746,7 @@ void AddTask_GammaIsoTree(
   fQA->SetChi2PerClsTPC(fChi2PerClsTPC);
   fQA->SetEtaCut(fEtaCut);
   fQA->SetMinPtCut(fPtCut);
+  fQA->SetDebugFlag(debugFlag);
 
   fQA->SetSignalMinM02(minSignalM02);
   fQA->SetSignalMaxM02(maxSignalM02);

--- a/PWGGA/GammaConvBase/AliCaloPhotonCuts.cxx
+++ b/PWGGA/GammaConvBase/AliCaloPhotonCuts.cxx
@@ -4477,6 +4477,17 @@ void AliCaloPhotonCuts::MatchTracksToClusters(AliVEvent* event, Double_t weight,
         if(aodt->Pt()<0.15) continue;
       }
 
+      if(fCaloTrackMatcher->GetRunningMode()==7){
+        // if you considered negative ID hybrid tracks, one needs to make sure
+        // that one only asks fCaloTrackMatcher->GetTrackClusterMatchingResidual()
+        // for hybrid tracks as well. Otherwise you will find multiple matches
+        // since this loop contains dublicates when not requiring Is
+        if(!aodt->IsHybridGlobalConstrainedGlobal()) continue;
+        if(TMath::Abs(aodt->Eta())>0.8) continue;
+        if(aodt->Pt()<0.15) continue;
+      }
+
+
     }
 
     Float_t clsPos[3] = {0.,0.,0.};
@@ -4572,7 +4583,7 @@ void AliCaloPhotonCuts::MatchTracksToClusters(AliVEvent* event, Double_t weight,
           if(fHistClusterdEtadPtAfterQA) fHistClusterdEtadPtAfterQA->Fill(dEta,inTrack->Pt());
           if(fHistClusterdPhidPtAfterQA) fHistClusterdPhidPtAfterQA->Fill(dPhi,inTrack->Pt());
         }
-        if(!fUseTMMIPsubtraction) break;
+        if(!fUseTMMIPsubtraction) continue; // was break;
       } else if(isEMCalOnly){
         if(fHistDistanceTrackToClusterAfterQA)fHistDistanceTrackToClusterAfterQA->Fill(TMath::Sqrt(dR2), weight);
         if(fHistClusterdEtadPhiAfterQA) fHistClusterdEtadPhiAfterQA->Fill(dEta, dPhi, weight);
@@ -4591,6 +4602,7 @@ void AliCaloPhotonCuts::MatchTracksToClusters(AliVEvent* event, Double_t weight,
 //________________________________________________________________________
 Bool_t AliCaloPhotonCuts::CheckClusterForTrackMatch(AliVCluster* cluster){
   vector<Int_t>::iterator it;
+  //cout << "SIZE = "<< fVectorMatchedClusterIDs.size() << endl;
   it = find (fVectorMatchedClusterIDs.begin(), fVectorMatchedClusterIDs.end(), cluster->GetID());
   if (it != fVectorMatchedClusterIDs.end()) return kTRUE;
   else return kFALSE;
@@ -9560,7 +9572,7 @@ std::vector<Int_t> AliCaloPhotonCuts::GetVectorMatchedTracksToCluster(AliVEvent*
 Bool_t AliCaloPhotonCuts::GetClosestMatchedTrackToCluster(AliVEvent* event, AliVCluster* cluster, Int_t &trackLabel){
   if(!fUseDistTrackToCluster || fUseElectronClusterCalibration) return kFALSE;
   vector<Int_t> labelsMatched = GetVectorMatchedTracksToCluster(event,cluster);
-
+  
   if((Int_t) labelsMatched.size()<1) return kFALSE;
 
   Float_t dEta = -100;
@@ -9571,7 +9583,7 @@ Bool_t AliCaloPhotonCuts::GetClosestMatchedTrackToCluster(AliVEvent* event, AliV
   for (Int_t i = 0; i < (Int_t)labelsMatched.size(); i++){
     AliVTrack* currTrack  = dynamic_cast<AliVTrack*>(event->GetTrack(labelsMatched.at(i)));
     if(!fCaloTrackMatcher->GetTrackClusterMatchingResidual(currTrack->GetID(), cluster->GetID(), dEta, dPhi)) continue;
-
+   
     Float_t tempDist = TMath::Sqrt((dEta*dEta)+(dPhi*dPhi));
     if(tempDist < smallestDist){
       smallestDist = tempDist;

--- a/PWGGA/GammaConvBase/AliCaloTrackMatcher.h
+++ b/PWGGA/GammaConvBase/AliCaloTrackMatcher.h
@@ -77,7 +77,8 @@ class AliCaloTrackMatcher : public AliAnalysisTaskSE {
 
     void               SetLightOutput( Bool_t flag )                    { fDoLightOutput = flag                       ;}
     void               SetMassHypothesis( Double_t mass)                {fMassHypothesis = mass;}
-
+    Int_t              GetRunningMode() {return fRunningMode;}
+    Bool_t             GetNegativeIDAllowed() {return fNegativeTrackIDAllowed;}
   private:
     //typedefs
     typedef pair<Int_t, Int_t> pairInt;
@@ -105,7 +106,8 @@ class AliCaloTrackMatcher : public AliAnalysisTaskSE {
                                                    // (1) matching of all tracks (dedicated for run 1), was standard until Feb 15, 2018
                                                    // (2) ITS matching mode
                                                    // (5) testing mode, (1) + some more restrictions
-                                                   // (6) testing mode, (5) + TrackCuts (primary+secondary)
+                                                   // (6) testing mode, (5) + TrackCuts (primary+secondary) 
+    Bool_t                fNegativeTrackIDAllowed;     // where negative IDs allowed when doing TM?
     TString               fV0ReaderName;           // Name of V0Reader
     TString               fCorrTaskSetting;        // Name of Corr Task Setting
     TString               fAnalysisTrainMode;      // AnalysisTrainMode: Grid or GSI //Grid by default
@@ -142,7 +144,7 @@ class AliCaloTrackMatcher : public AliAnalysisTaskSE {
     Bool_t                fDoLightOutput;          // switch for running light output, kFALSE -> normal mode, kTRUE -> light mode
 
     Double_t              fMassHypothesis;          // mass used for track propagation to calorimeter surface
-    ClassDef(AliCaloTrackMatcher,9)
+    ClassDef(AliCaloTrackMatcher,10)
 };
 
 #endif


### PR DESCRIPTION
- implemented fRunningMode=7 for AliCaloTrackMatcher which considers all hybrid tracks for track matching (which should be used after testing as default imo)
- current default mode 0 will only match hybrid tracks with SPD hits that have not been constrained to primary vertex (good global tracks) and will ignore other tracks of hybrid sample that can be selected in analysis
- fixed a minor bug that only affects cases where a TM cut is used which is not pt dependent. Some matches were not matched by accident
- fixed an issue that should only occur when choosing a very wide TM cut. If, for some reason, one track is matched to multiple clusters, there was an issue that the second matched cluster was thrown away and never considered as matched
- added warnings for fRunningMode = 7. Negative IDs are not unique, even though hybrid tracks contain no doubles and no double IDs. However, if the user runs with fRunningMode = 7, but in his analysis has tracks that are not hybrid, this can lead to unwanted behavior. Asking e.g. in analysis for dEta dPhi values of a TPCOnly track when the trackmatcher ran over hybrid tracks would return the dEta and dPhi of the hybrid track instead of the TPCOnly track. This is because the TM can't distinguish the two types at the point where the user asks in the analysis. Also, if the user for some reason considers multiple copies of the same track, the trackmatcher will faithfully return multiple matches.Therefore it is important that the user is not looking for something that was never checked by fRunningMode = 7