### PR TITLE
added extra cuts for selection of leading track

### DIFF
--- a/PWGLF/NUCLEX/Nuclei/Nuclei_UE/AliAnalysisTaskDeuteronsRT.cxx
+++ b/PWGLF/NUCLEX/Nuclei/Nuclei_UE/AliAnalysisTaskDeuteronsRT.cxx
@@ -607,7 +607,8 @@ void AliAnalysisTaskDeuteronsRT::UserCreateOutputObjects()  {
         fESDtrackCuts_LeadingTrack -> SetMaxChi2PerClusterITS(36);
         fESDtrackCuts_LeadingTrack -> SetEtaRange(-0.8,0.8);
         fESDtrackCuts_LeadingTrack -> SetPtRange(0.15,200);
-        fESDtrackCuts_LeadingTrack -> SetMaxDCAToVertexXY(2.4);
+        //fESDtrackCuts_LeadingTrack -> SetMaxDCAToVertexXY(2.4);
+        fESDtrackCuts_LeadingTrack -> SetMaxDCAToVertexXYPtDep("0.0105+0.0350/pt^1.1");
         fESDtrackCuts_LeadingTrack -> SetMaxDCAToVertexZ(2);
         fESDtrackCuts_LeadingTrack -> SetDCAToVertex2D(kFALSE);
         fESDtrackCuts_LeadingTrack -> SetRequireSigmaToVertex(kFALSE);
@@ -621,6 +622,8 @@ void AliAnalysisTaskDeuteronsRT::UserCreateOutputObjects()  {
         fESDtrackCuts_TransverseMult -> SetMaxDCAToVertexZ(3.2);
         fESDtrackCuts_TransverseMult -> SetMaxDCAToVertexXY(2.4);
         fESDtrackCuts_TransverseMult -> SetDCAToVertex2D(kTRUE);
+        fESDtrackCuts_TransverseMult -> SetEtaRange(-0.8,0.8);
+        fESDtrackCuts_TransverseMult -> SetPtRange(0.15,200);
     }
     
     


### PR DESCRIPTION
Added pt-dependent DCA_{xy} selection for leadinng track:

        fESDtrackCuts_LeadingTrack -> SetMaxDCAToVertexXYPtDep("0.0105+0.0350/pt^1.1");

Added pseudorapidity and pt cuts in the selection of tracks to calculate transverse mult

        fESDtrackCuts_TransverseMult -> SetEtaRange(-0.8,0.8);
        fESDtrackCuts_TransverseMult -> SetPtRange(0.15,200);
