### PR TITLE
Handle dependency on KFParticle as a CMake module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,6 +236,9 @@ else()
   # ZEROMQ
   find_package(ZeroMQ)
 
+  # KFParticke
+  find_package(KFParticle)
+
   # General flags -> Should be moved into a configuration file
   set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
   # Avoid problems with -fPIE (set automatically by the previous line).

--- a/PWGHF/correlationHF/CMakeLists.txt
+++ b/PWGHF/correlationHF/CMakeLists.txt
@@ -22,7 +22,6 @@ include_directories(${AliPhysics_SOURCE_DIR}/PWGHF/correlationHF)
 
 # Additional includes - alphabetical order except ROOT
 include_directories(${ROOT_INCLUDE_DIRS}
-                    $ENV{KFPARTICLE_ROOT}/include
                     ${AliPhysics_SOURCE_DIR}/CORRFW
                     ${AliPhysics_SOURCE_DIR}/OADB
                     ${AliPhysics_SOURCE_DIR}/PWG/Tools
@@ -30,6 +29,11 @@ include_directories(${ROOT_INCLUDE_DIRS}
                     ${AliPhysics_SOURCE_DIR}/PWGHF/hfe
                     ${AliPhysics_SOURCE_DIR}/PWGHF/vertexingHF
   )
+if(KFParticle_FOUND)
+  get_target_property(KFPARTICLE_INCLUDE_DIR KFParticle::KFParticle INTERFACE_INCLUDE_DIRECTORIES)
+  include_directories(${KFPARTICLE_INCLUDE_DIR})
+  add_definitions("-DWITH_KFPARTICLE")
+endif(KFParticle_FOUND)
 
 # Sources - alphabetical order
 set(SRCS
@@ -86,8 +90,11 @@ add_library_tested(${MODULE} SHARED  ${SRCS} G__${MODULE}.cxx)
 
 # Generate the ROOT map
 # Dependecies
-set(LIBDEPS ANALYSISalice PWGHFhfe PWGHFvertexingHF KFParticle)
-
+set(LIBDEPS ANALYSISalice PWGHFhfe PWGHFvertexingHF)
+if(KFParticle_FOUND)
+  get_target_property(KFPARTICLE_LIBRARY KFParticle::KFParticle IMPORTED_LOCATION)
+  set(LIBDEPS ${LIBDEPS} ${KFPARTICLE_LIBRARY})
+endif(KFParticle_FOUND)
 generate_rootmap("${MODULE}" "${LIBDEPS}" "${CMAKE_CURRENT_SOURCE_DIR}/${MODULE}LinkDef.h")
 
 # Generate a PARfile target for this library
@@ -95,7 +102,6 @@ add_target_parfile(${MODULE} "${SRCS}" "${HDRS}" "${MODULE}LinkDef.h" "${LIBDEPS
 
 # Linking the library
 target_link_libraries(${MODULE} ${LIBDEPS})
-target_link_libraries(${MODULE} \-L$ENV{KFPARTICLE_ROOT}/lib ${LIBDEPS})
 
 # Public include folders that will be propagated to the dependecies
 target_include_directories(${MODULE} PUBLIC ${incdirs})

--- a/PWGHF/hfe/CMakeLists.txt
+++ b/PWGHF/hfe/CMakeLists.txt
@@ -22,7 +22,6 @@ include_directories(${AliPhysics_SOURCE_DIR}/PWGHF/hfe)
 
 # Additional includes - alphabetical order except ROOT
 include_directories(${ROOT_INCLUDE_DIRS}
-                    $ENV{KFPARTICLE_ROOT}/include
                     ${AliPhysics_SOURCE_DIR}/CORRFW
                     ${AliPhysics_SOURCE_DIR}/OADB
                     ${AliPhysics_SOURCE_DIR}/PWG/CaloTrackCorrBase
@@ -35,6 +34,11 @@ include_directories(${ROOT_INCLUDE_DIRS}
                     ${AliPhysics_SOURCE_DIR}/PWGPP/EVCHAR/FlowVectorCorrections/QnCorrectionsInterface
 		    ${AliPhysics_SOURCE_DIR}/PWGHF/vertexingHF
 		    ${AliPhysics_SOURCE_DIR}/PWGHF/vertexingHF/charmFlow)
+if(KFParticle_FOUND)
+  get_target_property(KFPARTICLE_INCLUDE_DIR KFParticle::KFParticle INTERFACE_INCLUDE_DIRECTORIES)
+  include_directories(${KFPARTICLE_INCLUDE_DIR})
+  add_definitions("-DWITH_KFPARTICLE")
+endif(KFParticle_FOUND)
 
 # Sources - alphabetical order
 set(SRCS
@@ -160,7 +164,11 @@ add_library_tested(${MODULE} SHARED  ${SRCS} G__${MODULE}.cxx)
 
 # Generate the ROOT map
 # Dependecies
-set(LIBDEPS OADB ANALYSISalice CORRFW PWGflowTasks PWGTRD MLP PWGPPevcharQn PWGPPevcharQnInterface PWGHFvertexingHF KFParticle)
+set(LIBDEPS OADB ANALYSISalice CORRFW PWGflowTasks PWGTRD MLP PWGPPevcharQn PWGPPevcharQnInterface PWGHFvertexingHF)
+if(KFParticle_FOUND)
+    get_target_property(KFPARTICLE_LIBRARY KFParticle::KFParticle IMPORTED_LOCATION)
+    set(LIBDEPS ${LIBDEPS} ${KFPARTICLE_LIBRARY})
+endif(KFParticle_FOUND)
 generate_rootmap("${MODULE}" "${LIBDEPS}" "${CMAKE_CURRENT_SOURCE_DIR}/${MODULE}LinkDef.h")
 
 # Generate a PARfile target for this library
@@ -168,7 +176,6 @@ add_target_parfile(${MODULE} "${SRCS}" "${HDRS}" "${MODULE}LinkDef.h" "${LIBDEPS
 
 # Linking the library
 target_link_libraries(${MODULE} ${LIBDEPS})
-target_link_libraries(${MODULE} \-L$ENV{KFPARTICLE_ROOT}/lib ${LIBDEPS})
 
 # Public include folders that will be propagated to the dependecies
 target_include_directories(${MODULE} PUBLIC ${incdirs})

--- a/PWGHF/vertexingHF/CMakeLists.txt
+++ b/PWGHF/vertexingHF/CMakeLists.txt
@@ -26,7 +26,6 @@ include_directories(${AliPhysics_SOURCE_DIR}/PWGHF/vertexingHF/vHFBDT)
 
 # Additional includes - alphabetical order except ROOT
 include_directories(${ROOT_INCLUDE_DIRS}
-                    $ENV{KFPARTICLE_ROOT}/include
                     ${AliPhysics_SOURCE_DIR}/CORRFW
                     ${AliPhysics_SOURCE_DIR}/OADB
                     ${AliPhysics_SOURCE_DIR}/OADB/COMMON/MULTIPLICITY
@@ -38,6 +37,11 @@ include_directories(${ROOT_INCLUDE_DIRS}
                     ${AliPhysics_SOURCE_DIR}/PWGLF/NUCLEX
                     ${AliPhysics_SOURCE_DIR}/PWGLF/NUCLEX/Utils/O2vertexer/
 )
+if(KFParticle_FOUND)
+    get_target_property(KFPARTICLE_INCLUDE_DIR KFParticle::KFParticle INTERFACE_INCLUDE_DIRECTORIES)
+    include_directories(${KFPARTICLE_INCLUDE_DIR})
+    add_definitions("-DWITH_KFPARTICLE")
+endif(KFParticle_FOUND)
 
 # Sources - alphabetical order
 set(SRCS
@@ -194,7 +198,11 @@ add_library_tested(${MODULE} SHARED  ${SRCS} G__${MODULE}.cxx)
 
 # Generate the ROOT map
 # Dependecies
-set(LIBDEPS ANALYSISalice PWGflowBase PWGPPevcharQn PWGPPevcharQnInterface TMVA vHFBDT CORRFW KFParticle PWGTools PWGLFnuclex)
+set(LIBDEPS ANALYSISalice PWGflowBase PWGPPevcharQn PWGPPevcharQnInterface TMVA vHFBDT CORRFW PWGTools PWGLFnuclex)
+if(KFParticle_FOUND)
+    get_target_property(KFPARTICLE_LIBRARY KFParticle::KFParticle IMPORTED_LOCATION)
+    set(LIBDEPS ${LIBDEPS} ${KFPARTICLE_LIBRARY})
+endif(KFParticle_FOUND)
 generate_rootmap("${MODULE}" "${LIBDEPS}" "${CMAKE_CURRENT_SOURCE_DIR}/${MODULE}LinkDef.h")
 
 # Generate a PARfile target for this library
@@ -202,7 +210,6 @@ add_target_parfile(${MODULE} "${SRCS}" "${HDRS}" "${MODULE}LinkDef.h" "${LIBDEPS
 
 # Linking the library
 target_link_libraries(${MODULE} ${LIBDEPS})
-target_link_libraries(${MODULE} \-L$ENV{KFPARTICLE_ROOT}/lib ${LIBDEPS})
 
 # Public include folders that will be propagated to the dependecies
 target_include_directories(${MODULE} PUBLIC ${incdirs})

--- a/PWGHF/vertexingHF/vHFML/CMakeLists.txt
+++ b/PWGHF/vertexingHF/vHFML/CMakeLists.txt
@@ -23,7 +23,6 @@ include_directories(${AliPhysics_SOURCE_DIR}/PWGHF/vertexingHF/vHFML)
 
 # Additional includes - alphabetical order except ROOT
 include_directories(${ROOT_INCLUDE_DIRS}
-		    $ENV{KFPARTICLE_ROOT}/include
                     ${AliPhysics_SOURCE_DIR}/ML
                     ${AliPhysics_SOURCE_DIR}/OADB
                     ${AliPhysics_SOURCE_DIR}/PWGHF/vertexingHF
@@ -32,6 +31,11 @@ include_directories(${ROOT_INCLUDE_DIRS}
                     ${AliPhysics_SOURCE_DIR}/PWGPP/EVCHAR/FlowVectorCorrections/QnCorrectionsInterface/
                     ${AliPhysics_SOURCE_DIR}/PWG/FLOW/Base
 )
+if(KFParticle_FOUND)
+    get_target_property(KFPARTICLE_INCLUDE_DIR KFParticle::KFParticle INTERFACE_INCLUDE_DIRECTORIES)
+    include_directories(${KFPARTICLE_INCLUDE_DIR})
+    add_definitions("-DWITH_KFPARTICLE")
+endif(KFParticle_FOUND)
 
 # Sources - alphabetical order
 set(SRCS 
@@ -68,7 +72,11 @@ add_library_tested(${MODULEHFML} SHARED  ${SRCS} G__${MODULEHFML}.cxx)
 
 # Generate the ROOT map
 # Dependecies
-set(LIBDEPS ML PWGHFvertexingHF KFParticle)
+set(LIBDEPS ML PWGHFvertexingHF)
+if(KFParticle_FOUND)
+    get_target_property(KFPARTICLE_LIBRARY KFParticle::KFParticle IMPORTED_LOCATION)
+    set(LIBDEPS ${LIBDEPS} ${KFPARTICLE_LIBRARY})
+endif(KFParticle_FOUND)
 generate_rootmap("${MODULEHFML}" "${LIBDEPS}" "${CMAKE_CURRENT_SOURCE_DIR}/${MODULEHFML}LinkDef.h")
 
 # Generate a PARfile target for this library
@@ -76,7 +84,6 @@ add_target_parfile(${MODULEHFML} "${SRCS}" "${HDRS}" "${MODULEHFML}LinkDef.h" "$
 
 # Linking the library
 target_link_libraries(${MODULEHFML} ${LIBDEPS})
-target_link_libraries(${MODULEHFML} \-L$ENV{KFPARTICLE_ROOT}/lib ${LIBDEPS})
 # Public include folders that will be propagated to the dependecies
 target_include_directories(${MODULEHFML} PUBLIC ${incdirs})
 

--- a/PWGJE/EMCALJetTasks/CMakeLists.txt
+++ b/PWGJE/EMCALJetTasks/CMakeLists.txt
@@ -24,7 +24,6 @@ include_directories(${AliPhysics_SOURCE_DIR}/PWGJE/EMCALJetTasks
 
 # Additional include folders in alphabetical order except ROOT
 include_directories(${ROOT_INCLUDE_DIRS}
-                    $ENV{KFPARTICLE_ROOT}/include
                     ${AliPhysics_SOURCE_DIR}/CORRFW
                     ${AliPhysics_SOURCE_DIR}/OADB
                     ${AliPhysics_SOURCE_DIR}/PWG/DevNanoAOD
@@ -40,6 +39,8 @@ include_directories(${ROOT_INCLUDE_DIRS}
                     ${AliPhysics_SOURCE_DIR}/PWGPP/EVCHAR/FlowVectorCorrections/QnCorrections
                     ${AliPhysics_SOURCE_DIR}/PWGPP/EVCHAR/FlowVectorCorrections/QnCorrectionsInterface
                              )
+
+
 
 # Sources in alphabetical order
 set(SRCS
@@ -248,6 +249,13 @@ if(RooUnfold_FOUND)
     add_definitions("-DWITH_ROOUNFOLD")
 endif(RooUnfold_FOUND)
 
+if(KFParticle_FOUND)
+    get_target_property(KFPARTICLE_INCLUDE_DIR KFParticle::KFParticle INTERFACE_INCLUDE_DIRECTORIES)
+    include_directories(${KFPARTICLE_INCLUDE_DIR})
+    add_definitions("-DWITH_KFPARTICLE")
+endif(KFParticle_FOUND)
+
+
 # Tasks that need direct access to Fastjet
 if(FASTJET_FOUND)
     set(SRCS ${SRCS}
@@ -331,7 +339,7 @@ else()
     set(ROOT_DEPENDENCIES)
 endif()
 
-set(ALIROOT_DEPENDENCIES ANALYSIS CORRFW PHOSbase PWGEMCALbase PWGEMCALtrigger PWGJETFW PWGCaloTrackCorrBase PWGDevNanoAOD PWGPPevcharQn PWGPPevcharQnInterface KFParticle)
+set(ALIROOT_DEPENDENCIES ANALYSIS CORRFW PHOSbase PWGEMCALbase PWGEMCALtrigger PWGJETFW PWGCaloTrackCorrBase PWGDevNanoAOD PWGPPevcharQn PWGPPevcharQnInterface)
 if(FASTJET_FOUND)
     set(ALIROOT_DEPENDENCIES JETAN ${ALIROOT_DEPENDENCIES})
 endif(FASTJET_FOUND)
@@ -356,6 +364,10 @@ if(RooUnfold_FOUND)
     set(LIBDEPS ${LIBDEPS} ${ROOUNFOLD_LIBRARY})
     set(ROOUNFOLD_DEPENDENCIES ${ROOUNFOLD_LIBRARY})
 endif(RooUnfold_FOUND)
+if(KFParticle_FOUND)
+    get_target_property(KFPARTICLE_LIBRARY KFParticle::KFParticle IMPORTED_LOCATION)
+    set(LIBDEPS ${LIBDEPS} ${KFPARTICLE_LIBRARY})
+endif(KFParticle_FOUND)
 generate_rootmap("${MODULE}" "${LIBDEPS}" "${CMAKE_CURRENT_SOURCE_DIR}/${MODULE}LinkDef.h")
 
 # Generate a PARfile target for this library. Note the extra includes ("Tracks UserTasks")
@@ -367,7 +379,6 @@ add_library(${MODULE}-object OBJECT ${SRCS} G__${MODULE}.cxx)
 # Add a library to the project using the object
 add_library_tested(${MODULE} SHARED $<TARGET_OBJECTS:${MODULE}-object>)
 target_link_libraries(${MODULE} ${LIBDEPS})
-target_link_libraries(${MODULE} \-L$ENV{KFPARTICLE_ROOT}/lib ${LIBDEPS})
 
 # Setting the correct headers for the object as gathered from the dependencies
 target_include_directories(${MODULE}-object PUBLIC $<TARGET_PROPERTY:${MODULE},INCLUDE_DIRECTORIES>)

--- a/PWGLF/NUCLEX/CMakeLists.txt
+++ b/PWGLF/NUCLEX/CMakeLists.txt
@@ -26,13 +26,21 @@ include_directories(${AliPhysics_SOURCE_DIR}/PWGLF/NUCLEX
 # Additional includes - alphabetical order except ROOT
 include_directories(${ROOT_INCLUDE_DIRS}
                     ${ALIROOT_INCLUDE_DIRS}
-                    $ENV{KFPARTICLE_ROOT}/include
+                    ${AliPhysics_SOURCE_DIR}/CORRFW
                     ${AliPhysics_SOURCE_DIR}/OADB
                     ${AliPhysics_SOURCE_DIR}/OADB/COMMON/MULTIPLICITY
+                    ${AliPhysics_SOURCE_DIR}/PWG/Tools
+                    ${AliPhysics_SOURCE_DIR}/PWG/DevNanoAOD
 		                ${AliPhysics_SOURCE_DIR}/PWGCF/Correlations/Base
+                    ${AliPhysics_SOURCE_DIR}/PWGLF/CommonUtils
                     ${AliPhysics_SOURCE_DIR}/PWGPP/EVCHAR/FlowVectorCorrections/QnCorrections
 		                ${AliPhysics_SOURCE_DIR}/PWGPP/EVCHAR/FlowVectorCorrections/QnCorrectionsInterface/
   )
+if(KFParticle_FOUND)
+  get_target_property(KFPARTICLE_INCLUDE_DIR KFParticle::KFParticle INTERFACE_INCLUDE_DIRECTORIES)
+  include_directories(${KFPARTICLE_INCLUDE_DIR})
+  add_definitions("-DWITH_KFPARTICLE")
+endif(KFParticle_FOUND)
 
 if(ROOT_VERSION_MAJOR EQUAL 6)
 # Additional includes for ROOT 6 only dependencies - alphabetical order except ROOT
@@ -146,7 +154,11 @@ set(ALIROOT_DEPENDENCIES ANALYSISalice OADB PWGPPevcharQn PWGflowTasks EVGEN PWG
 
 # Generate the ROOT map
 # Dependencies
-set(LIBDEPS ${ALIROOT_DEPENDENCIES} ${ROOT_DEPENDENCIES} KFParticle)
+set(LIBDEPS ${ALIROOT_DEPENDENCIES} ${ROOT_DEPENDENCIES})
+if(KFParticle_FOUND)
+    get_target_property(KFPARTICLE_LIBRARY KFParticle::KFParticle IMPORTED_LOCATION)
+    set(LIBDEPS ${LIBDEPS} ${KFPARTICLE_LIBRARY})
+endif(KFParticle_FOUND)
 if(ROOT_VERSION_MAJOR EQUAL 6)
   set(LIBDEPS ${LIBDEPS} ML yaml-cpp)
 endif()
@@ -162,7 +174,7 @@ add_library(${MODULE}-object OBJECT ${SRCS} G__${MODULE}.cxx)
 
 # Add a library to the project using the object
 add_library_tested(${MODULE} SHARED $<TARGET_OBJECTS:${MODULE}-object>)
-target_link_libraries(${MODULE} \-L$ENV{KFPARTICLE_ROOT}/lib ${LIBDEPS})
+target_link_libraries(${MODULE} ${LIBDEPS})
 
 # Setting the correct headers for the object as gathered from the dependencies
 target_include_directories(${MODULE}-object PUBLIC $<TARGET_PROPERTY:${MODULE},INCLUDE_DIRECTORIES>)

--- a/cmake/FindKFParticle.cmake
+++ b/cmake/FindKFParticle.cmake
@@ -1,0 +1,70 @@
+####################################################################################
+# Copyright (C) 2020, Copyright Holders of the ALICE Collaboration                 #
+# All rights reserved.                                                             #
+#                                                                                  #
+# Redistribution and use in source and binary forms, with or without               #
+# modification, are permitted provided that the following conditions are met:      #
+#     * Redistributions of source code must retain the above copyright             #
+#       notice, this list of conditions and the following disclaimer.              #
+#     * Redistributions in binary form must reproduce the above copyright          #
+#       notice, this list of conditions and the following disclaimer in the        #
+#       documentation and/or other materials provided with the distribution.       #
+#     * Neither the name of the <organization> nor the                             #
+#       names of its contributors may be used to endorse or promote products       #
+#       derived from this software without specific prior written permission.      #
+#                                                                                  #
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  #
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    #
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           #
+# DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              #
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       #
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     #
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      #
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       #
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    #
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     #
+####################################################################################
+# Find module for KFParticle 
+# Copied and adapted from FindRooUnfold.cmake by Dario Berzano <dario.berzano@cern.ch>
+#
+# From your `CMakeLists.txt` use it as simply as:
+#
+#   find_package(KFParticle)
+#
+# It expects `-DKFPARTICLE=<prefix>` to be passed as argument, and it falls back
+# to the environment variable `KFPARTICLE_ROOT`.
+#
+# A target is exported if KFParticle is found. The target takes care of defining
+# all the library paths, compile flags, and include paths. Usage is very simple:
+#
+#   if(KFParticle_FOUND)
+#     target_link_library(MyAnalysisClass MyDep1 MyDep2 KFParticle::KFParticle)
+#   endif()
+#
+# No additional command is required (no `include_directories()`, etc.) and no
+# variable other than `KFParticle_FOUND` is exported.
+
+include(FindPackageHandleStandardArgs)
+
+if(NOT DEFINED KFPARTICLE)
+  set(KFPARTICLE "$ENV{KFPARTICLE_ROOT}")
+endif()
+
+find_library(KFPARTICLE_LIBRARY KFParticle
+             PATHS "${KFPARTICLE}/lib" NO_DEFAULT_PATH)
+find_path(KFPARTICLE_INCLUDE_DIR KFParticle.h
+          PATHS "${KFPARTICLE}/include" NO_DEFAULT_PATH)
+
+find_package_handle_standard_args(KFParticle DEFAULT_MSG
+                                  KFPARTICLE_LIBRARY KFPARTICLE_INCLUDE_DIR)
+
+# Set KFParticle::KFParticle target
+add_library(KFParticle::KFParticle SHARED IMPORTED)
+set_target_properties(KFParticle::KFParticle PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES "${KFPARTICLE_INCLUDE_DIR}"
+  IMPORTED_LOCATION             "${KFPARTICLE_LIBRARY}"
+  INTERFACE_COMPILE_DEFINITIONS "WITH_KFPARTICLE")
+
+# Unset RooUnfold variables
+unset(KFPARTICLE_LIBPATH)
+unset(KFPARTICLE_INCLUDE_DIR)


### PR DESCRIPTION
Provinding FindKFParticle.cmake copied and
adpated from FindRooUnfold.cmake which finds
the KFParticle package based on KFParticle_ROOT
and export include path and library as cmake
properties. CMakeLists.txt in libraries which
make use of KFParticles are adapted, and
find_package(KFParticle) is added to the global
CMakeLists.txs