### PR TITLE
Fixing EMCAL track selection unit tests

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliEmcalAODHybridTrackCuts.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEmcalAODHybridTrackCuts.cxx
@@ -30,9 +30,7 @@
 #include "AliLog.h"
 #include <iostream>
 
-/// \cond CLASSIMP
 ClassImp(PWG::EMCAL::AliEmcalAODHybridTrackCuts)
-/// \endcond
 
 using namespace PWG::EMCAL;
 
@@ -143,7 +141,7 @@ bool TestAliEmcalAODHybridTrackCuts::TestDef2010wRefit() const {
       AliErrorStream() << "Hybrid track information not found for track CAT2" << std::endl;
       nfailure++;          // no hybrid track type found - failure
     } else {
-      if(tracktype->IsHybridTrackConstrained()){
+      if(!tracktype->IsHybridTrackConstrained()){
         AliErrorStream() << "Track not selected as hybrid track CAT2: " << int(tracktype->GetHybridTrackType()) << std::endl;
         nfailure++; // wrong hybrid track type
       }
@@ -216,7 +214,7 @@ bool TestAliEmcalAODHybridTrackCuts::TestDef2010woRefit() const {
       AliErrorStream() << "Hybrid track information not found for track CAT2" << std::endl;
       nfailure++;          // no hybrid track type found - failure
     } else {
-      if(tracktype->IsHybridTrackConstrained()){
+      if(!tracktype->IsHybridTrackConstrained()){
         AliErrorStream() << "Track not selected as hybrid track CAT2: " << int(tracktype->GetHybridTrackType()) << std::endl;
         nfailure++; // wrong hybrid track type
       }
@@ -277,7 +275,7 @@ bool TestAliEmcalAODHybridTrackCuts::TestDef2011() const {
       AliErrorStream() << "Hybrid track information not found for track CAT2" << std::endl;
       nfailure++;
     } else {
-      if(tracktype->IsHybridTrackConstrained()){
+      if(!tracktype->IsHybridTrackConstrained()){
         AliErrorStream() << "Track not selected as hybrid track CAT2: " << int(tracktype->GetHybridTrackType()) << std::endl;
         nfailure++;
       }

--- a/PWG/EMCAL/EMCALbase/AliEmcalTrackSelResultHybrid.h
+++ b/PWG/EMCAL/EMCALbase/AliEmcalTrackSelResultHybrid.h
@@ -118,7 +118,7 @@ public:
    * @brief Check whether track is selected as any complementary (true or fake) hybrid track
    * @return True if the track is selected as complementary hybrid track, false otherwise
    */
-  Bool_t IsHybridTrackConstrained() const { return fHybridTrackType == kHybridConstrainedTrue || fHybridTrackType == kHybridConstrainedFake; }
+  Bool_t IsHybridTrackConstrained() const { return IsHybridTrackConstrainedTrue() || IsHybridTrackConstrainedFake(); }
 
   /**
    * @brief Check whether track is selected as true complementary hybrid track

--- a/PWG/EMCAL/EMCALbase/AliEmcalTrackSelectionAOD.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEmcalTrackSelectionAOD.cxx
@@ -338,7 +338,7 @@ bool TestAliEmcalTrackSelectionAOD::TestHybridDef2010wRefit() const {
       AliErrorStream() << "No hybrid selection result found for CAT2 hybrid track" << std::endl;
       nfailure++;
     } else {
-      if(hybridcat->IsHybridTrackConstrained()) {
+      if(!hybridcat->IsHybridTrackConstrained()) {
         AliErrorStream() << "Incorrect hybrid track type for CAT2 hybrid track: " << hybridcat->GetHybridTrackType() << std::endl;
         nfailure++;
       }
@@ -411,7 +411,7 @@ bool TestAliEmcalTrackSelectionAOD::TestHybridDef2010woRefit() const {
       AliErrorStream() << "No hybrid selection result found for CAT2 hybrid track" << std::endl;
       nfailure++;
     } else {
-      if(hybridcat->IsHybridTrackConstrained()) {
+      if(!hybridcat->IsHybridTrackConstrained()) {
         AliErrorStream() << "Incorrect hybrid track type for CAT2 hybrid track: " << hybridcat->GetHybridTrackType() << std::endl;
         nfailure++;
       }
@@ -472,7 +472,7 @@ bool TestAliEmcalTrackSelectionAOD::TestHybridDef2011() const {
       AliErrorStream() << "No hybrid selection result found for CAT2 hybrid track" << std::endl;
       nfailure++;
     } else {
-      if(hybridcat->IsHybridTrackConstrained()) {
+      if(!hybridcat->IsHybridTrackConstrained()) {
         AliErrorStream() << "Incorrect hybrid track type for CAT2 hybrid track: " << hybridcat->GetHybridTrackType() << std::endl;
         nfailure++;
       }


### PR DESCRIPTION
Condition for category 2 hybrid track selection
had to be negated as the if condition counts
the errors and not the successes.