### PR TITLE
PWGGA/GammaConv: GammaIsoTree fixed bug in cluster processing & more

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskGammaIsoTree.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaIsoTree.cxx
@@ -213,6 +213,12 @@ AliAnalysisTaskGammaIsoTree::AliAnalysisTaskGammaIsoTree() : AliAnalysisTaskSE()
   fConvTrueInvMass_FromDecay(NULL),
   fConvTrueInvMass_FromDirect(NULL),
   fCaloPt(NULL),
+  fTrackPt(NULL),
+  fTrackEta(NULL),
+  fTrackPhi(NULL),
+  fTrackPtHybridOnlyPosID(NULL),
+  fTrackEtaHybridOnlyPosID(NULL),
+  fTrackPhiHybridOnlyPosID(NULL),
   fCaloPtBeforeAcc(NULL),
   fCaloE(NULL),
   fCaloPtTaggedCalo(NULL),
@@ -227,6 +233,10 @@ AliAnalysisTaskGammaIsoTree::AliAnalysisTaskGammaIsoTree() : AliAnalysisTaskSE()
   fCaloRhoTimesAreaLeft(),
   fCaloRhoTimesAreaRight(),
   fCaloRhoTimesAreaBack(),
+  fCaloTruePhotonPt(NULL),
+  fCaloTruePhotonOldPt(NULL),
+  fCaloTruePhotonRecPt(NULL),
+  fCaloTruePhotonRecPtVsTruePt(NULL),
   fCaloTruePt(NULL),
   fCaloTruePtNotProper(NULL),
   fCaloTruePtNoIsPrimary(NULL),
@@ -361,6 +371,7 @@ AliAnalysisTaskGammaIsoTree::AliAnalysisTaskGammaIsoTree() : AliAnalysisTaskSE()
   fCaloTrueM02_FromDecay(),
   fCaloTrueM02_FromDirect(),
   fHistoMCHeaders(NULL),
+  fGenPtTruePhoton(NULL),
   fGenPhotonPt(NULL),
   fGenPhotonPt_FromDecay(NULL),
   fGenPhotonPt_FromDirect(NULL),
@@ -402,6 +413,7 @@ AliAnalysisTaskGammaIsoTree::AliAnalysisTaskGammaIsoTree() : AliAnalysisTaskSE()
   fBuffer_EventWeight(0),
   fBuffer_EventXsection(0),
   fBuffer_EventNtrials(0),
+  fBuffer_EventNPrimaryTracks(0),
   fBuffer_EventIsTriggered(0),
   fBuffer_ClusterE(0), 
   fBuffer_ClusterPx(0), 
@@ -417,7 +429,7 @@ AliAnalysisTaskGammaIsoTree::AliAnalysisTaskGammaIsoTree() : AliAnalysisTaskSE()
   fBuffer_ClusterIsoCharged1(0), 
   fBuffer_ClusterIsoCharged2(0), 
   fBuffer_ClusterIsoCharged3(0), 
-  fBuffer_ClusterIsoBckLeft(0), 
+  fBuffer_ClusterIsoBckPerp(0), 
   fBuffer_ClusterMatchTrackdEta(0), 
   fBuffer_ClusterMatchTrackdPhi(0), 
   fBuffer_ClusterMatchTrackP(0), 
@@ -441,7 +453,7 @@ AliAnalysisTaskGammaIsoTree::AliAnalysisTaskGammaIsoTree() : AliAnalysisTaskSE()
   fBuffer_GenPhotonMCIsoCharged1(0),
   fBuffer_GenPhotonMCIsoCharged2(0),
   fBuffer_GenPhotonMCIsoCharged3(0),
-  fBuffer_GenPhotonMCIsoBckLeft(0),
+  fBuffer_GenPhotonMCIsoBckPerp(0),
   fBuffer_GenPhotonIsConv(0),
   fBuffer_GenPhotonMCTag(0)
 {
@@ -639,6 +651,12 @@ AliAnalysisTaskGammaIsoTree::AliAnalysisTaskGammaIsoTree(const char *name) : Ali
   fConvTrueInvMass_FromDecay(NULL),
   fConvTrueInvMass_FromDirect(NULL),
   fCaloPt(NULL),
+  fTrackPt(NULL),
+  fTrackEta(NULL),
+  fTrackPhi(NULL),
+  fTrackPtHybridOnlyPosID(NULL),
+  fTrackEtaHybridOnlyPosID(NULL),
+  fTrackPhiHybridOnlyPosID(NULL),
   fCaloPtBeforeAcc(NULL),
   fCaloE(NULL),
   fCaloPtTaggedCalo(NULL),
@@ -654,6 +672,10 @@ AliAnalysisTaskGammaIsoTree::AliAnalysisTaskGammaIsoTree(const char *name) : Ali
   fCaloRhoTimesAreaLeft(),
   fCaloRhoTimesAreaRight(),
   fCaloRhoTimesAreaBack(),
+  fCaloTruePhotonPt(NULL),
+  fCaloTruePhotonOldPt(NULL),
+  fCaloTruePhotonRecPt(NULL),
+  fCaloTruePhotonRecPtVsTruePt(NULL),
   fCaloTruePt(NULL),
   fCaloTruePtNotProper(NULL),
   fCaloTruePtNoIsPrimary(NULL),
@@ -788,6 +810,7 @@ AliAnalysisTaskGammaIsoTree::AliAnalysisTaskGammaIsoTree(const char *name) : Ali
   fCaloTrueM02_FromDecay(),
   fCaloTrueM02_FromDirect(),
   fHistoMCHeaders(NULL),
+  fGenPtTruePhoton(NULL),
   fGenPhotonPt(NULL),
   fGenPhotonPt_FromDecay(NULL),
   fGenPhotonPt_FromDirect(NULL),
@@ -830,6 +853,7 @@ AliAnalysisTaskGammaIsoTree::AliAnalysisTaskGammaIsoTree(const char *name) : Ali
   fBuffer_EventWeight(0),
   fBuffer_EventXsection(0),
   fBuffer_EventNtrials(0),
+  fBuffer_EventNPrimaryTracks(0),
   fBuffer_EventIsTriggered(0),
   fBuffer_ClusterE(0), 
   fBuffer_ClusterPx(0), 
@@ -845,7 +869,7 @@ AliAnalysisTaskGammaIsoTree::AliAnalysisTaskGammaIsoTree(const char *name) : Ali
   fBuffer_ClusterIsoCharged1(0), 
   fBuffer_ClusterIsoCharged2(0), 
   fBuffer_ClusterIsoCharged3(0), 
-  fBuffer_ClusterIsoBckLeft(0), 
+  fBuffer_ClusterIsoBckPerp(0), 
   fBuffer_ClusterMatchTrackdEta(0), 
   fBuffer_ClusterMatchTrackdPhi(0), 
   fBuffer_ClusterMatchTrackP(0), 
@@ -869,7 +893,7 @@ AliAnalysisTaskGammaIsoTree::AliAnalysisTaskGammaIsoTree(const char *name) : Ali
   fBuffer_GenPhotonMCIsoCharged1(0),
   fBuffer_GenPhotonMCIsoCharged2(0),
   fBuffer_GenPhotonMCIsoCharged3(0),
-  fBuffer_GenPhotonMCIsoBckLeft(0),
+  fBuffer_GenPhotonMCIsoBckPerp(0),
   fBuffer_GenPhotonIsConv(0),
   fBuffer_GenPhotonMCTag(0)
 {
@@ -1579,10 +1603,31 @@ void AliAnalysisTaskGammaIsoTree::UserCreateOutputObjects()
   fCaloFolderRec->SetName("caloPhotonsRec");
   fCaloFolderRec->SetOwner(kTRUE);
   fOutputList->Add(fCaloFolderRec);
-  // always fill this for trigger rejection factor
+  // always fill this for trigger rejection factor and QA
   fCaloPt = new TH1F("fCaloPt","calo photons in EMC acc;p_{T} (GeV/c); counts",nPtBins,minPt,maxPt);
+  fTrackPt = new TH1F("fTrackPt","pt distribution of hybrid tracks;p_{T} (GeV/c); counts",nPtBins,minPt,maxPt);
+  fTrackEta = new TH1F("fTrackEta","#eta distribution of hybrid tracks;#eta; counts",200,-0.9,0.9);
+  fTrackPhi = new TH1F("fTrackPhi","#phi distribution of hybrid tracks;#phi; counts",200,0,2*TMath::Pi());
+  
+  fTrackPtHybridOnlyPosID = new TH1F("fTrackPtHybridOnlyPosID","pt distribution of hybrid tracks;p_{T} (GeV/c); counts",nPtBins,minPt,maxPt);
+  fTrackEtaHybridOnlyPosID = new TH1F("fTrackEtaHybridOnlyPosID","#eta distribution of hybrid tracks;#eta; counts",200,-0.9,0.9);
+  fTrackPhiHybridOnlyPosID = new TH1F("fTrackPhiHybridOnlyPosID","#phi distribution of hybrid tracks;#phi; counts",200,0,2*TMath::Pi());
+
   fCaloPt->Sumw2();
+  fTrackPt->Sumw2();
+  fTrackEta->Sumw2();
+  fTrackPhi->Sumw2();
+  fTrackPtHybridOnlyPosID->Sumw2();
+  fTrackEtaHybridOnlyPosID->Sumw2();
+  fTrackPhiHybridOnlyPosID->Sumw2();
   fCaloFolderRec->Add(fCaloPt);
+  fCaloFolderRec->Add(fTrackPt);
+  fCaloFolderRec->Add(fTrackEta);
+  fCaloFolderRec->Add(fTrackPhi);
+
+  fCaloFolderRec->Add(fTrackPtHybridOnlyPosID);
+  fCaloFolderRec->Add(fTrackEtaHybridOnlyPosID);
+  fCaloFolderRec->Add(fTrackPhiHybridOnlyPosID);
   if(fUseHistograms){
 
     fCaloPtBeforeAcc = new TH1F("fCaloPtBeforeAcc", "calo photons all acc;p_{T} (GeV/c); counts", nPtBins,minPt,maxPt);
@@ -1658,12 +1703,32 @@ void AliAnalysisTaskGammaIsoTree::UserCreateOutputObjects()
       fCaloIsoCell[r]->Sumw2();
       fCaloFolderRec->Add(fCaloIsoCell[r]);
     }
+  }
 
-    fCaloFolderTrue          = new TList();
-    fCaloFolderTrue->SetName("caloPhotonsTrue");
-    fCaloFolderTrue->SetOwner(kTRUE);
+  fCaloFolderTrue          = new TList();
+  fCaloFolderTrue->SetName("caloPhotonsTrue");
+  fCaloFolderTrue->SetOwner(kTRUE);
+  if(fIsMC>0) {
+    fOutputList->Add(fCaloFolderTrue);
+    // QA
+    fCaloTruePhotonPt = new TH1F("fCaloTruePhotonPt", "true photon cluster;p_{T} gen (GeV/c); counts", nPtBins,minPt,maxPt);
+    fCaloTruePhotonOldPt = new TH1F("fCaloTruePhotonOldPt", "true photon cluster;p_{T} gen (leading) (GeV/c); counts", nPtBins,minPt,maxPt);
+    fCaloTruePhotonRecPt = new TH1F("fCaloTruePhotonRecPt", "true photon cluster;p_{T} rec (GeV/c); counts", nPtBins,minPt,maxPt);
+    fCaloTruePhotonRecPtVsTruePt = new TH2F("fCaloTruePhotonRecPtVsTruePt", "true pt;rec. pt", nPtBins,minPt,maxPt,nPtBins,minPt,maxPt);
+    
+    fCaloTruePhotonPt->Sumw2();
+    fCaloTruePhotonOldPt->Sumw2();
+    fCaloTruePhotonRecPt->Sumw2();
+    fCaloTruePhotonRecPtVsTruePt->Sumw2();
+
+    fCaloFolderTrue->Add(fCaloTruePhotonPt);
+    fCaloFolderTrue->Add(fCaloTruePhotonOldPt);
+    fCaloFolderTrue->Add(fCaloTruePhotonRecPt);
+    fCaloFolderTrue->Add(fCaloTruePhotonRecPtVsTruePt);
+  }
+
+  if(fUseHistograms){
     if(fIsMC > 0){
-      fOutputList->Add(fCaloFolderTrue);
       fCaloTruePt = new TH1F("fCaloTruePt", "validated calo photons in EMC acceptance;p_{T} (GeV/c); counts", nPtBins,minPt,maxPt);
       fCaloTruePtNotProper = new TH1F("fCaloTruePtNotProper", "validated calo photons in EMC acceptance;p_{T} (GeV/c); counts", nPtBins,minPt,maxPt);
       fCaloTruePtNoIsPrimary = new TH1F("fCaloTruePtNoIsPrimary", "validated calo photons in EMC acceptance;p_{T} (GeV/c); counts", nPtBins,minPt,maxPt);
@@ -2312,16 +2377,23 @@ void AliAnalysisTaskGammaIsoTree::UserCreateOutputObjects()
             fCaloFolderRec->Add(fCaloM02FullIsolated[r][e]);
         }
     }
-
-    //
-    // ─── GENERATOR LEVEL ─────────────────────────────────────────────
-    //
-    if(fIsMC > 0){
+  }
+  if(fIsMC > 0){
       fGeneratorFolder          = new TList();
       fGeneratorFolder->SetName("genLevel");
       fGeneratorFolder->SetOwner(kTRUE);
       fOutputList->Add(fGeneratorFolder);
 
+      fGenPtTruePhoton = new TH1F("fGenPtTruePhoton", "true photon cluster;p_{T} gen (GeV/c); counts", nPtBins,minPt,maxPt);
+      fGenPtTruePhoton->Sumw2();
+      fGeneratorFolder->Add(fGenPtTruePhoton);
+  }
+  if(fUseHistograms){
+
+    //
+    // ─── GENERATOR LEVEL ─────────────────────────────────────────────
+    //
+    if(fIsMC > 0){
       fHistoMCHeaders = new TH1I("MC_Headers", "MC_Headers", 20, 0, 20);
       fGenPhotonPt = new TH1F("fGenPhotonPt","fGenPhotonPt;gen. p_{T} (GeV/c); counts",nPtBins,minPt,maxPt);
       fGenPhotonPt_FromDecay  = new TH1F("fGenPhotonPt_FromDecay","fGenPhotonPt_FromDecay;gen. p_{T} (GeV/c); counts",nPtBins,minPt,maxPt);
@@ -2394,6 +2466,7 @@ void AliAnalysisTaskGammaIsoTree::UserCreateOutputObjects()
   OpenFile(2);
   // fConversionCandidates = new TClonesArray("AliAODConversionPhoton",50);
   fClusterEMCalCandidates = new TList();
+  fClusterEMCalCandidates->SetOwner(kTRUE);
   fClusterEMCalCandidatesIsolation = new TList();
   fClusterEMCalCandidatesTagging = new TList();
   fClusterPHOSCandidates = new TList();
@@ -2411,6 +2484,7 @@ void AliAnalysisTaskGammaIsoTree::UserCreateOutputObjects()
     if(fIsMC>0) fAnalysisTree->Branch("Event_Weight", &fBuffer_EventWeight,"Event_Weight/D");
     if(fIsMC>0) fAnalysisTree->Branch("Event_Xsection", &fBuffer_EventXsection,"Event_Xsection/F");
     if(fIsMC>0) fAnalysisTree->Branch("Event_Ntrials", &fBuffer_EventNtrials,"Event_Ntrials/s");
+    fAnalysisTree->Branch("Event_NPrimaryTracks", &fBuffer_EventNPrimaryTracks,"Event_NPrimaryTracks/s");
     fAnalysisTree->Branch("Event_IsTriggered", &fBuffer_EventIsTriggered,"Event_IsTriggered/O");
     fAnalysisTree->Branch("Cluster_E","std::vector<Float_t>",&fBuffer_ClusterE);
     fAnalysisTree->Branch("Cluster_Px","std::vector<Float_t>",&fBuffer_ClusterPx);
@@ -2426,7 +2500,7 @@ void AliAnalysisTaskGammaIsoTree::UserCreateOutputObjects()
     fAnalysisTree->Branch("Cluster_IsoCharged1","std::vector<Float_t>",&fBuffer_ClusterIsoCharged1);
     fAnalysisTree->Branch("Cluster_IsoCharged2","std::vector<Float_t>",&fBuffer_ClusterIsoCharged2);
     fAnalysisTree->Branch("Cluster_IsoCharged3","std::vector<Float_t>",&fBuffer_ClusterIsoCharged3);
-    fAnalysisTree->Branch("Cluster_IsoBckLeft","std::vector<Float_t>",&fBuffer_ClusterIsoBckLeft);
+    fAnalysisTree->Branch("Cluster_IsoBckPerp","std::vector<Float_t>",&fBuffer_ClusterIsoBckPerp);
     fAnalysisTree->Branch("Cluster_MatchTrackdEta","std::vector<Float_t>",&fBuffer_ClusterMatchTrackdEta);
     fAnalysisTree->Branch("Cluster_MatchTrackdPhi","std::vector<Float_t>",&fBuffer_ClusterMatchTrackdPhi);
     fAnalysisTree->Branch("Cluster_MatchTrackP","std::vector<Float_t>",&fBuffer_ClusterMatchTrackP);
@@ -2452,7 +2526,7 @@ void AliAnalysisTaskGammaIsoTree::UserCreateOutputObjects()
       fAnalysisTree->Branch("GenPhoton_MCIsoCharged1","std::vector<Float_t>",&fBuffer_GenPhotonMCIsoCharged1);
       fAnalysisTree->Branch("GenPhoton_MCIsoCharged2","std::vector<Float_t>",&fBuffer_GenPhotonMCIsoCharged2);
       fAnalysisTree->Branch("GenPhoton_MCIsoCharged3","std::vector<Float_t>",&fBuffer_GenPhotonMCIsoCharged3);
-      fAnalysisTree->Branch("GenPhoton_MCIsoBckLeft","std::vector<Float_t>",&fBuffer_GenPhotonMCIsoBckLeft);
+      fAnalysisTree->Branch("GenPhoton_MCIsoBckPerp","std::vector<Float_t>",&fBuffer_GenPhotonMCIsoBckPerp);
       fAnalysisTree->Branch("GenPhoton_IsConv","std::vector<Bool_t>",&fBuffer_GenPhotonIsConv);  
       fAnalysisTree->Branch("GenPhoton_MCTag","std::vector<Int_t>",&fBuffer_GenPhotonMCTag);  
     }
@@ -2557,6 +2631,9 @@ void AliAnalysisTaskGammaIsoTree::UserExec(Option_t *){
   fGeomEMCAL                          = AliEMCALGeometry::GetInstance();
   if(!fGeomEMCAL){ AliFatal("EMCal geometry not initialized!");}
 
+  // cout << fEventCuts->GetSignalRejection() << endl;
+  // cout << fEventCuts->GetCutNumber() << endl;
+
   if(fIsMC> 0){
   // Process MC Particle
   if(((AliConvEventCuts*)fEventCuts)->GetSignalRejection() != 0){
@@ -2605,6 +2682,7 @@ void AliAnalysisTaskGammaIsoTree::UserExec(Option_t *){
   }
   // auto startMCPart = std::chrono::high_resolution_clock::now();
   if(fIsMC>0) ProcessMCParticles();
+  ProcessTracks(); // always run ProcessTracks before calo photons! (even if save tracks is false)
   // auto endMCPart = std::chrono::high_resolution_clock::now();
   if(!fUseHistograms){
     fBuffer_EventWeight = fWeightJetJetMC;
@@ -2629,8 +2707,6 @@ void AliAnalysisTaskGammaIsoTree::UserExec(Option_t *){
   Double_t vertex[3] = {0};
   InputEvent()->GetPrimaryVertex()->GetXYZ(vertex);
 
-
-  //ProcessTracks(); // always run ProcessTracks before calo photons! (even if save tracks is false)
   if(fSaveConversions) ProcessConversionPhotons();
   // auto startCalo = std::chrono::high_resolution_clock::now();
   ProcessCaloPhotons(); // track matching is done here as well
@@ -2641,16 +2717,18 @@ void AliAnalysisTaskGammaIsoTree::UserExec(Option_t *){
   // processing was needed anyways because of track matching
   // and isolation
 
-  if( fIsMC > 0 && fInputEvent->IsA()==AliAODEvent::Class() && !(fV0Reader->AreAODsRelabeled())){
-    RelabelAODPhotonCandidates(kFALSE); // Back to ESDMC Label
-    fV0Reader->RelabelAODs(kFALSE);
-  }
   // fill output
   if(!fUseHistograms){
     fBuffer_EventRho = fChargedRho;
     fBuffer_EventRhoMC = fChargedRhoMC;
+    
     fAnalysisTree->Fill();
     PostData(2, fAnalysisTree);
+  }
+
+  if( fIsMC > 0 && fInputEvent->IsA()==AliAODEvent::Class() && !(fV0Reader->AreAODsRelabeled())){
+    RelabelAODPhotonCandidates(kFALSE); // Back to ESDMC Label
+    fV0Reader->RelabelAODs(kFALSE);
   }
   // std::chrono::duration<double> eventLoading = startMCPart - start;
   // std::chrono::duration<double> mcLoop = endMCPart - startMCPart;
@@ -2707,7 +2785,7 @@ void AliAnalysisTaskGammaIsoTree::ResetBuffer(){
   fBuffer_ClusterIsoCharged1.clear(); 
   fBuffer_ClusterIsoCharged2.clear(); 
   fBuffer_ClusterIsoCharged3.clear(); 
-  fBuffer_ClusterIsoBckLeft.clear(); 
+  fBuffer_ClusterIsoBckPerp.clear(); 
   fBuffer_ClusterMatchTrackdEta.clear(); 
   fBuffer_ClusterMatchTrackdPhi.clear(); 
   fBuffer_ClusterMatchTrackP.clear(); 
@@ -2732,9 +2810,11 @@ void AliAnalysisTaskGammaIsoTree::ResetBuffer(){
   fBuffer_GenPhotonMCIsoCharged1.clear();
   fBuffer_GenPhotonMCIsoCharged2.clear();
   fBuffer_GenPhotonMCIsoCharged3.clear();
-  fBuffer_GenPhotonMCIsoBckLeft.clear();
+  fBuffer_GenPhotonMCIsoBckPerp.clear();
   fBuffer_GenPhotonIsConv.clear();
   fBuffer_GenPhotonMCTag.clear();
+
+  fBuffer_EventNPrimaryTracks = 0;
 
 
 }
@@ -2762,7 +2842,7 @@ void AliAnalysisTaskGammaIsoTree::ProcessConversionPhotons(){
     if(fIsFromDesiredHeader){
       // new((*fConversionCandidates)[pos]) AliAODConversionPhoton(*PhotonCandidate);
 
-
+    
       Int_t      tmp_tag= 0;
       Double32_t tmp_isoNeutral[2] = {0,0};
       Double32_t tmp_isoCell[2] = {0,0};
@@ -3328,11 +3408,10 @@ void AliAnalysisTaskGammaIsoTree::ProcessMCCaloPhoton(AliAODCaloCluster* clus,Al
 }
 //________________________________________________________________________
 void AliAnalysisTaskGammaIsoTree::ProcessCaloPhotons(){
+   fClusterEMCalCandidates->Clear(); // safety first
    Int_t nclus                         = 0;
 
    Int_t posEMC = 0;
-   Int_t posEMCIso = 0;
-   Int_t posEMCTag = 0;
    Int_t posPHOS = 0;
    Double_t vertex[3] = {0};
    InputEvent()->GetPrimaryVertex()->GetXYZ(vertex);
@@ -3369,7 +3448,7 @@ void AliAnalysisTaskGammaIsoTree::ProcessCaloPhotons(){
 
       // Loop over EMCal clusters
       for(Long_t i = 0; i < nclus; i++){
-        clus                                = (AliAODCaloCluster*)arrClustersProcess->At(i);
+        clus = new AliAODCaloCluster(*(AliAODCaloCluster*) arrClustersProcess->At(i));
 
         if(!clus) continue;
 
@@ -3403,9 +3482,10 @@ void AliAnalysisTaskGammaIsoTree::ProcessCaloPhotons(){
           }
         }
 
-        isFromDesiredHeader.push_back(fIsFromDesiredHeader);
+        //isFromDesiredHeader.push_back(fIsFromDesiredHeader);
 
         if ( !clus->IsEMCAL()){ // for PHOS: cluster->GetType() == AliVCluster::kPHOSNeutral
+          delete clus;
           continue;
         }
 
@@ -3414,12 +3494,12 @@ void AliAnalysisTaskGammaIsoTree::ProcessCaloPhotons(){
         if ( (fIsFromDesiredHeader && !fIsOverlappingWithOtherHeader && !fAllowOverlapHeaders) || (fIsFromDesiredHeader && fAllowOverlapHeaders) ){
 
           // get additional cluster info
-          Short_t nLM = ((AliCaloPhotonCuts*)fClusterCutsEMC)->GetNumberOfLocalMaxima(clus, fInputEvent);
-          Short_t matchIndex = -1;
+          // Short_t nLM = ((AliCaloPhotonCuts*)fClusterCutsEMC)->GetNumberOfLocalMaxima(clus, fInputEvent);
+          // Short_t matchIndex = -1;
           // if(fDoOwnTrackMatching){
           //     matchIndex = ProcessTrackMatching(clus,fTracks);
           // }
-          Float_t eFrac = GetExoticEnergyFraction(clus,fInputEvent);
+          // Float_t eFrac = GetExoticEnergyFraction(clus,fInputEvent);
           // if(((AliCaloPhotonCuts*)fClusterCutsIsolationEMC)->ClusterIsSelected(clus,fInputEvent,fMCEvent,fIsMC, tempClusterWeight,i)){
           //   if(!IsMatchedWithConv(clus,fClusterCutsIsolationEMC)){
           //     new((*fExtraClusterInfoBackground)[posEMCIso]) AliExtraClusterInfoHelper(nLM,matchIndex,eFrac);
@@ -3437,117 +3517,127 @@ void AliAnalysisTaskGammaIsoTree::ProcessCaloPhotons(){
 
           // check if given EMC cuts are fulfilled
           if(!((AliCaloPhotonCuts*)fClusterCutsEMC)->ClusterIsSelected(clus,fInputEvent,fMCEvent,fIsMC, tempClusterWeight,i)){
+            delete clus;
             continue;
           }
           // if(IsMatchedWithConv(clus,fClusterCutsEMC)){
           //   delete clus;
           //   continue;
           // }
+          // AliInfo(Form("Added index %i \tE=%f\n",i,clus->E()));
+          // AliInfo(Form("fIsFromDesiredHeader = %i",fIsFromDesiredHeader));
+          // AliInfo(Form("fAllowOverlapHeaders = %i",fAllowOverlapHeaders));
           fClusterEMCalCandidates->Add(clus);
           clusWeights.push_back(tempPhotonWeight);
           clusterPos.push_back(i);
           isFromDesiredHeader.push_back(fIsFromDesiredHeader);
           posEMC++;
+        } else{
+          cout << "Did some header rejection stuff" << endl;
         }
       } // end of initial cluster loop
   }
+  // AliInfo("-----> End of cluster loop");
 
 
 
 
   // Loop over normal clusters
-  for(Long_t i = 0; i < nclus; i++){
-    clus                                = (AliAODCaloCluster*)fInputEvent->GetCaloCluster(i);
+  if(!arrClustersProcess){ // TODO breaks PHOS for now but saves some time
+      for(Long_t i = 0; i < nclus; i++){
+        clus  = new AliAODCaloCluster(*(AliAODCaloCluster*) fInputEvent->GetCaloCluster(i));
 
-    if(!clus) continue;
+        if(!clus) continue;
 
-    // Do all needed checks
-    Double_t tempClusterWeight        = fWeightJetJetMC;
-    Double_t tempPhotonWeight         = fWeightJetJetMC;
+        // Do all needed checks
+        Double_t tempClusterWeight        = fWeightJetJetMC;
+        Double_t tempPhotonWeight         = fWeightJetJetMC;
 
-    // Set the jetjet weight to 1 in case the cluster orignated from the minimum bias header
-    if (fIsMC>0 && (fEventCuts->GetSignalRejection() == 4)){
-      if(fEventCuts->IsParticleFromBGEvent(clus->GetLabelAt(0), fMCEvent, fInputEvent) == 2)
-        tempClusterWeight = 1;
-    }
+        // Set the jetjet weight to 1 in case the cluster orignated from the minimum bias header
+        if (fIsMC>0 && (fEventCuts->GetSignalRejection() == 4)){
+          if(fEventCuts->IsParticleFromBGEvent(clus->GetLabelAt(0), fMCEvent, fInputEvent) == 2)
+            tempClusterWeight = 1;
+        }
 
-    // Header check
-    fIsFromDesiredHeader          = kTRUE;
-    fIsOverlappingWithOtherHeader = kFALSE;
-    // test whether largest contribution to cluster orginates in added signals
-    if (fIsMC>0 && fEventCuts->GetSignalRejection() > 0){
-      Int_t* mclabelsCluster = clus->GetLabels();
-      // Set the jetjet weight to 1 in case the photon candidate orignated from the minimum bias header
-      if ( fEventCuts->IsParticleFromBGEvent(mclabelsCluster[0], fMCEvent, fInputEvent) == 2 && fEventCuts->GetSignalRejection() == 4) tempPhotonWeight = 1;
-      if ( fEventCuts->IsParticleFromBGEvent(mclabelsCluster[0], fMCEvent, fInputEvent) == 0) fIsFromDesiredHeader = kFALSE;
-      if (clus->GetNLabels()>1){
-        // Int_t* mclabelsCluster = clus->GetLabels();
-        // if (fLocalDebugFlag > 1)   cout << "testing if other labels in cluster belong to different header, need to test " << (Int_t)clus->GetNLabels()-1 << " additional labels" << endl;
-          for (Int_t l = 1; l < (Int_t)clus->GetNLabels(); l++ ){
-            if (fEventCuts->IsParticleFromBGEvent(mclabelsCluster[l], fMCEvent, fInputEvent, 0) == 0) fIsOverlappingWithOtherHeader = kTRUE;
+        // Header check
+        fIsFromDesiredHeader          = kTRUE;
+        fIsOverlappingWithOtherHeader = kFALSE;
+        // test whether largest contribution to cluster orginates in added signals
+        if (fIsMC>0 && fEventCuts->GetSignalRejection() > 0){
+          Int_t* mclabelsCluster = clus->GetLabels();
+          // Set the jetjet weight to 1 in case the photon candidate orignated from the minimum bias header
+          if ( fEventCuts->IsParticleFromBGEvent(mclabelsCluster[0], fMCEvent, fInputEvent) == 2 && fEventCuts->GetSignalRejection() == 4) tempPhotonWeight = 1;
+          if ( fEventCuts->IsParticleFromBGEvent(mclabelsCluster[0], fMCEvent, fInputEvent) == 0) fIsFromDesiredHeader = kFALSE;
+          if (clus->GetNLabels()>1){
+            // Int_t* mclabelsCluster = clus->GetLabels();
+            // if (fLocalDebugFlag > 1)   cout << "testing if other labels in cluster belong to different header, need to test " << (Int_t)clus->GetNLabels()-1 << " additional labels" << endl;
+              for (Int_t l = 1; l < (Int_t)clus->GetNLabels(); l++ ){
+                if (fEventCuts->IsParticleFromBGEvent(mclabelsCluster[l], fMCEvent, fInputEvent, 0) == 0) fIsOverlappingWithOtherHeader = kTRUE;
+              }
+            // if (fLocalDebugFlag > 1 && fIsOverlappingWithOtherHeader) cout << "found overlapping header: " << endl;
           }
-        // if (fLocalDebugFlag > 1 && fIsOverlappingWithOtherHeader) cout << "found overlapping header: " << endl;
-      }
-    }
+        }
 
-    if(!arrClustersProcess && clus->IsEMCAL()){ // if is was not saved already
-      if ( (fIsFromDesiredHeader && !fIsOverlappingWithOtherHeader && !fAllowOverlapHeaders) || (fIsFromDesiredHeader && fAllowOverlapHeaders) ){
-        // get additional cluster info
-        Short_t nLM = ((AliCaloPhotonCuts*)fClusterCutsEMC)->GetNumberOfLocalMaxima(clus, fInputEvent);
-        Short_t matchIndex = -1;
-        // if(fDoOwnTrackMatching){
-        //       matchIndex = ProcessTrackMatching(clus,fTracks);
-        // }
-        Float_t eFrac = GetExoticEnergyFraction(clus,fInputEvent);
+        if(!arrClustersProcess && clus->IsEMCAL()){ // if is was not saved already
+          if ( (fIsFromDesiredHeader && !fIsOverlappingWithOtherHeader && !fAllowOverlapHeaders) || (fIsFromDesiredHeader && fAllowOverlapHeaders) ){
+            // get additional cluster info
+            // Short_t nLM = ((AliCaloPhotonCuts*)fClusterCutsEMC)->GetNumberOfLocalMaxima(clus, fInputEvent);
+            // Short_t matchIndex = -1;
+            // if(fDoOwnTrackMatching){
+            //       matchIndex = ProcessTrackMatching(clus,fTracks);
+            // }
+            // Float_t eFrac = GetExoticEnergyFraction(clus,fInputEvent);
 
-        // if(((AliCaloPhotonCuts*)fClusterCutsIsolationEMC)->ClusterIsSelected(clus,fInputEvent,fMCEvent,fIsMC, tempClusterWeight,i)){
-        //   if(!IsMatchedWithConv(clus,fClusterCutsIsolationEMC)){
-        //     new((*fExtraClusterInfoBackground)[posEMCIso]) AliExtraClusterInfoHelper(nLM,matchIndex,eFrac);
-        //     new((*fClusterEMCalCandidatesIsolation)[posEMCIso]) AliAODCaloCluster(*clus);
-        //     posEMCIso++;
-        //   }
-        // }
+            // if(((AliCaloPhotonCuts*)fClusterCutsIsolationEMC)->ClusterIsSelected(clus,fInputEvent,fMCEvent,fIsMC, tempClusterWeight,i)){
+            //   if(!IsMatchedWithConv(clus,fClusterCutsIsolationEMC)){
+            //     new((*fExtraClusterInfoBackground)[posEMCIso]) AliExtraClusterInfoHelper(nLM,matchIndex,eFrac);
+            //     new((*fClusterEMCalCandidatesIsolation)[posEMCIso]) AliAODCaloCluster(*clus);
+            //     posEMCIso++;
+            //   }
+            // }
 
-        // if(((AliCaloPhotonCuts*)fClusterCutsTaggingEMC)->ClusterIsSelected(clus,fInputEvent,fMCEvent,fIsMC, tempClusterWeight,i)){
-        //   if(!IsMatchedWithConv(clus,fClusterCutsTaggingEMC)){
-        //     new((*fClusterEMCalCandidatesTagging)[posEMCTag]) AliAODCaloCluster(*clus);
-        //     posEMCTag++;
-        //   }
-        // }
-        if(!((AliCaloPhotonCuts*)fClusterCutsEMC)->ClusterIsSelected(clus,fInputEvent,fMCEvent,fIsMC, tempClusterWeight,i)){
-          // delete clus;
+            // if(((AliCaloPhotonCuts*)fClusterCutsTaggingEMC)->ClusterIsSelected(clus,fInputEvent,fMCEvent,fIsMC, tempClusterWeight,i)){
+            //   if(!IsMatchedWithConv(clus,fClusterCutsTaggingEMC)){
+            //     new((*fClusterEMCalCandidatesTagging)[posEMCTag]) AliAODCaloCluster(*clus);
+            //     posEMCTag++;
+            //   }
+            // }
+            if(!((AliCaloPhotonCuts*)fClusterCutsEMC)->ClusterIsSelected(clus,fInputEvent,fMCEvent,fIsMC, tempClusterWeight,i)){
+              delete clus;
+              continue;
+            }
+            // if(IsMatchedWithConv(clus,fClusterCutsEMC)){
+            //   delete clus;
+            //   continue;
+            // }
+            
+            // no track matching at this point, do manually fi tree
+
+            fClusterEMCalCandidates->Add(clus);
+            clusWeights.push_back(tempPhotonWeight);
+            clusterPos.push_back(i);
+            isFromDesiredHeader.push_back(fIsFromDesiredHeader);
+            posEMC++;
+          }
           continue;
         }
-        // if(IsMatchedWithConv(clus,fClusterCutsEMC)){
-        //   delete clus;
-        //   continue;
-        // }
-        
-        // no track matching at this point, do manually fi tree
-
-        fClusterEMCalCandidates->Add(clus);
-        clusWeights.push_back(tempPhotonWeight);
-        clusterPos.push_back(i);
-        isFromDesiredHeader.push_back(fIsFromDesiredHeader);
-        posEMC++;
+        if(clus->IsPHOS() && fSavePHOSClusters){
+        // if(clus->GetType() == AliVCluster::kPHOSNeutral){
+          if(!((AliCaloPhotonCuts*)fClusterCutsPHOS)->ClusterIsSelected(clus,fInputEvent,fMCEvent,fIsMC, tempClusterWeight,i)){
+            delete clus;
+            continue;
+          }
+          // if(!fSavePHOSClusters) new((*fClusterPHOSCandidates)[posPHOS]) AliAODCaloCluster(*clus);
+          posPHOS++;
+          continue;
+        }
       }
-      continue;
-    }
-    if(clus->IsPHOS() && fSavePHOSClusters){
-    // if(clus->GetType() == AliVCluster::kPHOSNeutral){
-      if(!((AliCaloPhotonCuts*)fClusterCutsPHOS)->ClusterIsSelected(clus,fInputEvent,fMCEvent,fIsMC, tempClusterWeight,i)){
-        continue;
-      }
-      // if(!fSavePHOSClusters) new((*fClusterPHOSCandidates)[posPHOS]) AliAODCaloCluster(*clus);
-      posPHOS++;
-      continue;
-    }
   }
 
   // Loop again over selected cluster candidates to do isolation and tagging
   for (Int_t c = 0; c < fClusterEMCalCandidates->GetEntries(); c++)
   {
-     AliAODCaloCluster* clus = (AliAODCaloCluster*) fClusterEMCalCandidates->At(c);
+     clus = (AliAODCaloCluster*) fClusterEMCalCandidates->At(c);
      Double32_t tmp_isoCharged[2] = {0,0};
      Double32_t tmp_isoNeutral[2] = {0,0};
      Double32_t tmp_isoCell[2] = {0,0};
@@ -3600,11 +3690,14 @@ void AliAnalysisTaskGammaIsoTree::ProcessCaloPhotons(){
      TLorentzVector clusterVector;
      clus->GetMomentum(clusterVector,vertex);
 
+    //  AliInfo(Form("clustervector %i \t E=%f \n",c,clusterVector.E()));
+
 
      TLorentzVector* tmpvec = new TLorentzVector();
      tmpvec->SetPxPyPzE(clusterVector.Px(),clusterVector.Py(),clusterVector.Pz(),clusterVector.E());
      // convert to AODConversionPhoton
      AliAODConversionPhoton *PhotonCandidate=new AliAODConversionPhoton(tmpvec);
+      // AliInfo(Form("photoncandidate %i \t E=%f \n",c,PhotonCandidate->E()));
      if(!PhotonCandidate){ delete tmpvec; continue;}
 
      // Flag Photon as CaloPhoton
@@ -3624,9 +3717,11 @@ void AliAnalysisTaskGammaIsoTree::ProcessCaloPhotons(){
          }
        }
        if(!fAODMCTrackArray) fAODMCTrackArray = dynamic_cast<TClonesArray*>(fInputEvent->FindListObject(AliAODMCParticle::StdBranchName()));
-       PhotonCandidate->SetCaloPhotonMCFlagsAOD(fAODMCTrackArray, kFALSE);
+       PhotonCandidate->SetCaloPhotonMCFlagsAOD(fAODMCTrackArray, kTRUE); // change to true?
 
      }
+
+      // AliInfo(Form("photoncandidate (second check) %i \t E=%f \n",c,PhotonCandidate->E()));
 
      // Only consider clusters that allow for a cone of 0.4 with tracking
      Bool_t isWithinTPC =IsWithinRadiusTPC(PhotonCandidate->Eta(),PhotonCandidate->Phi(),fExclusionRadius);
@@ -3647,6 +3742,7 @@ void AliAnalysisTaskGammaIsoTree::ProcessCaloPhotons(){
       continue;
      }
 
+
      if(fUseHistograms){
        FillCaloHistos(clus,PhotonCandidate,isoCharged,isoNeutral,isoCell,tmp_tag,clusWeights.at(c));
      } else{ // fill even in case of tree for trigger rejection
@@ -3659,13 +3755,20 @@ void AliAnalysisTaskGammaIsoTree::ProcessCaloPhotons(){
   clusWeights.clear();
   clusterPos.clear();
   isFromDesiredHeader.clear();
+  
+  fClusterEMCalCandidates->Clear(); // SetOwner=kTRUE, it should clear and delete
+
 }
 
 ///________________________________________________________________________
-Bool_t AliAnalysisTaskGammaIsoTree::TrackIsSelectedAOD(AliAODTrack* lTrack) {
+Bool_t AliAnalysisTaskGammaIsoTree::TrackIsSelectedAOD(AliAODTrack* lTrack, Bool_t requirePosID = kFALSE) {
   // apply filter bits
   if( ! lTrack->IsHybridGlobalConstrainedGlobal()){
     return kFALSE;
+  }
+
+  if(requirePosID){
+    if(lTrack->GetID()<0) return kFALSE;
   }
 
 	// Absolute TPC Cluster cut
@@ -3691,18 +3794,15 @@ Bool_t AliAnalysisTaskGammaIsoTree::TrackIsSelectedAOD(AliAODTrack* lTrack) {
 
 //_____________________________________________________________________________
 void AliAnalysisTaskGammaIsoTree::ProcessTracks(){
-  Int_t pos = 0;
+  UShort_t prim = 0;
+  AliAODTrack *fCurrentTrack = NULL;
   for(Int_t t=0;t<fInputEvent->GetNumberOfTracks();t++){
-      AliAODTrack *fCurrentTrack = static_cast<AliAODTrack*> (fInputEvent->GetTrack(t));
-      //if(!TrackIsSelectedAOD(fCurrentTrack)){
-        // save empty track to preserve position
-      //  new((*fTracks)[pos]) AliAODTrack();
-      //} else{
-
-      // we need to save all tracks in order to identify tracks from conv for isolation
-      // new((*fTracks)[pos]) AliAODTrack(*fCurrentTrack);
-      // pos++;
+      fCurrentTrack = static_cast<AliAODTrack*> (fInputEvent->GetTrack(t));
+      if(!TrackIsSelectedAOD(fCurrentTrack)) continue;
+      prim++;
   }
+  fBuffer_EventNPrimaryTracks = prim;
+  return;
 }
 
 //_____________________________________________________________________________
@@ -3714,7 +3814,6 @@ void AliAnalysisTaskGammaIsoTree::ProcessMCParticles(){
   Double_t mcProdVtxZ   = primVtxMC->GetZ();
 
   if(!fAODMCTrackArray) fAODMCTrackArray = dynamic_cast<TClonesArray*>(fInputEvent->FindListObject(AliAODMCParticle::StdBranchName()));
-  Int_t pos = 0;
   if (fAODMCTrackArray){
     for(Int_t i = 0; i < fAODMCTrackArray->GetEntriesFast(); i++) {
       Double_t tempParticleWeight       = fWeightJetJetMC;
@@ -3815,7 +3914,7 @@ void AliAnalysisTaskGammaIsoTree::ProcessMCParticles(){
         }
       }
       if(!isPrimary) continue;
-
+      
       // in EMC acceptance and not gamma as mother to avoid double counting
       // this should only count photon highest up the chain, technically could have wrong pT
       Bool_t isWithinTPC =IsWithinRadiusTPC(particle->Eta(),particle->Phi(),fExclusionRadius);
@@ -3859,7 +3958,7 @@ void AliAnalysisTaskGammaIsoTree::ProcessMCParticles(){
             fBuffer_GenPhotonMCIsoCharged1.push_back(mcIso.isolationCone.at(0));
             if(mcIso.isolationCone.size()>1) fBuffer_GenPhotonMCIsoCharged2.push_back(mcIso.isolationCone.at(1));
             if(mcIso.isolationCone.size()>2) fBuffer_GenPhotonMCIsoCharged3.push_back(mcIso.isolationCone.at(2));
-            fBuffer_GenPhotonMCIsoBckLeft.push_back(mcIso.backgroundLeft.at(2));
+            fBuffer_GenPhotonMCIsoBckPerp.push_back(mcIso.backgroundLeft.at(2)+mcIso.backgroundRight.at(2));
             Bool_t isConv = kFALSE;
             
             Int_t nDaughters = particle->GetNDaughters();
@@ -3883,6 +3982,8 @@ void AliAnalysisTaskGammaIsoTree::ProcessMCParticles(){
 
             fBuffer_GenPhotonIsConv.push_back(isConv);
             fBuffer_GenPhotonMCTag.push_back(tag);
+
+            fGenPtTruePhoton->Fill(particle->Pt(),fWeightJetJetMC);
           }
 
 
@@ -4125,11 +4226,25 @@ isoValues AliAnalysisTaskGammaIsoTree::ProcessChargedIsolation(AliAODCaloCluster
     {
         AliAODTrack *aodt = static_cast<AliAODTrack*>(fInputEvent->GetTrack(t));
         if(!aodt) continue;
-        if(!TrackIsSelectedAOD(aodt)) continue;
+
         v4track.SetPxPyPzE(aodt->Px(),aodt->Py(),aodt->Pz(),aodt->E());
         Double_t trackEta = v4track.Eta();
         Double_t trackPhi = v4track.Phi();
         if (trackPhi < 0) trackPhi += 2*TMath::Pi();
+
+        if(TrackIsSelectedAOD(aodt,kTRUE)){
+           fTrackPtHybridOnlyPosID->Fill(aodt->Pt(),fWeightJetJetMC);
+           fTrackEtaHybridOnlyPosID->Fill(trackEta,fWeightJetJetMC);
+           fTrackPhiHybridOnlyPosID->Fill(trackPhi,fWeightJetJetMC);
+        }
+
+        if(!TrackIsSelectedAOD(aodt)) continue;
+      
+
+        // for QA to check for dead TPC sectors
+        fTrackPt->Fill(aodt->Pt(),fWeightJetJetMC);
+        fTrackEta->Fill(trackEta,fWeightJetJetMC);
+        fTrackPhi->Fill(trackPhi,fWeightJetJetMC);
 
         Double_t dEta = trackEta - clusterEta;
         Double_t dPhi = trackPhi - clusterPhi;
@@ -5101,7 +5216,7 @@ void AliAnalysisTaskGammaIsoTree::FillCaloHistosPurity(AliAODCaloCluster* clus,A
         
         // for split efficiency
         fCaloTrueSignalPtClusterCuts->Fill(MCPhoton->Pt(),weight);
-        fCaloTrueSignalRecPtClusterCuts->Fill(MCPhoton->Pt(),weight);
+        fCaloTrueSignalRecPtClusterCuts->Fill(photon->Pt(),weight);
       }
     }
   }
@@ -5256,11 +5371,6 @@ void AliAnalysisTaskGammaIsoTree::FillCaloTree(AliAODCaloCluster* clus,AliAODCon
   } // end conv matching case
 
   if(fishyCase && fDebug>1) {
-    Double_t etaMatchedNew = kFALSE;
-    Double_t phiMatchedNew = kFALSE;
-    Double_t etaMatchedOld = kFALSE;
-    Double_t phiMatchedOld = kFALSE;
-
     cout << "--> Debug: mathed with track pT = " << trackPt << " before pt = " << trackPtOld << endl;
   }
 
@@ -5268,9 +5378,6 @@ void AliAnalysisTaskGammaIsoTree::FillCaloTree(AliAODCaloCluster* clus,AliAODCon
   if(fishyCase && fIsMC && (trackP<0) && fDebug>0){
      Int_t photonlabel = -1;
      const AliVVertex* primVtxMC   = fMCEvent->GetPrimaryVertex();
-     Double_t mcProdVtxX   = primVtxMC->GetX();
-     Double_t mcProdVtxY   = primVtxMC->GetY();
-     Double_t mcProdVtxZ   = primVtxMC->GetZ();
      cout << "--> Debug: I found no matches!" << endl;
      cout << "--> Debug: -----------------------------" << endl;
      cout << "--> Debug: Photon pt = " << photon->Pt() << "Iso is = " << isoCharged.isolationCone.at(2) << endl;
@@ -5466,20 +5573,31 @@ void AliAnalysisTaskGammaIsoTree::FillCaloTree(AliAODCaloCluster* clus,AliAODCon
       }
       if (photon->IsLargestComponentPhoton() || (photon->IsLargestComponentElectron() && photon->IsConversion())) {
          Bool_t isPrimary = fEventCuts->IsConversionPrimaryAOD(fInputEvent, MCPhoton, mcProdVtxX, mcProdVtxY, mcProdVtxZ);
-         if(isPrimary){
-           isTruePhoton = kTRUE;
-           if(photon->IsLargestComponentElectron() && photon->IsConversion()){
-             truePhotonFromConv = kTRUE;
-           } else if(photon->IsLargestComponentPhoton()){
-             truePhotonNormal = kTRUE;
-           }
-
+         if (photon->IsLargestComponentElectron() && photon->IsConversion()){
+            if (MCPhoton->GetMother()> -1){
+              AliAODMCParticle *Mother  = (AliAODMCParticle*) fAODMCTrackArray->At(MCPhoton->GetMother());
+              isPrimary = fEventCuts->IsConversionPrimaryAOD(fInputEvent, Mother, mcProdVtxX, mcProdVtxY, mcProdVtxZ);
+              photonlabel = MCPhoton->GetMother();
+              MCPhoton = Mother;
+            }
          }
+        Bool_t isWithinTPC =IsWithinRadiusTPC(MCPhoton->Eta(),MCPhoton->Phi(),fExclusionRadius);
+        if (fClusterCutsEMC->ClusterIsSelectedAODMC(MCPhoton,fAODMCTrackArray) && isWithinTPC){
+          if(isPrimary){
+            isTruePhoton = kTRUE;
+            if(photon->IsLargestComponentElectron() && photon->IsConversion()){
+              truePhotonFromConv = kTRUE;
+            } else if(photon->IsLargestComponentPhoton()){
+              truePhotonNormal = kTRUE;
+            }
 
-         // check for proper label, in case of conversion return photon label,otherwise do nothing
-         Int_t tmplabel = GetProperLabel(MCPhoton);
-         if(tmplabel != -99) photonlabel = tmplabel;
-         MCPhoton = (AliAODMCParticle*) fAODMCTrackArray->At(photonlabel);
+          }
+        }
+
+        //  // check for proper label, in case of conversion return photon label,otherwise do nothing
+        //  Int_t tmplabel = GetProperLabel(MCPhoton);
+        //  if(tmplabel != -99) photonlabel = tmplabel;
+        //  MCPhoton = (AliAODMCParticle*) fAODMCTrackArray->At(photonlabel);
 
          isDecay = IsDecayPhoton(photonlabel);
          isPrompt = IsPromptPhoton(photonlabel);
@@ -5532,10 +5650,10 @@ void AliAnalysisTaskGammaIsoTree::FillCaloTree(AliAODCaloCluster* clus,AliAODCon
                       
 
   // Do recalculation for V2 clusterizer in 5x5 window
-        GetCaloUtils()->GetEMCALRecoUtils()->RecalculateClusterShowerShapeParametersNxNCells
-      (fGeomEMCAL, cells, clus,
-       onlyNeighbours, cellDiff, cellEcut, 1000000,
-       energy5x5, nMaxima5x5, m02_5x5, m20_5x5, dispp, dEta, dPhi, sEta, sPhi, sEtaPhi);
+  GetCaloUtils()->GetEMCALRecoUtils()->RecalculateClusterShowerShapeParametersNxNCells
+(fGeomEMCAL, cells, clus,
+  onlyNeighbours, cellDiff, cellEcut, 1000000,
+  energy5x5, nMaxima5x5, m02_5x5, m20_5x5, dispp, dEta, dPhi, sEta, sPhi, sEtaPhi);
 
   cellDiff = 3;
   Int_t   nMaxima7x7 = 0; // output: number of local maxima on NxN region
@@ -5544,10 +5662,10 @@ void AliAnalysisTaskGammaIsoTree::FillCaloTree(AliAODCaloCluster* clus,AliAODCon
   Float_t energy7x7 = 0; // output: sum of energy in NxN region
   
   // Do recalculation for V2 clusterizer in 7x7 window
-        GetCaloUtils()->GetEMCALRecoUtils()->RecalculateClusterShowerShapeParametersNxNCells
-      (fGeomEMCAL, cells, clus,
-       onlyNeighbours, cellDiff, cellEcut, 1000000,
-       energy7x7, nMaxima7x7, m02_7x7, m20_7x7, dispp, dEta, dPhi, sEta, sPhi, sEtaPhi);
+    GetCaloUtils()->GetEMCALRecoUtils()->RecalculateClusterShowerShapeParametersNxNCells
+  (fGeomEMCAL, cells, clus,
+    onlyNeighbours, cellDiff, cellEcut, 1000000,
+    energy7x7, nMaxima7x7, m02_7x7, m20_7x7, dispp, dEta, dPhi, sEta, sPhi, sEtaPhi);
 
   // ────────────────────────────────────────────────────────────────────────────────
    // get Max cell ID to get SM number
@@ -5601,6 +5719,13 @@ void AliAnalysisTaskGammaIsoTree::FillCaloTree(AliAODCaloCluster* clus,AliAODCon
   if(clusSub1)         delete clusSub1;
   if(clusSub2)         delete clusSub2;
 
+  TLorentzVector clusterVector;
+  clus->GetMomentum(clusterVector,vertex);
+
+  // TLorentzVector* tmpvec = new TLorentzVector();
+  // tmpvec->SetPxPyPzE(clusterVector.Px(),clusterVector.Py(),clusterVector.Pz(),clusterVector.E());
+  // printf("PhotonPt= %1.4f \t ClusterPt=%1.4f \n",photon->Pt(),tmpvec->Pt());
+  // delete tmpvec;
 
   Double_t clusPx = photon->Px();
   Double_t clusPy = photon->Py();
@@ -5609,8 +5734,9 @@ void AliAnalysisTaskGammaIsoTree::FillCaloTree(AliAODCaloCluster* clus,AliAODCon
   Double_t clusM02 = m02;
   Double_t clusM20 = m20;
   Double_t clusV1SplitMass = mass;
-  Double_t clusterIsoCharged = isoCharged.isolationCone.at(0);
+ // Double_t clusterIsoCharged = isoCharged.isolationCone.at(0);
   Double_t clusterIsoChargedLeft = isoCharged.backgroundLeft.at(2);
+  Double_t clusterIsoChargedRight = isoCharged.backgroundRight.at(2);
 
   //cout << "IsoCharged =" << isoCharged.isolationCone.at(0) << endl;
   
@@ -5640,7 +5766,7 @@ void AliAnalysisTaskGammaIsoTree::FillCaloTree(AliAODCaloCluster* clus,AliAODCon
   fBuffer_ClusterIsoCharged1.push_back(isoCharged.isolationCone.at(0));
   if(isoCharged.isolationCone.size()>1) fBuffer_ClusterIsoCharged2.push_back(isoCharged.isolationCone.at(1));
   if(isoCharged.isolationCone.size()>2) fBuffer_ClusterIsoCharged3.push_back(isoCharged.isolationCone.at(2));
-  fBuffer_ClusterIsoBckLeft.push_back(clusterIsoChargedLeft);
+  fBuffer_ClusterIsoBckPerp.push_back(clusterIsoChargedLeft+clusterIsoChargedRight);
 
   fBuffer_ClusterMatchTrackdEta.push_back(trackdEta); 
   fBuffer_ClusterMatchTrackdPhi.push_back(trackdPhi); 
@@ -5668,6 +5794,13 @@ void AliAnalysisTaskGammaIsoTree::FillCaloTree(AliAODCaloCluster* clus,AliAODCon
       Int_t tag = GetMCAnalysisUtils()->CheckOrigin(photonlabel, fMCEvent,headerName,1.);
       trueClusterIsSignal = tag;
       trueClusterIsConv = truePhotonFromConv;
+      if((m02<=0.5) && (m02>=0.1)){
+        fCaloTruePhotonPt->Fill(MCPhoton->Pt(),fWeightJetJetMC);
+        fCaloTruePhotonOldPt->Fill(MCPhotonOld->Pt(),fWeightJetJetMC);
+        fCaloTruePhotonRecPt->Fill(photon->Pt(),fWeightJetJetMC);
+        fCaloTruePhotonRecPtVsTruePt->Fill(MCPhoton->Pt(),photon->Pt(),fWeightJetJetMC);
+      }
+      
     }
     fBuffer_TrueClusterE.push_back(trueClusterE);
     fBuffer_TrueClusterPx.push_back(trueClusterPx);

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaIsoTree.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaIsoTree.h
@@ -471,6 +471,13 @@ class AliAnalysisTaskGammaIsoTree : public AliAnalysisTaskSE{
     // ─── CALO HISTOS ─────────────────────────────────────────────────
     //
     TH1F*                       fCaloPt;//!
+    TH1F*                       fTrackPt;//!
+    TH1F*                       fTrackEta;//!
+    TH1F*                       fTrackPhi;//!
+    TH1F*                       fTrackPtHybridOnlyPosID;//!
+    TH1F*                       fTrackEtaHybridOnlyPosID;//!
+    TH1F*                       fTrackPhiHybridOnlyPosID;//!
+
     TH1F*                       fCaloPtBeforeAcc;//!
 
     TH1F*                       fCaloE;//!
@@ -488,6 +495,12 @@ class AliAnalysisTaskGammaIsoTree : public AliAnalysisTaskSE{
     TH2F*                       fCaloRhoTimesAreaLeft[5]; //!
     TH2F*                       fCaloRhoTimesAreaRight[5]; //!
     TH2F*                       fCaloRhoTimesAreaBack[5]; //!
+    // true for QA (always stored)
+    TH1F*                       fCaloTruePhotonPt; //!
+    TH1F*                       fCaloTruePhotonOldPt; //!
+    TH1F*                       fCaloTruePhotonRecPt; //!
+    TH2F*                       fCaloTruePhotonRecPtVsTruePt; //!
+    
     // True conv histos
     TH1F*                       fCaloTruePt; //!
     TH1F*                       fCaloTruePtNotProper; //!
@@ -639,6 +652,11 @@ class AliAnalysisTaskGammaIsoTree : public AliAnalysisTaskSE{
     //
 
     TH1I*                       fHistoMCHeaders;                                      //! array of histos for header names
+    
+    // always on (QA)
+    TH1F*                       fGenPtTruePhoton;//!
+
+    // normal hists
     TH1F*                       fGenPhotonPt;//!
     TH1F*                       fGenPhotonPt_FromDecay;//!
     TH1F*                       fGenPhotonPt_FromDirect;//!
@@ -694,7 +712,9 @@ class AliAnalysisTaskGammaIsoTree : public AliAnalysisTaskSE{
     Double_t fBuffer_EventWeight; //
     Float_t fBuffer_EventXsection; //
     UShort_t fBuffer_EventNtrials; //
+    UShort_t fBuffer_EventNPrimaryTracks; //
     Bool_t fBuffer_EventIsTriggered; //
+
     std::vector<Float_t> fBuffer_ClusterE;     //!<! array buffer
     std::vector<Float_t> fBuffer_ClusterPx;     //!<! array buffer
     std::vector<Float_t> fBuffer_ClusterPy;     //!<! array buffer
@@ -709,7 +729,7 @@ class AliAnalysisTaskGammaIsoTree : public AliAnalysisTaskSE{
     std::vector<Float_t> fBuffer_ClusterIsoCharged1; // isolation for three different radii 
     std::vector<Float_t> fBuffer_ClusterIsoCharged2; 
     std::vector<Float_t> fBuffer_ClusterIsoCharged3; 
-    std::vector<Float_t> fBuffer_ClusterIsoBckLeft; 
+    std::vector<Float_t> fBuffer_ClusterIsoBckPerp; 
     std::vector<Float_t> fBuffer_ClusterMatchTrackdEta; 
     std::vector<Float_t> fBuffer_ClusterMatchTrackdPhi; 
     std::vector<Float_t> fBuffer_ClusterMatchTrackP; 
@@ -734,7 +754,7 @@ class AliAnalysisTaskGammaIsoTree : public AliAnalysisTaskSE{
     std::vector<Float_t> fBuffer_GenPhotonMCIsoCharged1;
     std::vector<Float_t> fBuffer_GenPhotonMCIsoCharged2;
     std::vector<Float_t> fBuffer_GenPhotonMCIsoCharged3;
-    std::vector<Float_t> fBuffer_GenPhotonMCIsoBckLeft;
+    std::vector<Float_t> fBuffer_GenPhotonMCIsoBckPerp;
     std::vector<Bool_t> fBuffer_GenPhotonIsConv;
     std::vector<Int_t> fBuffer_GenPhotonMCTag;
 
@@ -751,7 +771,7 @@ class AliAnalysisTaskGammaIsoTree : public AliAnalysisTaskSE{
     void ProcessMCConversionPhoton(AliAODConversionPhoton* photon,vector<Double32_t> isoCharged,vector<Double32_t> isoNeutral,vector<Double32_t> isoCell,Int_t tmptag);
     void ProcessMCCaloPhoton(AliAODCaloCluster* clus,AliAODConversionPhoton* photon,vector<Double32_t> isoCharged,vector<Double32_t> isoNeutral,vector<Double32_t> isoCell,Int_t tmptag, Double_t weight);
     void ProcessCaloPhotons();
-    Bool_t TrackIsSelectedAOD(AliAODTrack* lTrack);
+    Bool_t TrackIsSelectedAOD(AliAODTrack* lTrack,  Bool_t requirePosID);
     void ProcessTracks();
     void ProcessMCParticles();
     Int_t ProcessTrackMatching(AliAODCaloCluster* clus, TList* tracks);
@@ -790,7 +810,7 @@ class AliAnalysisTaskGammaIsoTree : public AliAnalysisTaskSE{
     Int_t GetProperLabel(AliAODMCParticle* mcpart);
     AliAnalysisTaskGammaIsoTree(const AliAnalysisTaskGammaIsoTree&); // Prevent copy-construction
     AliAnalysisTaskGammaIsoTree& operator=(const AliAnalysisTaskGammaIsoTree&); // Prevent assignment  
-    ClassDef(AliAnalysisTaskGammaIsoTree, 35);
+    ClassDef(AliAnalysisTaskGammaIsoTree, 36);
 
 };
 

--- a/PWGGA/GammaConv/macros/AddTask_GammaIsoTree.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaIsoTree.C
@@ -20,6 +20,7 @@ void AddTask_GammaIsoTree(
   TString   fileNameExternalInputs        = "",
   Double_t  genPtCut                      = 0, // only save particles from stack with gen pt > genPtCut
   Double_t  recPtCut                      = 0, // only save clusters with rec pt > recPtCut
+  TString   additionalFileEnding          = "",
   TString   additionalTrainConfig         = "0"       // additional counter for trainconfig
   ){
 
@@ -80,56 +81,62 @@ void AddTask_GammaIsoTree(
   Double_t                    fYMCCut = 9999;  
 
   Double_t                    fAntiIsolation[2] = {5.,10};
-  if(trainConfig == 1){ 
+  if(trainConfig == 1){  // min bias (cuts from PCMEMC 84 + loose iso)
       TaskEventCutnumber                = "00010113";
-      TaskClusterCutnumberEMC           = "1111132060032230000";
-      TaskClusterCutnumberIsolationEMC = "1111100060022700000";
-      TaskClusterCutnumberTaggingEMC = "1111100060022700000";
-      TaskClusterCutnumberPHOS          = "2444411044013300000";
-      TaskConvCutnumber                 = "0dm00009f9730000dge0404000";
-  } else if(trainConfig == 2){ 
-      TaskEventCutnumber                = "00052113";
-      TaskClusterCutnumberEMC           = "1111132060032230000";
-      TaskClusterCutnumberIsolationEMC = "1111100060022700000";
-      TaskClusterCutnumberTaggingEMC = "1111100060022700000";
-      TaskClusterCutnumberPHOS          = "2444411044013300000";
-      TaskConvCutnumber                 = "0dm00009f9730000dge0404000";
-  } else if(trainConfig == 3){ 
-      TaskEventCutnumber                = "00081113";
-      TaskClusterCutnumberEMC           = "1111132010032230000";
-      TaskClusterCutnumberIsolationEMC = "1111100060022700000";
-      TaskClusterCutnumberTaggingEMC = "1111100060022700000";
-      TaskClusterCutnumberPHOS          = "2444411044013300000";
-      TaskConvCutnumber                 = "0dm00009f9730000dge0404000";
-
-  } else if(trainConfig == 4){  // min bias loose cluster cuts
-      TaskEventCutnumber                = "00010113";
-      TaskClusterCutnumberEMC           = "111113200f000000000";
-      TaskClusterCutnumberIsolationEMC  = "111113206f022700000";
+      TaskClusterCutnumberEMC           = "1111132060032000000";
+      TaskTMCut = TaskClusterCutnumberEMC.Data();
+      TaskTMCut.Replace(9,1,"5");
+      TaskClusterCutnumberIsolationEMC  = "111113206f022000000";
       TaskClusterCutnumberTaggingEMC    = "111113206f000000000";
       TaskClusterCutnumberPHOS          = "2444411044013300000";
       TaskConvCutnumber                 = "0dm00009f9730000dge0404000";
 
+      minSignalM02 = 0.1;
+      maxSignalM02 = 0.5;
+
       backgroundTrackMatching = kFALSE; // obsolete
-      doNeutralIso = kTRUE;
+      doNeutralIso = kFALSE;
       doChargedIso = kTRUE;
-      doTagging = kTRUE;
-      doCellIso = kTRUE;
-  } else if(trainConfig == 5){  // min bias loose cluster cuts
-      TaskEventCutnumber                = "00052103";
-      TaskClusterCutnumberEMC           = "111113200f000000000";
-      TaskClusterCutnumberIsolationEMC = "111113206f022700000";
-      TaskClusterCutnumberTaggingEMC = "111113206f022700000";
+      doTagging = kFALSE;
+      doCellIso = kFALSE;
+  } else if(trainConfig == 2){  // trigger
+      TaskEventCutnumber                = "00052113";
+      TaskClusterCutnumberEMC           = "1111132060032000000";
+      TaskTMCut = TaskClusterCutnumberEMC.Data();
+      TaskTMCut.Replace(9,1,"5");
+      TaskClusterCutnumberIsolationEMC  = "111113206f022000000";
+      TaskClusterCutnumberTaggingEMC    = "111113206f000000000";
       TaskClusterCutnumberPHOS          = "2444411044013300000";
       TaskConvCutnumber                 = "0dm00009f9730000dge0404000";
 
-      backgroundTrackMatching = kFALSE; // obsolete
-      doNeutralIso = kTRUE;
-      doChargedIso = kTRUE;
-      doTagging = kTRUE;
-      doCellIso = kTRUE;
+      minSignalM02 = 0.1;
+      maxSignalM02 = 0.5;
 
-  // cut based study
+      backgroundTrackMatching = kFALSE; // obsolete
+      doNeutralIso = kFALSE;
+      doChargedIso = kTRUE;
+      doTagging = kFALSE;
+      doCellIso = kFALSE;
+  } else if(trainConfig == 3){  // trigger
+      TaskEventCutnumber                = "00081113";
+      TaskClusterCutnumberEMC           = "1111132060032000000";
+      TaskTMCut = TaskClusterCutnumberEMC.Data();
+      TaskTMCut.Replace(9,1,"5");
+      TaskClusterCutnumberIsolationEMC  = "111113206f022000000";
+      TaskClusterCutnumberTaggingEMC    = "111113206f000000000";
+      TaskClusterCutnumberPHOS          = "2444411044013300000";
+      TaskConvCutnumber                 = "0dm00009f9730000dge0404000";
+
+      minSignalM02 = 0.1;
+      maxSignalM02 = 0.5;
+
+      backgroundTrackMatching = kFALSE; // obsolete
+      doNeutralIso = kFALSE;
+      doChargedIso = kTRUE;
+      doTagging = kFALSE;
+      doCellIso = kFALSE;
+
+  // DEFAULT
   } else if(trainConfig == 6){  // min bias (cuts from PCMEMC 84 + loose iso)
       TaskEventCutnumber                = "00010103";
       TaskClusterCutnumberEMC           = "1111132060032000000";
@@ -168,6 +175,27 @@ void AddTask_GammaIsoTree(
       doCellIso = kFALSE;
   } else if(trainConfig == 8){  // trigger
       TaskEventCutnumber                = "00081103";
+      TaskClusterCutnumberEMC           = "1111132060032000000";
+      TaskTMCut = TaskClusterCutnumberEMC.Data();
+      TaskTMCut.Replace(9,1,"5");
+      TaskClusterCutnumberIsolationEMC  = "111113206f022000000";
+      TaskClusterCutnumberTaggingEMC    = "111113206f000000000";
+      TaskClusterCutnumberPHOS          = "2444411044013300000";
+      TaskConvCutnumber                 = "0dm00009f9730000dge0404000";
+
+      minSignalM02 = 0.1;
+      maxSignalM02 = 0.5;
+
+      backgroundTrackMatching = kFALSE; // obsolete
+      doNeutralIso = kFALSE;
+      doChargedIso = kTRUE;
+      doTagging = kFALSE;
+      doCellIso = kFALSE;
+
+  // END OF DEFAULT
+    // TEST TO CHECK INFLUENCE ON ORDERING
+  } else if(trainConfig == 9){  // min bias (cuts from PCMEMC 84 + loose iso)
+      TaskEventCutnumber                = "00010103";
       TaskClusterCutnumberEMC           = "1111132060032000000";
       TaskTMCut = TaskClusterCutnumberEMC.Data();
       TaskTMCut.Replace(9,1,"5");
@@ -757,24 +785,28 @@ void AddTask_GammaIsoTree(
   AliAnalysisDataContainer *coutput = NULL;
   AliAnalysisDataContainer *histos = NULL;
 
+  if(additionalFileEnding.CompareTo("")!=0){
+     additionalFileEnding = Form("_%s",additionalFileEnding.Data());
+  }
+
   if(corrTaskSetting.CompareTo("")){
     coutput =mgr->CreateContainer( Form("GammaIsoTree_%d_%s",trainConfig,corrTaskSetting.Data()),
                                                               TTree::Class(),
                                                               AliAnalysisManager::kOutputContainer,
-                                                              Form("GammaIsoTree_%d.root",trainConfig));
+                                                              Form("GammaIsoTree_%d%s.root",trainConfig,additionalFileEnding.Data()));
     histos = mgr->CreateContainer( Form("GammaIsoTree_histos_%d_%s",trainConfig,corrTaskSetting.Data()),
                                                               TList::Class(),
                                                               AliAnalysisManager::kOutputContainer,
-                                                              Form("GammaIsoTree_histos_%d.root",trainConfig));
+                                                              Form("GammaIsoTree_histos_%d%s.root",trainConfig,additionalFileEnding.Data()));
   } else{
     coutput =mgr->CreateContainer( Form("GammaIsoTree_%d",trainConfig),
                                                               TTree::Class(),
                                                               AliAnalysisManager::kOutputContainer,
-                                                              Form("GammaIsoTree_%d.root",trainConfig));
+                                                              Form("GammaIsoTree_%d%s.root",trainConfig,additionalFileEnding.Data()));
     histos = mgr->CreateContainer( Form("GammaIsoTree_histos_%d",trainConfig),
                                                               TList::Class(),
                                                               AliAnalysisManager::kOutputContainer,
-                                                              Form("GammaIsoTree_histos_%d.root",trainConfig));
+                                                              Form("GammaIsoTree_histos_%d%s.root",trainConfig,additionalFileEnding.Data()));
    
   }
   


### PR DESCRIPTION
- fixed loading of clusters which previously caused memory problems when running over multiple train configs in one train
- added trackingQA histos to check pPb with partial TPC coverage
- added primary track multiplicity to tree to study efficiency
- changed perp cone to include left _and_ right side in phi (previously only left), area is now 2xcone