### PR TITLE
PWG/EMCAL: Adding correction component for low energetic clusters

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliClusterContainer.h
+++ b/PWG/EMCAL/EMCALbase/AliClusterContainer.h
@@ -39,7 +39,7 @@ class AliClusterContainer : public AliEmcalContainer {
   static const std::map <std::string, VCluUserDefEnergy_t> fgkClusterEnergyTypeMap; //!<!
 
   AliClusterContainer();
-  AliClusterContainer(const char *name); 
+  AliClusterContainer(const char *name);
   virtual ~AliClusterContainer(){;}
 
   virtual TObject *operator[] (int index) const { return GetCluster(index); }
@@ -49,6 +49,7 @@ class AliClusterContainer : public AliEmcalContainer {
   virtual Bool_t              AcceptCluster(Int_t i, UInt_t &rejectionReason)                 const;
   virtual Bool_t              AcceptCluster(const AliVCluster* vp, UInt_t &rejectionReason)   const;
   virtual Bool_t              ApplyClusterCuts(const AliVCluster* clus, UInt_t &rejectionReason) const;
+  virtual Bool_t              GetPassedSpecialNCell(const AliVCluster* clus) const;
   AliVCluster                *GetAcceptCluster(Int_t i)              const;
   AliVCluster                *GetAcceptClusterWithLabel(Int_t lab)   const;
   void                        SetClusECut(Double_t cut)                    { SetMinE(cut)     ; }
@@ -79,6 +80,7 @@ class AliClusterContainer : public AliEmcalContainer {
   void 						            SetEmcalM02Range(Double_t min, Double_t max) { fEmcalMinM02 = min; fEmcalMaxM02 = max; }
   void                        SetEmcalMaxM02Energy(Double_t max)           { fEmcalMaxM02CutEnergy = max; }
   void                        SetMaxFractionEnergyLeadingCell(Double_t max)  { fMaxFracEnergyLeadingCell = max; }
+  void                        SetEmcalMaxNCellEfficiencyEnergy(Double_t max) { fEmcalMaxNCellEffCutEnergy = max; }
   void                        SetArray(const AliVEvent * event);
   void                        SetClusUserDefEnergyCut(Int_t t, Double_t cut);
   Double_t                    GetClusUserDefEnergyCut(Int_t t) const;
@@ -113,7 +115,7 @@ class AliClusterContainer : public AliEmcalContainer {
    */
   virtual TString             GetDefaultArrayName(const AliVEvent * const ev) const;
 
-  
+
 #if !(defined(__CINT__) || defined(__MAKECINT__))
   static AliEmcalContainerIndexMap <TClonesArray, AliVCluster> fgEmcalContainerIndexMap; //!<! Mapping from containers to indices
 #endif
@@ -132,13 +134,14 @@ class AliClusterContainer : public AliEmcalContainer {
   Double_t 		     fEmcalMaxM02;				   ///< max value of M02 for EMCAL clusters
   Double_t         fEmcalMaxM02CutEnergy;       ///< max EMCal cluster energy for which to apply M02 cut
   Double_t         fMaxFracEnergyLeadingCell;   ///< max fraction of energy in the leading cell
+  Double_t         fEmcalMaxNCellEffCutEnergy;  ///< maximum energy that a 1 cell cluster can have to be considered for NCell efficiency
 
  private:
   AliClusterContainer(const AliClusterContainer& obj); // copy constructor
   AliClusterContainer& operator=(const AliClusterContainer& other); // assignment
 
   /// \cond CLASSIMP
-  ClassDef(AliClusterContainer,12);
+  ClassDef(AliClusterContainer,13);
   /// \endcond
 };
 
@@ -154,4 +157,3 @@ class AliClusterContainer : public AliEmcalContainer {
 int TestClusterContainerIterator(const AliClusterContainer *const cont, int iteratorType = 0, bool verbose = false);
 
 #endif
-

--- a/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.cxx
@@ -1640,9 +1640,14 @@ void AliEMCALRecoUtils::InitNCellEfficiencyParam()
     fNCellEfficiencyParams[0] = 0.213184;
     fNCellEfficiencyParams[1] = -0.0580118;
   }
-
+  else if (fNCellEfficiencyFunction == kNCeGammaAndElec) {
+    fNCellEfficiencyParams[0] = 0.0901375;
+    fNCellEfficiencyParams[1] = 1.28118;
+    fNCellEfficiencyParams[2] = 0.583403;
+  }
 
 }
+
 ///
 /// Artificially widen 1 cell cluster in the MC
 /// Still in testing at this point. Recommended setting:
@@ -1683,22 +1688,43 @@ Bool_t AliEMCALRecoUtils::GetIsNCellCorrected(AliVCluster* cluster, AliVCaloCell
   {
     case kNCeAllClusters:
     {
+      // based on all clusters in data and MC
+      // data clusters influenced by exotics above 2 GeV
       // fNCellEfficiencyParams[0] = 2.71596e-01;
       // fNCellEfficiencyParams[1] = 1.80393;
       // fNCellEfficiencyParams[2] = 6.50026e-01;
       Float_t val = fNCellEfficiencyParams[0]*exp(
                     -0.5*((energy-fNCellEfficiencyParams[1])/fNCellEfficiencyParams[2])*
                     ((energy-fNCellEfficiencyParams[1])/fNCellEfficiencyParams[2]));
-      if(val < randNr) return kTRUE;
+      if(randNr < val) return kTRUE;
       else return kFALSE;
       break;
     }
+
     case kNCeTestBeam:
     {
+      // based on test beam measurements
+      // should behave like pure photon clusters
       // fNCellEfficiencyParams[0] = 0.213184;
       // fNCellEfficiencyParams[1] = -0.0580118;
       Float_t val = fNCellEfficiencyParams[0] + fNCellEfficiencyParams[1]*energy;
-      if(val < randNr) return kTRUE;
+      if(randNr < val) return kTRUE;
+      else return kFALSE;
+      break;
+    }
+
+    case kNCeGammaAndElec:
+    {
+      // based on clusters which are part of a cluster pair with a mass of: [M(Pi0) - 0.05;M(Pi0) + 0.02]
+      // mostly photon clusters and electron(conversion) clusters (purity about 95%)
+      // exotics should be nearly cancled by that
+      // fNCellEfficiencyParams[0] = 0.0901375;
+      // fNCellEfficiencyParams[1] = 1.28118;
+      // fNCellEfficiencyParams[2] = 0.583403;
+      Float_t val = fNCellEfficiencyParams[0]*exp(
+                    -0.5*((energy-fNCellEfficiencyParams[1])/fNCellEfficiencyParams[2])*
+                    ((energy-fNCellEfficiencyParams[1])/fNCellEfficiencyParams[2]));
+      if(randNr < val) return kTRUE;
       else return kFALSE;
       break;
     }

--- a/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.cxx
@@ -54,6 +54,7 @@ AliEMCALRecoUtils::AliEMCALRecoUtils():
   fW0(0),                                 fShowerShapeCellLocationType(0),
   fNonLinearityFunction(0),               fNonLinearThreshold(0),                 fUseShaperNonlin(kFALSE),
   fSmearClusterEnergy(kFALSE),            fRandom(),
+  fNCellEfficiencyFunction(0),
   fCellsRecalibrated(kFALSE),             fRecalibration(kFALSE),                 fUse1Drecalib(kFALSE),                  fEMCALRecalibrationFactors(),
   fCellsSingleChannelRecalibrated(kFALSE),fSingleChannelRecalibration(kFALSE),    fEMCALSingleChannelRecalibrationFactors(nullptr),
   fConstantTimeShift(0),                  fTimeRecalibration(kFALSE),             fEMCALTimeRecalibrationFactors(nullptr),       fLowGain(kFALSE),
@@ -108,6 +109,7 @@ AliEMCALRecoUtils::AliEMCALRecoUtils(const AliEMCALRecoUtils & reco)
   fNonLinearityFunction(reco.fNonLinearityFunction),         fNonLinearThreshold(reco.fNonLinearThreshold),
   fUseShaperNonlin(reco.fUseShaperNonlin),
   fSmearClusterEnergy(reco.fSmearClusterEnergy),             fRandom(),
+  fNCellEfficiencyFunction(reco.fNCellEfficiencyFunction),
   fCellsRecalibrated(reco.fCellsRecalibrated),
   fRecalibration(reco.fRecalibration),                       fUse1Drecalib(reco.fUse1Drecalib),
   fEMCALRecalibrationFactors(NULL),
@@ -153,12 +155,13 @@ AliEMCALRecoUtils::AliEMCALRecoUtils(const AliEMCALRecoUtils & reco)
   fCutRequireITSStandAlone(reco.fCutRequireITSStandAlone),   fCutRequireITSpureSA(reco.fCutRequireITSpureSA),
   fNMCGenerToAccept(reco.fNMCGenerToAccept),                 fMCGenerToAcceptForTrack(reco.fMCGenerToAcceptForTrack)
 {
-  for (Int_t i = 0; i < 15 ; i++) { fMisalRotShift[i]      = reco.fMisalRotShift[i]      ;
-                                    fMisalTransShift[i]    = reco.fMisalTransShift[i]    ; }
-  for (Int_t i = 0; i < 10  ; i++){ fNonLinearityParams[i] = reco.fNonLinearityParams[i] ; }
-  for (Int_t i = 0; i < 3  ; i++) { fSmearClusterParam[i]  = reco.fSmearClusterParam[i]  ; }
-  for (Int_t j = 0; j < 5  ; j++) { fMCGenerToAccept[j]    = reco.fMCGenerToAccept[j]    ; }
-  for (Int_t j = 0; j < 4  ; j++) { fBadStatusSelection[j] = reco.fBadStatusSelection[j] ; }
+  for (Int_t i = 0; i < 15 ; i++) { fMisalRotShift[i]         = reco.fMisalRotShift[i]         ;
+                                    fMisalTransShift[i]       = reco.fMisalTransShift[i]       ; }
+  for (Int_t i = 0; i < 10 ; i++) { fNonLinearityParams[i]    = reco.fNonLinearityParams[i]    ; }
+  for (Int_t i = 0; i < 3  ; i++) { fSmearClusterParam[i]     = reco.fSmearClusterParam[i]     ; }
+  for (Int_t i = 0; i < 10 ; i++) { fNCellEfficiencyParams[i] = reco.fNCellEfficiencyParams[i] ; }
+  for (Int_t j = 0; j < 5  ; j++) { fMCGenerToAccept[j]       = reco.fMCGenerToAccept[j]       ; }
+  for (Int_t j = 0; j < 4  ; j++) { fBadStatusSelection[j]    = reco.fBadStatusSelection[j]    ; }
 
   if(reco.fEMCALBadChannelMap) {
     // Copy constructor - not taking ownership over calibration histograms
@@ -203,6 +206,7 @@ AliEMCALRecoUtils & AliEMCALRecoUtils::operator = (const AliEMCALRecoUtils & rec
     fMisalRotShift[i]      = reco.fMisalRotShift[i]      ; }
   for (Int_t i = 0; i < 10  ; i++) { fNonLinearityParams[i] = reco.fNonLinearityParams[i] ; }
   for (Int_t i = 0; i < 3  ; i++) { fSmearClusterParam[i]  = reco.fSmearClusterParam[i]  ; }
+  for (Int_t i = 0; i < 10  ; i++) { fNCellEfficiencyParams[i] = reco.fNCellEfficiencyParams[i] ; }
 
   fParticleType              = reco.fParticleType;
   fPosAlgo                   = reco.fPosAlgo;
@@ -213,6 +217,7 @@ AliEMCALRecoUtils & AliEMCALRecoUtils::operator = (const AliEMCALRecoUtils & rec
   fNonLinearThreshold        = reco.fNonLinearThreshold;
   fUseShaperNonlin           = reco.fUseShaperNonlin;
   fSmearClusterEnergy        = reco.fSmearClusterEnergy;
+  fNCellEfficiencyFunction   = reco.fNCellEfficiencyFunction;
 
   fCellsRecalibrated         = reco.fCellsRecalibrated;
   fRecalibration             = reco.fRecalibration;
@@ -455,7 +460,7 @@ Bool_t AliEMCALRecoUtils::AcceptCalibrateCell(Int_t absID, Int_t bc,
   // Recalibrate time
   time = cells->GetCellTime(absID);
 
-  if (IsTimeECorrectionOn()) 
+  if (IsTimeECorrectionOn())
     CorrectCellTimeVsE(amp, time, isLowGain);
   time-=fConstantTimeShift*1e-9; // only in case of old Run1 simulation
 
@@ -699,6 +704,89 @@ Float_t AliEMCALRecoUtils::GetECross(Int_t absID, Double_t tcell,
   if ( ecell4 < cellMinEn || w4 <= 0 ) ecell4 = 0 ;
 
   return ecell1+ecell2+ecell3+ecell4;
+}
+
+
+///
+/// Check if a cell is next to a cluster. Only the 4 direct neighboring cells are considered
+/// Used in number of cell efficiency calculation.
+/// cells that are directly next to a cluster are not considered for this correction
+/// very similar to function GetECross
+///
+/// \param absID: controlled cell absolute ID number
+/// \param Ethresh: aggregation threshold
+/// \param cells: full list of cells
+///
+/// \return true if the cell is next to a cell  above the aggregation threshold
+///
+//___________________________________________________________________________
+Bool_t AliEMCALRecoUtils::IsCellNextToCluster(Int_t absID, Float_t eThresh, AliVCaloCells* cells, Int_t bc){
+
+  AliEMCALGeometry * geom = AliEMCALGeometry::GetInstance();
+
+  if(!geom)
+  {
+    AliError("No instance of the geometry is available");
+    return -1;
+  }
+
+  Int_t imod = -1, iphi =-1, ieta=-1,iTower = -1, iIphi = -1, iIeta = -1;
+  geom->GetCellIndex(absID,imod,iTower,iIphi,iIeta);
+  geom->GetCellPhiEtaIndexInSModule(imod,iTower,iIphi, iIeta,iphi,ieta);
+
+  // Get close cells index, energy and time, not in corners
+
+  Int_t absID1 = -1;
+  Int_t absID2 = -1;
+
+  if ( iphi < AliEMCALGeoParams::fgkEMCALRows-1) absID1 = geom->GetAbsCellIdFromCellIndexes(imod, iphi+1, ieta);
+  if ( iphi > 0 )                                absID2 = geom->GetAbsCellIdFromCellIndexes(imod, iphi-1, ieta);
+
+  // check the first two cells
+  Float_t  ecell1  = 0, ecell2  = 0;
+  Double_t tcell1  = 0, tcell2  = 0;
+
+  AcceptCalibrateCell(absID1,bc, ecell1,tcell1,cells);
+  AcceptCalibrateCell(absID2,bc, ecell2,tcell2,cells);
+
+  if(ecell1 > eThresh) return kTRUE;
+  if(ecell2 > eThresh) return kTRUE;
+
+  // In case of cell in eta = 0 border, depending on SM shift the cross cell index
+
+  Int_t absID3 = -1;
+  Int_t absID4 = -1;
+
+  if ( ieta == AliEMCALGeoParams::fgkEMCALCols-1 && !(imod%2) )
+  {
+    absID3 = geom-> GetAbsCellIdFromCellIndexes(imod+1, iphi, 0);
+    absID4 = geom-> GetAbsCellIdFromCellIndexes(imod,   iphi, ieta-1);
+  }
+  else if ( ieta == 0 && imod%2 )
+  {
+    absID3 = geom-> GetAbsCellIdFromCellIndexes(imod,   iphi, ieta+1);
+    absID4 = geom-> GetAbsCellIdFromCellIndexes(imod-1, iphi, AliEMCALGeoParams::fgkEMCALCols-1);
+  }
+  else
+  {
+    if ( ieta < AliEMCALGeoParams::fgkEMCALCols-1 )
+      absID3 = geom-> GetAbsCellIdFromCellIndexes(imod, iphi, ieta+1);
+    if ( ieta > 0 )
+      absID4 = geom-> GetAbsCellIdFromCellIndexes(imod, iphi, ieta-1);
+  }
+
+
+  Float_t  ecell3  = 0, ecell4  = 0;
+  Double_t tcell3  = 0, tcell4  = 0;
+
+  AcceptCalibrateCell(absID3,bc, ecell3,tcell3,cells);
+  AcceptCalibrateCell(absID4,bc, ecell4,tcell4,cells);
+
+  if(ecell1 > eThresh) return kTRUE;
+  if(ecell2 > eThresh) return kTRUE;
+
+  // all 4 neighbours were checked, cell is not next to cluster
+  return kFALSE;
 }
 
 //________________________________________________________________________________________
@@ -1535,6 +1623,90 @@ if (fNonLinearityFunction == kPCMv1) {
  }
 }
 
+
+///
+/// Initialising number of cell efficiency Parameters for the different
+/// parametrizations available, defined in enum NCellEfficiencyFunctions
+///
+//__________________________________________________
+void AliEMCALRecoUtils::InitNCellEfficiencyParam()
+{
+  if (fNCellEfficiencyFunction == kNCeAllClusters) {
+    fNCellEfficiencyParams[0] = 2.71596e-01;
+    fNCellEfficiencyParams[1] = 1.80393;
+    fNCellEfficiencyParams[2] = 6.50026e-01;
+  }
+  else if (fNCellEfficiencyFunction == kNCeTestBeam) {
+    fNCellEfficiencyParams[0] = 0.213184;
+    fNCellEfficiencyParams[1] = -0.0580118;
+  }
+
+
+}
+///
+/// Artificially widen 1 cell cluster in the MC
+/// Still in testing at this point. Recommended setting:
+///
+/// \return true if cluster should be widened
+///
+//____________________________________________________________________________
+Bool_t AliEMCALRecoUtils::GetIsNCellCorrected(AliVCluster* cluster, AliVCaloCells* cells, Bool_t correctNextToClus)
+{
+
+  // cells = (AliVCaloCells*)event->GetEMCALCells();
+
+  if (!cluster)
+  {
+    AliInfo("Cluster pointer null!");
+    return 0;
+  }
+
+  Float_t energy = cluster->E();
+  if (energy < 0.100)
+  {
+    // Clusters with less than 100 MeV or negative are not possible
+    AliInfo(Form("Too low cluster energy for number of cells correction!, E = %f < 0.100 GeV",energy));
+    return 0;
+  }
+  else if(energy > 10.)
+  {
+    AliInfo(Form("Too high cluster energy!, E = %f GeV, do not apply number of cells correction",energy));
+    return 0;
+  }
+
+  if(correctNextToClus){
+    if(IsCellNextToCluster(cluster->GetCellAbsId(0), 0.100 ,cells)) return kFALSE;
+  }
+
+  Float_t randNr = fRandom.Rndm();
+  switch (fNCellEfficiencyFunction)
+  {
+    case kNCeAllClusters:
+    {
+      // fNCellEfficiencyParams[0] = 2.71596e-01;
+      // fNCellEfficiencyParams[1] = 1.80393;
+      // fNCellEfficiencyParams[2] = 6.50026e-01;
+      Float_t val = fNCellEfficiencyParams[0]*exp(
+                    -0.5*((energy-fNCellEfficiencyParams[1])/fNCellEfficiencyParams[2])*
+                    ((energy-fNCellEfficiencyParams[1])/fNCellEfficiencyParams[2]));
+      if(val < randNr) return kTRUE;
+      else return kFALSE;
+      break;
+    }
+    case kNCeTestBeam:
+    {
+      // fNCellEfficiencyParams[0] = 0.213184;
+      // fNCellEfficiencyParams[1] = -0.0580118;
+      Float_t val = fNCellEfficiencyParams[0] + fNCellEfficiencyParams[1]*energy;
+      if(val < randNr) return kTRUE;
+      else return kFALSE;
+      break;
+    }
+  }
+
+  return kFALSE;
+}
+
 ///
 /// Set the type of channels to be declared as bad
 /// \param all  : all cases are bad, default true
@@ -2040,6 +2212,9 @@ void AliEMCALRecoUtils::InitParameters()
   fSmearClusterParam[0] = 0.07; // * sqrt E term
   fSmearClusterParam[1] = 0.00; // * E term
   fSmearClusterParam[2] = 0.00; // constant
+
+  // number of cell efficiency
+  for (Int_t i = 0; i < 10  ; i++) fNCellEfficiencyParams[i] = 0.;
 }
 
 ///
@@ -2313,7 +2488,7 @@ void AliEMCALRecoUtils::RecalibrateClusterEnergy(const AliEMCALGeometry* geom,
   Float_t frac     = 0;
   Int_t   absIdMax = -1;
   Float_t emax    = 0.;
-  
+
   // Loop on the cells, get the cell amplitude and recalibration factor, multiply and and to the new energy
   for (Int_t icell = 0; icell < ncells; icell++){
     absId = index[icell];
@@ -2415,10 +2590,10 @@ Float_t AliEMCALRecoUtils::CorrectShaperNonLin(Float_t Emeas, Float_t EcalibHG)
 
 ///
 /// Correct Slewing for each channel
-/// 
+///
 /// \param energy: cell energy
 /// \param celltime: cell time to be returned calibrated
-/// \param isLowGain: low gain cell 
+/// \param isLowGain: low gain cell
 void AliEMCALRecoUtils::CorrectCellTimeVsE(Double_t energy, Double_t & celltime, Bool_t isLowGain) const
 {
   Double_t offset = 0;        // in ns
@@ -2433,14 +2608,14 @@ void AliEMCALRecoUtils::CorrectCellTimeVsE(Double_t energy, Double_t & celltime,
 }
 
 ///
-/// energy dependent time offset for low gain 
+/// energy dependent time offset for low gain
 /// returns slewing for low gain at certain cell energy
 /// \param energy: cell energy
 ///
 Double_t AliEMCALRecoUtils::GetLowGainSlewing (Double_t energy) const
 {
   Double_t offset = 0;
-  
+
   if (energy > 14 && energy <= 80){
     offset = 2.2048848 - 0.19256571*energy + 0.0034679678*TMath::Power(energy,2) - 1.9102064e-05*TMath::Power(energy,2);
   } else if (energy <= 14) {
@@ -3044,7 +3219,7 @@ void AliEMCALRecoUtils::RecalculateClusterShowerShapeParametersWithCellCuts(cons
         etai=(Double_t)ieta;
         phii=(Double_t)iphi;
       } else if( fShowerShapeCellLocationType == 1 ) {  // Cell angle location
-      
+
         geom->EtaPhiFromIndex(absId, etai, phii);
         etai *= TMath::RadToDeg(); // change units to degrees instead of radians
         phii *= TMath::RadToDeg(); // change units to degrees instead of radians
@@ -3112,7 +3287,7 @@ void AliEMCALRecoUtils::RecalculateClusterShowerShapeParametersWithCellCuts(cons
         etai=(Double_t)ieta;
         phii=(Double_t)iphi;
       } else if( fShowerShapeCellLocationType == 1 ) {  // Cell angle location
-      
+
         geom->EtaPhiFromIndex(absId, etai, phii);
         etai *= TMath::RadToDeg(); // change units to degrees instead of radians
         phii *= TMath::RadToDeg(); // change units to degrees instead of radians
@@ -3201,7 +3376,7 @@ void AliEMCALRecoUtils::RecalculateClusterShowerShapeParametersNxNCells
     AliInfo("Cluster pointer null!");
     return;
   }
-  
+
   Double_t eCell   = 0.;
   Double_t tCell   = 0.;
   Bool_t   shared  = kFALSE;
@@ -3213,7 +3388,7 @@ void AliEMCALRecoUtils::RecalculateClusterShowerShapeParametersNxNCells
   Int_t   iSupModMax = -1;
   Int_t   iphiMax    = -1;
   Int_t   ietaMax    = -1;
-  
+
   Int_t    iSupMod = -1;
   Int_t    iTower  = -1;
   Int_t    iIphi   = -1;
@@ -3222,7 +3397,7 @@ void AliEMCALRecoUtils::RecalculateClusterShowerShapeParametersNxNCells
   Int_t    ieta    = -1;
   Double_t etai    = -1.;
   Double_t phii    = -1.;
-  
+
   Int_t    nstat   = 0 ;
   Float_t  wtot    = 0.;
   Double_t w       = 0.;
@@ -3237,7 +3412,7 @@ void AliEMCALRecoUtils::RecalculateClusterShowerShapeParametersNxNCells
   UShort_t cellsAbsIdNxN[nCellsFix];
   Bool_t   cellsNeighNxN[nCellsFix];
   Float_t  cellsEnerNxN [nCellsFix];
-  
+
   Int_t nCells = 0;
   shared = kFALSE;
   for(Int_t ietadiff = -cellDiff; ietadiff <= cellDiff; ietadiff++)
@@ -3248,33 +3423,33 @@ void AliEMCALRecoUtils::RecalculateClusterShowerShapeParametersNxNCells
       Int_t iSM   = iSupModMax;
 
       iphi = iphiMax+iphidiff;
-      ieta = ietaMax+ietadiff; 
+      ieta = ietaMax+ietadiff;
       if      ( ieta >= 48 && (iSupModMax%2) )
       {
-        iSM    = iSupModMax+1; 
+        iSM    = iSupModMax+1;
         ieta  -= AliEMCALGeoParams::fgkEMCALCols;
-        shared = kTRUE; 
+        shared = kTRUE;
       }
       else if ( ieta <   0 && !(iSupModMax%2) )
-      { 
-        iSM    = iSupModMax-1; 
+      {
+        iSM    = iSupModMax-1;
         ieta  += AliEMCALGeoParams::fgkEMCALCols;
-        shared = kTRUE; 
+        shared = kTRUE;
       }
-      
+
       if ( iphi < 24 && iphi >= 0 &&
            ieta < 48 && ieta >= 0    )
       {
-        absId = geom->GetAbsCellIdFromCellIndexes(iSM, iphi, ieta); 
+        absId = geom->GetAbsCellIdFromCellIndexes(iSM, iphi, ieta);
       }
-      
+
       if ( absId <= 0 )
       {
         //printf("Not found: max  absId %d, sm %d, ieta %d, iphi %d, diff eta %d, diff phi %d\n",
         //       absIdMax,iSupModMax, ietaMax, iphiMax, ietadiff,iphidiff);
         continue;
       }
-      
+
 //        if ( shared )
 //        {
 //          printf("max  sm %d, ieta %d, iphi %d, absId %d\n",iSupModMax, ietaMax, iphiMax, absIdMax);
@@ -3283,14 +3458,14 @@ void AliEMCALRecoUtils::RecalculateClusterShowerShapeParametersNxNCells
 //          geom->GetCellPhiEtaIndexInSModule(iSupMod,iTower,iIphi,iIeta, iphi,ieta);
 //          printf("\t Check: ism %d, ieta %d\n",iSupMod,ieta);
 //        }
-      
+
       eCell  = cells->GetCellAmplitude(absId);
       tCell  = cells->GetCellTime     (absId);
       tCell*=1e9;
       tCell-=fConstantTimeShift;
-      
-      if ( absId >= 0 && 
-          eCell > cellEcut && 
+
+      if ( absId >= 0 &&
+          eCell > cellEcut &&
           TMath::Abs(tCell) < cellTimeCut  )
       {
         energy += eCell;
@@ -3302,24 +3477,24 @@ void AliEMCALRecoUtils::RecalculateClusterShowerShapeParametersNxNCells
         nCells++;
         //printf("Add %d, absId (%d,%d), cell (%f,%f)\n",nCells-1,absId,cellsAbsIdNxN[nCells-1],cellsEnerNxN [nCells-1], eCell);
       }
-      
+
     } // iphidiff
   } // ietadiff
-  
+
   if ( energy < cellEcut ) return;
 
 //  if ( cluster->E() > 10 )
 //  {
 //    printf("Cluster E (%2.2f,%2.2f), ncells (%d,%d), shared %d\n",
 //           cluster->E(), energy, cluster->GetNCells(),nCells, shared);
-//    
+//
 //    for(Int_t icell = 0; icell < cluster->GetNCells(); icell++)
 //    {
 //      Int_t   id = cluster->GetCellAbsId(icell);
 //      Float_t ec = cells->GetCellAmplitude(id);
 //      printf("\t Org cell %d, absId %d en %f\n",icell, id, ec);
 //    }
-//    
+//
 //    for(Int_t icell = 0; icell < nCells; icell++)
 //    {
 //      Int_t   id = cellsAbsIdNxN[icell];
@@ -3327,7 +3502,7 @@ void AliEMCALRecoUtils::RecalculateClusterShowerShapeParametersNxNCells
 //      printf("\t NxN cell %d, absId %d en %f\n",icell, id, ec);
 //    }
 //  }
-  
+
   // Tag the cells neighbour to absIdMax cell
   // and neighobours to those, from inner cells to outer cells
   //
@@ -3454,7 +3629,7 @@ void AliEMCALRecoUtils::RecalculateClusterShowerShapeParametersNxNCells
   l0 = 0;  l1 = 0;
   disp = 0; dEta = 0; dPhi = 0;
   sEta = 0; sPhi = 0; sEtaPhi = 0;
-  
+
   // Loop on cells to calculate weights and shower shape terms parameters
   //
   for (Int_t iDigit=0; iDigit < nCells; iDigit++)
@@ -3463,21 +3638,21 @@ void AliEMCALRecoUtils::RecalculateClusterShowerShapeParametersNxNCells
 
     // Get from the absid the supermodule, tower and eta/phi numbers
     Int_t absId = cellsAbsIdNxN[iDigit];
-    
+
     geom->GetCellIndex(absId,iSupMod,iTower,iIphi,iIeta);
     geom->GetCellPhiEtaIndexInSModule(iSupMod,iTower,iIphi,iIeta, iphi,ieta);
-    
+
     eCell  = cells->GetCellAmplitude(absId);
     tCell  = cells->GetCellTime     (absId);
     tCell*=1e9;
     tCell-=fConstantTimeShift;
-    
+
     // In case of a shared cluster, index of SM in C side, columns start at 48 and ends at 48*2
     // C Side impair SM, nSupMod%2=1; A side pair SM, nSupMod%2=0
     if (shared && iSupMod%2) ieta+=AliEMCALGeoParams::fgkEMCALCols;
-    
+
     w  = GetCellWeight(eCell, energy);
-    
+
     // Cell index
     if     ( fShowerShapeCellLocationType == 0 )
     {
@@ -3494,7 +3669,7 @@ void AliEMCALRecoUtils::RecalculateClusterShowerShapeParametersNxNCells
     else
     {
       geom->GetGlobal(absId,pGlobal);
-      
+
       // Cell x-z location
       if( fShowerShapeCellLocationType == 2 )
       {
@@ -3508,12 +3683,12 @@ void AliEMCALRecoUtils::RecalculateClusterShowerShapeParametersNxNCells
         phii = TMath::Sqrt(pGlobal[0]*pGlobal[0]+pGlobal[1]*pGlobal[1]);
       }
     }
-    
+
     if (w > 0.0)
     {
       wtot += w ;
       nstat++;
-      
+
       // Shower shape
       sEta     += w * etai * etai ;
       etaMean  += w * etai ;
@@ -3525,7 +3700,7 @@ void AliEMCALRecoUtils::RecalculateClusterShowerShapeParametersNxNCells
   } // cell loop
 
   //printf("sEta %f sPhi %f etaMean %f phiMean %f sEtaPhi %f wtot %f\n",sEta,sPhi,etaMean,phiMean,sEtaPhi, wtot);
-  
+
   if ( wtot <= 0 && nstat <= 1)
   {
     l0   = 0. ;
@@ -3535,11 +3710,11 @@ void AliEMCALRecoUtils::RecalculateClusterShowerShapeParametersNxNCells
     AliDebug(2,Form("Wrong weight %f\n", wtot));
     return;
   }
-  
+
   // Normalize to the weight
   etaMean /= wtot ;
   phiMean /= wtot ;
-  
+
   // Loop on cells to calculate dispersion
   for (Int_t iDigit=0; iDigit < nCells; iDigit++)
   {
@@ -3550,7 +3725,7 @@ void AliEMCALRecoUtils::RecalculateClusterShowerShapeParametersNxNCells
 
     geom->GetCellIndex(absId,iSupMod,iTower,iIphi,iIeta);
     geom->GetCellPhiEtaIndexInSModule(iSupMod,iTower,iIphi,iIeta, iphi,ieta);
-    
+
     eCell  = cells->GetCellAmplitude(absId);
     tCell  = cells->GetCellTime     (absId);
     tCell*=1e9;
@@ -3561,7 +3736,7 @@ void AliEMCALRecoUtils::RecalculateClusterShowerShapeParametersNxNCells
     if (shared && iSupMod%2) ieta+=AliEMCALGeoParams::fgkEMCALCols;
 
     w  = GetCellWeight(eCell,energy);
-    
+
     // Cell index
     if     ( fShowerShapeCellLocationType == 0 )
     {
@@ -3578,7 +3753,7 @@ void AliEMCALRecoUtils::RecalculateClusterShowerShapeParametersNxNCells
     else
     {
       geom->GetGlobal(absId,pGlobal);
-      
+
       // Cell x-z location
       if( fShowerShapeCellLocationType == 2 )
       {
@@ -3592,14 +3767,14 @@ void AliEMCALRecoUtils::RecalculateClusterShowerShapeParametersNxNCells
         phii = TMath::Sqrt(pGlobal[0]*pGlobal[0]+pGlobal[1]*pGlobal[1]);
       }
     }
-    
+
     if (w > 0.0)
     {
       disp +=  w *((etai-etaMean)*(etai-etaMean)+(phii-phiMean)*(phii-phiMean));
       dEta +=  w * (etai-etaMean)*(etai-etaMean) ;
       dPhi +=  w * (phii-phiMean)*(phii-phiMean) ;
     }
-    
+
   }// cell loop
 
   // Normalize to the weigth and set shower shape parameters
@@ -3610,11 +3785,11 @@ void AliEMCALRecoUtils::RecalculateClusterShowerShapeParametersNxNCells
   sEta    /= wtot ;
   sPhi    /= wtot ;
   sEtaPhi /= wtot ;
-  
+
   sEta    -= etaMean * etaMean ;
   sPhi    -= phiMean * phiMean ;
   sEtaPhi -= etaMean * phiMean ;
-  
+
   l0 = (0.5 * (sEta + sPhi) + TMath::Sqrt( 0.25 * (sEta - sPhi) * (sEta - sPhi) + sEtaPhi * sEtaPhi ));
   l1 = (0.5 * (sEta + sPhi) - TMath::Sqrt( 0.25 * (sEta - sPhi) * (sEta - sPhi) + sEtaPhi * sEtaPhi ));
 
@@ -4962,6 +5137,10 @@ void AliEMCALRecoUtils::Print(const Option_t *) const
   printf("\tNon linearity function %d, parameters:\n", fNonLinearityFunction);
   if (fNonLinearityFunction != 3) // print only if not kNoCorrection
     for (Int_t i=0; i<10; i++) printf("param[%d]=%f\n",i, fNonLinearityParams[i]);
+
+  printf("\tNCell efficiency function %d, parameters:\n", fNCellEfficiencyFunction);
+  if (fNCellEfficiencyFunction != 0) // print only if not kNoCorrection
+    for (Int_t i=0; i<10; i++) printf("param[%d]=%f\n",i, fNCellEfficiencyParams[i]);
 
   printf("\tPosition Recalculation option %d, Particle Type %d, fW0 %2.2f, Recalibrate Data %d \n",fPosAlgo,fParticleType,fW0, fRecalibration);
 

--- a/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.h
+++ b/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.h
@@ -23,10 +23,10 @@
 /// Plus other helper methods.
 ///
 /// Class derived from AliEMCALRecoUtilsBase since AliRoot tag v5-09-26
-/// The base class just contains few track-matching extrapolation methods used in the 
+/// The base class just contains few track-matching extrapolation methods used in the
 /// EMCAL reconstruction module (AliEMCALTracker and AliEMCALReconstructor) and ANALYSIS ESD to AOD filtering task
 ///
-/// \author:  Gustavo Conesa Balbastre, <Gustavo.Conesa.Balbastre@cern.ch>, LPSC- Grenoble 
+/// \author:  Gustavo Conesa Balbastre, <Gustavo.Conesa.Balbastre@cern.ch>, LPSC- Grenoble
 /// \author:  Rongrong Ma, Yale. Track matching part
 ///
 ///////////////////////////////////////////////////////////////////////////////
@@ -61,22 +61,22 @@ class AliExternalTrackParam;
 class AliVTrack;
 
 class AliEMCALRecoUtils : public AliEMCALRecoUtilsBase {
-  
+
 public:
-  
+
   AliEMCALRecoUtils();
-  AliEMCALRecoUtils(           const AliEMCALRecoUtils&); 
-  AliEMCALRecoUtils& operator=(const AliEMCALRecoUtils&); 
-  virtual ~AliEMCALRecoUtils() ;  
-  
+  AliEMCALRecoUtils(           const AliEMCALRecoUtils&);
+  AliEMCALRecoUtils& operator=(const AliEMCALRecoUtils&);
+  virtual ~AliEMCALRecoUtils() ;
+
   void     InitParameters();
   void     Print(const Option_t*) const;
 
-  /// Non linearity enum list of possible parametrizations. 
+  /// Non linearity enum list of possible parametrizations.
   /// Recomended for data kTestBeamShaper and for simulation kTestBeamFinalMC
   /// (this also requires enableShaperCorrection: true in the .yaml configuration for data)
   enum     NonlinearityFunctions
-  { 
+  {
     kPi0MC   = 0, kPi0GammaGamma = 1,
     kPi0GammaConversion = 2, kNoCorrection = 3,
     kBeamTest= 4, kBeamTestCorrected = 5,
@@ -85,7 +85,7 @@ public:
     kSDMv5   = 9, kPi0MCv5 = 10,
     kSDMv6   =11, kPi0MCv6 = 12,
     kBeamTestCorrectedv3   = 13,
-    kPCMv1 = 14,               // pure symmetric decay muon method 
+    kPCMv1 = 14,               // pure symmetric decay muon method
     kPCMplusBTCv1 = 15,        // kPCMv1 convoluted with kBeamTestCorrectedv3
     kPCMsysv1 = 16,            // variation of kPCMv1 to calculate systematics
     kBeamTestCorrectedv4 = 17, // Different parametrization of v3 but similar, improve E>100 GeV linearity
@@ -95,36 +95,47 @@ public:
     kTestBeamFinalMC = 21      // Final/official fit of all avail. TB points and E>100 GeV MC
   };
 
+  /// NCell efficiency enum list of possible parametrizations.
+  /// Recomended setting:
+  enum     NCellEfficiencyFunctions
+  {
+    kNCeNoCorrection   = 0,
+    kNCeAllClusters   = 1,
+    kNCeGammaAndElec   = 2,
+    kNCeElectrons   = 3,
+    kNCeTestBeam   = 4
+  };
+
   /// Cluster position enum list of possible algoritms
   enum     PositionAlgorithms{kUnchanged=-1,kPosTowerIndex=0, kPosTowerGlobal=1};
-  
+
   /// Track matching, Marcel
-  enum     { kNCuts = 12 }; 
-  
-  /// Track matching cuts enum list 
-  enum     TrackCutsType{ kTPCOnlyCut = 0, kGlobalCut = 1, kLooseCut = 2, kITSStandAlone = 3, 
-                          kGlobalCut2011 = 4, kLooseCutWithITSrefit = 5};  
+  enum     { kNCuts = 12 };
+
+  /// Track matching cuts enum list
+  enum     TrackCutsType{ kTPCOnlyCut = 0, kGlobalCut = 1, kLooseCut = 2, kITSStandAlone = 3,
+                          kGlobalCut2011 = 4, kLooseCutWithITSrefit = 5};
 
   //-----------------------------------------------------
   // Position recalculation
   //-----------------------------------------------------
-  void     RecalculateClusterPosition               (const AliEMCALGeometry *geom, AliVCaloCells* cells, AliVCluster* clu); 
-  void     RecalculateClusterPositionFromTowerIndex (const AliEMCALGeometry *geom, AliVCaloCells* cells, AliVCluster* clu); 
-  void     RecalculateClusterPositionFromTowerGlobal(const AliEMCALGeometry *geom, AliVCaloCells* cells, AliVCluster* clu); 
-  
+  void     RecalculateClusterPosition               (const AliEMCALGeometry *geom, AliVCaloCells* cells, AliVCluster* clu);
+  void     RecalculateClusterPositionFromTowerIndex (const AliEMCALGeometry *geom, AliVCaloCells* cells, AliVCluster* clu);
+  void     RecalculateClusterPositionFromTowerGlobal(const AliEMCALGeometry *geom, AliVCaloCells* cells, AliVCluster* clu);
+
   Float_t  GetCellWeight(Float_t eCell, Float_t eCluster) const ;
-  void     GetMaxEnergyCell(const AliEMCALGeometry *geom, AliVCaloCells* cells, const AliVCluster* clu, 
+  void     GetMaxEnergyCell(const AliEMCALGeometry *geom, AliVCaloCells* cells, const AliVCluster* clu,
                             Int_t & absId,  Int_t& iSupMod, Int_t& ieta, Int_t& iphi, Bool_t &shared);
-  
+
   Float_t  GetMisalTransShift(Int_t i)       const { if(i < 15 ) { return fMisalTransShift[i] ; }
-                                                     else        { AliInfo(Form("Index %d larger than 15, do nothing\n",i)) ; 
+                                                     else        { AliInfo(Form("Index %d larger than 15, do nothing\n",i)) ;
                                                                    return 0.                  ; } }
   Float_t* GetMisalTransShiftArray()                  { return fMisalTransShift ; }
   void     SetMisalTransShift(Int_t i, Float_t shift) { if(i < 15 ) { fMisalTransShift[i] = shift ; }
                                                         else        { AliInfo(Form("Index %d larger than 15, do nothing\n",i)) ; } }
   void     SetMisalTransShiftArray(Float_t * misal)   { for(Int_t i = 0; i < 15; i++) fMisalTransShift[i] = misal[i]  ; }
   Float_t  GetMisalRotShift(Int_t i)         const    { if(i < 15 ) { return fMisalRotShift[i]    ; }
-                                                        else        { AliInfo(Form("Index %d larger than 15, do nothing\n",i)) ; 
+                                                        else        { AliInfo(Form("Index %d larger than 15, do nothing\n",i)) ;
                                                                       return 0.                   ; } }
   Float_t* GetMisalRotShiftArray()                    { return fMisalRotShift                     ; }
   void     SetMisalRotShift(Int_t i, Float_t shift)   { if(i < 15 ) { fMisalRotShift[i] = shift   ; }
@@ -138,7 +149,7 @@ public:
   void     SetW0(Float_t w0)                             { fW0  = w0                ; }
 
   void     SetShowerShapeCellLocationType(Int_t type)    { fShowerShapeCellLocationType = type ; }
-  
+
   //-----------------------------------------------------
   // Non Linearity
   //-----------------------------------------------------
@@ -161,9 +172,19 @@ public:
   Float_t  SmearClusterEnergy(const AliVCluster* clu) ;
   void     SwitchOnClusterEnergySmearing()               { fSmearClusterEnergy = kTRUE         ; }
   void     SwitchOffClusterEnergySmearing()              { fSmearClusterEnergy = kFALSE        ; }
-  Bool_t   IsClusterEnergySmeared()                const { return fSmearClusterEnergy          ; }   
+  Bool_t   IsClusterEnergySmeared()                const { return fSmearClusterEnergy          ; }
   void     SetSmearingParameters(Int_t i, Float_t param) { if(i < 3){ fSmearClusterParam[i] = param ; }
                                                            else     { AliInfo(Form("Index %d larger than 2, do nothing\n",i)) ; } }
+
+   //-----------------------------------------------------
+   // MC cluster number of cell efficiency
+   //-----------------------------------------------------
+
+   UInt_t  GetNCellEfficiencyFunction()                  { return fNCellEfficiencyFunction    ; }
+   void    SetNCellEfficiencyFunction(Int_t func)        { fNCellEfficiencyFunction = func    ; }
+   Bool_t  GetIsNCellCorrected(AliVCluster* cluster, AliVCaloCells* cells, Bool_t correctNextToClus = kTRUE);
+   void    InitNCellEfficiencyParam();
+
   //-----------------------------------------------------
   // Recalibration
   //-----------------------------------------------------
@@ -177,103 +198,103 @@ public:
   Bool_t   IsRecalibrationOn()                     const { return fRecalibration ; }
   Float_t  CorrectShaperNonLin(Float_t Emeas, Float_t EcalibHG) ; // shaper energy nonlinearity
   void     SwitchOffRecalibration()                      { fRecalibration = kFALSE ; }
-  void     SwitchOnRecalibration()                       { fRecalibration = kTRUE  ; 
+  void     SwitchOnRecalibration()                       { fRecalibration = kTRUE  ;
                                                            if(!fEMCALRecalibrationFactors)InitEMCALRecalibrationFactors() ; }
   void     SetUse1DRecalibration(Bool_t use)             { fUse1Drecalib = use; }
   void     InitEMCALRecalibrationFactors() ;
   void     InitEMCALRecalibrationFactors1D() ;
   TObjArray* GetEMCALRecalibrationFactorsArray()   const { return fEMCALRecalibrationFactors ; }
-  TH2F *   GetEMCALChannelRecalibrationFactors(Int_t iSM)     const;	
-  TH1S *   GetEMCALChannelRecalibrationFactors1D()            const { return (TH1S*)fEMCALRecalibrationFactors->At(0) ; }	
+  TH2F *   GetEMCALChannelRecalibrationFactors(Int_t iSM)     const;
+  TH1S *   GetEMCALChannelRecalibrationFactors1D()            const { return (TH1S*)fEMCALRecalibrationFactors->At(0) ; }
   void     SetEMCALChannelRecalibrationFactors(const TObjArray *map);
   void     SetEMCALChannelRecalibrationFactors(Int_t iSM , const TH2F* h);
   void     SetEMCALChannelRecalibrationFactors1D(const TH1S* h);
-  Float_t  GetEMCALChannelRecalibrationFactor(Int_t iSM , Int_t iCol, Int_t iRow) const { 
-    if(fEMCALRecalibrationFactors) 
-      return (Float_t) ((TH2F*)fEMCALRecalibrationFactors->At(iSM))->GetBinContent(iCol,iRow); 
+  Float_t  GetEMCALChannelRecalibrationFactor(Int_t iSM , Int_t iCol, Int_t iRow) const {
+    if(fEMCALRecalibrationFactors)
+      return (Float_t) ((TH2F*)fEMCALRecalibrationFactors->At(iSM))->GetBinContent(iCol,iRow);
     else return 1 ; }
-  Float_t  GetEMCALChannelRecalibrationFactor1D(UInt_t iCell ) const { 
-    if(fEMCALRecalibrationFactors) 
-      return (Float_t) ((TH1S*)fEMCALRecalibrationFactors->At(0))->GetBinContent(iCell)/1000; 
-    else return 1 ; } 
-  void     SetEMCALChannelRecalibrationFactor(Int_t iSM , Int_t iCol, Int_t iRow, Double_t c = 1) { 
+  Float_t  GetEMCALChannelRecalibrationFactor1D(UInt_t iCell ) const {
+    if(fEMCALRecalibrationFactors)
+      return (Float_t) ((TH1S*)fEMCALRecalibrationFactors->At(0))->GetBinContent(iCell)/1000;
+    else return 1 ; }
+  void     SetEMCALChannelRecalibrationFactor(Int_t iSM , Int_t iCol, Int_t iRow, Double_t c = 1) {
     if(!fEMCALRecalibrationFactors) InitEMCALRecalibrationFactors() ;
     ((TH2F*)fEMCALRecalibrationFactors->At(iSM))->SetBinContent(iCol,iRow,c) ; }
 
-  void     SetEMCALChannelRecalibrationFactor1D(UInt_t icell, Double_t c = 1) { 
+  void     SetEMCALChannelRecalibrationFactor1D(UInt_t icell, Double_t c = 1) {
     if(!fEMCALRecalibrationFactors) InitEMCALRecalibrationFactors1D() ;
     ((TH1S*)fEMCALRecalibrationFactors->At(0))->SetBinContent(icell,c) ; }
-  
+
   // Recalibrate channels energy with run dependent corrections
   Bool_t   IsRunDepRecalibrationOn()               const { return fUseRunCorrectionFactors ; }
   void     SwitchOffRunDepCorrection()                   { fUseRunCorrectionFactors = kFALSE ; }
-  void     SwitchOnRunDepCorrection()                    { fUseRunCorrectionFactors = kTRUE  ; 
-                                                           SwitchOnRecalibration()           ; }      
+  void     SwitchOnRunDepCorrection()                    { fUseRunCorrectionFactors = kTRUE  ;
+                                                           SwitchOnRecalibration()           ; }
   // Single Channel Calibration
   Bool_t   IsSingleChannelRecalibrationOn()                     const { return fSingleChannelRecalibration ; }
   void     SwitchOffSingleChannelRecalibration()                      { fSingleChannelRecalibration = kFALSE ; }
-  void     SwitchOnSingleChannelRecalibration()                       { fSingleChannelRecalibration = kTRUE  ; 
+  void     SwitchOnSingleChannelRecalibration()                       { fSingleChannelRecalibration = kTRUE  ;
                                                                         if(!fEMCALSingleChannelRecalibrationFactors)InitEMCALSingleChannelRecalibrationFactors() ; }
   void     InitEMCALSingleChannelRecalibrationFactors() ;
   TObjArray* GetEMCALSingleChannelRecalibrationFactorsArray()   const { return fEMCALSingleChannelRecalibrationFactors ; }
-  TH2F *   GetEMCALSingleChannelRecalibrationFactors(Int_t iSM)     const { return (TH2F*)fEMCALSingleChannelRecalibrationFactors->At(iSM) ; }	
-  Float_t  GetEMCALSingleChannelRecalibrationFactor(Int_t iSM , Int_t iCol, Int_t iRow) const { 
-    if(fEMCALSingleChannelRecalibrationFactors) 
-      return (Float_t) ((TH2F*)fEMCALSingleChannelRecalibrationFactors->At(iSM))->GetBinContent(iCol,iRow); 
-    else return 1 ; } 
+  TH2F *   GetEMCALSingleChannelRecalibrationFactors(Int_t iSM)     const { return (TH2F*)fEMCALSingleChannelRecalibrationFactors->At(iSM) ; }
+  Float_t  GetEMCALSingleChannelRecalibrationFactor(Int_t iSM , Int_t iCol, Int_t iRow) const {
+    if(fEMCALSingleChannelRecalibrationFactors)
+      return (Float_t) ((TH2F*)fEMCALSingleChannelRecalibrationFactors->At(iSM))->GetBinContent(iCol,iRow);
+    else return 1 ; }
   void     SetEMCALSingleChannelRecalibrationFactors(const TObjArray *map);
   void     SetEMCALSingleChannelRecalibrationFactors(Int_t iSM , const TH2F* h);
-  void     SetEMCALSingleChannelRecalibrationFactor(Int_t iSM , Int_t iCol, Int_t iRow, Double_t c = 1) { 
+  void     SetEMCALSingleChannelRecalibrationFactor(Int_t iSM , Int_t iCol, Int_t iRow, Double_t c = 1) {
     if(!fEMCALSingleChannelRecalibrationFactors) InitEMCALSingleChannelRecalibrationFactors() ;
     ((TH2F*)fEMCALSingleChannelRecalibrationFactors->At(iSM))->SetBinContent(iCol,iRow,c) ; }
-  
+
   // Time Recalibration
   Bool_t   IsTimeECorrectionOn()                   const { return fTimeECorrection; }
-  void     SwitchOffTimeECorrection()                  { fTimeECorrection = kFALSE ; }                                                
+  void     SwitchOffTimeECorrection()                  { fTimeECorrection = kFALSE ; }
   void     SwitchOnTimeECorrection()                   { fTimeECorrection = kTRUE  ; }
 
   void     CorrectCellTimeVsE(Double_t energy, Double_t & celltime, Bool_t isLowGain) const;
   Double_t GetLowGainSlewing (Double_t energy) const;
   Bool_t   InitializedTimeVsEHighGainSlewingCorr(){
     if (fEMCALTimeEShiftCorrection)
-      return kTRUE; 
-    else 
+      return kTRUE;
+    else
       return kFALSE;
   }
   void     SetEMCALTimeVsEHighGainSlewingCorr(const TSpline3* spline);
   TSpline3*  GetEMCALTimeVsEHighGainSlewingCorr(){
     if (fEMCALTimeEShiftCorrection)
-      return fEMCALTimeEShiftCorrection; 
-    else 
+      return fEMCALTimeEShiftCorrection;
+    else
       return nullptr;
-  }  
+  }
 
   void     SetUseOneHistForAllBCs(Bool_t useOneHist)     { fDoUseMergedBC = useOneHist ; }
   void     SetConstantTimeShift(Float_t shift)           { fConstantTimeShift = shift  ; }
 
   void     RecalibrateCellTime(Int_t absId, Int_t bc, Double_t & time,Bool_t isLGon = kFALSE) const;
-  
+
   Bool_t   IsTimeRecalibrationOn()                 const { return fTimeRecalibration   ; }
   void     SwitchOffTimeRecalibration()                  { fTimeRecalibration = kFALSE ; }
-  void     SwitchOnTimeRecalibration()                   { fTimeRecalibration = kTRUE  ; 
+  void     SwitchOnTimeRecalibration()                   { fTimeRecalibration = kTRUE  ;
                                                            if(!fEMCALTimeRecalibrationFactors)InitEMCALTimeRecalibrationFactors() ; }
   void     InitEMCALTimeRecalibrationFactors() ;
   TObjArray* GetEMCALTimeRecalibrationFactorsArray() const { return fEMCALTimeRecalibrationFactors ; }
 
-  Float_t  GetEMCALChannelTimeRecalibrationFactor(Int_t bc, Int_t absID, Bool_t isLGon = kFALSE) const { 
+  Float_t  GetEMCALChannelTimeRecalibrationFactor(Int_t bc, Int_t absID, Bool_t isLGon = kFALSE) const {
     if(fEMCALTimeRecalibrationFactors){
       if(fDoUseMergedBC)
-        return (Float_t) ((TH1S*)fEMCALTimeRecalibrationFactors->At(1*isLGon))->GetBinContent(absID); 
-      else 
+        return (Float_t) ((TH1S*)fEMCALTimeRecalibrationFactors->At(1*isLGon))->GetBinContent(absID);
+      else
         return (Float_t) ((TH1F*)fEMCALTimeRecalibrationFactors->At(bc+4*isLGon))->GetBinContent(absID);
-    } else return 0 ; } 
-  void     SetEMCALChannelTimeRecalibrationFactor(Int_t bc, Int_t absID, Double_t c = 0, Bool_t isLGon=kFALSE) { 
+    } else return 0 ; }
+  void     SetEMCALChannelTimeRecalibrationFactor(Int_t bc, Int_t absID, Double_t c = 0, Bool_t isLGon=kFALSE) {
     if(!fEMCALTimeRecalibrationFactors) InitEMCALTimeRecalibrationFactors() ;
     if(fDoUseMergedBC)
       ((TH1S*)fEMCALTimeRecalibrationFactors->At(isLGon))->SetBinContent(absID,c) ;
     else
-      ((TH1F*)fEMCALTimeRecalibrationFactors->At(bc+4*isLGon))->SetBinContent(absID,c) ; }  
-  
+      ((TH1F*)fEMCALTimeRecalibrationFactors->At(bc+4*isLGon))->SetBinContent(absID,c) ; }
+
   TH1  *   GetEMCALChannelTimeRecalibrationFactors(Int_t bc)const       { return (TH1*)fEMCALTimeRecalibrationFactors->At(bc) ; }
   void     SetEMCALChannelTimeRecalibrationFactors(const TObjArray *map);
   void     SetEMCALChannelTimeRecalibrationFactors(Int_t bc , const TH1* h);
@@ -286,21 +307,21 @@ public:
   // Time Recalibration with L1 phase
   Bool_t   IsL1PhaseInTimeRecalibrationOn()          const { return fUseL1PhaseInTimeRecalibration   ; }
   void     SwitchOffL1PhaseInTimeRecalibration()           { fUseL1PhaseInTimeRecalibration = kFALSE ; }
-  void     SwitchOnL1PhaseInTimeRecalibration()            { fUseL1PhaseInTimeRecalibration = kTRUE  ; 
+  void     SwitchOnL1PhaseInTimeRecalibration()            { fUseL1PhaseInTimeRecalibration = kTRUE  ;
     if(!fEMCALL1PhaseInTimeRecalibration) InitEMCALL1PhaseInTimeRecalibration() ; }
   void     InitEMCALL1PhaseInTimeRecalibration() ;
 
   void     RecalibrateCellTimeL1Phase(Int_t iSM, Int_t bc, Double_t & time, Short_t par=0) const;
   TObjArray* GetEMCALL1PhaseInTimeRecalibrationArray() const { return fEMCALL1PhaseInTimeRecalibration ; }
-  Int_t  GetEMCALL1PhaseInTimeRecalibrationForSM(Int_t iSM, Short_t par=0) const { 
-    if(fEMCALL1PhaseInTimeRecalibration) 
-      return (Int_t) ((TH1C*)fEMCALL1PhaseInTimeRecalibration->At(par))->GetBinContent(iSM); 
-    else return 0 ; } 
-  void     SetEMCALL1PhaseInTimeRecalibrationForSM(Int_t iSM, Int_t c = 0, Short_t par=0) { 
+  Int_t  GetEMCALL1PhaseInTimeRecalibrationForSM(Int_t iSM, Short_t par=0) const {
+    if(fEMCALL1PhaseInTimeRecalibration)
+      return (Int_t) ((TH1C*)fEMCALL1PhaseInTimeRecalibration->At(par))->GetBinContent(iSM);
+    else return 0 ; }
+  void     SetEMCALL1PhaseInTimeRecalibrationForSM(Int_t iSM, Int_t c = 0, Short_t par=0) {
     if(!fEMCALL1PhaseInTimeRecalibration) InitEMCALL1PhaseInTimeRecalibration();
-    ((TH1C*)fEMCALL1PhaseInTimeRecalibration->At(par))->SetBinContent(iSM,c) ; }  
-  
-  TH1C *   GetEMCALL1PhaseInTimeRecalibrationForAllSM(Short_t par=0) const      { return (TH1C*)fEMCALL1PhaseInTimeRecalibration->At(par) ; }	
+    ((TH1C*)fEMCALL1PhaseInTimeRecalibration->At(par))->SetBinContent(iSM,c) ; }
+
+  TH1C *   GetEMCALL1PhaseInTimeRecalibrationForAllSM(Short_t par=0) const      { return (TH1C*)fEMCALL1PhaseInTimeRecalibration->At(par) ; }
   void     SetEMCALL1PhaseInTimeRecalibrationForAllSM(const TObjArray *map);
   void     SetEMCALL1PhaseInTimeRecalibrationForAllSM(const TH1C* h, Short_t par=0);
 
@@ -310,7 +331,7 @@ public:
   Short_t GetCurrentParNumber()         { return fCurrentParNumber ; }
   void SetCurrentParNumber(Short_t par) { fCurrentParNumber = par ; }
   Short_t GetNPars()                    { return fGlobalEventID.GetSize() ; }
-  void SetNPars(Short_t npars)          { 
+  void SetNPars(Short_t npars)          {
     fGlobalEventID.Set(npars);
     fGlobalEventID.Reset();
   }
@@ -325,44 +346,44 @@ public:
   //-----------------------------------------------------
   // Modules fiducial region, remove clusters in borders
   //-----------------------------------------------------
-  Bool_t   CheckCellFiducialRegion(const AliEMCALGeometry* geom, 
-                                   const AliVCluster* cluster, 
+  Bool_t   CheckCellFiducialRegion(const AliEMCALGeometry* geom,
+                                   const AliVCluster* cluster,
                                    AliVCaloCells* cells) ;
   void     SetNumberOfCellsFromEMCALBorder(Int_t n){ fNCellsFromEMCALBorder = n      ; }
   Int_t    GetNumberOfCellsFromEMCALBorder()      const  { return fNCellsFromEMCALBorder   ; }
-    
+
   void     SwitchOnNoFiducialBorderInEMCALEta0()         { fNoEMCALBorderAtEta0 = kTRUE    ; }
   void     SwitchOffNoFiducialBorderInEMCALEta0()        { fNoEMCALBorderAtEta0 = kFALSE   ; }
   Bool_t   IsEMCALNoBorderAtEta0()                 const { return fNoEMCALBorderAtEta0     ; }
-  
+
   //-----------------------------------------------------
   // Bad channels
   //-----------------------------------------------------
   Bool_t   IsBadChannelsRemovalSwitchedOn()        const { return fRemoveBadChannels       ; }
   void     SwitchOffBadChannelsRemoval()                 { fRemoveBadChannels = kFALSE     ; }
-  void     SwitchOnBadChannelsRemoval ()                 { fRemoveBadChannels = kTRUE ; 
+  void     SwitchOnBadChannelsRemoval ()                 { fRemoveBadChannels = kTRUE ;
                                                            if(!fEMCALBadChannelMap)InitEMCALBadChannelStatusMap() ; }
   void     SetUse1DBadChannelMap(Bool_t use)             { fUse1Dmap = use;}
   Bool_t   IsDistanceToBadChannelRecalculated()    const { return fRecalDistToBadChannels   ; }
   void     SwitchOffDistToBadChannelRecalculation()      { fRecalDistToBadChannels = kFALSE ; }
-  void     SwitchOnDistToBadChannelRecalculation()       { fRecalDistToBadChannels = kTRUE  ; 
+  void     SwitchOnDistToBadChannelRecalculation()       { fRecalDistToBadChannels = kTRUE  ;
                                                            if(!fEMCALBadChannelMap)InitEMCALBadChannelStatusMap() ; }
   TObjArray* GetEMCALBadChannelStatusMapArray()    const { return fEMCALBadChannelMap ; }
   void     InitEMCALBadChannelStatusMap() ;
   void     InitEMCALBadChannelStatusMap1D() ;
   void     SetEMCALBadChannelStatusSelection(Bool_t all, Bool_t dead, Bool_t hot, Bool_t warm);
-  void     SetWarmChannelAsGood() 
+  void     SetWarmChannelAsGood()
            { fBadStatusSelection[0] = kFALSE; fBadStatusSelection[AliCaloCalibPedestal::kWarning] = kFALSE; }
-  void     SetDeadChannelAsGood() 
+  void     SetDeadChannelAsGood()
            { fBadStatusSelection[0] = kFALSE; fBadStatusSelection[AliCaloCalibPedestal::kDead]    = kFALSE; }
-  void     SetHotChannelAsGood() 
-           { fBadStatusSelection[0] = kFALSE; fBadStatusSelection[AliCaloCalibPedestal::kHot]     = kFALSE; } 
+  void     SetHotChannelAsGood()
+           { fBadStatusSelection[0] = kFALSE; fBadStatusSelection[AliCaloCalibPedestal::kHot]     = kFALSE; }
   Bool_t   GetEMCALChannelStatus(Int_t iSM , Int_t iCol, Int_t iRow, Int_t & status) const ;
   Bool_t   GetEMCALChannelStatus1D(Int_t iCell, Int_t & status) const ;
-  void     SetEMCALChannelStatus(Int_t iSM , Int_t iCol, Int_t iRow, Double_t status = 1) { 
+  void     SetEMCALChannelStatus(Int_t iSM , Int_t iCol, Int_t iRow, Double_t status = 1) {
     if(!fEMCALBadChannelMap)InitEMCALBadChannelStatusMap()               ;
     ((TH2I*)fEMCALBadChannelMap->At(iSM))->SetBinContent(iCol,iRow,status)    ; }
-  void     SetEMCALChannelStatus1D(Int_t iCell, Double_t status = 1) { 
+  void     SetEMCALChannelStatus1D(Int_t iCell, Double_t status = 1) {
     if(!fEMCALBadChannelMap)InitEMCALBadChannelStatusMap1D()               ;
     ((TH1C*)fEMCALBadChannelMap->At(0))->SetBinContent(iCell,status)    ; }
   TH2I *   GetEMCALChannelStatusMap(Int_t iSM)     const;
@@ -371,7 +392,7 @@ public:
   void     SetEMCALChannelStatusMap(Int_t iSM , const TH2I* h);
   void     SetEMCALChannelStatusMap1D(const TH1C* h);
   Bool_t   ClusterContainsBadChannel(const AliEMCALGeometry* geom, const UShort_t* cellList, Int_t nCells);
- 
+
   //-----------------------------------------------------
   // Recalculate other cluster parameters
   //-----------------------------------------------------
@@ -390,19 +411,19 @@ public:
   void     RecalculateClusterDistanceToBadChannel (const AliEMCALGeometry * geom, AliVCaloCells* cells, AliVCluster * cluster);
   void     RecalculateClusterShowerShapeParameters(const AliEMCALGeometry * geom, AliVCaloCells* cells, AliVCluster * cluster);
   void     RecalculateClusterShowerShapeParameters(const AliEMCALGeometry * geom, AliVCaloCells* cells, AliVCluster * cluster,
-                                                   Float_t & l0,   Float_t & l1,   
+                                                   Float_t & l0,   Float_t & l1,
                                                    Float_t & disp, Float_t & dEta, Float_t & dPhi,
                                                    Float_t & sEta, Float_t & sPhi, Float_t & sEtaPhi);
-  
-  void     RecalculateClusterShowerShapeParametersWithCellCuts(const AliEMCALGeometry * geom, AliVCaloCells* cells, AliVCluster * cluster, 
+
+  void     RecalculateClusterShowerShapeParametersWithCellCuts(const AliEMCALGeometry * geom, AliVCaloCells* cells, AliVCluster * cluster,
                                                                Float_t cellEcut, Float_t cellTimeCut, Int_t bc, Float_t & enAfterCuts);
 
   void     RecalculateClusterShowerShapeParametersWithCellCuts(const AliEMCALGeometry * geom, AliVCaloCells* cells, AliVCluster * cluster,
                                                                Float_t cellEcut, Float_t cellTimeCut, Int_t bc,
-                                                               Float_t & enAfterCuts, Float_t & l0,   Float_t & l1,   
+                                                               Float_t & enAfterCuts, Float_t & l0,   Float_t & l1,
                                                                Float_t & disp, Float_t & dEta, Float_t & dPhi,
                                                                Float_t & sEta, Float_t & sPhi, Float_t & sEtaPhi);
-  
+
   void     RecalculateClusterShowerShapeParametersNxNCells(const AliEMCALGeometry * geom,
                                                            AliVCaloCells* cells, AliVCluster * cluster,
                                                            Bool_t selectNeighbours, Int_t cellDiff,
@@ -411,7 +432,7 @@ public:
                                                            Float_t & l0,   Float_t & l1,
                                                            Float_t & disp, Float_t & dEta, Float_t & dPhi,
                                                            Float_t & sEta, Float_t & sPhi, Float_t & sEtaPhi);
-  
+
   void     RecalculateClusterPID(AliVCluster * cluster);
   AliEMCALPIDUtils * GetPIDUtils() { return fPIDUtils;}
 
@@ -419,22 +440,22 @@ public:
   // Track matching
   //----------------------------------------------------
   void     FindMatches(AliVEvent *event, TObjArray * clusterArr=0x0, const AliEMCALGeometry *geom=0x0, AliMCEvent* mc = 0x0);
-  Int_t    FindMatchedClusterInEvent(const AliESDtrack *track, const AliVEvent *event, 
+  Int_t    FindMatchedClusterInEvent(const AliESDtrack *track, const AliVEvent *event,
                                      const AliEMCALGeometry *geom, Float_t &dEta, Float_t &dPhi);
-  Int_t    FindMatchedClusterInClusterArr(const AliExternalTrackParam *emcalParam, 
-                                          AliExternalTrackParam *trkParam, 
-                                          const TObjArray * clusterArr, 
+  Int_t    FindMatchedClusterInClusterArr(const AliExternalTrackParam *emcalParam,
+                                          AliExternalTrackParam *trkParam,
+                                          const TObjArray * clusterArr,
                                           Float_t &dEta, Float_t &dPhi);
- 
+
   // Needed by analysis task in AliPhysics, could be removed once base class committed and analysis task is fixed.
   static Bool_t ExtrapolateTrackToCluster (AliExternalTrackParam *trkParam, const AliVCluster *cluster,
                                            Double_t mass, Double_t step,
                                            Float_t &tmpEta, Float_t &tmpPhi)
   { return AliEMCALRecoUtilsBase::ExtrapolateTrackToCluster (trkParam, cluster, mass, step, tmpEta, tmpPhi) ; }
-  
-  Bool_t   ExtrapolateTrackToCluster (AliExternalTrackParam *trkParam, const AliVCluster *cluster, 
+
+  Bool_t   ExtrapolateTrackToCluster (AliExternalTrackParam *trkParam, const AliVCluster *cluster,
                                       Float_t &tmpEta, Float_t &tmpPhi);
-  
+
   UInt_t   FindMatchedPosForCluster(Int_t clsIndex) const;
   UInt_t   FindMatchedPosForTrack  (Int_t trkIndex) const;
   void     GetMatchedResiduals       (Int_t clsIndex, Float_t &dEta, Float_t &dPhi);
@@ -444,8 +465,8 @@ public:
   Bool_t   IsClusterMatched(Int_t clsIndex)         const;
   Bool_t   IsTrackMatched  (Int_t trkIndex)         const;
   void     SetClusterMatchedToTrack (const AliVEvent *event);
-  void     SetTracksMatchedToCluster(const AliVEvent *event);  
-  void     SwitchOnCutEtaPhiSum()                     { fCutEtaPhiSum      = kTRUE    ; 
+  void     SetTracksMatchedToCluster(const AliVEvent *event);
+  void     SwitchOnCutEtaPhiSum()                     { fCutEtaPhiSum      = kTRUE    ;
                                                         fCutEtaPhiSeparate = kFALSE   ; }
   void     SwitchOnCutEtaPhiSeparate()                { fCutEtaPhiSeparate = kTRUE    ;
                                                         fCutEtaPhiSum      = kFALSE   ; }
@@ -465,15 +486,15 @@ public:
   void     SetMass(Double_t mass)                     { fMass = mass                  ; }
   void     SetStep(Double_t step)                     { fStepSurface = step           ; }
   void     SetStepCluster(Double_t step)              { fStepCluster = step           ; }
-  void     SetITSTrackSA(Bool_t isITS)                { fITSTrackSA = isITS           ; } //Special Handle of AliExternTrackParam    
-  void     SwitchOnOuterTrackParam()                  { fUseOuterTrackParam = kTRUE   ; } 
-  void     SwitchOffOuterTrackParam()                 { fUseOuterTrackParam = kFALSE  ; } 
-  
-  
-  // Track Cuts 
+  void     SetITSTrackSA(Bool_t isITS)                { fITSTrackSA = isITS           ; } //Special Handle of AliExternTrackParam
+  void     SwitchOnOuterTrackParam()                  { fUseOuterTrackParam = kTRUE   ; }
+  void     SwitchOffOuterTrackParam()                 { fUseOuterTrackParam = kFALSE  ; }
+
+
+  // Track Cuts
   Bool_t   IsAccepted(AliESDtrack *track);
   void     InitTrackCuts();
-  void     SetTrackCutsType(Int_t type)              { fTrackCutsType = type           ; 
+  void     SetTrackCutsType(Int_t type)              { fTrackCutsType = type           ;
                                                        InitTrackCuts()                 ; }
   Int_t    GetTrackCutsType() const                  { return fTrackCutsType; }
 
@@ -500,8 +521,8 @@ public:
   void     SetRequireITSStandAlone(Bool_t b=kFALSE)    {fCutRequireITSStandAlone= b    ; } //Marcel
   void     SetRequireITSPureStandAlone(Bool_t b=kFALSE){fCutRequireITSpureSA    = b    ; }
   void     SetRequireTrackDCA(Bool_t b=kFALSE)       { fUseTrackDCA             = b    ; }
-  
-  // getters								
+
+  // getters
   Double_t GetMinTrackPt()                     const { return fCutMinTrackPt           ; }
   Int_t    GetMinNClusterTPC()                 const { return fCutMinNClusterTPC       ; }
   Int_t    GetMinNClustersITS()                const { return fCutMinNClusterITS       ; }
@@ -513,19 +534,20 @@ public:
   Float_t  GetMaxDCAToVertexXY()               const { return fCutMaxDCAToVertexXY     ; }
   Float_t  GetMaxDCAToVertexZ()                const { return fCutMaxDCAToVertexZ      ; }
   Bool_t   GetDCAToVertex2D()                  const { return fCutDCAToVertex2D        ; }
-  Bool_t   GetRequireITSStandAlone()           const { return fCutRequireITSStandAlone ; } //Marcel  
-  Bool_t   GetRequireTrackDCA()                const { return fUseTrackDCA             ; } 
+  Bool_t   GetRequireITSStandAlone()           const { return fCutRequireITSStandAlone ; } //Marcel
+  Bool_t   GetRequireTrackDCA()                const { return fUseTrackDCA             ; }
 
   //----------------------------------------------------
   // Exotic cells / clusters
   //----------------------------------------------------
-  
+
   Bool_t   IsExoticCell(Int_t absId, AliVCaloCells* cells, Int_t bc =-1) ;
   void     SwitchOnRejectExoticCell()                 { fRejectExoticCells = kTRUE     ; }
-  void     SwitchOffRejectExoticCell()                { fRejectExoticCells = kFALSE    ; } 
+  void     SwitchOffRejectExoticCell()                { fRejectExoticCells = kFALSE    ; }
   Bool_t   IsRejectExoticCell()                 const { return fRejectExoticCells      ; }
-  Float_t  GetECross(Int_t absID, Double_t tcell, AliVCaloCells* cells, Int_t bc, 
+  Float_t  GetECross(Int_t absID, Double_t tcell, AliVCaloCells* cells, Int_t bc,
                      Float_t cellMinEn = 0., Bool_t useWeight = kFALSE, Float_t energyClus = 0.);
+  Bool_t   IsCellNextToCluster(Int_t absID, Float_t eThresh, AliVCaloCells* cells, Int_t bc = -1);
   Float_t  GetExoticCellFractionCut()           const { return fExoticCellFraction     ; }
   Float_t  GetExoticCellDiffTimeCut()           const { return fExoticCellDiffTime     ; }
   Float_t  GetExoticCellMinAmplitudeCut()       const { return fExoticCellMinAmplitude ; }
@@ -538,82 +560,86 @@ public:
   void     SwitchOffRejectExoticCluster()             { fRejectExoticCluster = kFALSE  ; }
   Bool_t   IsRejectExoticCluster()              const { return fRejectExoticCluster    ; }
 
-  Bool_t   IsAbsIDsFromTCard(Int_t absId1, Int_t absId2, 
+  Bool_t   IsAbsIDsFromTCard(Int_t absId1, Int_t absId2,
                              Int_t & rowDiff, Int_t & colDiff) const ;
-  
+
   void     GetEnergyAndNumberOfCellsInTCard(AliVCluster* clus, Int_t absIdMax, AliVCaloCells* cells,
-                                            Int_t   & nDiff, Int_t   & nSame, 
-                                            Float_t & eDiff, Float_t & eSame, 
+                                            Int_t   & nDiff, Int_t   & nSame,
+                                            Float_t & eDiff, Float_t & eSame,
                                             Float_t   emin = 0.);
-  
+
   // Cluster selection
-  Bool_t   IsGoodCluster(AliVCluster *cluster, const AliEMCALGeometry *geom, 
+  Bool_t   IsGoodCluster(AliVCluster *cluster, const AliEMCALGeometry *geom,
                          AliVCaloCells* cells, Int_t bc =-1);
 
   //----------------------------------------------------
   // MC labels in cells
   //----------------------------------------------------
-  
-  Int_t    GetNumberOfMCGeneratorsToAccept()    const { return fNMCGenerToAccept ; } 
-  void     SetNumberOfMCGeneratorsToAccept(Int_t nGen){ fNMCGenerToAccept = nGen ; 
-    if      ( nGen > 5 ) fNMCGenerToAccept = 5 ; 
+
+  Int_t    GetNumberOfMCGeneratorsToAccept()    const { return fNMCGenerToAccept ; }
+  void     SetNumberOfMCGeneratorsToAccept(Int_t nGen){ fNMCGenerToAccept = nGen ;
+    if      ( nGen > 5 ) fNMCGenerToAccept = 5 ;
     else if ( nGen < 0 ) fNMCGenerToAccept = 0 ; }
-  
-  TString  GetNameOfMCGeneratorsToAccept(Int_t ig) const 
-  { if (ig < fNMCGenerToAccept && ig > 0 && ig < 5 ) return fMCGenerToAccept[ig] ; 
+
+  TString  GetNameOfMCGeneratorsToAccept(Int_t ig) const
+  { if (ig < fNMCGenerToAccept && ig > 0 && ig < 5 ) return fMCGenerToAccept[ig] ;
     else return "" ; }
   void     SetNameOfMCGeneratorsToAccept(Int_t ig, TString name) { if ( ig < 5 && ig >= 0 ) fMCGenerToAccept[ig] = name ; }
-  
-  
+
+
   void     SwitchOffMCGeneratorToAcceptForTrackMatching() { fMCGenerToAcceptForTrack = kFALSE ; }
   void     SwitchOnMCGeneratorToAcceptForTrackMatching () { fMCGenerToAcceptForTrack = kTRUE  ; }
   Bool_t   AcceptMCGeneratorForTrackMatching()      const { return fMCGenerToAcceptForTrack   ; }
-  
+
   void     RecalculateCellLabelsRemoveAddedGenerator( Int_t absID, AliVCluster* clus, AliMCEvent* mc,
                                                       Float_t & amp, TArrayI & labeArr, TArrayF & eDepArr ) const;
-private:  
-  
+private:
+
   // Position recalculation
   Float_t    fMisalTransShift[15];       ///< Cluster position translation shift parameters
   Float_t    fMisalRotShift[15];         ///< Cluster position rotation shift parameters
   Int_t      fParticleType;              ///< Particle type for depth calculation, see enum ParticleType
   Int_t      fPosAlgo;                   ///< Position recalculation algorithm, see enum PositionAlgorithms
-  
+
   Float_t    fW0;                        ///< Energy weight used in cluster position and shower shape calculations
-  
+
   ///< Type of cell position used for shower shape calculation:
   ///< 0-index; 1-global eta/phi; 2-local x/z; 3- local r/z; 4- global x/z; 5- global r/z
-  Int_t      fShowerShapeCellLocationType;  
-  
+  Int_t      fShowerShapeCellLocationType;
+
   // Non linearity
   Int_t      fNonLinearityFunction;      ///< Non linearity function choice, see enum NonlinearityFunctions
   Float_t    fNonLinearityParams[10];    ///< Parameters for the non linearity function
-  Int_t	     fNonLinearThreshold;        ///< Non linearity threshold value for kBeamTest non linearity function 
+  Int_t	     fNonLinearThreshold;        ///< Non linearity threshold value for kBeamTest non linearity function
   Bool_t     fUseShaperNonlin;        ///< Shaper non linearity correction for towers
-  
+
   // Energy smearing for MC
   Bool_t     fSmearClusterEnergy;        ///< Smear cluster energy, to be done only for simulated data to match real data
   Float_t    fSmearClusterParam[3];      ///< Energy smearing parameters
   TRandom3   fRandom;                    ///< Random generator for cluster energy smearing
-    
-  // Energy Recalibration 
+
+  // number of cell Efficiency
+  Int_t      fNCellEfficiencyFunction;    ///< number of cells efficiency function choice for enum NCellEfficnecyFunctions
+  Float_t    fNCellEfficiencyParams[10];  ///< Parameters for the number of cells efficiency
+
+  // Energy Recalibration
   Bool_t     fCellsRecalibrated;         ///< Internal bool to check if cells (time/energy) where recalibrated and not recalibrate them when recalculating different things
   Bool_t     fRecalibration;             ///< Switch on or off the recalibration
   Bool_t     fUse1Drecalib;              ///< Flag to use one dimensional recalibration histogram
   TObjArray* fEMCALRecalibrationFactors; ///< Array of histograms with map of recalibration factors, EMCAL
 
-  // Single Channel Energy Recalibration 
+  // Single Channel Energy Recalibration
   Bool_t     fCellsSingleChannelRecalibrated;         ///< Internal bool to check if cells (time/energy) where recalibrated and not recalibrate them when recalculating different things
   Bool_t     fSingleChannelRecalibration;             ///< Switch on or off the single channel calibration
   TObjArray* fEMCALSingleChannelRecalibrationFactors; ///< Array of histograms with map of single channel calibration factors, EMCAL and DCAL
-  
-  // Time Recalibration 
+
+  // Time Recalibration
   Float_t    fConstantTimeShift;         ///< Apply a 600 ns (+15.8) time shift in case of simulation, shift in ns.
   Bool_t     fTimeRecalibration;         ///< Switch on or off the time recalibration
   TObjArray* fEMCALTimeRecalibrationFactors;   ///< Array of histograms with map of time recalibration factors, EMCAL
   Bool_t     fLowGain;                   ///< Switch on or off calibration with low gain channels
 
-  // Time Recalibration with L1 phase 
+  // Time Recalibration with L1 phase
   Bool_t     fUseL1PhaseInTimeRecalibration;   ///< Switch on or off the L1 phase in time recalibration
   TObjArray* fEMCALL1PhaseInTimeRecalibration; ///< Histogram with map of L1 phase per SM, EMCAL
   Bool_t     fIsParRun;                        //!<! flag if run contains PAR
@@ -624,36 +650,36 @@ private:
   // energy dependent time clalibration
   Bool_t     fTimeECorrection;            ///< Switch on or off the energy dependent time recalibration
   TSpline3*  fEMCALTimeEShiftCorrection;  ///< Spline to correct energy dependent time shift for high gain cells
-  
+
   // R
   // Recalibrate with run dependent corrections, energy
   Bool_t     fUseRunCorrectionFactors;   ///< Use Run Dependent Correction
-    
+
   // Bad Channels
   Bool_t     fRemoveBadChannels;         ///< Check the channel status provided and remove clusters with bad channels
   Bool_t     fRecalDistToBadChannels;    ///< Calculate distance from highest energy tower of cluster to closes bad channel
   TObjArray* fEMCALBadChannelMap;        ///< Array of histograms with map of bad channels, EMCAL
   Bool_t     fUse1Dmap;                  ///< Flag to use one 1D bad channel map (for all cells)
-  Bool_t     fBadStatusSelection[4];     ///< Declare as bad all the types of bad channels or only some. 
+  Bool_t     fBadStatusSelection[4];     ///< Declare as bad all the types of bad channels or only some.
                                          ///<   0- Set all types to bad if true
                                          ///<   1- Set dead as good if false
                                          ///<   2- Set hot as good if false
                                          ///<   3- Set warm as good if false
-  
+
   // Border cells
   Int_t      fNCellsFromEMCALBorder;     ///< Number of cells from EMCAL border the cell with maximum amplitude has to be.
   Bool_t     fNoEMCALBorderAtEta0;       ///< Do fiducial cut in EMCAL region eta = 0?
-  
+
   // Exotic cell / cluster
   Bool_t     fRejectExoticCluster;       ///< Switch on or off exotic cluster rejection
   Bool_t     fRejectExoticCells;         ///< Remove exotic cells
   Float_t    fExoticCellFraction;        ///< Good cell if fraction < 1-ecross/ecell
   Float_t    fExoticCellDiffTime;        ///< If time of candidate to exotic and close cell is too different (in ns), it must be noisy, set amp to 0
   Float_t    fExoticCellMinAmplitude;    ///< Check for exotic only if amplitud is larger than this value
-  
+
   // PID
   AliEMCALPIDUtils * fPIDUtils;          ///< Recalculate PID parameters
-    
+
   // Local maxima
   Float_t    fLocMaxCutE;                ///<  Local maxima cut must have more than this energy.
   Float_t    fLocMaxCutEDiff;            ///<  Local maxima cut, when aggregating cells, next can be a bit higher.
@@ -662,8 +688,8 @@ private:
   UInt_t     fAODFilterMask;             ///< Filter mask to select AOD tracks. Refer to $ALICE_ROOT/ANALYSIS/macros/AddTaskESDFilter.C
   Bool_t     fAODHybridTracks;           ///< Match with hybrid
   Bool_t     fAODTPCOnlyTracks;          ///< Match with TPC only tracks
-  
-  TArrayI    fMatchedTrackIndex;         ///< Array that stores indexes of matched tracks      
+
+  TArrayI    fMatchedTrackIndex;         ///< Array that stores indexes of matched tracks
   TArrayI    fMatchedClusterIndex;       ///< Array that stores indexes of matched clusters
   TArrayF    fResidualEta;               ///< Array that stores the residual eta
   TArrayF    fResidualPhi;               ///< Array that stores the residual phi
@@ -676,16 +702,16 @@ private:
   Double_t   fMass;                      ///< Mass hypothesis of the track
   Double_t   fStepSurface;               ///< Length of step to extrapolate tracks to EMCal surface
   Double_t   fStepCluster;               ///< Length of step to extrapolate tracks to clusters
-  Bool_t     fITSTrackSA;                ///< If track matching is to be done with ITS tracks standing alone, ESDs	
-  Bool_t     fUseTrackDCA;               ///< Activate use of aodtrack->GetXYZ or XvYxZv like in AliEMCALRecoUtilsBase::ExtrapolateTrackToEMCalSurface 
+  Bool_t     fITSTrackSA;                ///< If track matching is to be done with ITS tracks standing alone, ESDs
+  Bool_t     fUseTrackDCA;               ///< Activate use of aodtrack->GetXYZ or XvYxZv like in AliEMCALRecoUtilsBase::ExtrapolateTrackToEMCalSurface
   Bool_t     fUseOuterTrackParam;        ///< Use OuterTrackParam not InnerTrackParam, ESDs
   Double_t   fEMCalSurfaceDistance;      ///< EMCal surface distance (= 430 by default, the last 10 cm are propagated on a cluster-track pair basis)
- 
-  // Track cuts  
+
+  // Track cuts
   Int_t      fTrackCutsType;             ///< ESD track cuts type for matching, see enum TrackCutsType
   Double_t   fCutMinTrackPt;             ///< Cut on track pT
   Int_t      fCutMinNClusterTPC;         ///< Min number of tpc clusters
-  Int_t      fCutMinNClusterITS;         ///< Min number of its clusters  
+  Int_t      fCutMinNClusterITS;         ///< Min number of its clusters
   Float_t    fCutMaxChi2PerClusterTPC;   ///< Max tpc fit chi2 per tpc cluster
   Float_t    fCutMaxChi2PerClusterITS;   ///< Max its fit chi2 per its cluster
   Bool_t     fCutRequireTPCRefit;        ///< Require TPC refit
@@ -696,18 +722,16 @@ private:
   Bool_t     fCutDCAToVertex2D;          ///< If true a 2D DCA cut is made.
   Bool_t     fCutRequireITSStandAlone;   ///< Require ITSStandAlone
   Bool_t     fCutRequireITSpureSA;       ///< ITS pure standalone tracks
-  
+
   // MC labels in cells
   Int_t      fNMCGenerToAccept;          ///<  Number of MC generators that should not be included in analysis
   TString    fMCGenerToAccept[5];        ///<  List with name of generators that should not be included
   Bool_t     fMCGenerToAcceptForTrack;   ///<  Activate the removal of tracks entering the track matching that come from a particular generator
-  
+
   /// \cond CLASSIMP
-  ClassDef(AliEMCALRecoUtils, 36) ;
+  ClassDef(AliEMCALRecoUtils, 37) ;
   /// \endcond
 
 };
 
 #endif // ALIEMCALRECOUTILS_H
-
-

--- a/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.h
+++ b/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.h
@@ -100,10 +100,9 @@ public:
   enum     NCellEfficiencyFunctions
   {
     kNCeNoCorrection   = 0,
-    kNCeAllClusters   = 1,
-    kNCeGammaAndElec   = 2,
-    kNCeElectrons   = 3,
-    kNCeTestBeam   = 4
+    kNCeAllClusters    = 1,
+    kNCeTestBeam       = 2,
+    kNCeGammaAndElec   = 3
   };
 
   /// Cluster position enum list of possible algoritms

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterLowEnergyEfficiency.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterLowEnergyEfficiency.cxx
@@ -1,0 +1,138 @@
+// AliEmcalCorrectionClusterLowEnergyEfficiency
+//
+
+#include "AliEmcalCorrectionClusterLowEnergyEfficiency.h"
+
+// #include <TList.h>
+#include "AliInputEventHandler.h"
+
+#include "AliClusterContainer.h"
+
+/// \cond CLASSIMP
+ClassImp(AliEmcalCorrectionClusterLowEnergyEfficiency);
+/// \endcond
+
+// Actually registers the class with the base class
+RegisterCorrectionComponent<AliEmcalCorrectionClusterLowEnergyEfficiency> AliEmcalCorrectionClusterLowEnergyEfficiency::reg("AliEmcalCorrectionClusterLowEnergyEfficiency");
+
+const std::map <std::string, AliEMCALRecoUtils::NCellEfficiencyFunctions> AliEmcalCorrectionClusterLowEnergyEfficiency::fgkNCellEfficiencyFunctionMap = {
+    { "kAllClusters", AliEMCALRecoUtils::kNCeAllClusters },
+    { "kTestBeam", AliEMCALRecoUtils::kNCeTestBeam }
+};
+
+/**
+ * Default constructor
+ */
+AliEmcalCorrectionClusterLowEnergyEfficiency::AliEmcalCorrectionClusterLowEnergyEfficiency() :
+  AliEmcalCorrectionComponent("AliEmcalCorrectionClusterLowEnergyEfficiency"),
+  fNCellDistBefore(0),
+  fNCellDistAfter(0),
+  fRejectNextToClus(0)
+{
+  printf("constructor AliEmcalCorrectionClusterLowEnergyEfficiency\n");
+}
+
+/**
+ * Destructor
+ */
+AliEmcalCorrectionClusterLowEnergyEfficiency::~AliEmcalCorrectionClusterLowEnergyEfficiency()
+{
+  printf("constructor AliEmcalCorrectionClusterLowEnergyEfficiency\n");
+}
+
+/**
+ * Initialize and configure the component.
+ */
+Bool_t AliEmcalCorrectionClusterLowEnergyEfficiency::Initialize()
+{
+  // Initialization
+  AliEmcalCorrectionComponent::Initialize();
+  std::string nCellFunctStr = "";
+  GetProperty("nCellFunct", nCellFunctStr);
+  UInt_t nonLinFunct = fgkNCellEfficiencyFunctionMap.at(nCellFunctStr);
+
+  fRejectNextToClus = false;
+  GetProperty("setRejectNextToClus", fRejectNextToClus);
+
+  // init reco utils
+  if (!fRecoUtils)
+    fRecoUtils  = new AliEMCALRecoUtils;
+
+  if (fRecoUtils) {
+    fRecoUtils->SetNCellEfficiencyFunction(nonLinFunct);
+    fRecoUtils->InitNCellEfficiencyParam();
+    fRecoUtils->Print("");
+  }
+
+  return kTRUE;
+}
+
+/**
+ * Create run-independent objects for output. Called before running over events.
+ */
+void AliEmcalCorrectionClusterLowEnergyEfficiency::UserCreateOutputObjects()
+{
+  AliEmcalCorrectionComponent::UserCreateOutputObjects();
+
+  // Create my user objects.
+  if (fCreateHisto){
+    fNCellDistBefore = new TH1F("hNCellDistBefore","hNCellDistBefore;N_{cells} in cluster",100,-0.5, 99.5);
+    fOutput->Add(fNCellDistBefore);
+    fNCellDistAfter = new TH1F("hNCellDistAfter","hNCellDistAfter;N_{cells} in cluster",100,-0.5, 99.5);
+    fOutput->Add(fNCellDistAfter);
+
+    // Take ownership of output list
+    fOutput->SetOwner(kTRUE);
+  }
+}
+
+/**
+ * Called for each event to process the event data.
+ */
+Bool_t AliEmcalCorrectionClusterLowEnergyEfficiency::Run()
+{
+  AliEmcalCorrectionComponent::Run();
+
+  // only apply on MC clusters
+  if(!fMCEvent) return kTRUE;
+
+  // loop over clusters
+  AliVCluster *clus = 0;
+  AliClusterContainer * clusCont = 0;
+  TIter nextClusCont(&fClusterCollArray);
+  while ((clusCont = static_cast<AliClusterContainer*>(nextClusCont()))) {
+
+    if (!clusCont) return kFALSE;
+    auto clusItCont = clusCont->all_momentum();
+
+    for (AliClusterIterableMomentumContainer::iterator clusIterator = clusItCont.begin(); clusIterator != clusItCont.end(); ++clusIterator) {
+      clus = static_cast<AliVCluster *>(clusIterator->second);
+
+      if (!clus->IsEMCAL()) continue;
+
+      if (fCreateHisto) {
+        fNCellDistBefore->Fill(clus->GetNCells());
+      }
+      if (fRecoUtils) {
+        if(clus->GetNCells() == 1){
+          if (fRecoUtils->GetNCellEfficiencyFunction() != AliEMCALRecoUtils::kNCeNoCorrection) {
+            Bool_t isAccepted = fRecoUtils->GetIsNCellCorrected(clus, (AliVCaloCells*) fEventManager.InputEvent()->GetEMCALCells());
+            if ( isAccepted ) clus->SetChi2(1);
+            else clus->SetChi2(0);
+          }
+        }
+      }
+
+      if (fCreateHisto) {
+        // case if a cluster has only one cell but its rtificielly widened
+        if(clus->Chi2() == 1. && clus->GetNCells() == 1){
+          fNCellDistAfter->Fill(2);
+        } else {
+          fNCellDistAfter->Fill(clus->GetNCells());
+        }
+      }
+    }
+  }
+
+  return kTRUE;
+}

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterLowEnergyEfficiency.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterLowEnergyEfficiency.cxx
@@ -17,7 +17,8 @@ RegisterCorrectionComponent<AliEmcalCorrectionClusterLowEnergyEfficiency> AliEmc
 
 const std::map <std::string, AliEMCALRecoUtils::NCellEfficiencyFunctions> AliEmcalCorrectionClusterLowEnergyEfficiency::fgkNCellEfficiencyFunctionMap = {
     { "kAllClusters", AliEMCALRecoUtils::kNCeAllClusters },
-    { "kTestBeam", AliEMCALRecoUtils::kNCeTestBeam }
+    { "kTestBeam", AliEMCALRecoUtils::kNCeTestBeam },
+    { "kGammaAndElec", AliEMCALRecoUtils::kNCeGammaAndElec }
 };
 
 /**
@@ -29,7 +30,6 @@ AliEmcalCorrectionClusterLowEnergyEfficiency::AliEmcalCorrectionClusterLowEnergy
   fNCellDistAfter(0),
   fRejectNextToClus(0)
 {
-  printf("constructor AliEmcalCorrectionClusterLowEnergyEfficiency\n");
 }
 
 /**
@@ -37,7 +37,6 @@ AliEmcalCorrectionClusterLowEnergyEfficiency::AliEmcalCorrectionClusterLowEnergy
  */
 AliEmcalCorrectionClusterLowEnergyEfficiency::~AliEmcalCorrectionClusterLowEnergyEfficiency()
 {
-  printf("constructor AliEmcalCorrectionClusterLowEnergyEfficiency\n");
 }
 
 /**
@@ -92,7 +91,6 @@ void AliEmcalCorrectionClusterLowEnergyEfficiency::UserCreateOutputObjects()
 Bool_t AliEmcalCorrectionClusterLowEnergyEfficiency::Run()
 {
   AliEmcalCorrectionComponent::Run();
-
   // only apply on MC clusters
   if(!fMCEvent) return kTRUE;
 
@@ -109,7 +107,6 @@ Bool_t AliEmcalCorrectionClusterLowEnergyEfficiency::Run()
       clus = static_cast<AliVCluster *>(clusIterator->second);
 
       if (!clus->IsEMCAL()) continue;
-
       if (fCreateHisto) {
         fNCellDistBefore->Fill(clus->GetNCells());
       }
@@ -118,7 +115,6 @@ Bool_t AliEmcalCorrectionClusterLowEnergyEfficiency::Run()
           if (fRecoUtils->GetNCellEfficiencyFunction() != AliEMCALRecoUtils::kNCeNoCorrection) {
             Bool_t isAccepted = fRecoUtils->GetIsNCellCorrected(clus, (AliVCaloCells*) fEventManager.InputEvent()->GetEMCALCells());
             if ( isAccepted ) clus->SetChi2(1);
-            else clus->SetChi2(0);
           }
         }
       }

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterLowEnergyEfficiency.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterLowEnergyEfficiency.cxx
@@ -16,6 +16,7 @@ ClassImp(AliEmcalCorrectionClusterLowEnergyEfficiency);
 RegisterCorrectionComponent<AliEmcalCorrectionClusterLowEnergyEfficiency> AliEmcalCorrectionClusterLowEnergyEfficiency::reg("AliEmcalCorrectionClusterLowEnergyEfficiency");
 
 const std::map <std::string, AliEMCALRecoUtils::NCellEfficiencyFunctions> AliEmcalCorrectionClusterLowEnergyEfficiency::fgkNCellEfficiencyFunctionMap = {
+    { "kNoCorrection", AliEMCALRecoUtils::kNCeNoCorrection },
     { "kAllClusters", AliEMCALRecoUtils::kNCeAllClusters },
     { "kTestBeam", AliEMCALRecoUtils::kNCeTestBeam },
     { "kGammaAndElec", AliEMCALRecoUtils::kNCeGammaAndElec }
@@ -48,7 +49,7 @@ Bool_t AliEmcalCorrectionClusterLowEnergyEfficiency::Initialize()
   AliEmcalCorrectionComponent::Initialize();
   std::string nCellFunctStr = "";
   GetProperty("nCellFunct", nCellFunctStr);
-  UInt_t nonLinFunct = fgkNCellEfficiencyFunctionMap.at(nCellFunctStr);
+  UInt_t nCellEffiFunct = fgkNCellEfficiencyFunctionMap.at(nCellFunctStr);
 
   fRejectNextToClus = false;
   GetProperty("setRejectNextToClus", fRejectNextToClus);
@@ -58,7 +59,7 @@ Bool_t AliEmcalCorrectionClusterLowEnergyEfficiency::Initialize()
     fRecoUtils  = new AliEMCALRecoUtils;
 
   if (fRecoUtils) {
-    fRecoUtils->SetNCellEfficiencyFunction(nonLinFunct);
+    fRecoUtils->SetNCellEfficiencyFunction(nCellEffiFunct);
     fRecoUtils->InitNCellEfficiencyParam();
     fRecoUtils->Print("");
   }
@@ -91,6 +92,7 @@ void AliEmcalCorrectionClusterLowEnergyEfficiency::UserCreateOutputObjects()
 Bool_t AliEmcalCorrectionClusterLowEnergyEfficiency::Run()
 {
   AliEmcalCorrectionComponent::Run();
+
   // only apply on MC clusters
   if(!fMCEvent) return kTRUE;
 
@@ -107,6 +109,7 @@ Bool_t AliEmcalCorrectionClusterLowEnergyEfficiency::Run()
       clus = static_cast<AliVCluster *>(clusIterator->second);
 
       if (!clus->IsEMCAL()) continue;
+
       if (fCreateHisto) {
         fNCellDistBefore->Fill(clus->GetNCells());
       }

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterLowEnergyEfficiency.h
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterLowEnergyEfficiency.h
@@ -1,0 +1,59 @@
+#ifndef ALIEMCALCORRECTIONCLUSTERLOWENERGYEFFICIENCY_H
+#define ALIEMCALCORRECTIONCLUSTERLOWENERGYEFFICIENCY_H
+
+#include "AliEmcalCorrectionComponent.h"
+
+#include "AliEMCALRecoUtils.h"
+
+/**
+ * @class AliEmcalCorrectionClusterLowEnergyEfficiency
+ * @ingroup EMCALCORRECTIONFW
+ * @brief Cluster number of cells correction component in the EMCal correction framework.
+ *
+ * This task flags a fraction of the 1 cell clusters as 2 cell clusters. This is necessary because the fraction of 1 cell clusters does not match between data and MC.
+   If a cut on the number of cells is applied this correction is necessary to get correct results.
+   The artificially widened clusters will have the flag chi2 set to 1, other 1 cell clusters are set to chi2 = 0
+
+ *
+ * Based on code in AliEmcalClusterMaker.
+ *
+ * @author Constantin Loizides, LBNL, AliEmcalClusterMaker
+ * @author Salvatore Aiola, LBNL, AliEmcalClusterMaker
+ * @author James Mulligan <james.mulligan@yale.edu>, Yale University, centralize EMCal corrections using components
+ * @author Raymond Ehlers <raymond.ehlers@yale.edu>, Yale University, centralize EMCal corrections using components
+ * @date Jul 8, 2016
+ */
+
+
+class AliEmcalCorrectionClusterLowEnergyEfficiency : public AliEmcalCorrectionComponent {
+ public:
+  /// Relates string to the number of cells efficiency function enumeration for %YAML configuration
+  static const std::map <std::string, AliEMCALRecoUtils::NCellEfficiencyFunctions> fgkNCellEfficiencyFunctionMap; //!<!
+
+  AliEmcalCorrectionClusterLowEnergyEfficiency();
+  virtual ~AliEmcalCorrectionClusterLowEnergyEfficiency();
+
+  // Sets up and runs the task
+  Bool_t Initialize();
+  void UserCreateOutputObjects();
+  Bool_t Run();
+
+protected:
+  TH1F                  *fNCellDistBefore;          //!<!number of cells distribution before
+  TH1F                  *fNCellDistAfter;           //!<!number of cells distribution after
+
+  Bool_t                fRejectNextToClus;          //!<!Switch waether to reject 1 cell clusters with direct neighbours
+
+ private:
+  AliEmcalCorrectionClusterLowEnergyEfficiency(const AliEmcalCorrectionClusterLowEnergyEfficiency &);               // Not implemented
+  AliEmcalCorrectionClusterLowEnergyEfficiency &operator=(const AliEmcalCorrectionClusterLowEnergyEfficiency &);    // Not implemented
+
+  // Allows the registration of the class so that it is availble to be used by the correction task.
+  static RegisterCorrectionComponent<AliEmcalCorrectionClusterLowEnergyEfficiency> reg;
+
+  /// \cond CLASSIMP
+  ClassDef(AliEmcalCorrectionClusterLowEnergyEfficiency, 1); // EMCal cluster non-linearity correction component
+  /// \endcond
+};
+
+#endif /* ALIEMCALCORRECTIONCLUSTERLOWENERGYEFFICIENCY_H */

--- a/PWG/EMCAL/EMCALtasks/CMakeLists.txt
+++ b/PWG/EMCAL/EMCALtasks/CMakeLists.txt
@@ -81,6 +81,7 @@ set(SRCS
   AliEmcalCorrectionClusterizer.cxx
   AliEmcalCorrectionClusterNonLinearity.cxx
   AliEmcalCorrectionClusterNonLinearityMCAfterburner.cxx
+  AliEmcalCorrectionClusterLowEnergyEfficiency.cxx
   AliEmcalCorrectionClusterExotics.cxx
   AliEmcalCorrectionClusterTrackMatcher.cxx
   AliEmcalCorrectionClusterHadronicCorrection.cxx
@@ -126,7 +127,7 @@ if(${CMAKE_SYSTEM} MATCHES Darwin)
 endif(${CMAKE_SYSTEM} MATCHES Darwin)
 
 # Installation
-install(TARGETS ${MODULE} 
+install(TARGETS ${MODULE}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib)
 install(FILES ${HDRS} DESTINATION include)

--- a/PWG/EMCAL/EMCALtasks/PWGEMCALtasksLinkDef.h
+++ b/PWG/EMCAL/EMCALtasks/PWGEMCALtasksLinkDef.h
@@ -47,6 +47,7 @@
 #pragma link C++ class  AliEmcalCorrectionClusterizer+;
 #pragma link C++ class  AliEmcalCorrectionClusterNonLinearity+;
 #pragma link C++ class  AliEmcalCorrectionClusterNonLinearityMCAfterburner+;
+#pragma link C++ class  AliEmcalCorrectionClusterLowEnergyEfficiency+;
 #pragma link C++ class  AliEmcalCorrectionClusterExotics+;
 #pragma link C++ class  AliEmcalCorrectionClusterTrackMatcher+;
 #pragma link C++ class  AliEmcalCorrectionClusterHadronicCorrection+;

--- a/PWG/EMCAL/READMEemcCorrections.txt
+++ b/PWG/EMCAL/READMEemcCorrections.txt
@@ -23,6 +23,7 @@ The following correction components are available:
 - [ClusterExotics](\ref AliEmcalCorrectionClusterExotics) -- Flags exotic clusters for removal from the cluster collection.
 - [ClusterNonLinearity](\ref AliEmcalCorrectionClusterNonLinearity) -- Corrects cluster energy for non-linear response.
 - [ClusterNonLinearityMCAfterburner](\ref AliEmcalCorrectionClusterNonLinearityMCAfterburner.h) -- This is an additional correction for MC. The effect is that the pi0 mass position is the same for data and MC. It is only defined for specific periods.
+- [ClusterLowEnergyEfficiency](\ref AliEmcalCorrectionClusterLowEnergyEfficiency.h) -- Corrects the fraction of 1 cell clusters in MC to match the data distribution. The correction will flag a percentage of the MC 1 cell clusters such that they can be used as if they have 2 cells
 - [ClusterTrackMatcher](\ref AliEmcalCorrectionClusterTrackMatcher) -- Matches each track to a single cluster, if they are in close enough proximity.
 - [ClusterHadronicCorrection](\ref AliEmcalCorrectionClusterHadronicCorrection) -- For clusters that have one or more matched tracks, reduces the cluster energy in order to avoid overestimating the particle's energy.
 - [PHOSCorrection](\ref AliEmcalCorrectionPHOSCorrections) -- Perform PHOS correction via an interface to the PHOS tender.
@@ -43,7 +44,7 @@ instructions on how to transition from the old correction method(s) to the new c
 corrections, and how to **test your analysis** results in the new vs. old correction method. Testing your corrections configuration
 is an extremely important step, as failure to do so could lead to incorrect results!
 
-# %Setup the Correction Task 
+# %Setup the Correction Task
 
 There are two steps:
 - [Configure the Correction Add Task](\ref configureEMCalCorrectionRunMacro)
@@ -378,14 +379,14 @@ Clusterizer_mySpecialization:
 In this example, two clusterizers are configured: ``Clusterizer`` and ``Clusterizer_mySpecializedClusterizer``. Both have the exact same
 configuration, with the exception that ``Clusterizer`` uses ``defaultCells`` for cells and ``defaultClusterContainer`` for clusters,
 while ``Clusterizer_mySpecializedClusterizer`` uses ``anotherCells`` for cells and ``anotherClusterContainer`` for clusters (note: the
-cells branch would have to be created elsewhere, say with ``AliEmcalCopyCollection``). 
+cells branch would have to be created elsewhere, say with ``AliEmcalCopyCollection``).
 
 To execute these corrections, we must select them in the AddTask of the Correction Task. To do so, set the suffix argument of the AddTask
 to correspond with the specialization suffix that was set in the %YAML file. Continuing with the previous example, we would need to add:
 
 ~~~{.cxx}
 // The default argument is an empty string, so we don't have to set it here.
-AliEmcalCorrectionTask * correctionTask = AddTaskEmcalCorrectionTask(); 
+AliEmcalCorrectionTask * correctionTask = AddTaskEmcalCorrectionTask();
 // Create the specialized correction task
 AliEmcalCorrectionTask * correctionTaskSpecialized = AddTaskEmcalCorrectionTask("mySpecialization");
 ~~~
@@ -607,5 +608,5 @@ of your task name in this list will determine when it is executed relative to th
 You can find an analysis tutorial presentation [here](https://indico.cern.ch/event/586577/).
 
 For more information, contact the developers <james.mulligan@yale.edu> and <raymond.ehlers@yale.edu>.
- 
+
 */

--- a/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
+++ b/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
@@ -239,6 +239,15 @@ ClusterNonLinearityMCAfterburner:                   # MC Cluster additional non-
         - defaultCells                              # This object is defined above in the cells section of the input objects
     clusterContainersNames:                         # Names of the cluster input objects which should be attached to the correction
         - defaultClusterContainer_1                 # This object is defined above in the cluster section of the input objects
+ClusterLowEnergyEfficiency:                         # Cluster number of cell efficiency, artificially widens the cluster in MC if it only has 1 cell
+    enabled: false                                  # Whether to enable the task
+    createHistos: false                             # Whether the task should create output histograms
+    nCellFunct: kGammaAndElec                       # Sets the probabiliyt function for the ncell efficiency
+    setRejectNextToClus: true                       # Set if 1 cell clusters which are directly next to another cluster should be considered for the ncell efficiency (Should be enabled)
+    cellsNames:                                     # Names of the cells input objects which should be attached to the correction
+        - defaultCells                              # This object is defined above in the cells section of the input objects
+    clusterContainersNames:                         # Names of the cluster input objects which should be attached to the correction
+        - defaultClusterContainer_1                 # This object is defined above in the cluster section of the input objects
 ClusterTrackMatcher:                                # Cluster-track matcher component
     enabled: false                                  # Whether to enable the task
     createHistos: false                             # Whether the task should create output histograms
@@ -329,6 +338,7 @@ executionOrder:
     - ClusterExotics
     - ClusterNonLinearity
     - ClusterNonLinearityMCAfterburner
+    - ClusterLowEnergyEfficiency
     - ClusterTrackMatcher
     - ClusterHadronicCorrection
     - ClusterEnergyVariation

--- a/PWGGA/GammaConv/macros/AddTask_GammaCalo_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaCalo_pp.C
@@ -2497,13 +2497,13 @@ void AddTask_GammaCalo_pp(
   } else if (trainConfig == 2061){ // EMCAL+DCAL NLM = 1-2, EG1, NL , std TM, swapping back.
     cuts.AddCutCalo("0008d113","411792106fe32220003","0r631031000000d0"); // EG1  NL 12 + TB dir. gamma
 
-  // configuration for V1 Clusterizer with 1-100 local maxima
+  // configuration for V2 Clusterizer no NCell cut
   } else if (trainConfig == 2062){  // EMCAL+DCAL NLM = 1-100, INT7, NL , std TM, swapping back.
-    cuts.AddCutCalo("00010113","411792106fe32220000","0r631031000000d0"); // INT7 NL 12 + TB dir. gamma
+    cuts.AddCutCalo("00010113","411792106fe30220000","0r631031000000d0"); // INT7 NL 21 + TB dir. gamma
   } else if (trainConfig == 2063){ // EMCAL+DCAL NLM = 1-100, EG2, NL , std TM, swapping back.
-    cuts.AddCutCalo("0008e113","411792106fe32220000","0r631031000000d0"); // EG2  NL 12 + TB dir. gamma
+    cuts.AddCutCalo("0008e113","411792106fe30220000","0r631031000000d0"); // EG2  NL 21 + TB dir. gamma
   } else if (trainConfig == 2064){ // EMCAL+DCAL NLM = 1-100, EG1, NL , std TM, swapping back.
-    cuts.AddCutCalo("0008d113","411792106fe32220000","0r631031000000d0"); // EG1  NL 12 + TB dir. gamma
+    cuts.AddCutCalo("0008d113","411792106fe30220000","0r631031000000d0"); // EG1  NL 21 + TB dir. gamma
 
   // configuration for V1 unfold Clusterizer with 1-100 local maxima
   } else if (trainConfig == 2065){  // EMCAL+DCAL NLM = 1-100, INT7, NL , std TM, swapping back.
@@ -3216,6 +3216,18 @@ void AddTask_GammaCalo_pp(
     cuts.AddCutCalo("00010113","411792106fj3o220000","0r631031000000d0"); // Exotics > 4 GeV
     cuts.AddCutCalo("00010113","411792106fk3o220000","0r631031000000d0"); // Exotics > 5 GeV
     cuts.AddCutCalo("00010113","411792106fl3o220000","0r631031000000d0"); // Exotics > 6 GeV
+
+    // multiple configs for different settings in the correction framework
+  } else if (trainConfig == 2513) { // NCellEfficiency calculated in the correction framework
+    cuts.AddCutCalo("00010113","411792106fe3y220000","0r631031000000d0"); // INT7 NL 12 + TB
+  } else if (trainConfig == 2514) { // NCellEfficiency calculated in the correction framework
+    cuts.AddCutCalo("00010113","411792106fe3y220000","0r631031000000d0"); // INT7 NL 12 + TB
+  } else if (trainConfig == 2515) { // NCellEfficiency calculated in the correction framework
+    cuts.AddCutCalo("00010113","411792106fe3y220000","0r631031000000d0"); // INT7 NL 12 + TB
+  } else if (trainConfig == 2516) { // NCellEfficiency calculated in the correction framework
+    cuts.AddCutCalo("00010113","411792106fe3y220000","0r631031000000d0"); // INT7 NL 12 + TB
+  } else if (trainConfig == 2517) { // NCellEfficiency calculated in the correction framework
+    cuts.AddCutCalo("00010113","411792106fe3y220000","0r631031000000d0"); // INT7 NL 12 + TB
 
   // 3x3 clusterizer
   } else if (trainConfig == 2520) { // 3x3 clusterizer

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_pp.C
@@ -2827,6 +2827,22 @@ void AddTask_GammaConvCalo_pp(
     cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411790109fk3m220000","0163103100000010"); //  Exotics > 5 GeV
     cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411790109fl3m220000","0163103100000010"); //  Exotics > 6 GeV
 
+    // NCell effi from correction framework
+  } else if (trainConfig == 2150){ // std. cuts
+    cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411792109fe32220000","0163103100000010"); // NCell from CF
+  } else if (trainConfig == 2151){ // no NCell cut
+    cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411792109fe30220000","0163103100000010"); // NCell from CF
+  } else if (trainConfig == 2152){ // NCell from correction framework
+    cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411792109fe3y220000","0163103100000010"); // NCell from CF
+  } else if (trainConfig == 2153){ // NCell from correction framework
+    cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411792109fe3y220000","0163103100000010"); // NCell from CF
+  } else if (trainConfig == 2154){ // NCell from correction framework
+    cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411792109fe3y220000","0163103100000010"); // NCell from CF
+  } else if (trainConfig == 2155){ // NCell from correction framework
+    cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411792109fe3y220000","0163103100000010"); // NCell from CF
+  } else if (trainConfig == 2156){ // NCell from correction framework
+    cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411792109fe3y220000","0163103100000010"); // NCell from CF
+
   // PCM-EDC systematics
   } else if (trainConfig == 2200){ // PCM based systematics
     cuts.AddCutPCMCalo("00010113","00200009327000008250400000","4117918077032230000","0163103100000010"); // std
@@ -3783,7 +3799,7 @@ void AddTask_GammaConvCalo_pp(
     cuts.AddCutPCMCalo("00010113", "0dm00079f9730000iih0404000","24466190sa01cc00000","0163103100000010");  // eta < 0.8  // remove  55-72 bin, min pT 0  (40) MeV
     cuts.AddCutPCMCalo("00010113", "0dm000p9f9730000iih0404000","24466190sa01cc00000","0163103100000010");  // eta < 0.8  // remove  55-72 bin, min pT 30 (75) MeV
     cuts.AddCutPCMCalo("00010113", "0dm00069f9730000iih0404000","24466190sa01cc00000","0163103100000010");  // eta < 0.8  // remove  55-72 bin, min pT    100MeV
-    
+
   } else if (trainConfig == 3402) {   // TPC clusters, cosPA
     cuts.AddCutPCMCalo("00010113", "0dm00088f9730000iih0404000","24466190sa01cc00000","0163103100000010");  // TPC cluster 35%
     cuts.AddCutPCMCalo("00010113", "0dm00086f9730000iih0404000","24466190sa01cc00000","0163103100000010");  // TPC cluster 70%


### PR DESCRIPTION
This new correction component corrects the mismatch between the fraction of 1 cell clusters in MC and data.
A larger fraction of 1 cell clusters are observed in MC. The new correction flags a fraction of the 1 cell clusters via the Chi2() variable, those cells are then treated as if they would have 2 cells and thus passing the exotics and M02/M20 cut.
- The correction can be added via the yaml file with: ClusterLowEnergyEfficiency
- The functions for the corrections are still under preparation. For now the functions: kGammaAndElec or kAllClusters should be considered