### PR TITLE
Changes for automatic vertex-Z calibration in MultSelection

### DIFF
--- a/OADB/COMMON/MULTIPLICITY/AliMultEstimator.cxx
+++ b/OADB/COMMON/MULTIPLICITY/AliMultEstimator.cxx
@@ -130,11 +130,15 @@ void AliMultEstimator::SetupFormula(const AliMultInput* lInput)
 Float_t AliMultEstimator::Evaluate(const AliMultInput* lInput)
 {
     if (!fFormula) return fValue = 0;
+    Float_t lVertexZ = lInput->GetVariable("fEvSel_VtxZ")->GetValue();
     for (Int_t i = 0; i < lInput->GetNVariables(); i++) {
         AliMultVariable* v = lInput->GetVariable(i);
-        fFormula->SetParameter(i, v->IsInteger() ?
-                               v->GetValueInteger() :
-                               v->GetValue());
+        Double_t lv = v->IsInteger() ? v->GetValueInteger() : v->GetValue();
+        if(v->GetUseVertexZCorrection()){
+          Float_t lCorrection = lInput->GetVtxZCorrection(v, lVertexZ)/lInput->GetVtxZCorrection(v, 0.0);
+          lv = lv / lCorrection; //automatic vertex correction if requested
+        }
+        fFormula->SetParameter(i, lv);
     }
     return fValue = fFormula->Eval(0);
 }

--- a/OADB/COMMON/MULTIPLICITY/AliMultEstimator.h
+++ b/OADB/COMMON/MULTIPLICITY/AliMultEstimator.h
@@ -58,6 +58,7 @@ private:
     Float_t fAnchorPoint;       //Raw value below which
     Float_t fAnchorPercentile;  //Percentile of X-section at anchor point
     
-    ClassDef(AliMultEstimator, 1)
+    ClassDef(AliMultEstimator, 2)
+   //2 - addition of auto-vertex-Z corrections
 };
 #endif

--- a/OADB/COMMON/MULTIPLICITY/AliMultInput.cxx
+++ b/OADB/COMMON/MULTIPLICITY/AliMultInput.cxx
@@ -9,49 +9,117 @@
  **********************************************/
 
 #include "TList.h"
+#include "TProfile.h"
 #include "AliMultEstimator.h"
 #include "AliMultVariable.h"
 #include "AliMultInput.h"
+#include "AliOADBMultSelection.h"
 #include <TROOT.h>
+#include <TMap.h>
 
 ClassImp(AliMultInput);
 
+const TString AliMultInput::VarName[kNVariables] = {
+  "fAmplitude_V0A", "fAmplitude_V0A1", "fAmplitude_V0A2", "fAmplitude_V0A3", "fAmplitude_V0A4",
+  "fAmplitude_V0C", "fAmplitude_V0C1", "fAmplitude_V0C2", "fAmplitude_V0C3", "fAmplitude_V0C4",
+  "fAmplitude_V0Apartial", "fAmplitude_V0Cpartial", "fAmplitude_V0AEq", "fAmplitude_V0CEq",
+  "fAmplitude_OnlineV0A","fAmplitude_OnlineV0C",
+  "fnSPDClusters", "fnSPDClusters0", "fnSPDClusters1",
+  "fMultiplicity_ADA", "fMultiplicity_ADC",
+  "fRefMultEta5", "fRefMultEta8", "fnTracklets", "fnTracklets08", "fnTracklets15",
+  "fZncEnergy","fZpcEnergy","fZnaEnergy","fZpaEnergy", "fZem1Energy", "fZem2Energy",
+  "fZnaTower", "fZncTower", "fZpaTower", "fZpcTower",
+  "fZnaFired", "fZncFired", "fZpaFired", "fZpcFired",
+  "fNTracks", "fNTracksGlobal2015", "fNTracksGlobal2015Trigger", "fNTracksITSsa2010",
+  "fNTracksINELgtONE","fNPartINELgtONE","fEvSel_VtxZ",
+  "fMC_NPart","fMC_NColl","fMC_NchV0A","fMC_NchV0C",
+  "fMC_NchEta05","fMC_NchEta08","fMC_NchEta10","fMC_NchEta14",
+  "fMC_b", "fSpherocityMC", "fSpherocityTracksMC"
+};
+
+const Bool_t AliMultInput::VarIsInteger[kNVariables] = {
+  kFALSE, kFALSE, kFALSE, kFALSE, kFALSE,
+  kFALSE, kFALSE, kFALSE, kFALSE, kFALSE,
+  kFALSE, kFALSE, kFALSE, kFALSE,
+  kFALSE, kFALSE,
+  kTRUE, kTRUE, kTRUE,
+  kFALSE, kFALSE,
+  kTRUE, kTRUE, kTRUE, kTRUE, kTRUE,
+  kFALSE, kFALSE, kFALSE, kFALSE, kFALSE, kFALSE,
+  kFALSE, kFALSE, kFALSE, kFALSE,
+  kTRUE, kTRUE, kTRUE, kTRUE,
+  kTRUE, kTRUE, kTRUE, kTRUE,
+  kFALSE, kFALSE, kFALSE,
+  kTRUE, kTRUE, kTRUE, kTRUE,
+  kTRUE, kTRUE, kTRUE, kTRUE,
+  kFALSE, kFALSE, kFALSE
+};
+
 AliMultInput::AliMultInput() :
-  TNamed(), fNVars(0), fVariableList(0x0)
+TNamed(),
+fNVars(0), fVariableList(0x0),
+fNVtxZ(0), fVariableVertexZList(0x0),
+fMap(0)
 {
   // Constructor
-    fVariableList = new TList();
+  fVariableList = new TList();
+  fVariableVertexZList = new TList();
+  fVariableVertexZList->SetOwner();
 }
 
 AliMultInput::AliMultInput(const char * name, const char * title):
-TNamed(name,title), fNVars(0), fVariableList(0x0)
+TNamed(name,title),
+fNVars(0), fVariableList(0x0),
+fNVtxZ(0), fVariableVertexZList(0x0),
+fMap(0)
 {
   // Constructor
-    fVariableList = new TList();
+  fVariableList = new TList();
+  fVariableVertexZList = new TList();
+  fVariableVertexZList->SetOwner();
 }
 
 AliMultInput::AliMultInput(const AliMultInput& o)
-: TNamed(o), fNVars(0), fVariableList(0x0)
+: TNamed(o),
+fNVars(0), fVariableList(0x0),
+fNVtxZ(0), fVariableVertexZList(0x0),
+fMap(0)
 {
-    // Constructor
-    fVariableList = new TList();
-    TIter next(o.fVariableList);
-    AliMultVariable* v  = 0;
-    while ((v = static_cast<AliMultVariable*>(next())))  AddVariable(v);
+  // Constructor
+  fVariableList = new TList();
+  TIter next(o.fVariableList);
+  AliMultVariable* v  = 0;
+  while ((v = static_cast<AliMultVariable*>(next())))  AddVariable(v);
+  
+  // Constructor
+  fVariableVertexZList = new TList();
+  fVariableVertexZList->SetOwner();
+  TIter nextp(o.fVariableVertexZList);
+  TProfile* vp  = 0;
+  while ((vp = static_cast<TProfile*>(nextp())))  AddVtxZ(vp);
 }
 
 AliMultInput& AliMultInput::operator=(const AliMultInput& o)
 {
-    if (&o == this) return *this;
-    SetName(o.GetName());
-    SetTitle(o.GetTitle());
-    if (!fVariableList) fVariableList = new TList();
-    fVariableList->Clear();
-    fNVars = 0;
-    TIter next(o.fVariableList);
-    AliMultVariable* v  = 0;
-    while ((v = static_cast<AliMultVariable*>(next())))  AddVariable(v);
-    return *this;
+  if (&o == this) return *this;
+  SetName(o.GetName());
+  SetTitle(o.GetTitle());
+  if (!fVariableList) fVariableList = new TList();
+  fVariableList->Clear();
+  fNVars = 0;
+  TIter next(o.fVariableList);
+  AliMultVariable* v  = 0;
+  while ((v = static_cast<AliMultVariable*>(next())))  AddVariable(v);
+  
+  if (!fVariableVertexZList) fVariableVertexZList = new TList();
+  fVariableVertexZList->SetOwner();
+  fVariableVertexZList->Clear();
+  fNVtxZ = 0;
+  TIter nextp(o.fVariableVertexZList);
+  TProfile* vp  = 0;
+  while ((vp = static_cast<TProfile*>(nextp())))  AddVtxZ(vp);
+  
+  return *this;
 }
 
 AliMultInput::~AliMultInput(){
@@ -60,68 +128,194 @@ AliMultInput::~AliMultInput(){
 }
 void AliMultInput::AddVariable ( AliMultVariable *lVar )
 {
-    if (!lVar) return;
-    if (!fVariableList) {
-        fVariableList = new TList;
-        fNVars = 0;
-    }
-    //Protect against double-declaration 
-    if ( fVariableList->FindObject( lVar->GetName() ) ){ 
-      Printf("===========================================================================" );
-      Printf("                          !!!  WARNING !!!                                 " );
-      Printf("Variable named %s already exists, you're doing a double-declaration!",lVar->GetName() );
-      Printf("AddVariable call exiting without doing anything... Please check your logic!");
-      Printf("===========================================================================" );
-      return; 
-    }
-    
-    fVariableList->Add(lVar);
-    fNVars++;
+  if (!lVar) return;
+  if (!fVariableList) {
+    fVariableList = new TList;
+    fNVars = 0;
+  }
+  //Protect against double-declaration
+  if ( fVariableList->FindObject( lVar->GetName() ) ){
+    Printf("===========================================================================" );
+    Printf("                          !!!  WARNING !!!                                 " );
+    Printf("Variable named %s already exists, you're doing a double-declaration!",lVar->GetName() );
+    Printf("AddVariable call exiting without doing anything... Please check your logic!");
+    Printf("===========================================================================" );
+    return;
+  }
+  fVariableList->Add(lVar);
+  fNVars++;
 }
 
 AliMultVariable* AliMultInput::GetVariable (const TString& lName) const
 {
-    if (!fVariableList) return 0;
-    return static_cast<AliMultVariable*>(fVariableList->FindObject(lName));
+  if (!fVariableList) return 0;
+  return static_cast<AliMultVariable*>(fVariableList->FindObject(lName));
 }
 
 AliMultVariable* AliMultInput::GetVariable (Long_t iIdx) const
 {
-    if (!fVariableList) return 0;
-    if (iIdx < 0 || iIdx >= fNVars) return 0;
-    return static_cast<AliMultVariable*>(fVariableList->At(iIdx));
+  if (!fVariableList) return 0;
+  if (iIdx < 0 || iIdx >= fNVars) return 0;
+  return static_cast<AliMultVariable*>(fVariableList->At(iIdx));
+}
+
+void AliMultInput::AddVtxZ ( TProfile *prof )
+{
+  //Warning: not protected against naming!
+  if (!fVariableVertexZList) {
+    fVariableVertexZList = new TList;
+    fVariableVertexZList->SetOwner();
+    fNVtxZ = 0;
+  }
+  //Protect against double-declaration
+  if ( fVariableVertexZList->FindObject( prof->GetName() ) ){
+    Printf("===========================================================================" );
+    Printf("                          !!!  WARNING !!!                                 " );
+    Printf("A vtx-Z correction named %s already exists!",prof->GetName() );
+    Printf("AddVtxZ call exiting without doing anything... Please check your logic!");
+    Printf("===========================================================================" );
+    return;
+  }
+  TProfile *lProfClo = (TProfile*) prof->Clone(Form("copy_%s",prof->GetName()));
+  fVariableVertexZList->Add(lProfClo);
+  fNVtxZ++;
+}
+
+TProfile* AliMultInput::GetVtxZProfile (const AliMultVariable *v) const
+{
+  if (!fMap) return 0;
+  TPair* ret = static_cast<TPair*>(fMap->FindObject(v));
+  if (!ret) return 0;
+  return static_cast<TProfile*>(ret->Value());
+}
+
+Double_t AliMultInput::GetVtxZCorrection (const AliMultVariable *v, Double_t lVtxZ) const
+{
+  Float_t lReturnValue = 1.0;
+  if (!fMap) return 0;
+  TPair* ret = static_cast<TPair*>(fMap->FindObject(v));
+  if (!ret) return 0;
+  TProfile *profile = static_cast<TProfile*>(ret->Value());
+  Int_t lBin = profile -> FindBin(lVtxZ);
+  Float_t lBinContent = profile->GetBinContent(lBin);
+  Float_t lBinCenter = profile->GetBinCenter(lBin);
+  Float_t lBinWidth = profile->GetBinWidth(lBin);
+  if(lBinContent<1e-6) return 1.0; //not dealt with / uncalibrated
+  if( lVtxZ >= lBinCenter ){
+    //check next bin
+    Float_t lFrac = (lVtxZ-lBinCenter)/lBinWidth;
+    Float_t lBinContent1 = profile->GetBinContent(lBin+1);
+    if(lBinContent1<1e-6) lBinContent1 = lBinContent;
+    lReturnValue = (1-lFrac)*lBinContent + lFrac*lBinContent1;
+  }else{
+    //check preceding bin
+    Float_t lFrac = (lBinCenter-lVtxZ)/lBinWidth;
+    Float_t lBinContent1 = profile->GetBinContent(lBin-1);
+    if(lBinContent1<1e-6) lBinContent1 = lBinContent;
+    lReturnValue = (1-lFrac)*lBinContent + lFrac*lBinContent1;
+  }
+  return lReturnValue;
+}
+
+void AliMultInput::ClearVtxZ()
+{
+  if (fVariableVertexZList)
+    fVariableVertexZList->Delete();
+  fNVtxZ = fVariableVertexZList->GetEntries(); 
 }
 
 void AliMultInput::Clear(Option_t* option)
 {
-    TIter next(fVariableList);
-    AliMultVariable* var = 0;
-    while ((var = static_cast<AliMultVariable*>(next()))) {
-        var->Clear(option);
-    }
+  TIter next(fVariableList);
+  AliMultVariable* var = 0;
+  while ((var = static_cast<AliMultVariable*>(next()))) {
+    var->Clear(option);
+  }
 }
 
 void AliMultInput::Set(const AliMultInput* other)
 {
-    TIter next(fVariableList);
-    AliMultVariable* var = 0;
-    while ((var = static_cast<AliMultVariable*>(next()))) {
-        AliMultVariable* ovar = other->GetVariable(var->GetName());
-        var->Set(ovar);
-    }
+  TIter next(fVariableList);
+  AliMultVariable* var = 0;
+  while ((var = static_cast<AliMultVariable*>(next()))) {
+    AliMultVariable* ovar = other->GetVariable(var->GetName());
+    var->Set(ovar);
+  }
 }
 void AliMultInput::Print(Option_t* option) const
 {
-    Printf("%s: %s/%s %ld variables", ClassName(),
-           GetName(), GetTitle(), fNVars);
+  Printf("%s: %s/%s %ld variables", ClassName(),
+         GetName(), GetTitle(), fNVars);
+  gROOT->IndentLevel();
+  Printf("Variables");
+  gROOT->IncreaseDirLevel();
+  TIter next(fVariableList);
+  TObject* o = 0;
+  while ((o = next())) {
     gROOT->IndentLevel();
-    Printf("Variables");
-    gROOT->IncreaseDirLevel();
-    TIter next(fVariableList);
-    TObject* o = 0;
-    while ((o = next())) {
-        gROOT->IndentLevel();
-        o->Print(option);
-    }
-    gROOT->DecreaseDirLevel();
+    o->Print(option);
+  }
+  gROOT->DecreaseDirLevel();
 }
+//________________________________________________________________
+void AliMultInput::SetupAutoVtxZCorrection(){
+  Printf("Setting up AliMultVariable <-> TProfile map");
+  
+  if (fMap) {
+      delete fMap;
+      fMap = 0;
+  }
+  fMap = new TMap;
+  fMap->SetOwner(false);
+  Printf("Variable list size: %i, vertex-Z list size: %i",fVariableList->GetEntries(), fVariableVertexZList->GetEntries());
+  
+  for(Int_t ii=0 ; ii<kNVariables; ii++){
+    //Get var
+    AliMultVariable* v = static_cast<AliMultVariable*>(fVariableList->At(ii));
+    if (!v) continue;
+    
+    v->SetUseVertexZCorrection(kFALSE); //assume not found until proven otherwise
+    
+    //Warning: assumes complete list, usable at calibration time only
+    TProfile*   h = static_cast<TProfile*>(fVariableVertexZList->At(ii));
+    if (!h) continue;
+    
+    //Printf("Found vertex-Z calib profile for variable %s, profile name: %s", v->GetName(), h->GetName() );
+    v->SetUseVertexZCorrection(kTRUE); //assume not found until proven otherwise
+    
+    fMap->Add(v, h);
+  }
+  Printf("Number of automatically calibrated inputs: %i",fMap->GetEntries());
+}
+//________________________________________________________________
+void AliMultInput::SetupAutoVtxZCorrection( const AliOADBMultSelection *oadb){
+  Printf("Setting up automatic vertex-Z correction...");
+  
+  if (fMap) {
+      delete fMap;
+      fMap = 0;
+  }
+  fMap = new TMap;
+  fMap->SetOwner(false);
+  
+  for(Int_t ii=0 ; ii<kNVariables; ii++){
+    //Get var
+    AliMultVariable* v = static_cast<AliMultVariable*>(fVariableList->At(ii));
+    if (!v) continue;
+    //Printf("Looking for vertex-Z correction for variable: %s", v->GetName() );
+    v->SetUseVertexZCorrection(kFALSE); //assume not found until proven otherwise
+    
+    //Check existence of calib histo
+    TString name(Form("hCalibVtx_%s", v->GetName()));
+    TProfile*   h = oadb->GetCalibHistoVtx(name);
+    if (!h) continue;
+    
+    Printf("Found vertex-Z calib profile for variable %s, profile name: %s", v->GetName(), h->GetName() );
+    v->SetUseVertexZCorrection(kTRUE); //assume not found until proven otherwise
+    
+    fMap->Add(v, h);
+  }
+  Printf("Number of automatically calibrated inputs: %i",fMap->GetEntries()); 
+}
+
+

--- a/OADB/COMMON/MULTIPLICITY/AliMultInput.h
+++ b/OADB/COMMON/MULTIPLICITY/AliMultInput.h
@@ -1,29 +1,114 @@
 #ifndef AliMultInput_H
 #define AliMultInput_H
 #include <TNamed.h>
+#include "TProfile.h"
+#include <TMap.h>
 #include "AliMultVariable.h"
+#include "AliOADBMultSelection.h"
 
 class AliMultInput : public TNamed {
-    
+  
 public:
-    AliMultInput();
-    AliMultInput(const char * name, const char * title = "MultInput");
-    AliMultInput(const AliMultInput& o);
-    AliMultInput& operator=(const AliMultInput& o);
-    ~AliMultInput();
-
-    void     AddVariable ( AliMultVariable *lVar );
-    AliMultVariable* GetVariable (const TString& lName) const;
-    AliMultVariable* GetVariable (Long_t iIdx) const;
-    Long_t GetNVariables         () const { return fNVars; }
-    void Clear(Option_t* option="");
-    void Set(const AliMultInput* other);
-    void Print(Option_t* option="") const;
-    
+  AliMultInput();
+  AliMultInput(const char * name, const char * title = "MultInput");
+  AliMultInput(const AliMultInput& o);
+  AliMultInput& operator=(const AliMultInput& o);
+  ~AliMultInput();
+  
+  void     AddVariable ( AliMultVariable *lVar );
+  AliMultVariable* GetVariable (const TString& lName) const;
+  AliMultVariable* GetVariable (Long_t iIdx) const;
+  Long_t GetNVariables         () const { return fNVars; }
+  
+  void     AddVtxZ ( TProfile *prof );
+  TProfile* GetVtxZProfile   (const AliMultVariable *v) const;
+  Double_t GetVtxZCorrection (const AliMultVariable *v, Double_t lVtxZ) const;
+  Long_t GetNVtxZ         () const { return fNVtxZ; }
+  void ClearVtxZ (); //cleanup
+  
+  void Clear(Option_t* option="");
+  void Set(const AliMultInput* other);
+  void Print(Option_t* option="") const;
+  
+  void SetupAutoVtxZCorrection();
+  void SetupAutoVtxZCorrection(const AliOADBMultSelection *oadb); 
+  
+  //Aliases for multiplicity selection criteria
+  enum MultSelVar {
+    kAmplitude_V0A = 0,
+    kAmplitude_V0A1,
+    kAmplitude_V0A2,
+    kAmplitude_V0A3,
+    kAmplitude_V0A4,
+    kAmplitude_V0C,
+    kAmplitude_V0C1,
+    kAmplitude_V0C2,
+    kAmplitude_V0C3,
+    kAmplitude_V0C4,
+    kAmplitude_V0Apartial,
+    kAmplitude_V0Cpartial,
+    kAmplitude_V0AEq,
+    kAmplitude_V0CEq,
+    kAmplitude_OnlineV0A,
+    kAmplitude_OnlineV0C,
+    kMultiplicity_ADA,
+    kMultiplicity_ADC,
+    knSPDClusters,
+    knSPDClusters0,
+    knSPDClusters1,
+    knTracklets  ,
+    knTracklets08  ,
+    knTracklets15  ,
+    kRefMultEta5 ,
+    kRefMultEta8 ,
+    kZncEnergy,
+    kZpcEnergy,
+    kZnaEnergy,
+    kZpaEnergy,
+    kZem1Energy,
+    kZem2Energy,
+    kZnaTower,
+    kZncTower,
+    kZpaTower,
+    kZpcTower,
+    kZnaFired,
+    kZncFired,
+    kZpaFired,
+    kZpcFired,
+    kNTracks,
+    kNTracksGlobal2015,
+    kNTracksGlobal2015Trigger,
+    kNTracksITSsa2010,
+    kNTracksINELgtONE,
+    kNPartINELgtONE,
+    kEvSel_VtxZ,
+    kMC_NPart,
+    kMC_NColl,
+    kMC_NchV0A,
+    kMC_NchV0C,
+    kMC_NchEta05,
+    kMC_NchEta08,
+    kMC_NchEta10,
+    kMC_NchEta14,
+    kMC_b,
+    kSpherocityMC,
+    kSpherocityTracksMC,
+    kNVariables
+  };
+  
+  static const TString VarName[kNVariables];  //! Names of the TTree containers
+  static const Bool_t VarIsInteger[kNVariables]; //! Is this an integer or not?
+  
 private:
-    Long_t fNVars;
-    TList *fVariableList; //List containing all AliMultVariables
-    
-    ClassDef(AliMultInput, 1)
+  Long_t fNVars;
+  TList *fVariableList; //List containing all AliMultVariables
+  
+  Long_t fNVtxZ;
+  TList *fVariableVertexZList; //List containing variable profiles for usage
+  
+  TMap* fMap; //! Map variable to profile histogram if it exits
+  
+  ClassDef(AliMultInput, 2)
+  //2 - vertex-Z correction
 };
 #endif

--- a/OADB/COMMON/MULTIPLICITY/AliMultSelection.h
+++ b/OADB/COMMON/MULTIPLICITY/AliMultSelection.h
@@ -90,12 +90,13 @@ private:
     Bool_t fThisEvent_IsNotIncompleteDAQ;       //!
     Bool_t fThisEvent_HasGoodVertex2016;         //!
     
-    ClassDef(AliMultSelection, 6)
+    ClassDef(AliMultSelection, 7)
     // 1 - original implementation
     // 2 - added fEvSelCode for EvSel bypass + getter changed
     // 3 - added booleans to classify which event criteria are satisfied
     // 4 - added IsEventSelected
     // 5 - added Good vertex, adjustments
     // 6 - changed to inherit from AliMultSelectionBase
+    // 7 - addition of auto-vertex-Z correction
 };
 #endif

--- a/OADB/COMMON/MULTIPLICITY/AliMultSelectionCalibrator.cxx
+++ b/OADB/COMMON/MULTIPLICITY/AliMultSelectionCalibrator.cxx
@@ -26,8 +26,10 @@
 #include "AliESDEvent.h"
 #include "TList.h"
 #include "TFile.h"
+#include "TProfile.h"
 #include "TStopwatch.h"
 #include "TArrayL64.h"
+#include "TArrayF.h"
 
 ClassImp(AliMultSelectionCalibrator);
 
@@ -39,29 +41,49 @@ fNRunRanges(0), fRunRangesMap(), fMultSelectionList(0),
 fInputFileName(""), fBufferFileName("buffer.root"),
 fOutputFileName(""), fMultSelectionCuts(0), fCalibHists(0)
 {
-    // Constructor
-
-    // Create Event Selector
-    fMultSelectionCuts = new AliMultSelectionCuts();
-    fMultSelectionCuts -> Print();
-
-    //Basic I/O for MultSelection framework
-    fInput     = new AliMultInput();
-
-    //List of objects to use as AliMultSelection
-    fMultSelectionList = new TList();
-
-    //Make sure the TList owns its objects
-    fCalibHists = new TList();
-    fCalibHists -> SetOwner(kTRUE);
-
-    //Initialize
-    for( Int_t iv=0;iv<1000;iv++){ fFirstRun[iv] = 0; }
-    for( Int_t iv=0;iv<1000;iv++){ fLastRun[iv] = 0; }
+  // Constructor
+  Bool_t lVarDoAutocalib[] = {
+    kTRUE, kFALSE, kFALSE, kFALSE, kFALSE,
+    kTRUE, kFALSE, kFALSE, kFALSE, kFALSE,
+    kFALSE, kFALSE, kFALSE, kFALSE,
+    kFALSE, kFALSE,
+    kTRUE, kTRUE, kTRUE,
+    kFALSE, kFALSE,
+    kTRUE, kTRUE, kTRUE, kTRUE, kTRUE,
+    kFALSE, kFALSE, kFALSE, kFALSE, kFALSE, kFALSE,
+    kFALSE, kFALSE, kFALSE, kFALSE,
+    kFALSE, kFALSE, kFALSE, kFALSE,
+    kFALSE, kFALSE, kFALSE, kFALSE,
+    kFALSE, kFALSE, kFALSE,
+    kFALSE, kFALSE, kFALSE, kFALSE,
+    kFALSE, kFALSE, kFALSE, kFALSE,
+    kFALSE, kFALSE, kFALSE
+  };
+  
+  for(Int_t iVar = 0; iVar<AliMultInput::kNVariables; iVar++)
+  VarDoAutocalib[iVar] = lVarDoAutocalib[iVar];
+  
+  // Create Event Selector
+  fMultSelectionCuts = new AliMultSelectionCuts();
+  fMultSelectionCuts -> Print();
+  
+  //Basic I/O for MultSelection framework
+  fInput     = new AliMultInput();
+  
+  //List of objects to use as AliMultSelection
+  fMultSelectionList = new TList();
+  
+  //Make sure the TList owns its objects
+  fCalibHists = new TList();
+  fCalibHists -> SetOwner(kTRUE);
+  
+  //Initialize
+  for( Int_t iv=0;iv<1000;iv++){ fFirstRun[iv] = 0; }
+  for( Int_t iv=0;iv<1000;iv++){ fLastRun[iv] = 0; }
 }
 
 AliMultSelectionCalibrator::AliMultSelectionCalibrator(const char * name, const char * title):
-    TNamed(name,title),
+TNamed(name,title),
 fInput(0), fSelection(0), lDesiredBoundaries(0), lNDesiredBoundaries(0),
 fRunToUseAsDefault(-1), fMaxEventsPerRun(1e+9), fCheckTriggerType(kFALSE),
 fTrigType(AliVEvent::kAny), fPrefilterOnly(kFALSE), fFiredTrigString(""),
@@ -69,880 +91,900 @@ fNRunRanges(0), fRunRangesMap(), fMultSelectionList(0),
 fInputFileName(""), fBufferFileName("buffer.root"),
 fOutputFileName(""), fMultSelectionCuts(0), fCalibHists(0)
 {
-    // Named Constructor
-
-    // Create Event Selector
-    fMultSelectionCuts = new AliMultSelectionCuts();
-
-    //Set Standard Cuts (warning: this is pp-like!)
-    fMultSelectionCuts -> SetVzCut (10.0);
-    fMultSelectionCuts -> SetTriggerCut(kTRUE);
-    fMultSelectionCuts -> SetINELgtZEROCut(kTRUE);
-    fMultSelectionCuts -> SetTrackletsVsClustersCut(kTRUE);
-    fMultSelectionCuts -> SetRejectPileupInMultBinsCut(kTRUE);
-    fMultSelectionCuts -> SetVertexConsistencyCut(kTRUE);
-    fMultSelectionCuts -> SetNonZeroNContribs(kFALSE);
-    fMultSelectionCuts -> SetIsNotAsymmetricInVZERO(kFALSE);
-    fMultSelectionCuts -> SetIsNotIncompleteDAQ(kFALSE);
-    fMultSelectionCuts -> SetHasGoodVertex2016(kFALSE);
-
-    //Basic I/O for MultSelection framework
-    fInput     = new AliMultInput();
-
-    //List of objects to use as AliMultSelection
-    fMultSelectionList = new TList();
-
-    //Make sure the TList owns its objects
-    fCalibHists = new TList();
-    fCalibHists -> SetOwner(kTRUE);
-
-    //Initialize
-    for( Int_t iv=0;iv<1000;iv++){ fFirstRun[iv] = 0; }
-    for( Int_t iv=0;iv<1000;iv++){ fLastRun[iv] = 0; }
+  // Named Constructor
+  Bool_t lVarDoAutocalib[] = {
+    kTRUE, kFALSE, kFALSE, kFALSE, kFALSE,
+    kTRUE, kFALSE, kFALSE, kFALSE, kFALSE,
+    kFALSE, kFALSE, kFALSE, kFALSE,
+    kFALSE, kFALSE,
+    kTRUE, kTRUE, kTRUE,
+    kFALSE, kFALSE,
+    kTRUE, kTRUE, kTRUE, kTRUE, kTRUE,
+    kFALSE, kFALSE, kFALSE, kFALSE, kFALSE, kFALSE,
+    kFALSE, kFALSE, kFALSE, kFALSE,
+    kFALSE, kFALSE, kFALSE, kFALSE,
+    kFALSE, kFALSE, kFALSE, kFALSE,
+    kFALSE, kFALSE, kFALSE,
+    kFALSE, kFALSE, kFALSE, kFALSE,
+    kFALSE, kFALSE, kFALSE, kFALSE,
+    kFALSE, kFALSE, kFALSE
+  };
+  
+  for(Int_t iVar = 0; iVar<AliMultInput::kNVariables; iVar++)
+  VarDoAutocalib[iVar] = lVarDoAutocalib[iVar];
+  
+  // Create Event Selector
+  fMultSelectionCuts = new AliMultSelectionCuts();
+  
+  //Set Standard Cuts (warning: this is pp-like!)
+  fMultSelectionCuts -> SetVzCut (10.0);
+  fMultSelectionCuts -> SetTriggerCut(kTRUE);
+  fMultSelectionCuts -> SetINELgtZEROCut(kTRUE);
+  fMultSelectionCuts -> SetTrackletsVsClustersCut(kTRUE);
+  fMultSelectionCuts -> SetRejectPileupInMultBinsCut(kTRUE);
+  fMultSelectionCuts -> SetVertexConsistencyCut(kTRUE);
+  fMultSelectionCuts -> SetNonZeroNContribs(kFALSE);
+  fMultSelectionCuts -> SetIsNotAsymmetricInVZERO(kFALSE);
+  fMultSelectionCuts -> SetIsNotIncompleteDAQ(kFALSE);
+  fMultSelectionCuts -> SetHasGoodVertex2016(kFALSE);
+  
+  //Basic I/O for MultSelection framework
+  fInput     = new AliMultInput();
+  
+  //List of objects to use as AliMultSelection
+  fMultSelectionList = new TList();
+  
+  //Make sure the TList owns its objects
+  fCalibHists = new TList();
+  fCalibHists -> SetOwner(kTRUE);
+  
+  //Initialize
+  for( Int_t iv=0;iv<1000;iv++){ fFirstRun[iv] = 0; }
+  for( Int_t iv=0;iv<1000;iv++){ fLastRun[iv] = 0; }
 }
 //________________________________________________________________
 AliMultSelectionCalibrator::~AliMultSelectionCalibrator() {
-    // Destructor
-
-    if ( fInput ) {
-        delete fInput;
-        fInput = 0x0;
-    }
-    if ( fSelection ) {
-        delete fSelection;
-        fSelection = 0x0;
-    }
-    if ( fMultSelectionCuts ) {
-        delete fMultSelectionCuts;
-        fMultSelectionCuts = 0x0;
-    }
-    if ( fCalibHists ) {
-        delete fCalibHists;
-        fCalibHists = 0x0;
-    }
+  // Destructor
+  
+  if ( fInput ) {
+    delete fInput;
+    fInput = 0x0;
+  }
+  if ( fSelection ) {
+    delete fSelection;
+    fSelection = 0x0;
+  }
+  if ( fMultSelectionCuts ) {
+    delete fMultSelectionCuts;
+    fMultSelectionCuts = 0x0;
+  }
+  if ( fCalibHists ) {
+    delete fCalibHists;
+    fCalibHists = 0x0;
+  }
 }
+
 //________________________________________________________________
 void AliMultSelectionCalibrator::AddRunRange ( Int_t lFirst, Int_t lLast, AliMultSelection *lMultSelProvided ){
-    //Add mapping : all runs in range go to current value of fNRunRanges
-    //Ease of access
-    fFirstRun[fNRunRanges] = lFirst;
-    fLastRun [fNRunRanges] = lLast;
-    for( Int_t iRun = lFirst; iRun<=lLast; iRun++){
-        fRunRangesMap.insert( std::pair<int,int>(iRun,fNRunRanges));
-    }
-    //Add the provided AliMultSelection object among those to be used
-    fMultSelectionList -> Add ( lMultSelProvided ) ;
-
-    AliInfoF("Added Run Range #%i (%i - %i)", (Int_t)fNRunRanges, lFirst, lLast) ;
-    AliInfoF("Added AliMultSelection object. Existing objects: %i", fMultSelectionList->GetEntries()) ;
-    fNRunRanges++;
+  //Add mapping : all runs in range go to current value of fNRunRanges
+  //Ease of access
+  fFirstRun[fNRunRanges] = lFirst;
+  fLastRun [fNRunRanges] = lLast;
+  for( Int_t iRun = lFirst; iRun<=lLast; iRun++){
+    fRunRangesMap.insert( std::pair<int,int>(iRun,fNRunRanges));
+  }
+  //Add the provided AliMultSelection object among those to be used
+  fMultSelectionList -> Add ( lMultSelProvided ) ;
+  
+  AliInfoF("Added Run Range #%i (%i - %i)", (Int_t)fNRunRanges, lFirst, lLast) ;
+  AliInfoF("Added AliMultSelection object. Existing objects: %i", fMultSelectionList->GetEntries()) ;
+  fNRunRanges++;
 }
 //________________________________________________________________
 Bool_t AliMultSelectionCalibrator::Calibrate() {
-    // Function meant to generate calibration OADB
-    //
-    // --- input : fInputFileName, containing a TTree object
-    // --- output: fOutputFileName, containing OABD object
-    //
-    // Steps involved:
-    //  (1) Set up basic I/O
-    //  (2) Detect Runs From Input File
-    //  (3) Determine Averages
-    //     (3a) Create run-by-run buffer files with averages
-    //  (4) Determine Quantile Boundaries
-    //     (4a) Create run-by-run buffer files (requires averages)
-    //     (4b) Compute Quantile Boundaries for all estimators
-    //  (4) Save Quantiles + AliMultSelectionCuts to OADB File
-
-    cout<<"=== STARTING CALIBRATION PROCEDURE ==="<<endl;
-    cout<<" * Input File.....: "<<fInputFileName.Data()<<endl;
-    cout<<" * Output File....: "<<fOutputFileName.Data()<<endl;
-    cout<<endl;
-    cout<<" * Event Selection Peformed: "<<endl;
-    fMultSelectionCuts -> Print();
-    cout<<endl;
-
-    // STEP 1: Basic I/O
-    cout<<"(1) Opening File"<<endl;
-
-    //Open File
-    TFile *fInputFile = TFile::Open( fInputFileName.Data(), "READ");
-    if(!fInputFile) {
-        AliWarningF("File %s not found!", fInputFileName.Data() );
-        return kFALSE;
+  // Function meant to generate calibration OADB
+  //
+  // --- input : fInputFileName, containing a TTree object
+  // --- output: fOutputFileName, containing OABD object
+  //
+  // Steps involved:
+  //  (1) Set up basic I/O
+  //  (2) Detect Runs From Input File
+  //  (3) Determine Averages
+  //     (3a) Create run-by-run buffer files with averages
+  //  (4) Determine Quantile Boundaries
+  //     (4a) Create run-by-run buffer files (requires averages)
+  //     (4b) Compute Quantile Boundaries for all estimators
+  //  (4) Save Quantiles + AliMultSelectionCuts to OADB File
+  
+  
+  cout<<"=== STARTING CALIBRATION PROCEDURE ==="<<endl;
+  cout<<" * Input File.....: "<<fInputFileName.Data()<<endl;
+  cout<<" * Output File....: "<<fOutputFileName.Data()<<endl;
+  cout<<endl;
+  cout<<" * Event Selection Peformed: "<<endl;
+  fMultSelectionCuts -> Print();
+  cout<<endl;
+  
+  // STEP 1: Basic I/O
+  cout<<"(1) Opening File"<<endl;
+  
+  //Open File
+  TFile *fInputFile = TFile::Open( fInputFileName.Data(), "READ");
+  if(!fInputFile) {
+    AliWarningF("File %s not found!", fInputFileName.Data() );
+    return kFALSE;
+  }
+  //Locate TTree object
+  TTree* fTree = (TTree*)fInputFile->FindObjectAny("fTreeEvent");
+  if(!fTree) {
+    AliWarning("fTreeEvent object not found!" );
+    return kFALSE;
+  }
+  
+  //Event Selection Variables
+  Bool_t fEvSel_IsNotPileupInMultBins      = kFALSE ;
+  Bool_t fEvSel_Triggered                  = kFALSE ;
+  Bool_t fEvSel_INELgtZERO                 = kFALSE ;
+  Bool_t fEvSel_PassesTrackletVsCluster    = kFALSE ;
+  Bool_t fEvSel_HasNoInconsistentVertices  = kFALSE ;
+  Bool_t fEvSel_IsNotAsymmetricInVZERO     = kFALSE ;
+  Bool_t fEvSel_IsNotIncompleteDAQ         = kFALSE ;
+  Bool_t fEvSel_HasGoodVertex2016          = kFALSE ;
+  Int_t fRunNumber;
+  
+  //FIXME/CAUTION: non-zero if using tree without that branch
+  Int_t fnContributors = 1000;
+  
+  UInt_t fEvSel_TriggerMask; //! save full info for checking later
+  
+  //SetBranchAddresses for event Selection Variables
+  //(multiplicity related will be done automatically!)
+  fTree->SetBranchAddress("fEvSel_IsNotPileupInMultBins",&fEvSel_IsNotPileupInMultBins);
+  fTree->SetBranchAddress("fEvSel_PassesTrackletVsCluster",&fEvSel_PassesTrackletVsCluster);
+  fTree->SetBranchAddress("fEvSel_HasNoInconsistentVertices",&fEvSel_HasNoInconsistentVertices);
+  fTree->SetBranchAddress("fEvSel_Triggered",&fEvSel_Triggered);
+  fTree->SetBranchAddress("fEvSel_TriggerMask",&fEvSel_TriggerMask);
+  fTree->SetBranchAddress("fEvSel_INELgtZERO",&fEvSel_INELgtZERO);
+  fTree->SetBranchAddress("fRunNumber",&fRunNumber);
+  fTree->SetBranchAddress("fnContributors", &fnContributors);
+  fTree->SetBranchAddress("fEvSel_IsNotAsymmetricInVZERO", &fEvSel_IsNotAsymmetricInVZERO);
+  fTree->SetBranchAddress("fEvSel_IsNotIncompleteDAQ", &fEvSel_IsNotIncompleteDAQ);
+  fTree->SetBranchAddress("fEvSel_HasGoodVertex2016", &fEvSel_HasGoodVertex2016);
+  
+  TString *fFiredTriggerClasses = new TString();
+  fTree->SetBranchAddress("fFiredTriggerClasses",&fFiredTriggerClasses);
+  
+  //============================================================
+  // Auto-configure Input
+  //============================================================
+  
+  Bool_t lAutoDiscover = kFALSE;
+  
+  if ( fInput->GetNVariables() < 1 ){
+    cout<<"Error: No Input Variables configured!"<<endl;
+    cout<<"The simplest way to get rid of this problem is to remember to call SetupStandardInput()!"<<endl;
+    return kFALSE; //failure to calibrate
+  }
+  
+  if ( fMultSelectionList->GetEntries() == 0 ){
+    AliInfo("===============================================");
+    AliInfo(" Calibrator invoked without run mappings");
+    AliInfo(" Auto run discovery mode will be used!");
+    AliInfo("===============================================");
+    lAutoDiscover = kTRUE;
+  }
+  
+  if ( lAutoDiscover && !fSelection ) {
+    cout<<"Error: no default AliMultSelection defined!"<<endl;
+    cout<<"The simplest way to get rid of this problem is to remember to call SetMultSelection(...)!"<<endl;
+    return kFALSE; //failure to calibrate
+  }
+  
+  //Binding to input variables
+  for(Long_t iVar=0; iVar<fInput->GetNVariables(); iVar++) {
+    if( !fInput->GetVariable(iVar)->IsInteger() ) {
+      fTree->SetBranchAddress(fInput->GetVariable(iVar)->GetName(),&fInput->GetVariable(iVar)->GetRValue());
+    } else {
+      fTree->SetBranchAddress(fInput->GetVariable(iVar)->GetName(),&fInput->GetVariable(iVar)->GetRValueInteger());
     }
-    //Locate TTree object
-    TTree* fTree = (TTree*)fInputFile->FindObjectAny("fTreeEvent");
-    if(!fTree) {
-        AliWarning("fTreeEvent object not found!" );
-        return kFALSE;
-    }
-
-    //Event Selection Variables
-    Bool_t fEvSel_IsNotPileupInMultBins      = kFALSE ;
-    Bool_t fEvSel_Triggered                  = kFALSE ;
-    Bool_t fEvSel_INELgtZERO                 = kFALSE ;
-    Bool_t fEvSel_PassesTrackletVsCluster    = kFALSE ;
-    Bool_t fEvSel_HasNoInconsistentVertices  = kFALSE ;
-    Bool_t fEvSel_IsNotAsymmetricInVZERO     = kFALSE ;
-    Bool_t fEvSel_IsNotIncompleteDAQ         = kFALSE ;
-    Bool_t fEvSel_HasGoodVertex2016          = kFALSE ;
-    Int_t fRunNumber;
-
-    //FIXME/CAUTION: non-zero if using tree without that branch
-    Int_t fnContributors = 1000;
-
-    UInt_t fEvSel_TriggerMask; //! save full info for checking later
-
-    //SetBranchAddresses for event Selection Variables
-    //(multiplicity related will be done automatically!)
-    fTree->SetBranchAddress("fEvSel_IsNotPileupInMultBins",&fEvSel_IsNotPileupInMultBins);
-    fTree->SetBranchAddress("fEvSel_PassesTrackletVsCluster",&fEvSel_PassesTrackletVsCluster);
-    fTree->SetBranchAddress("fEvSel_HasNoInconsistentVertices",&fEvSel_HasNoInconsistentVertices);
-    fTree->SetBranchAddress("fEvSel_Triggered",&fEvSel_Triggered);
-    fTree->SetBranchAddress("fEvSel_TriggerMask",&fEvSel_TriggerMask);
-    fTree->SetBranchAddress("fEvSel_INELgtZERO",&fEvSel_INELgtZERO);
-    fTree->SetBranchAddress("fRunNumber",&fRunNumber);
-    fTree->SetBranchAddress("fnContributors", &fnContributors);
-    fTree->SetBranchAddress("fEvSel_IsNotAsymmetricInVZERO", &fEvSel_IsNotAsymmetricInVZERO);
-    fTree->SetBranchAddress("fEvSel_IsNotIncompleteDAQ", &fEvSel_IsNotIncompleteDAQ);
-    fTree->SetBranchAddress("fEvSel_HasGoodVertex2016", &fEvSel_HasGoodVertex2016);
-
-    TString *fFiredTriggerClasses = new TString();
-    fTree->SetBranchAddress("fFiredTriggerClasses",&fFiredTriggerClasses);
+  }
+  
+  Long64_t lNEv = fTree->GetEntries();
+  cout<<"(1) File opened, event count is "<<lNEv<<endl;
+  
+  cout<<"(2) Creating buffer, computing averages"<<endl;
+  const int lMax = 1000;
+  const int lMaxQuantiles = 10000;
+  Int_t lRunNumbers[lMaxQuantiles];
+  Long_t lRunStats[lMaxQuantiles];
+  
+  for( Int_t ix=0; ix<1000;ix++){
+    lRunNumbers[ix] = 0;
+    lRunStats[ix] = 0;
+  }
+  
+  Int_t lNRuns = 0;
+  Bool_t lNewRun = kTRUE;
+  Int_t lThisRunIndex = -1;
+  //Buffer file with run-by-run TTree objects needed for later processing
+  
+  TFile *fOutput = new TFile (fBufferFileName.Data(), "RECREATE");
+  TTree *sTree[lMaxQuantiles];
+  cout<<"Creating Trees..."<<endl;
+  //N.B. No need to Exceed Run Ranges in Calibration Code here!
+  Int_t lNTrees = 0;
+  if( !lAutoDiscover ){
+    lNTrees = fNRunRanges;
+  }else{
+    lNTrees = lMax;
+  }
+  for(Int_t iRun=0; iRun<lNTrees; iRun++) {
+    sTree[iRun] = new TTree(Form("sTree%i",iRun),Form("sTree%i",iRun));
     
-    //============================================================
-    // Auto-configure Input
-    //============================================================
-
-    Bool_t lAutoDiscover = kFALSE;
-
-    if ( fInput->GetNVariables() < 1 ){
-        cout<<"Error: No Input Variables configured!"<<endl;
-        cout<<"The simplest way to get rid of this problem is to remember to call SetupStandardInput()!"<<endl;
-        return kFALSE; //failure to calibrate
+    //useful for debugging / cross-checking
+    sTree[iRun]->Branch("fRunNumber", &fRunNumber, "fRunNumber/I");
+    
+    for( Int_t iQvar = 0; iQvar<fInput->GetNVariables(); iQvar++) {
+      if( !fInput->GetVariable(iQvar)->IsInteger() ) {
+        sTree[iRun]->Branch(Form("%s", fInput->GetVariable(iQvar)->GetName()  ),
+                            &fInput->GetVariable(iQvar)->GetRValue(),Form("%s/F",fInput->GetVariable(iQvar)->GetName()));
+      } else {
+        sTree[iRun]->Branch(Form("%s", fInput->GetVariable(iQvar)->GetName()  ),
+                            &fInput->GetVariable(iQvar)->GetRValueInteger(),Form("%s/I",fInput->GetVariable(iQvar)->GetName()));
+      }
     }
-
-    if ( fMultSelectionList->GetEntries() == 0 ){
-        AliInfo("===============================================");
-        AliInfo(" Calibrator invoked without run mappings");
-        AliInfo(" Auto run discovery mode will be used!");
-        AliInfo("===============================================");
-        lAutoDiscover = kTRUE;
+  }
+  
+  //const int lNEstimators = fSelection->GetNEstimators();
+  
+  const int lNEstimators = 50; //this is the MAX VALUE!
+  
+  //For computing average values of estimators
+  Double_t lAvEst[lNEstimators][lMax];
+  //For computing extreme values (useful for integer calibration mode)
+  Double_t lMaxEst[lNEstimators][lMax];
+  Double_t lMinEst[lNEstimators][lMax];
+  
+  //Sanity check. If insane, add kNoCalib histogram
+  Bool_t lInsane[lNEstimators][lMax];
+  
+  //Index of first value above anchor point threshold
+  Long64_t lAnchorEst[lNEstimators][lMax];
+  
+  //Vertex Z profiles
+  TProfile *hCalibVtx[1000][AliMultInput::kNVariables];
+  
+  if( !lAutoDiscover ){
+    for(Int_t iRun=0; iRun<lNRuns; iRun++) {
+      for(Int_t iVar=0; iVar<AliMultInput::kNVariables; iVar++) {
+        hCalibVtx[iRun][iVar] = new TProfile(Form("hCalibVtx_%i_%s",fFirstRun[iRun],AliMultInput::VarName[iVar].Data()),"",100, -20, 20);
+        hCalibVtx[iRun][iVar] ->SetDirectory(0);
+      }
     }
-
-    if ( lAutoDiscover && !fSelection ) {
-        cout<<"Error: no default AliMultSelection defined!"<<endl;
-        cout<<"The simplest way to get rid of this problem is to remember to call SetMultSelection(...)!"<<endl;
-        return kFALSE; //failure to calibrate
+  }
+  
+  for(Long_t iEst=0; iEst<lNEstimators; iEst++) {
+    for(Long_t iRun=0; iRun<lMax; iRun++) lAvEst[iEst][iRun] = 0;
+    for(Long_t iRun=0; iRun<lMax; iRun++) lMaxEst[iEst][iRun] = -1e+3;
+    for(Long_t iRun=0; iRun<lMax; iRun++) lMinEst[iEst][iRun] = 1e+6; //not more than a million, I hope?
+    for(Long_t iRun=0; iRun<lMax; iRun++) lAnchorEst[iEst][iRun] = -1; //invalid index
+    for(Long_t iRun=0; iRun<lMax; iRun++) lInsane[iEst][iRun] = kFALSE; //we're nice people. We assume no insanity unless there's proof otherwise
+  }
+  
+  //Add Timer
+  TStopwatch* timer = new TStopwatch();
+  timer->Start ( kTRUE );
+  
+  //Compute events-per-hour performance metric
+  Double_t lEventsPerSecond = 0;
+  
+  AliMultVariable *lVtxZLocalPointer = fInput -> GetVariable("fEvSel_VtxZ");
+  
+  for(Long64_t iEv = 0; iEv<fTree->GetEntries(); iEv++) {
+    if ( iEv % 100000 == 0 ) {
+      Double_t complete = 100. * ( double ) ( iEv ) / ( double ) ( fTree->GetEntries() );
+      cout << "\r" << "Event # " << iEv << "/" << fTree->GetEntries() << " (" << complete << "%, Time Left: ";
+      timer->Stop();
+      Double_t time = timer->RealTime();
+      
+      //events per hour:
+      lEventsPerSecond = ( ( Double_t ) ( iEv ) ) /time;
+      
+      timer->Start ( kFALSE );
+      Double_t secondsperstep = time / ( Double_t ) ( iEv+1 );
+      Double_t secondsleft = ( Double_t ) ( fTree->GetEntries()-iEv-1 ) * secondsperstep;
+      Long_t minutesleft = ( Long_t ) ( secondsleft / 60. );
+      secondsleft = ( Double_t ) ( ( Long_t ) ( secondsleft ) % 60 );
+      cout << minutesleft << "min " << secondsleft << "s, working at "<<lEventsPerSecond<<" Events/s..." << flush;
     }
-
-    //Binding to input variables
-    for(Long_t iVar=0; iVar<fInput->GetNVariables(); iVar++) {
-        if( !fInput->GetVariable(iVar)->IsInteger() ) {
-            fTree->SetBranchAddress(fInput->GetVariable(iVar)->GetName(),&fInput->GetVariable(iVar)->GetRValue());
-        } else {
-            fTree->SetBranchAddress(fInput->GetVariable(iVar)->GetName(),&fInput->GetVariable(iVar)->GetRValueInteger());
-        }
+    fTree->GetEntry(iEv);
+    //Perform Event selection
+    Bool_t lSaveThisEvent = kTRUE; //let's be optimistic
+    
+    //Apply trigger mask (will only work if not kAny)
+    Bool_t isSelected = 0;
+    isSelected = fEvSel_TriggerMask & fTrigType;
+    if(!isSelected && fCheckTriggerType) lSaveThisEvent = kFALSE;
+    
+    if(fFiredTrigString.EqualTo("")==kFALSE) {
+      if (fFiredTriggerClasses->Contains( fFiredTrigString.Data() ) == kFALSE ) lSaveThisEvent = kFALSE;
     }
-
-    Long64_t lNEv = fTree->GetEntries();
-    cout<<"(1) File opened, event count is "<<lNEv<<endl;
-
-    cout<<"(2) Creating buffer, computing averages"<<endl;
-    const int lMax = 1000;
-    const int lMaxQuantiles = 10000;
-    Int_t lRunNumbers[lMaxQuantiles];
-    Long_t lRunStats[lMaxQuantiles];
-
-    for( Int_t ix=0; ix<1000;ix++){
-        lRunNumbers[ix] = 0;
-        lRunStats[ix] = 0;
-    }
-
-    Int_t lNRuns = 0;
-    Bool_t lNewRun = kTRUE;
-    Int_t lThisRunIndex = -1;
-    //Buffer file with run-by-run TTree objects needed for later processing
-
-    TFile *fOutput = new TFile (fBufferFileName.Data(), "RECREATE");
-    TTree *sTree[lMaxQuantiles];
-    cout<<"Creating Trees..."<<endl;
-    //N.B. No need to Exceed Run Ranges in Calibration Code here!
-    Int_t lNTrees = 0;
-    if( !lAutoDiscover ){
-        lNTrees = fNRunRanges;
+    
+    //Check Selections as they are in the fMultSelectionCuts Object
+    if( fMultSelectionCuts->GetTriggerCut()    && ! fEvSel_Triggered  ) lSaveThisEvent = kFALSE;
+    if( fMultSelectionCuts->GetINELgtZEROCut() && ! fEvSel_INELgtZERO ) lSaveThisEvent = kFALSE;
+    //if( TMath::Abs( lVtxZLocalPointer->GetValue() ) > fMultSelectionCuts->GetVzCut()      ) lSaveThisEvent = kFALSE;
+    //ADD ME HERE: Tracklets Vs Clusters Cut?
+    if( fMultSelectionCuts->GetRejectPileupInMultBinsCut() && ! fEvSel_IsNotPileupInMultBins    ) lSaveThisEvent = kFALSE;
+    if( fMultSelectionCuts->GetTrackletsVsClustersCut()    && ! fEvSel_PassesTrackletVsCluster  ) lSaveThisEvent = kFALSE;
+    if( fMultSelectionCuts->GetVertexConsistencyCut()      && ! fEvSel_HasNoInconsistentVertices) lSaveThisEvent = kFALSE;
+    if( fMultSelectionCuts->GetNonZeroNContribs()          &&  fnContributors < 1 ) lSaveThisEvent = kFALSE;
+    if( fMultSelectionCuts->GetIsNotAsymmetricInVZERO()    && ! fEvSel_IsNotAsymmetricInVZERO) lSaveThisEvent = kFALSE;
+    if( fMultSelectionCuts->GetIsNotIncompleteDAQ()        && ! fEvSel_IsNotIncompleteDAQ) lSaveThisEvent = kFALSE;
+    if( fMultSelectionCuts->GetHasGoodVertex2016()         && ! fEvSel_HasGoodVertex2016) lSaveThisEvent = kFALSE;
+    Int_t lIndex = -1;
+    if ( !lAutoDiscover ){
+      //Consult map for run range equivalency
+      if ( fRunRangesMap.find( fRunNumber ) != fRunRangesMap.end() ) {
+        lIndex = fRunRangesMap[ fRunNumber ];
+      }else{
+        lSaveThisEvent = kFALSE;
+      }
     }else{
-        lNTrees = lMax;
-    }
-    for(Int_t iRun=0; iRun<lNTrees; iRun++) {
-        sTree[iRun] = new TTree(Form("sTree%i",iRun),Form("sTree%i",iRun));
-
-        //useful for debugging / cross-checking
-        sTree[iRun]->Branch("fRunNumber", &fRunNumber, "fRunNumber/I");
-
-        for( Int_t iQvar = 0; iQvar<fInput->GetNVariables(); iQvar++) {
-            if( !fInput->GetVariable(iQvar)->IsInteger() ) {
-                sTree[iRun]->Branch(Form("%s", fInput->GetVariable(iQvar)->GetName()  ),
-                                    &fInput->GetVariable(iQvar)->GetRValue(),Form("%s/F",fInput->GetVariable(iQvar)->GetName()));
-            } else {
-                sTree[iRun]->Branch(Form("%s", fInput->GetVariable(iQvar)->GetName()  ),
-                                    &fInput->GetVariable(iQvar)->GetRValueInteger(),Form("%s/I",fInput->GetVariable(iQvar)->GetName()));
-            }
+      lNewRun = kTRUE;
+      for(Int_t iRun=0; iRun<lNRuns; iRun++) {
+        if( lRunNumbers[iRun] == fRunNumber ) {
+          lNewRun = kFALSE;
+          lIndex = iRun;
         }
-    }
-
-    //const int lNEstimators = fSelection->GetNEstimators();
-
-    const int lNEstimators = 50; //this is the MAX VALUE!
-
-    //For computing average values of estimators
-    Double_t lAvEst[lNEstimators][lMax];
-    //For computing extreme values (useful for integer calibration mode)
-    Double_t lMaxEst[lNEstimators][lMax];
-    Double_t lMinEst[lNEstimators][lMax];
-
-    //Sanity check. If insane, add kNoCalib histogram
-    Bool_t lInsane[lNEstimators][lMax];
-
-    //Index of first value above anchor point threshold
-    Long64_t lAnchorEst[lNEstimators][lMax];
-
-    for(Long_t iEst=0; iEst<lNEstimators; iEst++) {
-        for(Long_t iRun=0; iRun<lMax; iRun++) lAvEst[iEst][iRun] = 0;
-        for(Long_t iRun=0; iRun<lMax; iRun++) lMaxEst[iEst][iRun] = -1e+3;
-        for(Long_t iRun=0; iRun<lMax; iRun++) lMinEst[iEst][iRun] = 1e+6; //not more than a million, I hope?
-        for(Long_t iRun=0; iRun<lMax; iRun++) lAnchorEst[iEst][iRun] = -1; //invalid index
-        for(Long_t iRun=0; iRun<lMax; iRun++) lInsane[iEst][iRun] = kFALSE; //we're nice people. We assume no insanity unless there's proof otherwise
-    }
-
-    //Add Timer
-    TStopwatch* timer = new TStopwatch();
-    timer->Start ( kTRUE );
-
-
-    //Compute events-per-hour performance metric
-    Double_t lEventsPerSecond = 0;
-
-    AliMultVariable *lVtxZLocalPointer = fInput -> GetVariable("fEvSel_VtxZ");
-
-    for(Long64_t iEv = 0; iEv<fTree->GetEntries(); iEv++) {
-
-        if ( iEv % 100000 == 0 ) {
-            Double_t complete = 100. * ( double ) ( iEv ) / ( double ) ( fTree->GetEntries() );
-            cout << "Event # " << iEv << "/" << fTree->GetEntries() << " (" << complete << "%, Time Left: ";
-            timer->Stop();
-            Double_t time = timer->RealTime();
-
-            //events per hour:
-            lEventsPerSecond = ( ( Double_t ) ( iEv ) ) /time;
-
-            timer->Start ( kFALSE );
-            Double_t secondsperstep = time / ( Double_t ) ( iEv+1 );
-            Double_t secondsleft = ( Double_t ) ( fTree->GetEntries()-iEv-1 ) * secondsperstep;
-            Long_t minutesleft = ( Long_t ) ( secondsleft / 60. );
-            secondsleft = ( Double_t ) ( ( Long_t ) ( secondsleft ) % 60 );
-            cout << minutesleft << "min " << secondsleft << "s, working at "<<lEventsPerSecond<<" Events/s..." << endl;
-        }
-        fTree->GetEntry(iEv);
-        //Perform Event selection
-        Bool_t lSaveThisEvent = kTRUE; //let's be optimistic
-
-        //Apply trigger mask (will only work if not kAny)
-        Bool_t isSelected = 0;
-        isSelected = fEvSel_TriggerMask & fTrigType;
-        if(!isSelected && fCheckTriggerType) lSaveThisEvent = kFALSE;
-
-        if(fFiredTrigString.EqualTo("")==kFALSE) {
-            if (fFiredTriggerClasses->Contains( fFiredTrigString.Data() ) == kFALSE ) lSaveThisEvent = kFALSE;
+      }
+      if( lNewRun == kTRUE ) {
+        cout<<endl<<"(Autodiscover) New Run Found: "<<fRunNumber<<", added as #"<<lNRuns<<" (so far: "<<lNRuns<<" runs)"<<endl;
+        //Adding vertex-Z profiles for this run
+        for(Int_t iVar=0; iVar<AliMultInput::kNVariables; iVar++) {
+          hCalibVtx[lNRuns][iVar] = new TProfile(Form("hCalibVtx_%i_%s",fRunNumber,AliMultInput::VarName[iVar].Data()),"",100, -20, 20);
+          hCalibVtx[lNRuns][iVar] ->SetDirectory(0);
         }
         
-        //Check Selections as they are in the fMultSelectionCuts Object
-        if( fMultSelectionCuts->GetTriggerCut()    && ! fEvSel_Triggered  ) lSaveThisEvent = kFALSE;
-        if( fMultSelectionCuts->GetINELgtZEROCut() && ! fEvSel_INELgtZERO ) lSaveThisEvent = kFALSE;
-        if( TMath::Abs( lVtxZLocalPointer->GetValue() ) > fMultSelectionCuts->GetVzCut()      ) lSaveThisEvent = kFALSE;
-        //ADD ME HERE: Tracklets Vs Clusters Cut?
-        if( fMultSelectionCuts->GetRejectPileupInMultBinsCut() && ! fEvSel_IsNotPileupInMultBins    ) lSaveThisEvent = kFALSE;
-        if( fMultSelectionCuts->GetTrackletsVsClustersCut()    && ! fEvSel_PassesTrackletVsCluster  ) lSaveThisEvent = kFALSE;
-        if( fMultSelectionCuts->GetVertexConsistencyCut()      && ! fEvSel_HasNoInconsistentVertices) lSaveThisEvent = kFALSE;
-        if( fMultSelectionCuts->GetNonZeroNContribs()          &&  fnContributors < 1 ) lSaveThisEvent = kFALSE;
-        if( fMultSelectionCuts->GetIsNotAsymmetricInVZERO()    && ! fEvSel_IsNotAsymmetricInVZERO) lSaveThisEvent = kFALSE;
-        if( fMultSelectionCuts->GetIsNotIncompleteDAQ()        && ! fEvSel_IsNotIncompleteDAQ) lSaveThisEvent = kFALSE;
-        if( fMultSelectionCuts->GetHasGoodVertex2016()         && ! fEvSel_HasGoodVertex2016) lSaveThisEvent = kFALSE;
-
-        Int_t lIndex = -1;
-        if ( !lAutoDiscover ){
-            //Consult map for run range equivalency
-            if ( fRunRangesMap.find( fRunNumber ) != fRunRangesMap.end() ) {
-                lIndex = fRunRangesMap[ fRunNumber ];
-            }else{
-                lSaveThisEvent = kFALSE;
-            }
-        }else{
-            lNewRun = kTRUE;
-            for(Int_t iRun=0; iRun<lNRuns; iRun++) {
-                if( lRunNumbers[iRun] == fRunNumber ) {
-                    lNewRun = kFALSE;
-                    lIndex = iRun;
-                }
-            }
-            if( lNewRun == kTRUE ) {
-                cout<<"(Autodiscover) New Run Found: "<<fRunNumber<<", added as #"<<lNRuns<<" (so far: "<<lNRuns<<" runs)"<<endl;
-
-                //Add to Map
-                fRunRangesMap.insert( std::pair<int,int>(fRunNumber,lNRuns));
-                lRunNumbers[lNRuns] = fRunNumber;
-                lIndex = lNRuns;
-                lNRuns++;
-                fNRunRanges++;
-            }
-        }
-        if ( lSaveThisEvent ) {
-            if( sTree[lIndex]->GetEntries()<fMaxEventsPerRun ){
-                sTree [ lIndex ] -> Fill();
-            }
-        }
-
+        //Add to Map
+        fRunRangesMap.insert( std::pair<int,int>(fRunNumber,lNRuns));
+        lRunNumbers[lNRuns] = fRunNumber;
+        lIndex = lNRuns;
+        lNRuns++;
+        fNRunRanges++;
+      }
     }
-
-    //Write buffer to file
-    for(Int_t iRun=0; iRun<lNRuns; iRun++) sTree[iRun]->Write();
-
-    if(!lAutoDiscover){
+    if ( lSaveThisEvent ) {
+      if( sTree[lIndex]->GetEntries()<fMaxEventsPerRun ){
+        
+        //Fill vertex-Z profiles for all Z
+        for(Int_t iVar=0; iVar<AliMultInput::kNVariables; iVar++) {
+          if(VarDoAutocalib[iVar]){
+            AliMultVariable *v1 = fInput->GetVariable(iVar);
+            hCalibVtx[lIndex][iVar]->Fill( lVtxZLocalPointer->GetValue(), v1->IsInteger() ? v1->GetValueInteger() : v1->GetValue() );
+          }
+        }
+        
+        //Only fill if this passes the vertex cut (default behaviour)
+        if ( TMath::Abs( lVtxZLocalPointer->GetValue() ) < fMultSelectionCuts->GetVzCut() ) sTree [ lIndex ] -> Fill();
+        
+      }
+    }
+  }
+  cout<<endl;
+  
+  //Write buffer to file
+  for(Int_t iRun=0; iRun<lNRuns; iRun++) sTree[iRun]->Write();
+  for(Int_t iRun=0; iRun<lNRuns; iRun++) lRunStats[iRun] = sTree[iRun]->GetEntries();
+  
+  //Write copies of the vertex-Z histos for cross-checks at this stage already
+  for(Int_t iRun=0; iRun<lNRuns; iRun++) {
+    for(Int_t iVar=0; iVar<AliMultInput::kNVariables; iVar++) {
+      if(VarDoAutocalib[iVar])
+        hCalibVtx[iRun][iVar] -> Write(Form("Debug_VertexZ_RunIdx%i_VarIdx%i",iRun,iVar));
+    }
+  }
+  
+  if(!lAutoDiscover){
     cout<<"(3) Inspect Run Ranges and corresponding statistics: "<<endl;
     for(Int_t iRun = 0; iRun<fNRunRanges; iRun++) {
-        cout<<" --- Range #"<<iRun<<", ("<<fFirstRun[iRun]<<" - "<<fLastRun[iRun]<<"), N(events) = "<<sTree[iRun]->GetEntries()<<endl;
+      cout<<" --- Range #"<<iRun<<", ("<<fFirstRun[iRun]<<" - "<<fLastRun[iRun]<<"), N(events) = "<<sTree[iRun]->GetEntries()<<endl;
     }
     cout<<endl;
+  }else{
+    cout<<"(3) Inspect Runs and corresponding statistics: "<<endl;
+    for(Int_t iRun = 0; iRun<fNRunRanges; iRun++) {
+      cout<<" --- Run #"<<iRun<<", (#"<<lRunNumbers[iRun]<<"), N(events) = "<<sTree[iRun]->GetEntries()<<endl;
+    }
+    cout<<endl;
+  }
+  
+  if( fPrefilterOnly ){
+    cout<<"Won't do anything else! But you should have filtered trees now for debugging..."<<endl;
+    fOutput->Write();
+    return 0;
+  }
+  
+  //FIXME Receive as parameter from the test macro
+  Double_t lNrawBoundaries[1000];
+  Double_t lMiddleOfBins[1000];
+  
+  for( Long_t lB=1; lB<lNDesiredBoundaries; lB++) {
+    //place squarely at the middle to ensure it's all fine
+    lMiddleOfBins[lB-1] = 0.5*(lDesiredBoundaries[lB]+lDesiredBoundaries[lB-1]);
+  }
+  
+  //Histograms to store calibration information
+  TH1F *hCalib[1000][lNEstimators];
+  
+  cout<<"(4) Look at average values"<<endl;
+  for(Int_t iRun=0; iRun<fNRunRanges; iRun++) {
+    //Contextualize AliMultSelection for this run
+    if ( !lAutoDiscover ) fSelection = (AliMultSelection*) fMultSelectionList->At(iRun);
+    
+    // Calibration pre-optimization and setup
+    fSelection->Setup ( fInput );
+    
+    const Int_t lNEstimatorsThis = fSelection->GetNEstimators();
+    
+    const Long64_t ntot = (Long64_t) sTree[iRun]->GetEntries();
+    if ( !lAutoDiscover ){
+      cout<<"--- Processing run range "<<fFirstRun[iRun]<<"-"<<fLastRun[iRun]<<" ("<<iRun<<"/"<<fNRunRanges<<"), with "<<ntot<<" events..."<<endl;
     }else{
-        cout<<"(3) Inspect Runs and corresponding statistics: "<<endl;
-        for(Int_t iRun = 0; iRun<fNRunRanges; iRun++) {
-            cout<<" --- Run #"<<iRun<<", (#"<<lRunNumbers[iRun]<<"), N(events) = "<<sTree[iRun]->GetEntries()<<endl;
+      cout<<"--- Processing run "<<lRunNumbers[iRun]<<" ("<<iRun<<"/"<<fNRunRanges<<"), with "<<ntot<<" events..."<<endl;
+    }
+    if( ntot < 1 ){ cout<<"Sample empty! Skipping..."<<endl; continue; }
+    sTree[iRun]->SetEstimate(ntot+1);
+    //Cast Run Number into drawing conditions
+    
+    fSelection->Setup ( fInput );
+    
+    cout<<"--- Initializing. Number of elements: "<<fInput->GetNVtxZ()<<endl;
+    fInput->ClearVtxZ();
+    cout<<"--- Cleared. Number of elements: "<<fInput->GetNVtxZ()<<endl;
+    for(Int_t iVar=0; iVar<AliMultInput::kNVariables; iVar++){
+      //cout<<"--- Adding var: "<<AliMultInput::VarName[iVar].Data()<<", pointer "<<hCalibVtx[iRun][iVar]<<endl;
+      fInput->AddVtxZ( hCalibVtx[iRun][iVar] );
+    }
+    cout<<"--- Setting up input maps for vertex-Z correction..."<<endl;
+    fInput->SetupAutoVtxZCorrection();
+    cout<<"--- Finished initalization. Number of elements: "<<fInput->GetNVtxZ()<<endl;
+    
+    timer->Reset();
+    timer->Start ( kTRUE );
+    lEventsPerSecond = 0;
+    
+    for( Long64_t iEntry=0; iEntry<ntot; iEntry++) {
+      if ( iEntry % 10000 == 0 ) {
+        cout << "\r" << "--- Looping over tree [ "<<Form("%.3f",100.*iEntry/ntot)<<"% ] [ ETA: "<< flush;
+        timer->Stop();
+        Double_t time = timer->RealTime();
+        
+        //events per hour:
+        lEventsPerSecond = ( ( Double_t ) ( iEntry ) ) /time;
+        
+        timer->Start ( kFALSE );
+        Double_t secondsperstep = time / ( Double_t ) ( iEntry+1 );
+        Double_t secondsleft = ( Double_t ) ( fTree->GetEntries()-iEntry-1 ) * secondsperstep;
+        Long_t minutesleft = ( Long_t ) ( secondsleft / 60. );
+        secondsleft = ( Double_t ) ( ( Long_t ) ( secondsleft ) % 60 );
+        cout << minutesleft << "min " << secondsleft << "s ] [ Speed: "<<lEventsPerSecond<<" events/s ]" << flush;
+      }
+      sTree[iRun]->GetEntry(iEntry); //Get all variables
+      fSelection->Evaluate ( fInput ); //Evaluate based on current variables
+      for(Int_t iEst=0; iEst<lNEstimatorsThis; iEst++) {
+        Double_t lThisVal = fSelection->GetEstimator(iEst)->GetValue();
+        lAvEst[iEst][iRun] += lThisVal;
+        if( lThisVal < lMinEst[iEst][iRun] ) {
+          lMinEst[iEst][iRun] = lThisVal;
         }
-        cout<<endl;
+        if( lThisVal > lMaxEst[iEst][iRun] ) {
+          lMaxEst[iEst][iRun] = lThisVal;
+        }
+      }
     }
-
-    if( fPrefilterOnly ){
-        cout<<"Won't do anything else! But you should have filtered trees now for debugging..."<<endl;
-        fOutput->Write();
-        return 0;
+    cout<<endl;
+    
+    for(Int_t iEst=0; iEst<lNEstimatorsThis; iEst++) {
+      if( sTree[iRun]->GetEntries() < 1 ) {
+        lAvEst[iEst][iRun] = -1;
+      } else {
+        lAvEst[iEst][iRun] /= ( (Double_t) (sTree[iRun]->GetEntries()) );
+      }
+      cout<<" Min = "<<lMinEst[iEst][iRun]<<", Max = "<<lMaxEst[iEst][iRun]<<", Av = "<<lAvEst[iEst][iRun]<<endl;
+      
+      if ( TMath::Abs( lMinEst[iEst][iRun] - lMaxEst[iEst][iRun] ) < 1e-6 ){
+        lInsane[iEst][iRun] = kTRUE; //No valid information to do calibration, please be careful !
+      }
     }
-
-
-    //FIXME Receive as parameter from the test macro
-    Double_t lNrawBoundaries[1000];
-    Double_t lMiddleOfBins[1000];
-
-    for( Long_t lB=1; lB<lNDesiredBoundaries; lB++) {
-        //place squarely at the middle to ensure it's all fine
-        lMiddleOfBins[lB-1] = 0.5*(lDesiredBoundaries[lB]+lDesiredBoundaries[lB-1]);
+  }
+  //might be needed
+  Long64_t lAcceptedEvents;
+  
+  //=========================================
+  // Determine Calibration Information
+  //=========================================
+  
+  //Open output OADB file, generate everything within loop
+  TFile * f = new TFile (fOutputFileName.Data(), "recreate");
+  AliOADBContainer * oadbContMS = new AliOADBContainer("MultSel");
+  
+  AliOADBMultSelection * oadbMultSelection = 0x0;
+  AliMultSelectionCuts * cuts = 0x0;
+  AliMultSelection     * fsels = 0x0;
+  
+  //Actual Calibration Histograms
+  TH1F * hCalibData[lNEstimators];
+  TProfile * hCalibDataVtx[AliMultInput::kNVariables];
+  
+  cout<<"(5) Generate Boundaries through a loop in all desired estimators"<<endl;
+  for(Int_t iRun=0; iRun<fNRunRanges; iRun++) {
+    cout<<"--- Initializing. Number of elements: "<<fInput->GetNVtxZ()<<endl;
+    fInput->ClearVtxZ();
+    cout<<"--- Cleared. Number of elements: "<<fInput->GetNVtxZ()<<endl;
+    for(Int_t iVar=0; iVar<AliMultInput::kNVariables; iVar++){
+      //cout<<"--- Adding var: "<<AliMultInput::VarName[iVar].Data()<<", pointer "<<hCalibVtx[iRun][iVar]<<endl;
+      fInput->AddVtxZ( hCalibVtx[iRun][iVar] );
     }
-
-    // STEP 4: Actual determination of boundaries...
-    Long64_t *index;
-    Double_t *lValues;
-
-    //Histograms to store calibration information
-    TH1F *hCalib[1000][lNEstimators];
-
-    cout<<"(4) Look at average values"<<endl;
-    for(Int_t iRun=0; iRun<fNRunRanges; iRun++) {
-
-        //Contextualize AliMultSelection for this run
-        if ( !lAutoDiscover ) fSelection = (AliMultSelection*) fMultSelectionList->At(iRun);
-
-        // Calibration pre-optimization and setup
-        fSelection->Setup ( fInput );
-
-        const Int_t lNEstimatorsThis = fSelection->GetNEstimators();
-
-        const Long64_t ntot = (Long64_t) sTree[iRun]->GetEntries();
-        if ( !lAutoDiscover ){
-            cout<<"--- Processing run range "<<fFirstRun[iRun]<<"-"<<fLastRun[iRun]<<" ("<<iRun<<"/"<<fNRunRanges<<"), with "<<ntot<<" events..."<<endl;
+    cout<<"--- Setting up input maps for vertex-Z correction..."<<endl;
+    fInput->SetupAutoVtxZCorrection();
+    cout<<"--- Finished initalization. Number of elements: "<<fInput->GetNVtxZ()<<endl;
+    
+    //Contextualize AliMultSelection for this run
+    if ( !lAutoDiscover ) fSelection = (AliMultSelection*) fMultSelectionList->At(iRun);
+    
+    const Int_t lNEstimatorsThis = fSelection->GetNEstimators();
+    
+    const Int_t ntot = (Int_t) sTree[iRun]->GetEntries();
+    if ( !lAutoDiscover ){
+      cout<<"--- Processing run range "<<fFirstRun[iRun]<<"-"<<fLastRun[iRun]<<" ("<<iRun<<"/"<<fNRunRanges<<"), with "<<ntot<<" events..."<<endl;
+    }else{
+      cout<<"--- Processing run "<<lRunNumbers[iRun]<<" ("<<iRun<<"/"<<fNRunRanges<<"), with "<<ntot<<" events..."<<endl;
+    }
+    if( ntot < 1 ){ cout<<"Sample empty! Skipping..."<<endl; continue; }
+    sTree[iRun]->SetEstimate(ntot+1);
+    
+    
+    //Memory allocation: this may be dangerous in computers with little memory, but it will make the process faster
+    //TArrayL64 index(ntot);
+    //TArrayF values(ntot);
+    
+    Int_t **index = new Int_t*[lNEstimatorsThis];
+    Float_t **values = new Float_t*[lNEstimatorsThis];
+    Long_t lAcceptedEventArray[lNEstimatorsThis];
+    
+    for(Int_t ii=0; ii<lNEstimatorsThis; ii++){
+      index[ii] = new Int_t[ntot];
+      values[ii] = new Float_t[ntot];
+    }
+    
+    timer->Reset();
+    timer->Start ( kTRUE );
+    lEventsPerSecond = 0;
+    
+    cout << "\r" << "--- Looping over tree [ 0% ] "<< flush;
+    for( Long64_t iEntry=0; iEntry<ntot; iEntry++) {
+      if ( iEntry % 10000 == 0 ) {
+        cout << "\r" << "--- Looping over tree [ "<<Form("%.3f",100.*iEntry/ntot)<<"% ] [ ETA: "<< flush;
+        timer->Stop();
+        Double_t time = timer->RealTime();
+        
+        //events per hour:
+        lEventsPerSecond = ( ( Double_t ) ( iEntry ) ) /time;
+        
+        timer->Start ( kFALSE );
+        Double_t secondsperstep = time / ( Double_t ) ( iEntry+1 );
+        Double_t secondsleft = ( Double_t ) ( fTree->GetEntries()-iEntry-1 ) * secondsperstep;
+        Long_t minutesleft = ( Long_t ) ( secondsleft / 60. );
+        secondsleft = ( Double_t ) ( ( Long_t ) ( secondsleft ) % 60 );
+        cout << minutesleft << "min " << secondsleft << "s ] [ Speed: "<<lEventsPerSecond<<" events/s ]" << flush;
+      }
+      sTree[iRun]->GetEntry(iEntry); //Get all variables
+      fSelection->Evaluate ( fInput ); //Evaluate based on current variables
+      for(Int_t iEst=0; iEst<lNEstimatorsThis; iEst++) {
+        values[iEst][iEntry] = fSelection->GetEstimator(iEst)->GetValue();
+        if( !fSelection->GetEstimator(iEst)->GetUseAnchor() ){
+          lAcceptedEventArray[iEst]++;
         }else{
-            cout<<"--- Processing run "<<lRunNumbers[iRun]<<" ("<<iRun<<"/"<<fNRunRanges<<"), with "<<ntot<<" events..."<<endl;
+          if(values[iEst][iEntry] > fSelection->GetEstimator(iEst)->GetAnchorPoint())
+            lAcceptedEventArray[iEst]++;
         }
-        if( ntot < 1 ){ cout<<"Sample empty! Skipping..."<<endl; continue; }
-        sTree[iRun]->SetEstimate(ntot+1);
-        //Cast Run Number into drawing conditions
-        for(Int_t iEst=0; iEst<lNEstimatorsThis; iEst++) {
-            lRunStats[iRun] = sTree[iRun]->Draw(fSelection->GetEstimator(iEst)->GetDefinition(),"","goff");
-            lValues = sTree[iRun]->GetV1();
-            cout<<"--- Calculating averages: "<<flush;
-            for( Long64_t iEntry=0; iEntry<ntot; iEntry++) {
-                Float_t lThisVal = lValues[iEntry]; //Test
-                lAvEst[iEst][iRun] += lThisVal;
-                if( lThisVal < lMinEst[iEst][iRun] ) {
-                    lMinEst[iEst][iRun] = lThisVal;
-                }
-                if( lThisVal > lMaxEst[iEst][iRun] ) {
-                    lMaxEst[iEst][iRun] = lThisVal;
-                }
-            }
-            if( sTree[iRun]->GetEntries() < 1 ) {
-                lAvEst[iEst][iRun] = -1;
-            } else {
-                lAvEst[iEst][iRun] /= ( (Double_t) (sTree[iRun]->GetEntries()) );
-            }
-            cout<<" Min = "<<lMinEst[iEst][iRun]<<", Max = "<<lMaxEst[iEst][iRun]<<", Av = "<<lAvEst[iEst][iRun]<<endl;
-
-            if ( TMath::Abs( lMinEst[iEst][iRun] - lMaxEst[iEst][iRun] ) < 1e-6 ){
-                lInsane[iEst][iRun] = kTRUE; //No valid information to do calibration, please be careful !
-            }
-
-        }
+      }
     }
-    //might be needed
-    Long64_t lAcceptedEvents;
-
-    //=========================================
-    // Determine Calibration Information
-    //=========================================
-
-    //Open output OADB file, generate everything within loop
-    TFile * f = new TFile (fOutputFileName.Data(), "recreate");
-    AliOADBContainer * oadbContMS = new AliOADBContainer("MultSel");
-
-    AliOADBMultSelection * oadbMultSelection = 0x0;
-    AliMultSelectionCuts * cuts = 0x0;
-    AliMultSelection     * fsels = 0x0;
-
-    //Actual Calibration Histograms
-    TH1F * hCalibData[lNEstimators];
-
-    cout<<"(5) Generate Boundaries through a loop in all desired estimators"<<endl;
-    for(Int_t iRun=0; iRun<fNRunRanges; iRun++) {
-
-        //Contextualize AliMultSelection for this run
-        if ( !lAutoDiscover ) fSelection = (AliMultSelection*) fMultSelectionList->At(iRun);
-
-        // Calibration pre-optimization and setup
-        fSelection->Setup ( fInput );
-
-        const Int_t lNEstimatorsThis = fSelection->GetNEstimators();
-
-        const Long64_t ntot = (Long64_t) sTree[iRun]->GetEntries();
-        if ( !lAutoDiscover ){
-            cout<<"--- Processing run range "<<fFirstRun[iRun]<<"-"<<fLastRun[iRun]<<" ("<<iRun<<"/"<<fNRunRanges<<"), with "<<ntot<<" events..."<<endl;
-        }else{
-            cout<<"--- Processing run "<<lRunNumbers[iRun]<<" ("<<iRun<<"/"<<fNRunRanges<<"), with "<<ntot<<" events..."<<endl;
+    cout<<endl;
+    
+    //Cast Run Number into drawing conditions
+    for(Int_t iEst=0; iEst<lNEstimatorsThis; iEst++) {
+      lAcceptedEvents = lAcceptedEventArray[iEst];
+      cout<<"--- Sorting estimator "<<fSelection->GetEstimator(iEst)->GetName()<<"..."<<flush;
+      
+      Int_t *index1 = index[iEst];
+      Float_t *values1 = values[iEst];
+      TMath::Sort(ntot, values1, index1 );
+      cout<<" Done! Getting Boundaries... "<<flush;
+      //Special override in case anchored estimator
+      
+      lNrawBoundaries[0] = 0.0; //Defined OK even if anchored
+      //Overwrite lower boundary in case this has a negative minimum...
+      if ( lMinEst[iEst][iRun] < 0 ) {
+        lNrawBoundaries[0] = lMinEst[iEst][iRun];
+        cout<<"Min Value Override, Negative..."<<flush;
+      }
+      
+      for( Long_t lB=1; lB<lNDesiredBoundaries; lB++) {
+        Long64_t position = (Long64_t) ( 0.01 * ((Double_t)(ntot)* lDesiredBoundaries[lB] ) );
+        
+        if( fSelection->GetEstimator(iEst)->GetUseAnchor() && ntot != 0 ){
+          //Make sure index position lAnchorEst corresponds to lAnchorPercentile
+          Double_t lAnchorPercentile = (Double_t) fSelection->GetEstimator(iEst)->GetAnchorPercentile();
+          Double_t lFractionAccepted = (((Double_t) lAcceptedEvents )/((Double_t) ntot));
+          Double_t lScalingFactor    = lFractionAccepted/((0.01)*lAnchorPercentile);
+          //Make sure: if AnchorPercentile requested, cut at AnchorPoint
+          position = (Long64_t) ( ( 0.01 * ((Double_t)(ntot)* lDesiredBoundaries[lB] ) ) * lScalingFactor );
+          if(position > ntot-1 ) position = ntot-1; //protection !
         }
-        if( ntot < 1 ){ cout<<"Sample empty! Skipping..."<<endl; continue; }
-        sTree[iRun]->SetEstimate(ntot+1);
-        // Memory allocation: don't repeat it per estimator! only per run
-        TArrayL64 index(ntot);
-        //Cast Run Number into drawing conditions
-        for(Int_t iEst=0; iEst<lNEstimatorsThis; iEst++) {
-            if( ! ( fSelection->GetEstimator(iEst)->IsInteger() ) ) {
-                //==== Floating Point Calibration Engine ====
-                lRunStats[iRun] = sTree[iRun]->Draw(fSelection->GetEstimator(iEst)->GetDefinition(),"","goff");
-                cout<<"--- Sorting estimator "<<fSelection->GetEstimator(iEst)->GetName()<<"..."<<flush;
-
-                TMath::Sort(ntot,sTree[iRun]->GetV1(), index.GetArray() );
-                cout<<" Done! Getting Boundaries... "<<flush;
-
-                //Special override in case anchored estimator
-                if( fSelection->GetEstimator(iEst)->GetUseAnchor() ){
-                    cout<<"Anchoring... "<<flush;
-                    //Require determination of index after which values are to be discarded
-                    //Count fraction of accepted
-                    TString lCondition = fSelection->GetEstimator(iEst)->GetDefinition();
-                    lCondition.Append(Form("> %.10f",fSelection->GetEstimator(iEst)->GetAnchorPoint() ) );
-                    lAcceptedEvents = sTree[iRun]->Draw(fSelection->GetEstimator(iEst)->GetDefinition(),lCondition.Data(),"goff");
-                    lRunStats[iRun] = lAcceptedEvents;
-                }
-                lNrawBoundaries[0] = 0.0; //Defined OK even if anchored
-                //Overwrite lower boundary in case this has a negative minimum...
-                if ( lMinEst[iEst][iRun] < 0 ) {
-                    lNrawBoundaries[0] = lMinEst[iEst][iRun];
-                    cout<<"Min Value Override, Negative..."<<flush;
-                }
-
-                for( Long_t lB=1; lB<lNDesiredBoundaries; lB++) {
-                    Long64_t position = (Long64_t) ( 0.01 * ((Double_t)(ntot)* lDesiredBoundaries[lB] ) );
-
-                    if( fSelection->GetEstimator(iEst)->GetUseAnchor() && ntot != 0 ){
-                        //Make sure index position lAnchorEst corresponds to lAnchorPercentile
-                        Double_t lAnchorPercentile = (Double_t) fSelection->GetEstimator(iEst)->GetAnchorPercentile();
-                        Double_t lFractionAccepted = (((Double_t) lAcceptedEvents )/((Double_t) ntot));
-                        Double_t lScalingFactor    = lFractionAccepted/((0.01)*lAnchorPercentile);
-                        //Make sure: if AnchorPercentile requested, cut at AnchorPoint
-                        position = (Long64_t) ( ( 0.01 * ((Double_t)(ntot)* lDesiredBoundaries[lB] ) ) * lScalingFactor );
-                        if(position > ntot-1 ) position = ntot-1; //protection !
-                    }
-                    //cout<<"Position requested: "<<position<<flush;
-                    sTree[iRun]->GetEntry( index[position] );
-                    //Calculate the estimator with this input, please
-                    fSelection->Evaluate ( fInput );
-                    //fSelection->PrintInfo();
-                    lNrawBoundaries[lB] = fSelection->GetEstimator(iEst)->GetValue();
-                }
-                //Cross-check correct rejection of anything beyond anchor point
-                if( fSelection->GetEstimator(iEst)->GetUseAnchor() && ntot != 0 ){
-                    for( Long_t lB=0; lB<lNDesiredBoundaries-1; lB++) {
-                        if (lNrawBoundaries[lB+1]>fSelection->GetEstimator(iEst)->GetAnchorPoint()){
-                            if(lNrawBoundaries[lB]<fSelection->GetEstimator(iEst)->GetAnchorPoint()){
-                                //This is the threshold, should actually be identical to anchor point please
-                                lNrawBoundaries[lB] = fSelection->GetEstimator(iEst)->GetAnchorPoint();
-                            }
-                        }
-                    }
-                }
-
-                cout<<" Done! Saving... "<<endl;
-
-                if( lInsane[iEst][iRun] == kFALSE) {
-                    //Create a sane calibration histogram
-                    //Should not be the source of excessive memory consumption...
-                    //...but can be rearranged if needed!
-                    hCalib[iRun][iEst] = new TH1F(Form("hCalib_%i_%s",lRunNumbers[iRun],fSelection->GetEstimator(iEst)->GetName()),"",lNDesiredBoundaries-1,lNrawBoundaries);
-                    hCalib[iRun][iEst]->SetDirectory(0);
-                    hCalib[iRun][iEst]->SetBinContent(0,100.5); //Just in case correction functions screw up the values ...
-                    for(Long_t ibin=1; ibin<hCalib[iRun][iEst]->GetNbinsX()+1; ibin++){
-                        hCalib[iRun][iEst] -> SetBinContent(ibin, lMiddleOfBins[ibin-1]);
-
-                        //override in case anchored!
-                        if( fSelection->GetEstimator(iEst)->GetUseAnchor() ){
-                            if ( hCalib[iRun][iEst]->GetBinCenter(ibin) < fSelection->GetEstimator(iEst)->GetAnchorPoint() ){
-                                //Override, this is useless!
-                                //Alberica's recommendation: outside of user range to be sure!
-                                hCalib[iRun][iEst] -> SetBinContent(ibin, 100.5);
-                            }
-                        }
-                    }
-                }else{
-                    hCalib[iRun][iEst] = new TH1F(Form("hCalib_%i_%s",lRunNumbers[iRun],fSelection->GetEstimator(iEst)->GetName()),"",1,0,1);
-                    hCalib[iRun][iEst]->SetDirectory(0);
-                    //There was insufficient information to generate a meaningful calibration for this estimator!
-                    hCalib[iRun][iEst]->SetBinContent(0,AliMultSelectionCuts::kNoCalib);
-                    hCalib[iRun][iEst]->SetBinContent(1,AliMultSelectionCuts::kNoCalib);
-                    hCalib[iRun][iEst]->SetBinContent(2,AliMultSelectionCuts::kNoCalib);
-                }
-                //==== End Floating Point Calibration Engine ====
-            } else {
-                //==== Integer Value Calibration Engine ====
-                //Procedure: Create histogram to be filled
-                cout<<"Integer calibration engine started!"<<endl;
-                const Long_t lNBins    = lMaxEst[iEst][iRun]-lMinEst[iEst][iRun]+1;
-                Float_t lLowEdge = lMinEst[iEst][iRun]-0.5;
-                Float_t lHighEdge= lMaxEst[iEst][iRun]+0.5;
-                cout<<"Inspect: "<<lNBins<<", low "<<lLowEdge<<", high "<<lHighEdge<<endl;
-                if( sTree[iRun]->GetEntries() < 1 ) {
-                    //Case of an empty run!
-                    hCalib[iRun][iEst] = new TH1F(Form("hCalib_%i_%s",lRunNumbers[iRun],fSelection->GetEstimator(iEst)->GetName()),"",1,0,1);
-                    hCalib[iRun][iEst]->SetDirectory(0);
-                } else {
-                    TH1F *hTemporary = new TH1F("hTemporary", "", lNBins, lMinEst[iEst][iRun]-0.5, lMaxEst[iEst][iRun]+0.5 );
-                    //hTemporary->SetDirectory(0);
-                    lRunStats[iRun] = sTree[iRun]->Draw(Form("%s>>hTemporary",fSelection->GetEstimator(iEst)->GetDefinition().Data()),"","goff");
-                    cout<<"entries = "<<lRunStats[iRun]<<endl;
-                    //In memory now: histogram with content, please normalize to unity
-                    hTemporary->Scale(1./((double)(lRunStats[iRun])));
-
-                    Float_t lBoundaries[lNBins+1]; //to store cumulative function
-                    lBoundaries[0] = 0;
-                    for(Long_t iB=1; iB<hTemporary->GetNbinsX()+1; iB++) {
-                        lBoundaries[iB] = lBoundaries[iB-1]+hTemporary->GetBinContent(iB);
-                    }
-                    //This won't follow what was requested (it cannot, mathematically)
-                    hCalib[iRun][iEst] = new TH1F(Form("hCalib_%i_%s",lRunNumbers[iRun],fSelection->GetEstimator(iEst)->GetName()),"",lNBins,lLowEdge,lHighEdge);
-                    hCalib[iRun][iEst]->SetDirectory(0);
-                    for(Long_t ibin=1; ibin<hCalib[iRun][iEst]->GetNbinsX()+1; ibin++) hCalib[iRun][iEst] -> SetBinContent(ibin, 100.0-50.0*(lBoundaries[ibin-1]+lBoundaries[ibin]));
-                    //Enough info for calibration determined...
-                    delete hTemporary;
-                    hTemporary = 0x0;
-                }
+        //cout<<"Position requested: "<<position<<flush;
+        //sTree[iRun]->GetEntry( index[position] );
+        //Calculate the estimator with this input, please
+        //fSelection->Evaluate ( fInput );
+        //fSelection->PrintInfo();
+        lNrawBoundaries[lB] = values[iEst][index[iEst][position]];
+        //cout<<sTree[iRun]->GetV1()<<" "<<lNrawBoundaries[lB]<<endl;
+      }
+      //Cross-check correct rejection of anything beyond anchor point
+      if( fSelection->GetEstimator(iEst)->GetUseAnchor() && ntot != 0 ){
+        for( Long_t lB=0; lB<lNDesiredBoundaries-1; lB++) {
+          if (lNrawBoundaries[lB+1]>fSelection->GetEstimator(iEst)->GetAnchorPoint()){
+            if(lNrawBoundaries[lB]<fSelection->GetEstimator(iEst)->GetAnchorPoint()){
+              //This is the threshold, should actually be identical to anchor point please
+              lNrawBoundaries[lB] = fSelection->GetEstimator(iEst)->GetAnchorPoint();
             }
+          }
         }
-
-        //Write OADB object
-        if ( !lAutoDiscover ){
-            cout<<"--- Processing run range "<<fFirstRun[iRun]<<"-"<<fLastRun[iRun]<<" ("<<iRun<<"/"<<fNRunRanges<<")..."<<endl;
-        }else{
-            cout<<"--- Processing run "<<lRunNumbers[iRun]<<" ("<<iRun<<"/"<<fNRunRanges<<")..."<<endl;
-        }
-        oadbMultSelection = new AliOADBMultSelection();
-        cuts              = new AliMultSelectionCuts();
-        cuts = fMultSelectionCuts;
-        fsels             = new AliMultSelection( fSelection );
-
-        oadbMultSelection->SetEventCuts    (cuts );
-        oadbMultSelection->SetMultSelection(fsels);
-        for ( Int_t iEst=0; iEst<lNEstimatorsThis; iEst++) {
-            //Average values
-            fsels->GetEstimator(iEst)->SetMean( lAvEst[iEst][iRun] );
-
-            //Beware similar names! Will be saved ...
-            hCalibData[iEst] = (TH1F*) hCalib[iRun][iEst]->Clone( Form("hCalib_%s",fSelection->GetEstimator(iEst)->GetName()) );
-            oadbMultSelection->AddCalibHisto( hCalibData[iEst] );
-            hCalibData[iEst]->SetDirectory(0);
-        }
-        cout<<"=================================================================================="<<endl;
-        if ( !lAutoDiscover ){
-            cout<<"AliMultSelection Object to be saved for run range "<<fFirstRun[iRun]<<"-"<<fLastRun[iRun]<<")"<<endl;
-        }else{
-            cout<<"AliMultSelection Object to be saved for run "<<lRunNumbers[iRun]<<")"<<endl;
-        }
-        fsels->PrintInfo();
-        cuts->Print();
-        cout<<"=================================================================================="<<endl;
-        //Protection against saving a calibration object that has been acquired
-        //with insufficient statistics
-        if ( lRunStats[iRun] > 1000){
-            if ( !lAutoDiscover ) {
-                oadbContMS->AppendObject(oadbMultSelection, fFirstRun[iRun], fLastRun[iRun] );
-            }else{
-                oadbContMS->AppendObject(oadbMultSelection, lRunNumbers[iRun], lRunNumbers[iRun] );
+      }
+      
+      cout<<" Done! Saving... "<<endl;
+      
+      if( lInsane[iEst][iRun] == kFALSE) {
+        //Create a sane calibration histogram
+        //Should not be the source of excessive memory consumption...
+        //...but can be rearranged if needed!
+        hCalib[iRun][iEst] = new TH1F(Form("hCalib_%i_%s",lRunNumbers[iRun],fSelection->GetEstimator(iEst)->GetName()),"",lNDesiredBoundaries-1,lNrawBoundaries);
+        hCalib[iRun][iEst]->SetDirectory(0);
+        hCalib[iRun][iEst]->SetBinContent(0,100.5); //Just in case correction functions screw up the values ...
+        for(Long_t ibin=1; ibin<hCalib[iRun][iEst]->GetNbinsX()+1; ibin++){
+          hCalib[iRun][iEst] -> SetBinContent(ibin, lMiddleOfBins[ibin-1]);
+          
+          //override in case anchored!
+          if( fSelection->GetEstimator(iEst)->GetUseAnchor() ){
+            if ( hCalib[iRun][iEst]->GetBinCenter(ibin) < fSelection->GetEstimator(iEst)->GetAnchorPoint() ){
+              //Override, this is useless!
+              //Alberica's recommendation: outside of user range to be sure!
+              hCalib[iRun][iEst] -> SetBinContent(ibin, 100.5);
             }
+          }
         }
-
-        Bool_t lThisIsReference = kFALSE;
-        if(!lAutoDiscover){
-            if ( fFirstRun[iRun] <= fRunToUseAsDefault && fRunToUseAsDefault <= fLastRun[iRun]) lThisIsReference = kTRUE;
-        }else{
-            if ( lRunNumbers[iRun] == fRunToUseAsDefault ) lThisIsReference = kTRUE;
-        }
-        if( lThisIsReference ){
-            //========================================================================
-            //DEFAULT OADB Object saving procedure STARTS here
-            oadbMultSelection = new AliOADBMultSelection("Default");
-            cuts              = new AliMultSelectionCuts();
-            cuts = fMultSelectionCuts;
-            fsels             = new AliMultSelection    ( fSelection         );
-
-            const Int_t lNEstimatorsThis = fSelection->GetNEstimators();
-
-            //Default Stuff
-            TH1F * hDummy[lNEstimatorsThis];
-            for ( Int_t iEst=0; iEst<lNEstimatorsThis; iEst++) {
-                //Get Meaningful means
-                fsels->GetEstimator(iEst)->SetMean( lAvEst[iEst][iRun] );
-                //Clone last histogram ...
-                hDummy[iEst]= (TH1F*) hCalib[iRun][iEst]->Clone( Form("hCalib_%s",fSelection->GetEstimator(iEst)->GetName()) );
-                hDummy[iEst]->SetDirectory(0);
-            }
-
-            cout<<"=================================================================================="<<endl;
-            cout<<" Detected that this particular run / run range is special, will save it as default"<<endl;
-            cout<<" AliMultSelection Object to be saved (DEFAULT)"<<endl;
-            fsels->PrintInfo();
-            cout<<"=================================================================================="<<endl;
-
-            oadbMultSelection->SetEventCuts        ( cuts  );
-            oadbMultSelection->SetMultSelection    ( fsels );
-            for ( Int_t iEst=0; iEst<lNEstimatorsThis; iEst++) oadbMultSelection->AddCalibHisto( hDummy[iEst] );
-            oadbContMS->AddDefaultObject(oadbMultSelection);
-            //DEFAULT OADB Object saving procedure ENDS here
-            //========================================================================
-        }
+      }else{
+        hCalib[iRun][iEst] = new TH1F(Form("hCalib_%i_%s",lRunNumbers[iRun],fSelection->GetEstimator(iEst)->GetName()),"",1,0,1);
+        hCalib[iRun][iEst]->SetDirectory(0);
+        //There was insufficient information to generate a meaningful calibration for this estimator!
+        hCalib[iRun][iEst]->SetBinContent(0,AliMultSelectionCuts::kNoCalib);
+        hCalib[iRun][iEst]->SetBinContent(1,AliMultSelectionCuts::kNoCalib);
+        hCalib[iRun][iEst]->SetBinContent(2,AliMultSelectionCuts::kNoCalib);
+      }
+      //==== End Floating Point Calibration Engine ====
     }
-
-    if( fRunToUseAsDefault < 0 ){
-        //========================================================================
-        //DEFAULT OADB Object saving procedure STARTS here
-        oadbMultSelection = new AliOADBMultSelection("Default");
-        cuts              = new AliMultSelectionCuts();
-        cuts = fMultSelectionCuts;
-        fsels             = new AliMultSelection    ( fSelection         );
-
-        const Int_t lNEstimatorsThis = fSelection->GetNEstimators();
-
-        cout<<"=================================================================================="<<endl;
-        cout<<" AliMultSelection Object to be saved (DEFAULT)"<<endl;
-        cout<<" Warning: this corresponds to the last calibrated run!"<<endl;
-        fsels->PrintInfo();
-        cout<<"=================================================================================="<<endl;
-
-        //Default Stuff
-        TH1F * hDummy[lNEstimatorsThis];
-        for ( Int_t iEst=0; iEst<lNEstimatorsThis; iEst++) {
-            //Clone last histogram ...
-            hDummy[iEst]= (TH1F*) hCalib[fNRunRanges-1][iEst]->Clone( Form("hCalib_%s",fSelection->GetEstimator(iEst)->GetName()) );
-            hDummy[iEst]->SetDirectory(0);
-        }
-
-        oadbMultSelection->SetEventCuts        ( cuts  );
-        oadbMultSelection->SetMultSelection    ( fsels );
-        for ( Int_t iEst=0; iEst<lNEstimatorsThis; iEst++) oadbMultSelection->AddCalibHisto( hDummy[iEst] );
-        oadbContMS->AddDefaultObject(oadbMultSelection);
-        //DEFAULT OADB Object saving procedure ENDS here
-        //========================================================================
+    /* DEPRECATED
+     else {
+     //==== Integer Value Calibration Engine ====
+     //Procedure: Create histogram to be filled
+     cout<<"Integer calibration engine started!"<<endl;
+     const Long_t lNBins    = lMaxEst[iEst][iRun]-lMinEst[iEst][iRun]+1;
+     Float_t lLowEdge = lMinEst[iEst][iRun]-0.5;
+     Float_t lHighEdge= lMaxEst[iEst][iRun]+0.5;
+     cout<<"Inspect: "<<lNBins<<", low "<<lLowEdge<<", high "<<lHighEdge<<endl;
+     if( sTree[iRun]->GetEntries() < 1 ) {
+     //Case of an empty run!
+     hCalib[iRun][iEst] = new TH1F(Form("hCalib_%i_%s",lRunNumbers[iRun],fSelection->GetEstimator(iEst)->GetName()),"",1,0,1);
+     hCalib[iRun][iEst]->SetDirectory(0);
+     } else {
+     TH1F *hTemporary = new TH1F("hTemporary", "", lNBins, lMinEst[iEst][iRun]-0.5, lMaxEst[iEst][iRun]+0.5 );
+     //hTemporary->SetDirectory(0);
+     lRunStats[iRun] = sTree[iRun]->Draw(Form("%s*(AliMultSelectionCalibrator::VtxCorrection(fEvSel_VtxZ))>>hTemporary",fSelection->GetEstimator(iEst)->GetDefinition().Data()),"","goff");
+     cout<<"entries = "<<lRunStats[iRun]<<endl;
+     //In memory now: histogram with content, please normalize to unity
+     hTemporary->Scale(1./((double)(lRunStats[iRun])));
+     
+     Float_t lBoundaries[lNBins+1]; //to store cumulative function
+     lBoundaries[0] = 0;
+     for(Long_t iB=1; iB<hTemporary->GetNbinsX()+1; iB++) {
+     lBoundaries[iB] = lBoundaries[iB-1]+hTemporary->GetBinContent(iB);
+     }
+     //This won't follow what was requested (it cannot, mathematically)
+     hCalib[iRun][iEst] = new TH1F(Form("hCalib_%i_%s",lRunNumbers[iRun],fSelection->GetEstimator(iEst)->GetName()),"",lNBins,lLowEdge,lHighEdge);
+     hCalib[iRun][iEst]->SetDirectory(0);
+     for(Long_t ibin=1; ibin<hCalib[iRun][iEst]->GetNbinsX()+1; ibin++) hCalib[iRun][iEst] -> SetBinContent(ibin, 100.0-50.0*(lBoundaries[ibin-1]+lBoundaries[ibin]));
+     //Enough info for calibration determined...
+     delete hTemporary;
+     hTemporary = 0x0;
+     }
+     } */
+    
+    //Write OADB object
+    if ( !lAutoDiscover ){
+      cout<<"--- Processing run range "<<fFirstRun[iRun]<<"-"<<fLastRun[iRun]<<" ("<<iRun<<"/"<<fNRunRanges<<")..."<<endl;
+    }else{
+      cout<<"--- Processing run "<<lRunNumbers[iRun]<<" ("<<iRun<<"/"<<fNRunRanges<<")..."<<endl;
     }
-
-    cout<<"All done, will write OADB..."<<endl;
-
-    oadbContMS->Write();
-    cout<<" Done!"<<endl;
-    return kTRUE;
+    oadbMultSelection = new AliOADBMultSelection();
+    cuts              = new AliMultSelectionCuts();
+    cuts = fMultSelectionCuts;
+    fsels             = new AliMultSelection( fSelection );
+    
+    oadbMultSelection->SetEventCuts    (cuts );
+    oadbMultSelection->SetMultSelection(fsels);
+    
+    for ( Int_t iVar=0; iVar<AliMultInput::kNVariables; iVar++) {
+      hCalibDataVtx[iVar] = (TProfile*) hCalibVtx[iRun][iVar]->Clone( Form("hCalibVtx_%s",AliMultInput::VarName[iVar].Data() ) );
+      if( VarDoAutocalib[iVar] ) oadbMultSelection->AddCalibHistoVtx( hCalibDataVtx[iVar] );
+    }
+    
+    for ( Int_t iEst=0; iEst<lNEstimatorsThis; iEst++) {
+      //Average values
+      fsels->GetEstimator(iEst)->SetMean( lAvEst[iEst][iRun] );
+      // hCalibVtx[iRun][iEst] = (TProfile*)gDirectory->Get(Form("hCalibVtx_%i_%s",lRunNumbers[iRun],fSelection->GetEstimator(iEst)->GetName()));
+      //Beware similar names! Will be saved ...
+      hCalibData[iEst] = (TH1F*) hCalib[iRun][iEst]->Clone( Form("hCalib_%s",fSelection->GetEstimator(iEst)->GetName()) );
+      oadbMultSelection->AddCalibHisto( hCalibData[iEst] );
+      hCalibData[iEst]->SetDirectory(0);
+      hCalibDataVtx[iEst]->SetDirectory(0);
+    }
+    cout<<"=================================================================================="<<endl;
+    if ( !lAutoDiscover ){
+      cout<<"AliMultSelection Object to be saved for run range ("<<fFirstRun[iRun]<<"-"<<fLastRun[iRun]<<")"<<endl;
+    }else{
+      cout<<"AliMultSelection Object to be saved for run "<<lRunNumbers[iRun]<<""<<endl;
+    }
+    fsels->PrintInfo();
+    cuts->Print();
+    cout<<"=================================================================================="<<endl;
+    //Protection against saving a calibration object that has been acquired
+    //with insufficient statistics
+    if ( lRunStats[iRun] > 1000){
+      if ( !lAutoDiscover ) {
+        oadbContMS->AppendObject(oadbMultSelection, fFirstRun[iRun], fLastRun[iRun] );
+      }else{
+        oadbContMS->AppendObject(oadbMultSelection, lRunNumbers[iRun], lRunNumbers[iRun] );
+      }
+    }
+    
+    Bool_t lThisIsReference = kFALSE;
+    if(!lAutoDiscover){
+      if ( fFirstRun[iRun] <= fRunToUseAsDefault && fRunToUseAsDefault <= fLastRun[iRun]) lThisIsReference = kTRUE;
+    }else{
+      if ( lRunNumbers[iRun] == fRunToUseAsDefault ) lThisIsReference = kTRUE;
+    }
+    if( lThisIsReference ){
+      //========================================================================
+      //DEFAULT OADB Object saving procedure STARTS here
+      oadbMultSelection = new AliOADBMultSelection("Default");
+      cuts              = new AliMultSelectionCuts();
+      cuts = fMultSelectionCuts;
+      fsels             = new AliMultSelection    ( fSelection         );
+      
+      const Int_t lNEstimatorsThis = fSelection->GetNEstimators();
+      
+      //Default Stuff
+      TH1F * hDummy[lNEstimatorsThis];
+      TProfile * hDummyVtxZ[AliMultInput::kNVariables];
+      for ( Int_t iVar=0; iVar<AliMultInput::kNVariables; iVar++) {
+        hDummyVtxZ[iVar] = (TProfile*) hCalibVtx[iRun][iVar]->Clone( Form("hCalibVtx_%s",AliMultInput::VarName[iVar].Data() ) );
+        if( VarDoAutocalib[iVar] ) oadbMultSelection->AddCalibHistoVtx( hDummyVtxZ[iVar] );
+      }
+      
+      for ( Int_t iEst=0; iEst<lNEstimatorsThis; iEst++) {
+        //Get Meaningful means
+        fsels->GetEstimator(iEst)->SetMean( lAvEst[iEst][iRun] );
+        //Clone last histogram ...
+        hDummy[iEst]= (TH1F*) hCalib[iRun][iEst]->Clone( Form("hCalib_%s",fSelection->GetEstimator(iEst)->GetName()) );
+        hDummy[iEst]->SetDirectory(0);
+      }
+      
+      cout<<"=================================================================================="<<endl;
+      cout<<" Detected that this particular run / run range is special, will save it as default"<<endl;
+      cout<<" AliMultSelection Object to be saved (DEFAULT)"<<endl;
+      fsels->PrintInfo();
+      cout<<"=================================================================================="<<endl;
+      
+      oadbMultSelection->SetEventCuts        ( cuts  );
+      oadbMultSelection->SetMultSelection    ( fsels );
+      for ( Int_t iEst=0; iEst<lNEstimatorsThis; iEst++) {
+        oadbMultSelection->AddCalibHisto( hDummy[iEst] );
+      }
+      oadbContMS->AddDefaultObject(oadbMultSelection);
+      //DEFAULT OADB Object saving procedure ENDS here
+      //========================================================================
+    }
+    //Cleanup
+    for(int ii = 0; ii < lNEstimatorsThis; ii++){
+      delete[] index[ii];
+      delete[] values[ii];
+    }
+    delete[] index;
+    delete[] values;
+  }
+  
+  if( fRunToUseAsDefault < 0 ){
+    //========================================================================
+    //DEFAULT OADB Object saving procedure STARTS here
+    oadbMultSelection = new AliOADBMultSelection("Default");
+    cuts              = new AliMultSelectionCuts();
+    cuts = fMultSelectionCuts;
+    fsels             = new AliMultSelection    ( fSelection         );
+    
+    const Int_t lNEstimatorsThis = fSelection->GetNEstimators();
+    
+    cout<<"=================================================================================="<<endl;
+    cout<<" AliMultSelection Object to be saved (DEFAULT)"<<endl;
+    cout<<" Warning: this corresponds to the last calibrated run!"<<endl;
+    fsels->PrintInfo();
+    cout<<"=================================================================================="<<endl;
+    
+    //Default Stuff
+    TH1F * hDummy[lNEstimatorsThis];
+    TProfile * hDummyVtxZ[lNEstimatorsThis];
+    for ( Int_t iEst=0; iEst<lNEstimatorsThis; iEst++) {
+      //Clone last histogram ...
+      hDummy[iEst]= (TH1F*) hCalib[fNRunRanges-1][iEst]->Clone( Form("hCalib_%s",fSelection->GetEstimator(iEst)->GetName()) );
+      hDummy[iEst]->SetDirectory(0);
+    }
+    
+    oadbMultSelection->SetEventCuts        ( cuts  );
+    oadbMultSelection->SetMultSelection    ( fsels );
+    for ( Int_t iEst=0; iEst<lNEstimatorsThis; iEst++){
+      oadbMultSelection->AddCalibHisto( hDummy[iEst] );
+      // oadbMultSelection->AddCalibHistoVtx( hDummyVtxZ[iEst] );
+    }
+    oadbContMS->AddDefaultObject(oadbMultSelection);
+    //DEFAULT OADB Object saving procedure ENDS here
+    //========================================================================
+  }
+  
+  cout<<"All done, will write OADB..."<<endl;
+  
+  oadbContMS->Write();
+  cout<<" Done!"<<endl;
+  return kTRUE;
 }
 //________________________________________________________________
 Float_t AliMultSelectionCalibrator::MinVal( Float_t A, Float_t B ) {
-    if( A < B ) {
-        return A;
-    }
-    else {
-        return B;
-    }
+  if( A < B ) {
+    return A;
+  }
+  else {
+    return B;
+  }
 }
 //________________________________________________________________
 void AliMultSelectionCalibrator::SetupStandardInput() {
-    //============================================================
-    // --- Definition of Variables for estimators ---
-    //============================================================
-
-    //Create input variables in AliMultInput Class
-    //V0 related
-    AliMultVariable *fAmplitude_V0A         = new AliMultVariable("fAmplitude_V0A");
-    AliMultVariable *fAmplitude_V0A1        = new AliMultVariable("fAmplitude_V0A1");
-    AliMultVariable *fAmplitude_V0A2        = new AliMultVariable("fAmplitude_V0A2");
-    AliMultVariable *fAmplitude_V0A3        = new AliMultVariable("fAmplitude_V0A3");
-    AliMultVariable *fAmplitude_V0A4        = new AliMultVariable("fAmplitude_V0A4");
-    AliMultVariable *fAmplitude_V0C         = new AliMultVariable("fAmplitude_V0C");
-    AliMultVariable *fAmplitude_V0C1        = new AliMultVariable("fAmplitude_V0C1");
-    AliMultVariable *fAmplitude_V0C2        = new AliMultVariable("fAmplitude_V0C2");
-    AliMultVariable *fAmplitude_V0C3        = new AliMultVariable("fAmplitude_V0C3");
-    AliMultVariable *fAmplitude_V0C4        = new AliMultVariable("fAmplitude_V0C4");
-    AliMultVariable *fAmplitude_V0Apartial = new AliMultVariable("fAmplitude_V0Apartial");
-    AliMultVariable *fAmplitude_V0Cpartial = new AliMultVariable("fAmplitude_V0Cpartial");
-    AliMultVariable *fAmplitude_V0AEq      = new AliMultVariable("fAmplitude_V0AEq");
-    AliMultVariable *fAmplitude_V0CEq      = new AliMultVariable("fAmplitude_V0CEq");
-    AliMultVariable *fAmplitude_OnlineV0A  = new AliMultVariable("fAmplitude_OnlineV0A");
-    AliMultVariable *fAmplitude_OnlineV0C  = new AliMultVariable("fAmplitude_OnlineV0C");
-    //SPD Related
-    AliMultVariable *fnSPDClusters         = new AliMultVariable("fnSPDClusters");
-    AliMultVariable *fnSPDClusters0        = new AliMultVariable("fnSPDClusters0");
-    AliMultVariable *fnSPDClusters1        = new AliMultVariable("fnSPDClusters1");
-    fnSPDClusters->SetIsInteger( kTRUE );
-    fnSPDClusters0->SetIsInteger( kTRUE );
-    fnSPDClusters1->SetIsInteger( kTRUE );
-    //AD Related
-    AliMultVariable *fMultiplicity_ADA     = new AliMultVariable("fMultiplicity_ADA");
-    AliMultVariable *fMultiplicity_ADC     = new AliMultVariable("fMultiplicity_ADC");
-
-    AliMultVariable *fRefMultEta5     = new AliMultVariable("fRefMultEta5");
-    fRefMultEta5->SetIsInteger( kTRUE );
-    AliMultVariable *fRefMultEta8     = new AliMultVariable("fRefMultEta8");
-    fRefMultEta8->SetIsInteger( kTRUE );
-    AliMultVariable *fnTracklets     = new AliMultVariable("fnTracklets");
-    fnTracklets->SetIsInteger( kTRUE );
-    AliMultVariable *fnTracklets08     = new AliMultVariable("fnTracklets08");
-    fnTracklets08->SetIsInteger( kTRUE );
-    AliMultVariable *fnTracklets15     = new AliMultVariable("fnTracklets15");
-    fnTracklets15->SetIsInteger( kTRUE );
-
-    //ZDC Related
-    AliMultVariable *fZncEnergy = new AliMultVariable("fZncEnergy");
-    AliMultVariable *fZpcEnergy = new AliMultVariable("fZpcEnergy");
-    AliMultVariable *fZnaEnergy = new AliMultVariable("fZnaEnergy");
-    AliMultVariable *fZpaEnergy = new AliMultVariable("fZpaEnergy");
-    AliMultVariable *fZem1Energy = new AliMultVariable("fZem1Energy");
-    AliMultVariable *fZem2Energy = new AliMultVariable("fZem2Energy");
-
-    AliMultVariable *fZnaTower = new AliMultVariable("fZnaTower");
-    AliMultVariable *fZncTower = new AliMultVariable("fZncTower");
-    AliMultVariable *fZpaTower = new AliMultVariable("fZpaTower");
-    AliMultVariable *fZpcTower = new AliMultVariable("fZpcTower");
-
-    //Fired or not booleans (stored as integer for compatibility)
-    AliMultVariable *fZnaFired = new AliMultVariable("fZnaFired");
-    fZnaFired->SetIsInteger(kTRUE);
-    AliMultVariable *fZncFired = new AliMultVariable("fZncFired");
-    fZncFired->SetIsInteger(kTRUE);
-    AliMultVariable *fZpaFired = new AliMultVariable("fZpaFired");
-    fZpaFired->SetIsInteger(kTRUE);
-    AliMultVariable *fZpcFired = new AliMultVariable("fZpcFired");
-    fZpcFired->SetIsInteger(kTRUE);
-
-    //Track counters (now useable as AliMultVariables as well)
-    AliMultVariable *fNTracks =                  new AliMultVariable("fNTracks");
-    fNTracks->SetIsInteger(kTRUE);
-    AliMultVariable *fNTracksGlobal2015 =        new AliMultVariable("fNTracksGlobal2015");
-    fNTracksGlobal2015->SetIsInteger(kTRUE);
-    AliMultVariable *fNTracksGlobal2015Trigger = new AliMultVariable("fNTracksGlobal2015Trigger");
-    fNTracksGlobal2015Trigger->SetIsInteger(kTRUE);
-    AliMultVariable *fNTracksITSsa2010 =         new AliMultVariable("fNTracksITSsa2010");
-    fNTracksITSsa2010->SetIsInteger(kTRUE);
-
-    AliMultVariable *fNTracksINELgtONE =       new AliMultVariable("fNTracksINELgtONE");
-    AliMultVariable *fNPartINELgtONE   =       new AliMultVariable("fNPartINELgtONE");
-
-    //vertex-Z
-    AliMultVariable *fEvSel_VtxZ = new AliMultVariable("fEvSel_VtxZ");
-
-    AliMultVariable *fMC_NPart =         new AliMultVariable("fMC_NPart");
-    fMC_NPart->SetIsInteger(kTRUE);
-    AliMultVariable *fMC_NColl =         new AliMultVariable("fMC_NColl");
-    fMC_NColl->SetIsInteger(kTRUE);
-    AliMultVariable *fMC_NchV0A =         new AliMultVariable("fMC_NchV0A");
-    fMC_NchV0A->SetIsInteger(kTRUE);
-    AliMultVariable *fMC_NchV0C =         new AliMultVariable("fMC_NchV0C");
-    fMC_NchV0C->SetIsInteger(kTRUE);
-    AliMultVariable *fMC_NchEta05 =         new AliMultVariable("fMC_NchEta05");
-    fMC_NchEta05->SetIsInteger(kTRUE);
-    AliMultVariable *fMC_NchEta08 =         new AliMultVariable("fMC_NchEta08");
-    fMC_NchEta08->SetIsInteger(kTRUE);
-    AliMultVariable *fMC_NchEta10 =         new AliMultVariable("fMC_NchEta10");
-    fMC_NchEta10->SetIsInteger(kTRUE);
-    AliMultVariable *fMC_NchEta14 =         new AliMultVariable("fMC_NchEta14");
-    fMC_NchEta14->SetIsInteger(kTRUE);
-
-    //Add to AliMultInput Object
-    fInput->AddVariable( fAmplitude_V0A );
-    fInput->AddVariable( fAmplitude_V0A1 );
-    fInput->AddVariable( fAmplitude_V0A2 );
-    fInput->AddVariable( fAmplitude_V0A3 );
-    fInput->AddVariable( fAmplitude_V0A4 );
-    fInput->AddVariable( fAmplitude_V0C );
-    fInput->AddVariable( fAmplitude_V0C1 );
-    fInput->AddVariable( fAmplitude_V0C2 );
-    fInput->AddVariable( fAmplitude_V0C3 );
-    fInput->AddVariable( fAmplitude_V0C4 );
-    fInput->AddVariable( fAmplitude_V0Apartial );
-    fInput->AddVariable( fAmplitude_V0Cpartial );
-    fInput->AddVariable( fAmplitude_V0AEq );
-    fInput->AddVariable( fAmplitude_V0CEq );
-    fInput->AddVariable( fAmplitude_OnlineV0A );
-    fInput->AddVariable( fAmplitude_OnlineV0C );
-    fInput->AddVariable( fMultiplicity_ADA );
-    fInput->AddVariable( fMultiplicity_ADC );
-    fInput->AddVariable( fnSPDClusters );
-    fInput->AddVariable( fnSPDClusters0 );
-    fInput->AddVariable( fnSPDClusters1 );
-    fInput->AddVariable( fnTracklets   );
-    fInput->AddVariable( fnTracklets08   );
-    fInput->AddVariable( fnTracklets15   );
-    fInput->AddVariable( fRefMultEta5  );
-    fInput->AddVariable( fRefMultEta8  );
-    fInput->AddVariable( fZncEnergy );
-    fInput->AddVariable( fZpcEnergy );
-    fInput->AddVariable( fZnaEnergy );
-    fInput->AddVariable( fZpaEnergy );
-    fInput->AddVariable( fZem1Energy );
-    fInput->AddVariable( fZem2Energy );
-    fInput->AddVariable( fZnaTower );
-    fInput->AddVariable( fZncTower );
-    fInput->AddVariable( fZpaTower );
-    fInput->AddVariable( fZpcTower );
-    fInput->AddVariable( fZnaFired );
-    fInput->AddVariable( fZncFired );
-    fInput->AddVariable( fZpaFired );
-    fInput->AddVariable( fZpcFired );
-    fInput->AddVariable( fNTracks                  );
-    fInput->AddVariable( fNTracksGlobal2015        );
-    fInput->AddVariable( fNTracksGlobal2015Trigger );
-    fInput->AddVariable( fNTracksITSsa2010         );
-    fInput->AddVariable( fNTracksINELgtONE );
-    fInput->AddVariable( fNPartINELgtONE         );
-    fInput->AddVariable( fEvSel_VtxZ  );
-
-    fInput->AddVariable( fMC_NPart );
-    fInput->AddVariable( fMC_NColl );
-    fInput->AddVariable( fMC_NchV0A );
-    fInput->AddVariable( fMC_NchV0C );
-    fInput->AddVariable( fMC_NchEta05 );
-    fInput->AddVariable( fMC_NchEta08 );
-    fInput->AddVariable( fMC_NchEta10 );
-    fInput->AddVariable( fMC_NchEta14 );
-    //============================================================
-
+  //============================================================
+  // --- Definition of Variables for estimators ---
+  //============================================================
+  cout<<"===================================="<<endl;
+  cout<<"==== Setting up standard input..."<<endl;
+  cout<<"===================================="<<endl;
+  
+  //Create input variables in AliMultInput Class
+  AliMultVariable *fVariable[AliMultInput::kNVariables];
+  
+  //More compact than explicitly writing everything
+  for(Int_t ii=0; ii<AliMultInput::kNVariables; ii++){
+    fVariable[ii] = new AliMultVariable(AliMultInput::VarName[ii].Data());
+    if( AliMultInput::VarIsInteger[ii] ) fVariable[ii] -> SetIsInteger(kTRUE);
+    fInput->AddVariable( fVariable[ii] );
+  }
 }
+
+
+

--- a/OADB/COMMON/MULTIPLICITY/AliMultSelectionCalibrator.h
+++ b/OADB/COMMON/MULTIPLICITY/AliMultSelectionCalibrator.h
@@ -80,9 +80,6 @@ public:
   
   //Helper
   Float_t MinVal( Float_t A, Float_t B );
-  
-  //calibrate vertex dependecy
-  Float_t VtxCorrection(Float_t vtxZ);
    
   Bool_t VarDoAutocalib[AliMultInput::kNVariables]; //! Do auto vertex Z calib or not: master switch
   

--- a/OADB/COMMON/MULTIPLICITY/AliMultSelectionCalibrator.h
+++ b/OADB/COMMON/MULTIPLICITY/AliMultSelectionCalibrator.h
@@ -4,121 +4,130 @@
 #include <iostream>
 #include "TNamed.h"
 #include "AliVEvent.h"
+#include "AliMultInput.h"
 //For Run Ranges functionality
 #include <map>
 
 using namespace std;
 class AliESDEvent;
 class AliMultSelectionCalibrator : public TNamed {
-    
-public:
-    
-    //Constructors/Destructor
-    AliMultSelectionCalibrator();
-    AliMultSelectionCalibrator(const char * name, const char * title = "Multiplicity Calibration Class");
-    ~AliMultSelectionCalibrator();
-    
-    //void    Print(Option_t *option="") const;
-    
-    //_________________________________________________________________________
-    //Interface: steering functions to be used in calibration macro
   
-    //Set Filenames
-    void SetInputFile ( TString lFile ) { fInputFileName = lFile.Data(); } 
-    void SetBufferFile ( TString lFile ) { fBufferFileName = lFile.Data(); } 
-    void SetOutputFile ( TString lFile ) { fOutputFileName = lFile.Data(); }
-    //Set Boundaries to find
-    void SetBoundaries ( Long_t lNB, Double_t *lB ){
-        if ( lNB<2 || lNB > 1e+6 ){
-            cout<<"Please make sure you are using a reasonable number of boundaries!"<<endl;
-            lNB = -1;
-        }
-        lDesiredBoundaries = lB;
-        lNDesiredBoundaries = lNB;
+public:
+  
+  //Constructors/Destructor
+  AliMultSelectionCalibrator();
+  AliMultSelectionCalibrator(const char * name, const char * title = "Multiplicity Calibration Class");
+  ~AliMultSelectionCalibrator();
+  
+  //void    Print(Option_t *option="") const;
+  
+  //_________________________________________________________________________
+  //Interface: steering functions to be used in calibration macro
+  
+  //Set Filenames
+  void SetInputFile ( TString lFile ) { fInputFileName = lFile.Data(); }
+  void SetBufferFile ( TString lFile ) { fBufferFileName = lFile.Data(); }
+  void SetOutputFile ( TString lFile ) { fOutputFileName = lFile.Data(); }
+  //Set Boundaries to find
+  void SetBoundaries ( Long_t lNB, Double_t *lB ){
+    if ( lNB<2 || lNB > 1e+6 ){
+      cout<<"Please make sure you are using a reasonable number of boundaries!"<<endl;
+      lNB = -1;
     }
-    
-    //Task Configuration: trigger selection
-    //This is in addition to the "IsTriggered" functionality. 
-    void SetSelectedTriggerClass(AliVEvent::EOfflineTriggerTypes trigType) { fTrigType = trigType; fCheckTriggerType=kTRUE; }
-    
-    void SetFiredTriggerString(TString lData) { fFiredTrigString = lData.Data(); } 
-    
-    //Run Ranges Interface
-    Long_t GetNRunRanges() const {return fNRunRanges; }
-    void AddRunRange ( Int_t lFirst, Int_t lLast, AliMultSelection *lMultSelProvided );
-    
-    //Getter for event selection criteria
-    AliMultSelectionCuts * GetEventCuts() const { return fMultSelectionCuts;     }
-    
-    //Getter for MultSelection object
-    AliMultSelection * GetMultSelection() const { return fSelection;     }
-    
-    //Setter (warning: not a copy...) 
-    void SetMultSelection(AliMultSelection *lMultSelProvided ){ fSelection = lMultSelProvided; }
-
-    //Getter for MultInput object
-    AliMultInput * GetMultInput() const { return fInput;     }
-    
-    //Setter for golden run
-    void SetRunToUseAsDefault ( Int_t lRunNumber ) { fRunToUseAsDefault = lRunNumber; }
-    
-    //Getter for golden run
-    Int_t GetRunToUseAsDefault() const { return fRunToUseAsDefault; } 
-    
-    //Getter for golden run
-    void SetMaxEventsPerRun(Long_t lVal) { fMaxEventsPerRun = lVal; }
-    
-    //Configure standard input
-    void SetupStandardInput();
-    
-    //Filter only flag
-    void SetFilterOnly(Bool_t lOpt = kTRUE){ fPrefilterOnly = lOpt; }
-    
-    //Master Function in this Class: To be called once filenames are set
-    Bool_t Calibrate();
-    
-    //Helper
-    Float_t MinVal( Float_t A, Float_t B );
-    
+    lDesiredBoundaries = lB;
+    lNDesiredBoundaries = lNB;
+  }
+  
+  //Task Configuration: trigger selection
+  //This is in addition to the "IsTriggered" functionality.
+  void SetSelectedTriggerClass(AliVEvent::EOfflineTriggerTypes trigType) { fTrigType = trigType; fCheckTriggerType=kTRUE; }
+  
+  void SetFiredTriggerString(TString lData) { fFiredTrigString = lData.Data(); }
+  
+  //Run Ranges Interface
+  Long_t GetNRunRanges() const {return fNRunRanges; }
+  void AddRunRange ( Int_t lFirst, Int_t lLast, AliMultSelection *lMultSelProvided );
+  
+  //Getter for event selection criteria
+  AliMultSelectionCuts * GetEventCuts() const { return fMultSelectionCuts;     }
+  
+  //Getter for MultSelection object
+  AliMultSelection * GetMultSelection() const { return fSelection;     }
+  
+  //Setter (warning: not a copy...)
+  void SetMultSelection(AliMultSelection *lMultSelProvided ){ fSelection = lMultSelProvided; }
+  
+  //Getter for MultInput object
+  AliMultInput * GetMultInput() const { return fInput;     }
+  
+  //Setter for golden run
+  void SetRunToUseAsDefault ( Int_t lRunNumber ) { fRunToUseAsDefault = lRunNumber; }
+  
+  //Getter for golden run
+  Int_t GetRunToUseAsDefault() const { return fRunToUseAsDefault; }
+  
+  //Getter for golden run
+  void SetMaxEventsPerRun(Long_t lVal) { fMaxEventsPerRun = lVal; }
+  
+  //Configure standard input
+  void SetupStandardInput();
+  
+  //Filter only flag
+  void SetFilterOnly(Bool_t lOpt = kTRUE){ fPrefilterOnly = lOpt; }
+  
+  //Master Function in this Class: To be called once filenames are set
+  Bool_t Calibrate();
+  
+  //Helper
+  Float_t MinVal( Float_t A, Float_t B );
+  
+  //calibrate vertex dependecy
+  Float_t VtxCorrection(Float_t vtxZ);
+   
+  Bool_t VarDoAutocalib[AliMultInput::kNVariables]; //! Do auto vertex Z calib or not: master switch
+  
+  //Set do autocalib or not
+  void SetDoAutocalib(Int_t lVar, Bool_t lOpt = kTRUE){ VarDoAutocalib[lVar] = lOpt; }
+  
 private:
-    AliMultInput     *fInput;     //Object for all input
-    AliMultSelection *fSelection; //(current) transient pointer object
-
-    //Calibration Boundaries to locate
-    Double_t *lDesiredBoundaries;
-    Long_t   lNDesiredBoundaries;
-    
-    Int_t fRunToUseAsDefault; //Give preference for this run to be the default
-    
-    Long_t fMaxEventsPerRun; //Implemented to get a grip on huge runs
-    
-    Bool_t fCheckTriggerType; 
-    AliVEvent::EOfflineTriggerTypes fTrigType; // trigger type to calibrate
-    Bool_t fPrefilterOnly; //stop before calibrating stuff
-    TString fFiredTrigString; //select on fired trigger string if desired
-    
-    //Run Ranges map - master storage
-    Long_t fNRunRanges;
-    std::map<int, int> fRunRangesMap;
-    Int_t fFirstRun[1000];
-    Int_t fLastRun[1000]; 
-    
-    TList *fMultSelectionList; // List of AliMultSelection objects to be used per run period 
-    
-    TString fInputFileName;  // Filename for TTree object for calibration purposes
-    TString fBufferFileName; // Filename for TTree object (buffer file)
-    TString fOutputFileName; // Filename for calibration OADB output
-    
-    // Object for storing event selection configuration
-    AliMultSelectionCuts *fMultSelectionCuts;
-    
-    // TList object for storing histograms
-    TList *fCalibHists; 
-
-    ClassDef(AliMultSelectionCalibrator, 2);
-    //(this classdef is only for bookkeeping, class will not usually
-    // be streamed according to current workflow except in very specific
-    // tests!) 
-    //2 - Adjustments of extra event selections
+  AliMultInput     *fInput;     //Object for all input
+  AliMultSelection *fSelection; //(current) transient pointer object
+  
+  //Calibration Boundaries to locate
+  Double_t *lDesiredBoundaries;
+  Long_t   lNDesiredBoundaries;
+  
+  Int_t fRunToUseAsDefault; //Give preference for this run to be the default
+  
+  Long_t fMaxEventsPerRun; //Implemented to get a grip on huge runs
+  
+  Bool_t fCheckTriggerType;
+  AliVEvent::EOfflineTriggerTypes fTrigType; // trigger type to calibrate
+  Bool_t fPrefilterOnly; //stop before calibrating stuff
+  TString fFiredTrigString; //select on fired trigger string if desired
+  
+  //Run Ranges map - master storage
+  Long_t fNRunRanges;
+  std::map<int, int> fRunRangesMap;
+  Int_t fFirstRun[1000];
+  Int_t fLastRun[1000];
+  
+  TList *fMultSelectionList; // List of AliMultSelection objects to be used per run period
+  
+  TString fInputFileName;  // Filename for TTree object for calibration purposes
+  TString fBufferFileName; // Filename for TTree object (buffer file)
+  TString fOutputFileName; // Filename for calibration OADB output
+  
+  // Object for storing event selection configuration
+  AliMultSelectionCuts *fMultSelectionCuts;
+  
+  // TList object for storing histograms
+  TList *fCalibHists;
+  
+  ClassDef(AliMultSelectionCalibrator, 2);
+  //(this classdef is only for bookkeeping, class will not usually
+  // be streamed according to current workflow except in very specific
+  // tests!)
+  //2 - Adjustments of extra event selections
 };
 #endif

--- a/OADB/COMMON/MULTIPLICITY/AliMultSelectionTask.cxx
+++ b/OADB/COMMON/MULTIPLICITY/AliMultSelectionTask.cxx
@@ -2352,6 +2352,8 @@ Int_t AliMultSelectionTask::SetupRun(const AliVEvent* const esd)
     
     if (sel) {
         sel->SetName(fStoredObjectName.Data());
+        AliInfo("---> Setting up input...");
+        fInput->SetupAutoVtxZCorrection(fOadbMultSelection);
         //Optimize evaluation
         sel->Setup(fInput);
     }
@@ -2439,9 +2441,11 @@ Int_t AliMultSelectionTask::SetupRunFromOADB(const AliVEvent* const esd)
     AliMultSelection* sel = fOadbMultSelection->GetMultSelection();
     
     if (sel) {
-        sel->SetName(fStoredObjectName.Data());
-        //Optimize evaluation
-        sel->Setup(fInput);
+      sel->SetName(fStoredObjectName.Data());
+      AliInfo("---> Setting up input...");
+      fInput->SetupAutoVtxZCorrection(fOadbMultSelection);
+      //Optimize evaluation
+      sel->Setup(fInput);
     }
     
     AliInfo("---> Successfully set up! Inspect MultSelection:");

--- a/OADB/COMMON/MULTIPLICITY/AliMultSelectionTask.h
+++ b/OADB/COMMON/MULTIPLICITY/AliMultSelectionTask.h
@@ -398,9 +398,10 @@ private:
     AliMultSelectionTask(const AliMultSelectionTask&);            // not implemented
     AliMultSelectionTask& operator=(const AliMultSelectionTask&); // not implemented
 
-    ClassDef(AliMultSelectionTask, 12);
+    ClassDef(AliMultSelectionTask, 13);
     //3 - extra QA histograms
     //8 - fOADB ponter
+    //13 - vertex Z 
 };
 
 #endif

--- a/OADB/COMMON/MULTIPLICITY/AliMultVariable.cxx
+++ b/OADB/COMMON/MULTIPLICITY/AliMultVariable.cxx
@@ -14,14 +14,17 @@ ClassImp(AliMultVariable);
 
 //________________________________________________________________
 AliMultVariable::AliMultVariable() :
-  TNamed(), fIsInteger(kFALSE), fValue(0), fValueInteger(0), fMean(0)
+  TNamed(), fIsInteger(kFALSE), fValue(0), fValueInteger(0), fMean(0),
+  fCorrectVertexZ(kFALSE)
+  
 {
   // Constructor
   
 }
 //________________________________________________________________
 AliMultVariable::AliMultVariable(const char * name, const char * title):
-TNamed(name,title), fIsInteger(kFALSE), fValue(0), fValueInteger(0), fMean(0)
+  TNamed(name,title), fIsInteger(kFALSE), fValue(0), fValueInteger(0), fMean(0),
+  fCorrectVertexZ(kFALSE)
 {
   // Constructor
   

--- a/OADB/COMMON/MULTIPLICITY/AliMultVariable.h
+++ b/OADB/COMMON/MULTIPLICITY/AliMultVariable.h
@@ -57,6 +57,9 @@ public:
     void     SetIsInteger( Bool_t lVal ){ fIsInteger = lVal; }
     Bool_t  IsInteger() const { return fIsInteger; }
     
+    void SetUseVertexZCorrection (Bool_t lVal = kTRUE) { fCorrectVertexZ = lVal; }
+    Bool_t GetUseVertexZCorrection () { return fCorrectVertexZ; } 
+  
     void Print(Option_t* option="") const;
     
 private:
@@ -64,7 +67,9 @@ private:
     Float_t fValue;    //Variable value
     Int_t   fValueInteger; //Variable value if integer
     Float_t fMean;     //Variable mean
+    Bool_t fCorrectVertexZ; // do auto-correction with vertex-Z
     
-    ClassDef(AliMultVariable, 1)
+    ClassDef(AliMultVariable, 2)
+    //2 - vertex-Z correction 
 };
 #endif

--- a/OADB/COMMON/MULTIPLICITY/AliOADBMultSelection.cxx
+++ b/OADB/COMMON/MULTIPLICITY/AliOADBMultSelection.cxx
@@ -1,5 +1,6 @@
 #include "AliOADBMultSelection.h"
 #include "TH1F.h"
+#include "TProfile.h"
 #include "TList.h"
 #include "AliMultEstimator.h"
 #include "AliMultVariable.h"
@@ -17,7 +18,7 @@ ClassImp(AliOADBMultSelection);
 //________________________________________________________________
 //Constructors/Destructor
 AliOADBMultSelection::AliOADBMultSelection() :
-TNamed("multSel",""), fCalibList(0), fEventCuts(0), fSelection(0), fMap(0)
+TNamed("multSel",""), fCalibList(0), fCalibListVtxZ(0), fEventCuts(0), fSelection(0), fMap(0), fMapVtxZ(0)
 {
     // constructor
     // fCalibList = new TList();
@@ -27,25 +28,35 @@ TNamed("multSel",""), fCalibList(0), fEventCuts(0), fSelection(0), fMap(0)
 AliOADBMultSelection::AliOADBMultSelection(const AliOADBMultSelection& o)
 : TNamed(o),
 fCalibList(0),
+fCalibListVtxZ(0),
 fEventCuts(0),
 fSelection(0),
-fMap(0)
+fMap(0),
+fMapVtxZ(0)
 {
     fCalibList = new TList();
     fCalibList->SetOwner (kTRUE);
-    TIter next(o.fCalibList);
+    fCalibListVtxZ = new TList();
+    fCalibListVtxZ->SetOwner (kTRUE);
     TObject* obj = 0;
+    
+    TIter next(o.fCalibList);
     while ((obj = next())) fCalibList->Add(obj->Clone());
+    TIter nextvtxZ(o.fCalibListVtxZ);
+    while ((obj = nextvtxZ())) fCalibListVtxZ->Add(obj->Clone());
+  
     fSelection = new AliMultSelection(*o.fSelection);
     fEventCuts = new AliMultSelectionCuts(*o.fEventCuts);
 }
 //________________________________________________________________
 AliOADBMultSelection::AliOADBMultSelection(const char * name, const char * title) :
-TNamed(name, title), fCalibList(0), fEventCuts(0), fSelection(0), fMap(0)
+TNamed(name, title), fCalibList(0), fCalibListVtxZ(0), fEventCuts(0), fSelection(0), fMap(0), fMapVtxZ(0)
 {
     // constructor
     fCalibList = new TList();
     fCalibList -> SetOwner (kTRUE) ;
+    fCalibListVtxZ = new TList();
+    fCalibListVtxZ -> SetOwner (kTRUE) ;
 }
 //________________________________________________________________
 AliOADBMultSelection& AliOADBMultSelection::operator=(const AliOADBMultSelection& o)
@@ -57,15 +68,30 @@ AliOADBMultSelection& AliOADBMultSelection::operator=(const AliOADBMultSelection
         fCalibList->Delete();
         fCalibList = 0;
     }
+    if (fCalibListVtxZ) {
+        fCalibListVtxZ->Delete();
+        fCalibListVtxZ = 0;
+    }
     if (fMap) {
         delete fMap;
         fMap = 0;
     }
+    if (fMapVtxZ) {
+        delete fMapVtxZ;
+        fMapVtxZ = 0;
+    }
+    TObject* obj = 0;
+  
     fCalibList = new TList();
     fCalibList->SetOwner (kTRUE);
     TIter next(o.fCalibList);
-    TObject* obj = 0;
     while ((obj = next())) fCalibList->Add(obj->Clone());
+  
+    fCalibListVtxZ = new TList();
+    fCalibListVtxZ->SetOwner (kTRUE);
+    TIter nextvtxZ(o.fCalibListVtxZ);
+    while ((obj = nextvtxZ())) fCalibListVtxZ->Add(obj->Clone());
+  
     SetMultSelection(new AliMultSelection(*o.fSelection));
     SetEventCuts(new AliMultSelectionCuts(*o.fEventCuts));
     return *this;
@@ -84,9 +110,11 @@ AliOADBMultSelection::~AliOADBMultSelection(){
 //________________________________________________________________
 void AliOADBMultSelection::Dissociate()
 {
-    TIter next(fCalibList);
     TH1*  hist = 0;
+    TIter next(fCalibList);
     while ((hist = static_cast<TH1*>(next()))) hist->SetDirectory(0);
+    TIter nextvtxZ(fCalibListVtxZ);
+    while ((hist = static_cast<TH1*>(nextvtxZ()))) hist->SetDirectory(0);
 }
 //________________________________________________________________
 void AliOADBMultSelection::AddCalibHisto (TH1F * var) {
@@ -97,6 +125,17 @@ void AliOADBMultSelection::AddCalibHisto (TH1F * var) {
         fCalibList->SetOwner();
     }
     fCalibList->Add(var);
+}
+
+//________________________________________________________________
+void AliOADBMultSelection::AddCalibHistoVtx (TProfile * varVtx) {
+    if (!varVtx) return;
+    if (!fCalibListVtxZ) {
+        //create if needed...
+      fCalibListVtxZ = new TList;
+      fCalibListVtxZ->SetOwner();
+    }
+  fCalibListVtxZ->Add(varVtx);
 }
 //________________________________________________________________
 void AliOADBMultSelection::SetEventCuts(AliMultSelectionCuts* c)
@@ -122,6 +161,19 @@ TH1F* AliOADBMultSelection::GetCalibHisto(const TString& lCalibHistoName) const
 {
     if (!fCalibList) return 0;
     return ((TH1F*)fCalibList->FindObject(lCalibHistoName));
+}
+//________________________________________________________________
+TProfile* AliOADBMultSelection::GetCalibHistoVtx(Long_t iVar) const
+{
+    if (!fCalibListVtxZ) return 0;
+    if (iVar < 0 || iVar >= fCalibListVtxZ->GetEntries()) return 0;
+    return (TProfile*) fCalibListVtxZ->At(iVar);
+}
+//________________________________________________________________
+TProfile* AliOADBMultSelection::GetCalibHistoVtx(const TString& lCalibHistoName) const
+{
+    if (!fCalibListVtxZ) return 0;
+    return ((TProfile*)fCalibListVtxZ->FindObject(lCalibHistoName));
 }
 //________________________________________________________________
 void AliOADBMultSelection::Print(Option_t* option) const
@@ -180,7 +232,12 @@ void AliOADBMultSelection::Browse(TBrowser *b)
         histoFolder->SetOwner();
         cutsFolder->SetOwner();
         estFolder->SetOwner();
-        for(Int_t iEst=0; iEst<fCalibList->GetEntries(); iEst++) histoFolder->Add(GetCalibHisto(iEst));
+        for(Int_t iEst=0; iEst<fCalibList->GetEntries(); iEst++){ 
+            histoFolder->Add(GetCalibHisto(iEst));
+        }
+        for(Int_t iEst=0; iEst<fCalibListVtxZ->GetEntries(); iEst++){
+            histoFolder->Add(GetCalibHistoVtx(iEst));
+        }
         
         //Info for Event Selection: Printouts 
         cutsFolder->Add(new TObjString(Form("Vertex Z cut: %f", GetEventCuts()->GetVzCut())));
@@ -241,7 +298,7 @@ void AliOADBMultSelection::Setup()
         AliMultEstimator* e = sel->GetEstimator(iEst);
         if (!e) continue;
         
-        TString name(Form("hCalib_%s", e->GetName()));
+      TString name(Form("hCalib_%s", e->GetName()));
         TH1F*   h = GetCalibHisto(name);
         if (!h) continue;
         

--- a/OADB/COMMON/MULTIPLICITY/AliOADBMultSelection.h
+++ b/OADB/COMMON/MULTIPLICITY/AliOADBMultSelection.h
@@ -2,53 +2,60 @@
 #define ALIOADBMULTSELECTION_H
 
 #include <TNamed.h>
+#include <TMap.h>
 #include <AliMultSelection.h>
 class TBrowser;
 class TH1F;
+class TProfile;
 class TList; 
 class AliMultSelectionCuts;
 class AliMultEstimator;
-class TMap;
 
 class AliOADBMultSelection : public TNamed {
-    
+  
 public:
-    AliOADBMultSelection();
-    AliOADBMultSelection(const AliOADBMultSelection& o);
-    AliOADBMultSelection(const char * name, const char * title = "OADB for multiplicity and centrality selection");
-    AliOADBMultSelection& operator=(const AliOADBMultSelection& o);
-    ~AliOADBMultSelection();
-    
-    //Getters
-    Long_t GetNEstimators () { return fSelection ? fSelection->GetNEstimators() : 0; }
-    
-    TH1F *GetCalibHisto(Long_t iEst) const;
-    TH1F *GetCalibHisto(const TString& lCalibHistoName) const;
-    
-    void AddCalibHisto (TH1F * var);
-    AliMultSelectionCuts * GetEventCuts() const                           { return fEventCuts;     }
-    void                   SetEventCuts (AliMultSelectionCuts * var);
-    AliMultSelection     * GetMultSelection() const                       { return fSelection;     }
-    void                   SetMultSelection(AliMultSelection * var );
-    
-    // Make it browsable
-    void Browse(TBrowser *b);
-    virtual Bool_t IsFolder() const { return kTRUE; }
-    void Dissociate();
-    
-    //Use internal map
-    void Setup();
-    TH1F* FindHisto(AliMultEstimator* e);
-    void Print(Option_t* option="") const;
-    
+  AliOADBMultSelection();
+  AliOADBMultSelection(const AliOADBMultSelection& o);
+  AliOADBMultSelection(const char * name, const char * title = "OADB for multiplicity and centrality selection");
+  AliOADBMultSelection& operator=(const AliOADBMultSelection& o);
+  ~AliOADBMultSelection();
+  
+  //Getters
+  Long_t GetNEstimators () { return fSelection ? fSelection->GetNEstimators() : 0; }
+  
+  TH1F *GetCalibHisto(Long_t iEst) const;
+  TH1F *GetCalibHisto(const TString& lCalibHistoName) const;
+  TProfile *GetCalibHistoVtx(Long_t iVar) const;
+  TProfile *GetCalibHistoVtx(const TString& lVarHistoName) const;
+  
+  void AddCalibHisto (TH1F * var);
+  void AddCalibHistoVtx (TProfile * varVtx);
+  AliMultSelectionCuts * GetEventCuts() const                           { return fEventCuts;     }
+  void                   SetEventCuts (AliMultSelectionCuts * var);
+  AliMultSelection     * GetMultSelection() const                       { return fSelection;     }
+  void                   SetMultSelection(AliMultSelection * var );
+  
+  // Make it browsable
+  void Browse(TBrowser *b);
+  virtual Bool_t IsFolder() const { return kTRUE; }
+  void Dissociate();
+  
+  //Use internal map
+  void Setup();
+  TH1F* FindHisto(AliMultEstimator* e);
+  void Print(Option_t* option="") const;
+  
 private:
-    TList *fCalibList; // Calibration Histograms
-    AliMultSelectionCuts * fEventCuts; // EventCuts
-    AliMultSelection     * fSelection; // Definition of Estimators
-    TMap*                  fMap; //! Map estimator to histogram
-    ClassDef(AliOADBMultSelection, 1)
-    
-    
+  TList *fCalibList; // Calibration Histograms
+  TList *fCalibListVtxZ; // Calibration Histograms for vertex-Z
+  AliMultSelectionCuts * fEventCuts; // EventCuts
+  AliMultSelection     * fSelection; // Definition of Estimators
+  TMap*                  fMap; //! Map estimator to histogram
+  TMap*                  fMapVtxZ; //! Map raw var to histogram
+  ClassDef(AliOADBMultSelection, 2)
+  //2 - Add Vertex-Z
+  
+  
 };
 
 #endif


### PR DESCRIPTION
This is a first commit of the changes to do automated vertex-Z calibrations with AliMultSelection for a re-calibration of pp and beyond. Further details can be seen in this [DPG AOT Events talk](https://indico.cern.ch/event/1012785/contributions/4250669/attachments/2201593/3723832/DDChinellato-VertexZ.pdf). 

This change has been extensively verified to have no impact on any of the operational OADBs in the framework and no OADB was touched so far. The point of this commit is to be able to run grid tests with customized wagons of AliMultSelection + brand-new OADBs with this functionality. 