### PR TITLE
[Doxygen] Move documentation in classes in EMCALbase consistently into header files

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.cxx
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.cxx
@@ -75,9 +75,7 @@
 
 Double_t AliAnalysisTaskEmcal::fgkEMCalDCalPhiDivide = 4.;
 
-/// \cond CLASSIMP
 ClassImp(AliAnalysisTaskEmcal);
-/// \endcond
 
 AliAnalysisTaskEmcal::AliAnalysisTaskEmcal() : 
   AliAnalysisTaskSE("AliAnalysisTaskEmcal"),

--- a/PWG/EMCAL/EMCALbase/AliClusterContainer.cxx
+++ b/PWG/EMCAL/EMCALbase/AliClusterContainer.cxx
@@ -1,17 +1,29 @@
-/**************************************************************************
- * Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights reserved. *
- *                                                                        *
- * Author: The ALICE Off-line Project.                                    *
- * Contributors are mentioned in the code where appropriate.              *
- *                                                                        *
- * Permission to use, copy, modify and distribute this software and its   *
- * documentation strictly for non-commercial purposes is hereby granted   *
- * without fee, provided that the above copyright notice appears in all   *
- * copies and that both the copyright notice and this permission notice   *
- * appear in the supporting documentation. The authors make no claims     *
- * about the suitability of this software for any purpose. It is          *
- * provided "as is" without express or implied warranty.                  *
- **************************************************************************/
+/************************************************************************************
+ * Copyright (C) 2013, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
 #include <algorithm>
 #include <cfloat>
 #include <iostream>
@@ -27,9 +39,7 @@
 
 #include "AliClusterContainer.h"
 
-/// \cond CLASSIMP
 ClassImp(AliClusterContainer);
-/// \endcond
 
 // string to enum map for use with the %YAML config
 const std::map <std::string, AliVCluster::VCluUserDefEnergy_t> AliClusterContainer::fgkClusterEnergyTypeMap = {
@@ -42,9 +52,6 @@ const std::map <std::string, AliVCluster::VCluUserDefEnergy_t> AliClusterContain
 // Properly instantiate the object
 AliEmcalContainerIndexMap <TClonesArray, AliVCluster> AliClusterContainer::fgEmcalContainerIndexMap;
 
-/**
- * Default constructor.
- */
 AliClusterContainer::AliClusterContainer():
   AliEmcalContainer(),
   fEMCALCells(nullptr),
@@ -70,10 +77,6 @@ AliClusterContainer::AliClusterContainer():
   }
 }
 
-/**
- * Standard constructor.
- * @param name Name of the array connected to this container
- */
 AliClusterContainer::AliClusterContainer(const char *name):
   AliEmcalContainer(name),
   fEMCALCells(nullptr),
@@ -99,11 +102,7 @@ AliClusterContainer::AliClusterContainer(const char *name):
   }
 }
 
-/**
- * Get the leading cluster; use e if "e" is contained in opt (otherwise et)
- * @param opt
- * @return
- */
+
 AliVCluster* AliClusterContainer::GetLeadingCluster(const char* opt)
 {
   TString option(opt);
@@ -129,12 +128,7 @@ AliVCluster* AliClusterContainer::GetLeadingCluster(const char* opt)
   return clusterMax.second;
 }
 
-/**
- * Get i^th cluster in array
- * @param i
- * @return
- */
-AliVCluster* AliClusterContainer::GetCluster(Int_t i) const
+AliVCluster* AliClusterContainer::GetCluster(Int_t i) const 
 {
   if(i<0 || i>fClArray->GetEntriesFast()) return 0;
   AliVCluster *vp = static_cast<AliVCluster*>(fClArray->At(i));
@@ -142,11 +136,6 @@ AliVCluster* AliClusterContainer::GetCluster(Int_t i) const
 
 }
 
-/**
- * Return pointer to cluster if cluster is accepted
- * @param i
- * @return
- */
 AliVCluster* AliClusterContainer::GetAcceptCluster(Int_t i) const
 {
   AliVCluster *vc = GetCluster(i);
@@ -161,33 +150,19 @@ AliVCluster* AliClusterContainer::GetAcceptCluster(Int_t i) const
   }
 }
 
-/**
- * Get particle with label lab in array
- * @param lab
- * @return
- */
-AliVCluster* AliClusterContainer::GetClusterWithLabel(Int_t lab) const
+AliVCluster* AliClusterContainer::GetClusterWithLabel(Int_t lab) const 
 {
   Int_t i = GetIndexFromLabel(lab);
   return GetCluster(i);
 }
 
-/**
- * Get particle with label lab in array
- * @param lab
- * @return
- */
 AliVCluster* AliClusterContainer::GetAcceptClusterWithLabel(Int_t lab) const
 {
   Int_t i = GetIndexFromLabel(lab);
   return GetAcceptCluster(i);
 }
 
-/**
- * Get next accepted cluster
- * @return
- */
-AliVCluster* AliClusterContainer::GetNextAcceptCluster()
+AliVCluster* AliClusterContainer::GetNextAcceptCluster() 
 {
   const Int_t n = GetNEntries();
   AliVCluster *c = 0;
@@ -200,11 +175,7 @@ AliVCluster* AliClusterContainer::GetNextAcceptCluster()
   return c;
 }
 
-/**
- * Get next cluster
- * @return
- */
-AliVCluster* AliClusterContainer::GetNextCluster()
+AliVCluster* AliClusterContainer::GetNextCluster() 
 {
   const Int_t n = GetNEntries();
   AliVCluster *c = 0;
@@ -271,46 +242,24 @@ Bool_t AliClusterContainer::GetMomentum(TLorentzVector &mom, const AliVCluster* 
   return kTRUE;
 }
 
-/**
- * Get momentum of the i^th particle in array
- * @param mom
- * @param i
- * @return
- */
 Bool_t AliClusterContainer::GetMomentum(TLorentzVector &mom, Int_t i) const
 {
   AliVCluster *vc = GetCluster(i);
   return GetMomentum(mom, vc);
 }
 
-/**
- * Get momentum of the next particle in array
- * @param mom
- * @return
- */
 Bool_t AliClusterContainer::GetNextMomentum(TLorentzVector &mom)
 {
   AliVCluster *vc = GetNextCluster();
   return GetMomentum(mom, vc);
 }
 
-/**
- * Get momentum of the i^th particle in array
- * @param mom
- * @param i
- * @return
- */
 Bool_t AliClusterContainer::GetAcceptMomentum(TLorentzVector &mom, Int_t i) const
 {
   AliVCluster *vc = GetAcceptCluster(i);
   return GetMomentum(mom, vc);
 }
 
-/**
- * Get momentum of the next accepted particle in array
- * @param mom
- * @return
- */
 Bool_t AliClusterContainer::GetNextAcceptMomentum(TLorentzVector &mom)
 {
   AliVCluster *vc = GetNextAcceptCluster();
@@ -339,12 +288,6 @@ Bool_t AliClusterContainer::AcceptCluster(const AliVCluster* clus, UInt_t &rejec
   return ApplyKinematicCuts(mom, rejectionReason);
 }
 
-/**
- * Return true if cluster is accepted.
- * @param clus The cluster to which the cuts will be applied
- * @param rejectionReason Contains the bit specifying the rejection reason
- * @return True if the cluster is accepted.
- */
 Bool_t AliClusterContainer::ApplyClusterCuts(const AliVCluster* clus, UInt_t &rejectionReason) const
 {
   if (!clus) {
@@ -434,14 +377,6 @@ Bool_t AliClusterContainer::ApplyClusterCuts(const AliVCluster* clus, UInt_t &re
   return kTRUE;
 }
 
-/**
- * Check if cluster has only one cell but should be accepted for the analysis
- * Only below a certain energy threshold (recommended = 4 GeV)
- * Based on the output of AliEmcalCorrectionClusterLowEnergyEfficiency.cxx
- * Chi2() value is used to flag clusters that should pass the cut
- * Clusters will only be flagged in MC, data does not change
- * @return
- */
 Bool_t AliClusterContainer::GetPassedSpecialNCell(const AliVCluster* clus) const
 {
   if(!clus->IsEMCAL()) return kFALSE;
@@ -450,10 +385,6 @@ Bool_t AliClusterContainer::GetPassedSpecialNCell(const AliVCluster* clus) const
   return kFALSE;
 }
 
-/**
- * Get number of accepted particles
- * @return
- */
 Int_t AliClusterContainer::GetNAcceptedClusters() const
 {
   UInt_t rejectionReason = 0;
@@ -465,11 +396,6 @@ Int_t AliClusterContainer::GetNAcceptedClusters() const
   return nClus;
 }
 
-/**
- * Get the energy cut of the applied on cluster energy of type t
- * @param t Cluster energy type (base energy, non-linearity corrected energy, hadronically corrected energy)
- * @return Cluster energy cut
- */
 Double_t AliClusterContainer::GetClusUserDefEnergyCut(Int_t t) const
 {
   if (t >= 0 && t <= AliVCluster::kLastUserDefEnergy){
@@ -480,11 +406,6 @@ Double_t AliClusterContainer::GetClusUserDefEnergyCut(Int_t t) const
   }
 }
 
-/**
- * Set the energy cut of the applied on cluster energy of type t
- * @param t Cluster energy type (base energy, non-linearity corrected energy, hadronically corrected energy)
- * @param cut Cluster energy cut
- */
 void AliClusterContainer::SetClusUserDefEnergyCut(Int_t t, Double_t cut)
 {
   if (t >= 0 && t <= AliVCluster::kLastUserDefEnergy){
@@ -495,14 +416,6 @@ void AliClusterContainer::SetClusUserDefEnergyCut(Int_t t, Double_t cut)
   }
 }
 
-/**
- * Connect the container to the array with content stored inside the virtual event.
- * The object name in the event must match the name given in the constructor.
- *
- * Additionally register the array into the index map and connect EMCAL cells
- *
- * @param event Input event containing the array with content.
- */
 void AliClusterContainer::SetArray(const AliVEvent * event)
 {
   AliEmcalContainer::SetArray(event);
@@ -514,38 +427,18 @@ void AliClusterContainer::SetArray(const AliVEvent * event)
   fgEmcalContainerIndexMap.RegisterArray(GetArray());
 }
 
-/**
- * Create an iterable container interface over all objects in the
- * EMCAL container.
- * @return iterable container over all objects in the EMCAL container
- */
 const AliClusterIterableContainer AliClusterContainer::all() const {
   return AliClusterIterableContainer(this, false);
 }
 
-/**
- * Create an iterable container interface over accepted objects in the
- * EMCAL container.
- * @return iterable container over accepted objects in the EMCAL container
- */
 const AliClusterIterableContainer AliClusterContainer::accepted() const {
   return AliClusterIterableContainer(this, true);
 }
 
-/**
- * Create an iterable container interface over all objects in the
- * EMCAL container.
- * @return iterable container over all objects in the EMCAL container
- */
 const AliClusterIterableMomentumContainer AliClusterContainer::all_momentum() const {
   return AliClusterIterableMomentumContainer(this, false);
 }
 
-/**
- * Create an iterable container interface over accepted objects in the
- * EMCAL container.
- * @return iterable container over accepted objects in the EMCAL container
- */
 const AliClusterIterableMomentumContainer AliClusterContainer::accepted_momentum() const {
   return AliClusterIterableMomentumContainer(this, true);
 }

--- a/PWG/EMCAL/EMCALbase/AliClusterContainer.h
+++ b/PWG/EMCAL/EMCALbase/AliClusterContainer.h
@@ -1,7 +1,31 @@
+/************************************************************************************
+ * Copyright (C) 2013, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
 #ifndef AliClusterContainer_H
 #define AliClusterContainer_H
-/* Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights reserved. *
- * See cxx source for full Copyright notice                               */
 
 class TLorentzVector;
 
@@ -38,36 +62,236 @@ class AliClusterContainer : public AliEmcalContainer {
   /// Relates string to the cluster energy enumeration for %YAML configuration
   static const std::map <std::string, VCluUserDefEnergy_t> fgkClusterEnergyTypeMap; //!<!
 
+  /**
+   * @brief Default constructor.
+   */
   AliClusterContainer();
-  AliClusterContainer(const char *name);
+
+  /**
+   * @brief Standard constructor.
+   * @param name Name of the array connected to this container
+   */
+  AliClusterContainer(const char *name); 
+
+  /**
+   * @brief Destructor
+   */
   virtual ~AliClusterContainer(){;}
 
+  /**
+   * @brief Access to cluster at a given index
+   * @param index Index in the container
+   * @return Cluster at the index (nullptr if the index is larger than the container size)
+   */
   virtual TObject *operator[] (int index) const { return GetCluster(index); }
 
+  /**
+   * @brief Check whether the cluster at a given index is accepted
+   * @param i Index of the cluster
+   * @param[out] rejectionReason Bitmap containing selections criteria which were not passed
+   * @return True if the cluster is accepted, false otherwise
+   * 
+   * The function is used by AliEmcalContainer in order to select the cluster at a given position
+   */
   virtual Bool_t              AcceptObject(Int_t i, UInt_t &rejectionReason) const              { return AcceptCluster(i, rejectionReason);}
+
+  /**
+   * @brief Check whether a object is accepted by the cluster cuts defined for this container
+   * @param obj Object to be checked (must inherit from AliVCluster)
+   * @param[out] rejectionReason Bitmap containing selections criteria which were not passed
+   * @return True if the cluster is accepted, false otherwise 
+   * 
+   * The function is used by AliEmcalContainer in order to select the cluster
+   */
   virtual Bool_t              AcceptObject(const TObject* obj, UInt_t &rejectionReason) const   { return AcceptCluster(dynamic_cast<const AliVCluster*>(obj), rejectionReason);}
+
+  /**
+   * @brief Check whether the cluster at a given index is accepted
+   * @param i Index of the cluster
+   * @param[out] rejectionReason Bitmap containing selections criteria which were not passed
+   * @return True if the cluster is accepted, false otherwise
+   */
   virtual Bool_t              AcceptCluster(Int_t i, UInt_t &rejectionReason)                 const;
+
+  /**
+   * @brief Check whether a cluster is accepted by the cluster cuts defined for this container
+   * @param vp Cluster to be checked
+   * @param[out] rejectionReason Bitmap containing selections criteria which were not passed
+   * @return True if the cluster is accepted, false otherwise 
+   */
   virtual Bool_t              AcceptCluster(const AliVCluster* vp, UInt_t &rejectionReason)   const;
+
+  /**
+   * @brief Apply cluster selection cuts
+   * @param clus The cluster to which the cuts will be applied
+   * @param[out] rejectionReason Contains the bit specifying the rejection reason
+   * @return True if the cluster is accepted, false otherwise
+   * 
+   * Cluster selection cuts contain time, energy, exoticity, ... . 
+   * Kinematic cuts are handled by the AliEmcalContainer directly
+   */
   virtual Bool_t              ApplyClusterCuts(const AliVCluster* clus, UInt_t &rejectionReason) const;
+
+  /**
+   * @brief Check if the particle passed the special cut on the number of cells
+   * @param clus Cluster to be checked
+   * @return True if the cluster is accepted, false otherwise
+   * 
+   * Check if cluster has only one cell but should be accepted for the analysis
+   * Only below a certain energy threshold (recommended = 4 GeV)
+   * Based on the output of AliEmcalCorrectionClusterLowEnergyEfficiency.cxx
+   * Chi2() value is used to flag clusters that should pass the cut
+   * Clusters will only be flagged in MC, data does not change
+   */
   virtual Bool_t              GetPassedSpecialNCell(const AliVCluster* clus) const;
+
+  /**
+   * @brief Access to cluster at position i if the cluster is accepted
+   * @param i Index of the custer in the array
+   * @return Cluster at index i (nullptr if index is larger than array size or cluster is not accepted)
+   */
   AliVCluster                *GetAcceptCluster(Int_t i)              const;
+
+  /**
+   * @brief Get cluster based on cluster label in array if the cluster is accepted
+   * @param lab Cluster label
+   * @return Cluster associated with label (nullptr if cluster is not fould or cluster is not accepted)
+   */
   AliVCluster                *GetAcceptClusterWithLabel(Int_t lab)   const;
+
+  /**
+   * @brief Set the default cluster energy cut
+   * @param cut Cluster energy cut
+   * @deprecated Use SetClusUserDefEnergyCut in order to specify which energy type is used for cluster selection
+   * 
+   * The cut is applied on the default cluster energy
+   */
   void                        SetClusECut(Double_t cut)                    { SetMinE(cut)     ; }
+
+  /**
+   * @brief Set the cluster \f$p_{t}\f$-cut
+   * @param \f$p_{t}\f$-cut of the cluster
+   */
   void                        SetClusPtCut(Double_t cut)                   { SetMinPt(cut)    ; }
+
+  /**
+   * @brief Get the cluster \f$p_{t}\f$-cut
+   * @return \f$p_{t}\f$-cut of the cluster
+   */
   Double_t                    GetClusPtCut()                         const { return GetMinPt(); }
+
+  /**
+   * Get \f$i^{th|}\f$ cluster in array
+   * @param i Position in array
+   * @return Cluster at positon (nullptr if index > array size)
+   */
   AliVCluster                *GetCluster(Int_t i)                    const;
+
+  /**
+   * Get cluster based on cluster label in array
+   * @param lab Cluster label
+   * @return Cluster associated with label (nullptr if cluster is not fould)
+   */
   AliVCluster                *GetClusterWithLabel(Int_t lab)         const;
+
+  /**
+  * @brief Get the leading cluster 
+  * @param opt Option: e - use cluster energy (default: \f$E_{t}\f$)
+  * @return Leading cluster 
+  */
   AliVCluster                *GetLeadingCluster(const char* opt="")       ;
+
+  /**
+   * @brief Fill momnetum vector for a given cluster under a user-defined mass hypothesis
+   * @param[out] mom Cluster momentum vector
+   * @param vc Cluster for which to calculate the momentum vector
+   * @param mass Mass hypothesis (default: 0 if mass hypothesis is negative)
+   * @return True if the cluster position is valid, false if the cluster position is invalid
+   */
   Bool_t                      GetMomentum(TLorentzVector &mom, const AliVCluster* vc, Double_t mass) const;
+
+  /**
+   * @brief Fill momnetum vector for a given cluster
+   * @param[out] mom Cluster momentum vector
+   * @param clus Cluster for which to calculate the momentum vector
+   * @return True if the cluster position is valid, false if the cluster position is invalid
+   * 
+   * As mass hypothesis the mass hypothesis specified in AliEmcalContainer 
+   * is used (default: -1). In case of a negative mass hypothesis masses
+   * particles (photons) are used instead.
+   */
   Bool_t                      GetMomentum(TLorentzVector &mom, const AliVCluster* clus) const;
+
+  /**
+   * @brief Fill momentum vector of the \f$i^{th}\f$ cluster in the array
+   * @param[out] mom Cluster momentum vector
+   * @param i Index of the cluster in the arrays
+   * @return True if access was successful, false if the index is beyond the container size
+   */
   Bool_t                      GetMomentum(TLorentzVector &mom, Int_t i) const;
+
+  /**
+   * @brief Fill momentum vector of the i^th cluster in the array in case the cluster was accepted
+   * @param[out] mom Cluster momentum vector
+   * @param i Index of the cluster in the arrays
+   * @return True if access was successful, false if the index is beyond the container size or the cluster was not accepted
+   */
   Bool_t                      GetAcceptMomentum(TLorentzVector &mom, Int_t i) const;
+
+  /**
+   * @brief Fill momentum vector of the next cluster in the array
+   * @param[out] mom Cluster momentum vector
+   * @return True if access was successful, false if there is no more cluster in the array
+   * @deprecated Use all_momentum() in order to iterate over all cluster momentum vectors in the container
+   * 
+   * Internal iterator over cluster momenta. Container must be reset
+   * at the beginning of the iteration via Reset().
+   */
   Bool_t                      GetNextMomentum(TLorentzVector &mom);
+
+  /**
+   * Fill momentum vector of the next accepted cluster in the array
+   * @param[out] mom Cluster momentum vector
+   * @return True if access was successful, false if there is no more accepted cluster in the array
+   * @deprecated Use accepted_momentum() in order to iterate over accepted cluster momentum vectors in the container
+   * 
+   * Internal iterator over accepted cluster momenta. Container must be reset
+   * at the beginning of the iteration via Reset().
+   */
   Bool_t                      GetNextAcceptMomentum(TLorentzVector &mom);
+
+  /**
+   * @brief Get next accepted cluster in the container
+   * @return Next accepted cluster (nullptr if no more accepted clusters are available)
+   * @deprecated Use accepted() to interate over the accepted clusters in the container
+   * 
+   * Internal iterator over accepted clusters. Container must be reset
+   * at the beginning of the iteration via Reset().
+   */
   AliVCluster                *GetNextAcceptCluster();
+
+  /**
+   * @brief Get next cluster in the container
+   * @return Next custer (nullptr if no more clusters are available)
+   * @deprecated Use all() to interate over the clusters in the container
+   * 
+   * Internal iterator over accepted clusters. Container must be reset
+   * at the beginning of the iteration via Reset().
+   */
   AliVCluster                *GetNextCluster();
+
+  /**
+   * @brief Get the number of clusters in the array
+   * @return Number of clusters in the array 
+   */
   Int_t                       GetNClusters()                         const { return GetNEntries();   }
+
+  /**
+   * @brief Get number of accepted clusters in the container
+   * @return Number of accepted clusters
+   */
   Int_t                       GetNAcceptedClusters()                 const;
+
   void                        SetClusTimeCut(Double_t min, Double_t max)   { fClusTimeCutLow  = min ; fClusTimeCutUp = max ; }
   void                        SetMinMCLabel(Int_t s)                       { fMinMCLabel      = s   ; }
   void                        SetMaxMCLabel(Int_t s)                       { fMaxMCLabel      = s   ; }
@@ -81,8 +305,28 @@ class AliClusterContainer : public AliEmcalContainer {
   void                        SetEmcalMaxM02Energy(Double_t max)           { fEmcalMaxM02CutEnergy = max; }
   void                        SetMaxFractionEnergyLeadingCell(Double_t max)  { fMaxFracEnergyLeadingCell = max; }
   void                        SetEmcalMaxNCellEfficiencyEnergy(Double_t max) { fEmcalMaxNCellEffCutEnergy = max; }
+
+  /**
+   * @brief Connect the container to the array with content stored inside the virtual event.
+   * @param event Input event containing the array with content.
+   * 
+   * The object name in the event must match the name given in the constructor.
+   * Additionally register the array into the index map and connect EMCAL cells
+   */
   void                        SetArray(const AliVEvent * event);
+
+  /**
+   * @brief Set the energy cut of the applied on cluster energy of type t
+   * @param t Cluster energy type (base energy, non-linearity corrected energy, hadronically corrected energy)
+   * @param cut Cluster energy cut
+   */
   void                        SetClusUserDefEnergyCut(Int_t t, Double_t cut);
+
+  /**
+   * @brief Get the energy cut of the applied on cluster energy of type t
+   * @param t Cluster energy type (base energy, non-linearity corrected energy, hadronically corrected energy)
+   * @return Cluster energy cut
+   */
   Double_t                    GetClusUserDefEnergyCut(Int_t t) const;
 
   void                        SetClusNonLinCorrEnergyCut(Double_t cut)                     { SetClusUserDefEnergyCut(AliVCluster::kNonLinCorr, cut); }
@@ -97,21 +341,44 @@ class AliClusterContainer : public AliEmcalContainer {
   /// Get the EMCal container utils associated with particle containers
   static const AliEmcalContainerIndexMap <TClonesArray, AliVCluster>& GetEmcalContainerIndexMap() { return fgEmcalContainerIndexMap; }
 
+  /**
+   * @brief Create an iterable container interface over all objects in the
+   * EMCAL container.
+   * @return iterable container over all objects in the EMCAL container
+   */
   const AliClusterIterableContainer      all() const;
+
+  /**
+   * @brief Create an iterable container interface over accepted objects in the
+   * EMCAL container.
+   * @return iterable container over accepted objects in the EMCAL container
+   */
   const AliClusterIterableContainer      accepted() const;
 
+  /**
+   * @brief Create an iterable container interface over all objects in the
+   * EMCAL container.
+   * @return iterable container over all objects in the EMCAL container
+   */
   const AliClusterIterableMomentumContainer      all_momentum() const;
+
+  /**
+   * @brief Create an iterable container interface over accepted objects in the
+   * EMCAL container.
+   * @return iterable container over accepted objects in the EMCAL container
+   */
   const AliClusterIterableMomentumContainer      accepted_momentum() const;
 #endif
 
  protected:
   /**
-   * Create default array name for the cluster container. The
-   * default array name will be
-   * - *caloClusters* in case of AOD event
-   * - *CaloClusters* in case of ESD event
+   * @brief Create default array name for the cluster container. 
    * @param[in] ev Input event, used for data type selection
    * @return Appropriate default array name
+   * 
+   * The default array name will be
+   * - *caloClusters* in case of AOD event
+   * - *CaloClusters* in case of ESD event
    */
   virtual TString             GetDefaultArrayName(const AliVEvent * const ev) const;
 
@@ -140,9 +407,7 @@ class AliClusterContainer : public AliEmcalContainer {
   AliClusterContainer(const AliClusterContainer& obj); // copy constructor
   AliClusterContainer& operator=(const AliClusterContainer& other); // assignment
 
-  /// \cond CLASSIMP
   ClassDef(AliClusterContainer,13);
-  /// \endcond
 };
 
 /**

--- a/PWG/EMCAL/EMCALbase/AliEmcalList.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEmcalList.cxx
@@ -1,18 +1,29 @@
-/**************************************************************************
- * Copyright(c) 1998-2016, ALICE Experiment at CERN, All rights reserved. *
- *                                                                        *
- * Author: R. Haake                                                       *
- * Contributors are mentioned in the code where appropriate.              *
- *                                                                        *
- * Permission to use, copy, modify and distribute this software and its   *
- * documentation strictly for non-commercial purposes is hereby granted   *
- * without fee, provided that the above copyright notice appears in all   *
- * copies and that both the copyright notice and this permission notice   *
- * appear in the supporting documentation. The authors make no claims     *
- * about the suitability of this software for any purpose. It is          *
- * provided "as is" without express or implied warranty.                  *
- **************************************************************************/
-
+/************************************************************************************
+ * Copyright (C) 2016, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
 #include <iostream>
 #include "TList.h"
 #include "TH1.h"
@@ -27,7 +38,6 @@
 
 ClassImp(AliEmcalList)
 
-/// \brief constructor
 //________________________________________________________________________
 AliEmcalList::AliEmcalList() : TList(), 
   fUseScaling(kFALSE),
@@ -36,7 +46,6 @@ AliEmcalList::AliEmcalList() : TList(),
 {
 }
 
-/// \brief Overridden ::Merge function
 //________________________________________________________________________
 Long64_t AliEmcalList::Merge(TCollection *hlist)
 {
@@ -86,7 +95,6 @@ Long64_t AliEmcalList::Merge(TCollection *hlist)
   return hlist->GetEntries() + 1;
 }
 
-/// \brief Function that does the scaling of all histograms in hlist recursively
 //________________________________________________________________________
 void AliEmcalList::ScaleAllHistograms(TCollection *hlist, Double_t scalingFactor)
 {
@@ -146,7 +154,6 @@ void AliEmcalList::ScaleAllHistograms(TCollection *hlist, Double_t scalingFactor
   }
 }
 
-/// \brief Helper function scaling factor
 //________________________________________________________________________
 Double_t AliEmcalList::GetScalingFactor(const TH1* xsection, const TH1* ntrials) const
 {
@@ -167,8 +174,6 @@ Double_t AliEmcalList::GetScalingFactor(const TH1* xsection, const TH1* ntrials)
   return scalingFactor;
 }
 
-/// \brief Helper function to determine whether we are in last merge step
-/// \param collection Collection of AliEmcalList objects
 //________________________________________________________________________
 Bool_t AliEmcalList::IsLastMergeLevel(const TCollection* collection) const 
 {
@@ -187,15 +192,6 @@ Bool_t AliEmcalList::IsLastMergeLevel(const TCollection* collection) const
   return kFALSE;
 }
 
-/// \brief Helper function checking whether type is supported for scaling
-///
-/// Supported types are: 
-///  - all TH1-derived / THnBase-derived histograms
-///  - objects inheriting from RooUnfoldResponse if AliPhysics is built with
-///    RooUnfold support
-///
-/// \param scaleobject Object for which to deterime scaling support
-/// \return true if object can be scaled, false otherwise
 //________________________________________________________________________
 bool AliEmcalList::IsScalingSupported(const TObject *scaleobject) const {
   if(scaleobject->InheritsFrom(TH1::Class()) || scaleobject->InheritsFrom(THnBase::Class())) return true;
@@ -205,9 +201,6 @@ bool AliEmcalList::IsScalingSupported(const TObject *scaleobject) const {
   return false;
 }
 
-/// \brief Helper function that returns the bin in a TH1 that is filled
-/// \param hist  Histogram
-/// \return bin number that is filled. If no or more than one bin is filled, 0.
 //________________________________________________________________________
 Int_t AliEmcalList::GetFilledBinNumber(const TH1* hist) const
 {

--- a/PWG/EMCAL/EMCALbase/AliEmcalList.h
+++ b/PWG/EMCAL/EMCALbase/AliEmcalList.h
@@ -1,53 +1,154 @@
+/************************************************************************************
+ * Copyright (C) 2016, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
 #ifndef ALIEMCALLIST_H
 #define ALIEMCALLIST_H
-/* Copyright(c) 1998-2016, ALICE Experiment at CERN, All rights reserved. *
- * See cxx source for full Copyright notice                               */
-
-/**
- * \class AliEmcalList
- * \brief Enhanced TList-derived class that implements correct merging for pt_hard binned production
- *
- * Must be activated using SetUseScaling(kTRUE). Otherwise the behavior is like a TList
- * Scaling is recursively applied also to all nested lists deriving from TCollection
- * fHistXsection and fHistTrials must be added directly to the list (not to a nested list)
- *
- * \author Ruediger Haake <ruediger.haake@cern.ch>, CERN
- * \date May 05, 2016
- * \ingroup EMCALCOREFW
- */
-//
 
 class TH1;
 
 #include "TList.h"
 #include "TString.h"
 
+/**
+ * @class AliEmcalList
+ * @brief Enhanced TList-derived class that implements correct merging for pt_hard binned production
+ * @author Ruediger Haake <ruediger.haake@cern.ch>, CERN
+ * @date May 05, 2016
+ * @ingroup EMCALCOREFW
+ *
+ * Must be activated using SetUseScaling(kTRUE). Otherwise the behavior is like a TList
+ * Scaling is recursively applied also to all nested lists deriving from TCollection
+ * fHistXsection and fHistTrials must be added directly to the list (not to a nested list)
+ */
 class AliEmcalList : public TList {
 
 public:
+
+  /**
+   * @brief Constructor
+   */
   AliEmcalList();
+
+  /**
+   * @brief Destructor
+   */
   ~AliEmcalList() {}
+  /**
+   * @brief Merge function including the reweighting of \f$p_{t}\f$-hard bins
+   * @param hlist Collection of object to be merged
+   * @return Number of entries to be merged
+   * 
+   * Overriding the standard Merge function in order to allow
+   * for reweighting of the histograms based on the weight for 
+   * the given \f$p_{t}\f$-hard bin: In case the last merging level
+   * (merging of files from different \f$p_{t}\f$-hard bins) is reached,
+   * all histograms in the list except from the usual scaling histograms
+   * which are created by the AliAnalysisTaskEmcal or AliAnalysisTaskEmcalLight
+   * are scaled by the cross section divided by the number of trials. The
+   * merging level is determined from whether different bins in the scaling
+   * histograms are filled for the various histograms to be merged.
+   */
   Long64_t                    Merge(TCollection *hlist);
+
+  /**
+   * @brief Set the container to rescaing mode
+   * @param val True for scaling mode, false for normal merging
+   */
   void                        SetUseScaling(Bool_t val) {fUseScaling = val;}
+
+  /**
+   * @brief Check if the merging is in scaling mode
+   * @return If true the merging is in scaling mode
+   */
   Bool_t                      IsUseScaling() const { return fUseScaling; }
+
+  /**
+   * @brief Set the name of the cross section histogram used for the weight calculation
+   * @param name Name of the cross section histogram
+   */
   void                        SetNameXsec(const char *name) { fNameXsec = name; }
+  
+  /**
+   * @brief Set the name of the histogram with the number of trials histogram used for the weight calculation
+   * @param name Name of the histogram with the number of trials
+   */
   void                        SetNameTrials(const char *name) { fNameNTrials = name; }
 
 private:
   // ####### Helper functions
+
+  /**
+   * @brief Scaling all histograms in the histogram list by the weight of the \f$p_{t}\f$-hard bin
+   * @param hlist List of histograms to be scaled
+   * @param scalingFactor Scaling factor to be applied on the histograms
+   * 
+   * Scaling of all histograms in hlist recursively. Histograms which are created
+   * by the AliAnalysisTaskEmcal or AliAnalysisTaskEmcalLight in order to obtain the
+   * scale factors are not scaled.
+   */
   void                        ScaleAllHistograms(TCollection *hlist, Double_t scalingFactor);
+  
+  /**
+   * @brief Helper function scaling factor
+   * @param xsection Histogram with the cross section for the different \f$p_{t}\f$-hard bins
+   * @param ntrials  Histogram with the number of triaks for the different \f$p_{t}\f$-hard bins
+   * @return Weight for the \f$p_{t}\f$-hard bin
+   */
   Double_t                    GetScalingFactor(const TH1* xsection, const TH1* ntrials) const;
+
+  /**
+   * @brief Helper function to determine whether we are in last merge step
+   * @param collection Collection of AliEmcalList objects
+   */
   Bool_t                      IsLastMergeLevel(const TCollection* collection) const;
+
+  /**
+   * @brief Helper function that returns the bin in a TH1 that is filled
+   * @param hist  Histogram
+   * @return bin number that is filled. If no or more than one bin is filled, 0.
+   */ 
   Int_t                       GetFilledBinNumber(const TH1* hist) const;
+
+  /**
+   * @brief Helper function checking whether type is supported for scaling
+   * @param scaleobject Object for which to deterime scaling support
+   * @return true if object can be scaled, false otherwise
+   * 
+   * Supported types are: 
+   * - all TH1-derived / THnBase-derived histograms
+   *  - objects inheriting from RooUnfoldResponse if AliPhysics is built with
+   *    RooUnfold support
+   */
   Bool_t                      IsScalingSupported(const TObject *scaleobject) const;
   
   Bool_t                      fUseScaling;                    ///< if true, scaling will be done. if false AliEmcalList simplifies to TList
   TString                     fNameXsec;                      ///< Name of the cross section histogram
   TString                     fNameNTrials;                   ///< Name of the histogram with the number of trials
 
-  /// \cond CLASSIMP
   ClassDef(AliEmcalList, 2);
-  /// \endcond
 };
 
 #endif

--- a/PWG/EMCAL/EMCALbase/AliMCParticleContainer.cxx
+++ b/PWG/EMCAL/EMCALbase/AliMCParticleContainer.cxx
@@ -1,8 +1,30 @@
-//
-// Container with name, TClonesArray and cuts for particles
-//
-// Author: M. Verweij, S. Aiola
 
+/************************************************************************************
+ * Copyright (C) 2013, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
 #include <iostream>
 
 #include <TClonesArray.h>
@@ -13,13 +35,8 @@
 #include "AliTLorentzVector.h"
 #include "AliMCParticleContainer.h"
 
-/// \cond CLASSIMP
 ClassImp(AliMCParticleContainer);
-/// \endcond
 
-/**
- * Default constructor.
- */
 AliMCParticleContainer::AliMCParticleContainer():
   AliParticleContainer(),
   fMCFlag(AliAODMCParticle::kPhysicalPrim)
@@ -28,10 +45,6 @@ AliMCParticleContainer::AliMCParticleContainer():
   SetClassName("AliAODMCParticle");
 }
 
-/**
- * Standard constructor.
- * @param[in] name Name of the container (= name of the array operated on)
- */
 AliMCParticleContainer::AliMCParticleContainer(const char *name):
   AliParticleContainer(name),
   fMCFlag(AliAODMCParticle::kPhysicalPrim)
@@ -40,11 +53,6 @@ AliMCParticleContainer::AliMCParticleContainer(const char *name):
   SetClassName("AliAODMCParticle");
 }
 
-/**
- * Get MC particle using the MC label
- * @param[in] lab Label of the particle
- * @return pointer to particle if particle is found, NULL otherwise
- */
 AliAODMCParticle* AliMCParticleContainer::GetMCParticleWithLabel(Int_t lab) const
 {
   Int_t i = GetIndexFromLabel(lab);
@@ -56,11 +64,6 @@ AliAODMCParticle* AliMCParticleContainer::GetMCParticleWithLabel(Int_t lab) cons
   }
 }
 
-/**
- * Get MC particle using the MC label
- * @param[in] lab Label of the particle
- * @return pointer to particle if particle is found and accepted, NULL otherwise
- */
 AliAODMCParticle* AliMCParticleContainer::GetAcceptMCParticleWithLabel(Int_t lab)
 {
   Int_t i = GetIndexFromLabel(lab);
@@ -72,11 +75,6 @@ AliAODMCParticle* AliMCParticleContainer::GetAcceptMCParticleWithLabel(Int_t lab
   }
 }
 
-/**
- * Get track at index in the container
- * @param[in] i Index of the particle in the container
- * @return pointer to particle if particle is found, NULL otherwise
- */
 AliAODMCParticle* AliMCParticleContainer::GetMCParticle(Int_t i) const
 {
   if (i == -1) i = fCurrentID;
@@ -85,11 +83,6 @@ AliAODMCParticle* AliMCParticleContainer::GetMCParticle(Int_t i) const
   return vp;
 }
 
-/**
- * Get track at index in the container
- * @param[in] i Index of the particle in the container
- * @return pointer to particle if particle is accepted, NULL otherwise
- */
 AliAODMCParticle* AliMCParticleContainer::GetAcceptMCParticle(Int_t i) const
 {
   //return pointer to particle if particle is accepted
@@ -105,11 +98,6 @@ AliAODMCParticle* AliMCParticleContainer::GetAcceptMCParticle(Int_t i) const
   }
 }
 
-/**
- * Get next accepted particle in the container selected using the track cuts provided.
- * @deprecated Old style iterator - for compatibility reasons, use AliParticleContainer::accept_iterator instead
- * @return Next accepted particle (NULL if the end of the array is reached)
- */
 AliAODMCParticle* AliMCParticleContainer::GetNextAcceptMCParticle()
 {
   const Int_t n = GetNEntries();
@@ -123,11 +111,6 @@ AliAODMCParticle* AliMCParticleContainer::GetNextAcceptMCParticle()
   return p;
 }
 
-/**
- * Get next particle in the container
- * @deprecated Old style iterator - for compatibility reasons, use AliParticleContainer::all_iterator instead
- * @return Next track in the container (NULL if end of the container is reached)
- */
 AliAODMCParticle* AliMCParticleContainer::GetNextMCParticle()
 {
   //Get next particle
@@ -143,15 +126,6 @@ AliAODMCParticle* AliMCParticleContainer::GetNextMCParticle()
   return p;
 }
 
-/**
- * Perform full MC particle selection for the particle vp, consisting
- * of kinematical particle selection and MC-specific cuts
- * @param[in] vp Particle to be checked
- * @param[in] rejectionReason Bitmap encoding the reason why the
- * particle was rejected. Note: The variable is not set to NULL
- * inside this function before changing its value.
- * @return True if the particle is accepted, false otherwise
- */
 Bool_t AliMCParticleContainer::AcceptMCParticle(const AliAODMCParticle *vp, UInt_t &rejectionReason) const
 {
   // Return true if vp is accepted.
@@ -164,15 +138,6 @@ Bool_t AliMCParticleContainer::AcceptMCParticle(const AliAODMCParticle *vp, UInt
   return ApplyKinematicCuts(mom, rejectionReason);
 }
 
-/**
- * Perform full MC particle selection for the particle vp, consisting
- * of kinematical particle selection and MC-specific cuts
- * @param[in] i Index of the particle to check
- * @param[in] rejectionReason Bitmap encoding the reason why the
- * particle was rejected. Note: The variable is not set to NULL
- * inside this function before changing its value.
- * @return True if the particle is accepted, false otherwise
- */
 Bool_t AliMCParticleContainer::AcceptMCParticle(Int_t i, UInt_t &rejectionReason) const
 {
   // Return true if vp is accepted.
@@ -186,14 +151,6 @@ Bool_t AliMCParticleContainer::AcceptMCParticle(Int_t i, UInt_t &rejectionReason
   return ApplyKinematicCuts(mom, rejectionReason);
 }
 
-/**
- * Apply MC particle cuts, e.g. primary particle selection.
- * @param[in] vp Particle to be checked
- * @param[in] rejectionReason Bitmap encoding the reason why the
- * particle was rejected. Note: The variable is not set to NULL
- * inside this function before changing its value.
- * @return True if the particle is accepted, false otherwise
- */
 Bool_t AliMCParticleContainer::ApplyMCParticleCuts(const AliAODMCParticle* vp, UInt_t &rejectionReason) const
 {
   // Return true if i^th particle is accepted.
@@ -207,48 +164,22 @@ Bool_t AliMCParticleContainer::ApplyMCParticleCuts(const AliAODMCParticle* vp, U
   return ApplyParticleCuts(vp, rejectionReason);
 }
 
-/**
- * Create an iterable container interface over all objects in the
- * EMCAL container.
- * @return iterable container over all objects in the EMCAL container
- */
 const AliMCParticleIterableContainer AliMCParticleContainer::all() const {
   return AliMCParticleIterableContainer(this, false);
 }
 
-/**
- * Create an iterable container interface over accepted objects in the
- * EMCAL container.
- * @return iterable container over accepted objects in the EMCAL container
- */
 const AliMCParticleIterableContainer AliMCParticleContainer::accepted() const {
   return AliMCParticleIterableContainer(this, true);
 }
 
-/**
- * Create an iterable container interface over all objects in the
- * EMCAL container.
- * @return iterable container over all objects in the EMCAL container
- */
 const AliMCParticleIterableMomentumContainer AliMCParticleContainer::all_momentum() const {
   return AliMCParticleIterableMomentumContainer(this, false);
 }
 
-/**
- * Create an iterable container interface over accepted objects in the
- * EMCAL container.
- * @return iterable container over accepted objects in the EMCAL container
- */
 const AliMCParticleIterableMomentumContainer AliMCParticleContainer::accepted_momentum() const {
   return AliMCParticleIterableMomentumContainer(this, true);
 }
 
-/**
- * Build title of the container consisting of the container name
- * and a string encoding the minimum \f$ p_{t} \f$ cut applied
- * in the kinematic particle selection.
- * @return Title of the container
- */
 const char* AliMCParticleContainer::GetTitle() const
 {
   static TString trackString;

--- a/PWG/EMCAL/EMCALbase/AliMCParticleContainer.h
+++ b/PWG/EMCAL/EMCALbase/AliMCParticleContainer.h
@@ -1,3 +1,29 @@
+/************************************************************************************
+ * Copyright (C) 2013, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
 #ifndef ALIMCPARTICLECONTAINER_H
 #define ALIMCPARTICLECONTAINER_H
 
@@ -20,43 +46,227 @@ typedef EMCALIterableContainer::AliEmcalIterableContainerT<AliAODMCParticle, EMC
  * @brief Container for MC-true particles within the EMCAL framework
  * @ingroup EMCALCOREFW
  * @author Salvatore Aiola <salvatore.aiola@cern.ch>, Yale University
+ * 
+ * Container with name, TClonesArray and cuts for particles
  */
 class AliMCParticleContainer : public AliParticleContainer {
  public:
 
+  /**
+   * @brief Default constructor.
+   */
   AliMCParticleContainer();
+
+  /**
+   * @brief Standard constructor.
+   * @param[in] name Name of the container (= name of the array operated on)
+   */
   AliMCParticleContainer(const char *name);
+
+  /**
+   * @brief Destructor
+   */
   virtual ~AliMCParticleContainer(){;}
 
+  /**
+   * @brief Apply MC particle cuts, e.g. primary particle selection.
+   * @param[in] vp Particle to be checked
+   * @param[in] rejectionReason Bitmap encoding the reason why the
+   * particle was rejected. Note: The variable is not set to NULL
+   * inside this function before changing its value.
+   * @return True if the particle is accepted, false otherwise
+   */
   virtual Bool_t              ApplyMCParticleCuts(const AliAODMCParticle* vp, UInt_t &rejectionReason) const;
+
+  /**
+   * @brief Check whether particle at a given index is accepted
+   * @param i Index of the particle in the container
+   * @param[out] rejectionReason Bitmap containing selections criteria which were not passed
+   * @return True if the particle is accepted, false otherwise 
+   * 
+   * The function is used by AliEmcalContainer in order to select the particle at a given position 
+   */
   virtual Bool_t              AcceptObject(Int_t i, UInt_t &rejectionReason) const { return AcceptMCParticle(i, rejectionReason);}
+
+  /**
+   * @brief Check whether a given particle is accepted
+   * @param obj Particle to be checked
+   * @param[out] rejectionReason Bitmap containing selections criteria which were not passed
+   * @return True if the particle is accepted, false otherwise 
+   * 
+   * The function is used by AliEmcalContainer in order to select a given particle
+   */
   virtual Bool_t              AcceptObject(const TObject* obj, UInt_t &rejectionReason) const { return AcceptMCParticle(dynamic_cast<const AliAODMCParticle*>(obj), rejectionReason);}
+
+  /**
+   * @brief Check whether a particle is selected among the selection cut defined for this container
+   * @param vp Particle for which to perform the selection
+   * @param rejectionReason Bitmap with the reason why the particle was accepted.
+   * Note: The value is not set to 0 in the function in order to combine the information
+   * with other selection steps.
+   * @return True if the particle is accepted, false otherwise.
+   */
   virtual Bool_t              AcceptParticle(Int_t i, UInt_t &rejectionReason) const { return AcceptMCParticle(i, rejectionReason);}
+
+  /**
+   * @brief Check whether the particle at a given index in the container is selected among the selection cut defined for this container 
+   * @param[in] i Index of the particle to select.
+   * @param[out] rejectionReason Bitmap with the reason why the particle was accepted.
+   * Note: The value is not set to 0 in the function in order to combine the information
+   * with other selection steps.
+   * @return True if the particle was accepted, false otherwise
+   */
   virtual Bool_t              AcceptParticle(const AliVParticle* vp, UInt_t &rejectionReason) const { return AcceptMCParticle(dynamic_cast<const AliAODMCParticle*>(vp), rejectionReason);}
+
+  /**
+   * @brief Check whether the MC particle is accepted
+   * @param[in] vp Particle to be checked
+   * @param[in] rejectionReason Bitmap encoding the reason why the
+   * particle was rejected. Note: The variable is not set to NULL
+     * inside this function before changing its value.
+   * @return True if the particle is accepted, false otherwise
+   * 
+   * Perform full MC particle selection for the particle vp, consisting
+   * of kinematical particle selection and MC-specific cuts
+   */
   virtual Bool_t              AcceptMCParticle(const AliAODMCParticle* vp, UInt_t &rejectionReason) const;
+
+  /**
+   * @brief Check whether the MC particle at a given index in the container is accepted
+   * @param[in] i Index of the particle to check
+   * @param[in] rejectionReason Bitmap encoding the reason why the
+   * particle was rejected. Note: The variable is not set to NULL
+   * inside this function before changing its value.
+   * @return True if the particle is accepted, false otherwise
+   * 
+   * Perform full MC particle selection for the particle vp, consisting
+   * of kinematical particle selection and MC-specific cuts
+   */
   virtual Bool_t              AcceptMCParticle(Int_t i, UInt_t &rejectionReason) const;
+
+  /**
+   * @brief Get MC particle using the MC label
+   * @param[in] lab Label of the particle
+   * @return pointer to particle if particle is found, NULL otherwise
+   */
   virtual AliAODMCParticle   *GetMCParticleWithLabel(Int_t lab)         const;
+
+  /**
+   * @brief Get MC particle using the MC label in case the particle was accepted
+   * @param[in] lab Label of the particle
+   * @return pointer to particle if particle is found and accepted, NULL otherwise
+   */
   virtual AliAODMCParticle   *GetAcceptMCParticleWithLabel(Int_t lab)        ;
+
+  /**
+   * @brief Get the highest energetic MC particle 
+   * @param opt Option among which to select the leading partice
+   * @return Leading particle in the container
+   */
   virtual AliAODMCParticle   *GetLeadingMCParticle(const char* opt="")        { return static_cast<AliAODMCParticle*>(GetLeadingParticle(opt)); }
+
+  /**
+   * @brief Get particle at index in the container
+   * @param[in] i Index of the particle in the container
+   * @return pointer to particle if particle is found, NULL otherwise
+   */
   virtual AliAODMCParticle   *GetMCParticle(Int_t i=-1)                 const;
+
+  /**
+   * @brief Get track at index in the container
+   * @param[in] i Index of the particle in the container
+   * @return pointer to particle if particle is accepted, NULL otherwise
+   */
   virtual AliAODMCParticle   *GetAcceptMCParticle(Int_t i=-1)           const;
+
+  /**
+   * @brief Get next accepted particle in the container selected using the track cuts provided.
+   * @return Next accepted particle (NULL if the end of the array is reached)
+   * @deprecated Old style iterator - for compatibility reasons, use AliParticleContainer::accept_iterator instead
+   */
   virtual AliAODMCParticle   *GetNextAcceptMCParticle()                      ;
+
+  /**
+   * @brief Get next particle in the container
+   * @return Next track in the container (NULL if end of the container is reached)
+   * @deprecated Old style iterator - for compatibility reasons, use AliParticleContainer::all_iterator instead
+   */
   virtual AliAODMCParticle   *GetNextMCParticle()                            ;
+
+  /**
+   * @brief Get the particle at a given index in the container 
+   * @param i Index in the container
+   * @return Particle at the index (nullptr if the index is larger than then number of particles in the container)
+   */
   virtual AliVParticle       *GetParticle(Int_t i=-1)                   const { return GetMCParticle(i)           ; }
+
+  /**
+   * @brief Get the particle at a given index in the container in case it was accepted
+   * @param i Index in the container
+   * @return Particle at the index in case it was accepted (nullptr if the particle was not accepted or he index is larger than then number of particles in the container)
+   */
   virtual AliVParticle       *GetAcceptParticle(Int_t i=-1)             const { return GetAcceptMCParticle(i)     ; }
+
+  /**
+   * @brief Get the next accepted particle in the container
+   * @return Next accepted particle in the container (nullptr if no more acceped particles can be found)
+   * @deprecated Old style iterator - for compatibility reasons, use AliParticleContainer::all_iterator instead
+   */
   virtual AliVParticle       *GetNextAcceptParticle()                         { return GetNextAcceptMCParticle()  ; }
+
+  /**
+   * @brief Get the next particle in the container
+   * @return Next particle in the container (nullptr if no more particles can be found)
+   * @deprecated Old style iterator - for compatibility reasons, use AliParticleContainer::accepted_iterator instead
+   */
   virtual AliVParticle       *GetNextParticle()                               { return GetNextMCParticle()        ; }
 
   void                        SetMCFlag(UInt_t m)                             { fMCFlag          = m ; }
+
+  /**
+   * @brief Require particle to be a physical primary particle
+   * @param s If true only physical primary particles are selected 
+   */
   void                        SelectPhysicalPrimaries(Bool_t s)               { if (s) fMCFlag |=  AliAODMCParticle::kPhysicalPrim ;   }
 
+  /**
+   * @brief Get the title of the MC particle container
+   * @return Title of the container
+   * 
+   * Build title of the container consisting of the container name
+   * and a string encoding the minimum \f$ p_{t} \f$ cut applied
+   * in the kinematic particle selection.
+   */
   const char*                 GetTitle() const;
 
 #if !(defined(__CINT__) || defined(__MAKECINT__))
+
+  /**
+   * @brief Create an iterable container interface over all objects in the
+   * EMCAL container.
+   * @return iterable container over all objects in the EMCAL container
+   */
   const AliMCParticleIterableContainer      all() const;
+
+  /**
+   * @brief Create an iterable container interface over accepted objects in the
+   * EMCAL container.
+   * @return iterable container over accepted objects in the EMCAL container
+   */
   const AliMCParticleIterableContainer      accepted() const;
 
+  /**
+   * @brief Create an iterable container interface over all objects in the
+   * EMCAL container.
+   * @return iterable container over all objects in the EMCAL container
+   */
   const AliMCParticleIterableMomentumContainer      all_momentum() const;
+
+  /**
+   * @brief Create an iterable container interface over accepted objects in the
+   * EMCAL container.
+   * @return iterable container over accepted objects in the EMCAL container
+   */
   const AliMCParticleIterableMomentumContainer      accepted_momentum() const;
 #endif
 

--- a/PWG/EMCAL/EMCALbase/AliParticleContainer.cxx
+++ b/PWG/EMCAL/EMCALbase/AliParticleContainer.cxx
@@ -1,17 +1,29 @@
-/**************************************************************************
- * Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights reserved. *
- *                                                                        *
- * Author: The ALICE Off-line Project.                                    *
- * Contributors are mentioned in the code where appropriate.              *
- *                                                                        *
- * Permission to use, copy, modify and distribute this software and its   *
- * documentation strictly for non-commercial purposes is hereby granted   *
- * without fee, provided that the above copyright notice appears in all   *
- * copies and that both the copyright notice and this permission notice   *
- * appear in the supporting documentation. The authors make no claims     *
- * about the suitability of this software for any purpose. It is          *
- * provided "as is" without express or implied warranty.                  *
- **************************************************************************/
+/************************************************************************************
+ * Copyright (C) 2013, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
 #include <algorithm>
 #include <iostream>
 #include <vector>
@@ -23,16 +35,11 @@
 #include "AliTLorentzVector.h"
 #include "AliParticleContainer.h"
 
-/// \cond CLASSIMP
 ClassImp(AliParticleContainer);
-/// \endcond
 
 // Properly instantiate the object
 AliEmcalContainerIndexMap <TClonesArray, AliVParticle> AliParticleContainer::fgEmcalContainerIndexMap;
 
-/**
- * Default constructor.
- */
 AliParticleContainer::AliParticleContainer():
   AliEmcalContainer(),
   fMinDistanceTPCSectorEdge(-1),
@@ -43,10 +50,6 @@ AliParticleContainer::AliParticleContainer():
   SetClassName("AliVParticle");
 }
 
-/**
- * Standard constructor.
- * @param name Name of the particle branch (TClonesArray)
- */
 AliParticleContainer::AliParticleContainer(const char *name) :
   AliEmcalContainer(name),
   fMinDistanceTPCSectorEdge(-1),
@@ -57,12 +60,6 @@ AliParticleContainer::AliParticleContainer(const char *name) :
   SetClassName("AliVParticle");
 }
 
-/**
- * Get the leading particle in the container. If "p" is contained in the parameter opt,
- * then the absolute momentum is use instead of the transverse momentum.
- * @param[in] opt Options for the selection of the leading particle
- * @return Leading particle in the container
- */
 AliVParticle* AliParticleContainer::GetLeadingParticle(const char* opt) 
 {
   TString option(opt);
@@ -90,11 +87,6 @@ AliVParticle* AliParticleContainer::GetLeadingParticle(const char* opt)
   return partMax;
 }
 
-/**
- * Get \f$ i^{th} \f$ particle in the container.
- * @param[in] i Index of the particle to access
- * @return Parrticle at the given index (NULL if the index is out of range)
- */
 AliVParticle* AliParticleContainer::GetParticle(Int_t i) const 
 {
   //
@@ -104,12 +96,6 @@ AliVParticle* AliParticleContainer::GetParticle(Int_t i) const
   return vp;
 }
 
-/**
- * Get \f$ i^{th} \f$ particle in the container if it is accepted.
- * In case it is not accepted a nullpointer is returned.
- * @param[in] i Index of the particle
- * @return Particle at the index if it is accepted, NULL otherwise
- */
 AliVParticle* AliParticleContainer::GetAcceptParticle(Int_t i) const
 {
   UInt_t rejectionReason = 0;
@@ -123,12 +109,6 @@ AliVParticle* AliParticleContainer::GetAcceptParticle(Int_t i) const
   }
 }
 
-/**
- * Iterator over accepted particles in the container. Get the next accepted
- * particle in the array. If the end is reached, NULL is returned.
- * @deprecated Only for backward compatibility - use accept_iterator instead
- * @return Next accepted particle in the array (NULL if the end is reached)
- */
 AliVParticle* AliParticleContainer::GetNextAcceptParticle()
 {
   const Int_t n = GetNEntries();
@@ -142,12 +122,6 @@ AliVParticle* AliParticleContainer::GetNextAcceptParticle()
   return p;
 }
 
-/**
- * Iterator over all particles in the container. Get the next particle in
- * the array. If the end is reached, NULL is returned.
- * @deprecated Only for backward compatibility - use all_iterator instead.
- * @return Next particle in the array (NULL if the end is reached)
- */
 AliVParticle* AliParticleContainer::GetNextParticle()
 {
   const Int_t n = GetNEntries();
@@ -161,15 +135,6 @@ AliVParticle* AliParticleContainer::GetNextParticle()
   return p;
 }
 
-/**
- * Retrieve momentum information of a particle (part) and fill a TLorentzVector
- * with it. In case the optional parameter mass is provided, it is used as mass
- * hypothesis, otherwise the mass hypothesis from the particle itself is used.
- * @param[out] mom Momentum vector to be filled
- * @param[in] part Particle from which the momentum information is obtained.
- * @param[in] mass (Optional) Mass hypothesis
- * @return
- */
 Bool_t AliParticleContainer::GetMomentumFromParticle(TLorentzVector &mom, const AliVParticle* part, Double_t mass) const
 {
   if (part && part->Eta() < 1e6 && part->Eta() > -1e6) { // protection against FPE in sinh(eta)
@@ -183,27 +148,11 @@ Bool_t AliParticleContainer::GetMomentumFromParticle(TLorentzVector &mom, const 
   }
 }
 
-/**
- * Fills a TLorentzVector with the momentum information of the particle provided
- * under a global mass hypothesis.
- * @param[out] mom Momentum vector of the particle provided
- * @param[in] part Particle from which to obtain the momentum information
- * @return Always true
- */
 Bool_t AliParticleContainer::GetMomentumFromParticle(TLorentzVector &mom, const AliVParticle* part) const
 {
   return GetMomentumFromParticle(mom,part,fMassHypothesis);
 }
 
-/**
- * Fills a TLorentzVector with the monentum infomation of the
- * \f$ i^{th} \f$ particle in the container, using a global
- * mass hypothesis. In case the provided index is out of
- * range, false is returned as return value.
- * @param[out] mom Momentum vector of the \f$ i^{th} \f$ particle in the array
- * @param[in] i Index of th particle to check
- * @return True if the request was successfull, false otherwise
- */
 Bool_t AliParticleContainer::GetMomentum(TLorentzVector &mom, Int_t i) const
 {
   if (i == -1) i = fCurrentID;
@@ -211,31 +160,12 @@ Bool_t AliParticleContainer::GetMomentum(TLorentzVector &mom, Int_t i) const
   return GetMomentumFromParticle(mom, vp);
 }
 
-/**
- * Fills a TLorentzVector with the monentum infomation of the
- * next particle in the container, using a global mass hypothesis.
- * In case the iterator reached the end of the array, false
- * is returned as return value.
- * @deprecated Old style iterator - use all_iterator instead
- * @param[out] mom Momentum vector of the next particle
- * @return True if the request was successfull, false otherwise
- */
 Bool_t AliParticleContainer::GetNextMomentum(TLorentzVector &mom)
 {
   AliVParticle *vp = GetNextParticle();
   return GetMomentumFromParticle(mom, vp);
 }
 
-/**
- * Fills a TLorentzVector with the monentum infomation of the
- * \f$ i^{th} \f$ accepted particle in the container, using a
- * global mass hypothesis. In case the provided index is out of
- * range, or the particle under the index is not accepted, false
- * is returned as return value.
- * @param[out] mom Momentum vector of the accepted particle
- * @param[in] i Index to check
- * @return True if the request was successfull, false otherwise
- */
 Bool_t AliParticleContainer::GetAcceptMomentum(TLorentzVector &mom, Int_t i) const
 {
   if (i == -1) i = fCurrentID;
@@ -243,31 +173,12 @@ Bool_t AliParticleContainer::GetAcceptMomentum(TLorentzVector &mom, Int_t i) con
   return GetMomentumFromParticle(mom, vp);
 }
 
-/**
- * Fills a TLorentzVector with the monentum infomation of the
- * next accepted particle in the container, using a global
- * mass hypothesis. In case the iteration reached the end of
- * the array, false is returned as return value.
- * @deprecated Old style iterator - use accept_iterator instead
- * @param[out] mom Momentum vector of the next particle in the array
- * @return True if the request was successfull, false (no more entries) otherwise
- */
 Bool_t AliParticleContainer::GetNextAcceptMomentum(TLorentzVector &mom)
 {
   AliVParticle *vp = GetNextAcceptParticle();
   return GetMomentumFromParticle(mom, vp);
 }
 
-/**
- * Perform full particle selection consisting of kinematical and particle property
- * selection on the particle provided. In case the particle is rejected, the
- * reason for the rejection is encoded in the bitmap rejectionReason.
- * @param vp Particle for which to perform the selection
- * @param rejectionReason Bitmap with the reason why the particle was accepted.
- * Note: The value is not set to 0 in the function in order to combine the information
- * with other selection steps.
- * @return True if the particle is accepted, false otherwise.
- */
 Bool_t AliParticleContainer::AcceptParticle(const AliVParticle *vp, UInt_t &rejectionReason) const
 {
   Bool_t r = ApplyParticleCuts(vp, rejectionReason);
@@ -288,16 +199,6 @@ Bool_t AliParticleContainer::AcceptParticle(const AliVParticle *vp, UInt_t &reje
   return ApplyKinematicCuts(mom, rejectionReason);
 }
 
-/**
- * Perform full particle selection consisting of kinematical and particle property
- * selection on the \f$ i^{th} \f$ particle in the array. In case the particle is
- * rejected, the reason for the rejection is encoded in the bitmap rejectionReason.
- * @param[in] i Index of the particle to select.
- * @param[out] rejectionReason Bitmap with the reason why the particle was accepted.
- * Note: The value is not set to 0 in the function in order to combine the information
- * with other selection steps.
- * @return True if the particle was accepted, false otherwise
- */
 Bool_t AliParticleContainer::AcceptParticle(Int_t i, UInt_t &rejectionReason) const
 {
   Bool_t r = ApplyParticleCuts(GetParticle(i), rejectionReason);
@@ -309,18 +210,6 @@ Bool_t AliParticleContainer::AcceptParticle(Int_t i, UInt_t &rejectionReason) co
   return ApplyKinematicCuts(mom, rejectionReason);
 }
 
-/**
- * Apply cuts on the particle properties. Implemented are
- * - Monte-Carlo label
- * - Charge
- * - Generator index
- *
- * @param[in] vp Particle for which the selection is performed
- * @param[out] rejectionReason Bitmap with the reason why the particle was accepted.
- * Note: The value is not set to 0 in the function in order to combine the information
- * with other selection steps.
- * @return True if the particle is accepted, False otherwise
- */
 Bool_t AliParticleContainer::ApplyParticleCuts(const AliVParticle* vp, UInt_t &rejectionReason) const
 {
   if (!vp) {
@@ -384,17 +273,6 @@ Bool_t AliParticleContainer::ApplyParticleCuts(const AliVParticle* vp, UInt_t &r
   return kTRUE;
 }
 
-/**
- * Apply kinematical cuts to the momentum vector provided. In addition
- * to the standard kinematical cuts in \f$ p_{t} \f$, \f$ \eta \f$ and
- * \f$ \phi \f$, implemented in the AliEmcalContainer::ApplyKinematicCuts,
- * also the distance to the TPC sector boundary is checked.
- * @param[in] mom Momentum vector for which
- * @param[out] rejectionReason  Bitmap with the reason why the particle was accepted.
- * Note: The value is not set to 0 in the function in order to combine the information
- * with other selection steps.
- * @return True if the momentum vector was selected under the given cuts, false otherwise
- */
 Bool_t AliParticleContainer::ApplyKinematicCuts(const AliTLorentzVector& mom, UInt_t &rejectionReason) const
 {
   if(fMinDistanceTPCSectorEdge>0.) {
@@ -410,12 +288,6 @@ Bool_t AliParticleContainer::ApplyKinematicCuts(const AliTLorentzVector& mom, UI
   return AliEmcalContainer::ApplyKinematicCuts(mom, rejectionReason);
 }
 
-/**
- * Get number of accepted particles. In order to get this number,
- * the selection has to be applied to each particle within this
- * function.
- * @return Number of selected particles under the given particle selection
- */
 Int_t AliParticleContainer::GetNAcceptedParticles() const
 {
   Int_t nPart = 0;
@@ -426,11 +298,6 @@ Int_t AliParticleContainer::GetNAcceptedParticles() const
   return nPart;
 }
 
-/**
- * Make a title of the container name based on the min \f$ p_{t} \f$ used
- * in the particle selection process.
- * @return Title of the container
- */
 const char* AliParticleContainer::GetTitle() const
 {
   static TString trackString;
@@ -438,14 +305,6 @@ const char* AliParticleContainer::GetTitle() const
   return trackString.Data();
 }
 
-/**
- * Connect the container to the array with content stored inside the virtual event.
- * The object name in the event must match the name given in the constructor.
- *
- * Additionally register the array into the index map.
- *
- * @param event Input event containing the array with content.
- */
 void AliParticleContainer::SetArray(const AliVEvent * event)
 {
   AliEmcalContainer::SetArray(event);
@@ -454,38 +313,18 @@ void AliParticleContainer::SetArray(const AliVEvent * event)
   fgEmcalContainerIndexMap.RegisterArray(GetArray());
 }
 
-/**
- * Create an iterable container interface over all objects in the
- * EMCAL container.
- * @return iterable container over all objects in the EMCAL container
- */
 const AliParticleIterableContainer AliParticleContainer::all() const {
   return AliParticleIterableContainer(this, false);
 }
 
-/**
- * Create an iterable container interface over accepted objects in the
- * EMCAL container.
- * @return iterable container over accepted objects in the EMCAL container
- */
 const AliParticleIterableContainer AliParticleContainer::accepted() const {
   return AliParticleIterableContainer(this, true);
 }
 
-/**
- * Create an iterable container interface over all objects in the
- * EMCAL container.
- * @return iterable container over all objects in the EMCAL container
- */
 const AliParticleIterableMomentumContainer AliParticleContainer::all_momentum() const {
   return AliParticleIterableMomentumContainer(this, false);
 }
 
-/**
- * Create an iterable container interface over accepted objects in the
- * EMCAL container.
- * @return iterable container over accepted objects in the EMCAL container
- */
 const AliParticleIterableMomentumContainer AliParticleContainer::accepted_momentum() const {
   return AliParticleIterableMomentumContainer(this, true);
 }

--- a/PWG/EMCAL/EMCALbase/AliParticleContainer.h
+++ b/PWG/EMCAL/EMCALbase/AliParticleContainer.h
@@ -1,7 +1,31 @@
+/************************************************************************************
+ * Copyright (C) 2013, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
 #ifndef ALIPARTICLECONTAINER_H
 #define ALIPARTICLECONTAINER_H
-/* Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights reserved. *
- * See cxx source for full Copyright notice                               */
 
 #include <TArrayI.h>
 #include <AliVParticle.h>
@@ -32,24 +56,109 @@ class AliParticleContainer : public AliEmcalContainer {
  public:
   enum EChargeCut_t { kNoChargeCut, kCharged, kNeutral, kPositiveCharge, kNegativeCharge };
 
+  /**
+   * @brief Default constructor.
+   */
   AliParticleContainer();
+
+  /**
+   * @brief Standard constructor.
+   * @param name Name of the particle branch (TClonesArray)
+   */
   AliParticleContainer(const char *name);
+
+  /**
+   * @brief Destructor
+   */
   virtual ~AliParticleContainer(){;}
 
   /**
-   * Index operator: Providing access to track in the container with the
-   * given index.
+   * @brief Index operator 
    * @param[in] index Index of the particle in the array
    * @return Particle at the given index
+   * 
+   * Providing access to track in the container with the given index.
    */
   virtual TObject *operator[](int index) const { return GetParticle(index); }
 
+  /**
+   * @brief Select particle based on particle level cuts
+   * @param[in] vp Particle for which the selection is performed
+   * @param[out] rejectionReason Bitmap with the reason why the particle was accepted.
+   * Note: The value is not set to 0 in the function in order to combine the information
+   * with other selection steps.
+   * @return True if the particle is accepted, False otherwise
+   * 
+   * Apply cuts on the particle properties. Implemented are
+   * - Monte-Carlo label
+   * - Charge
+   * - Generator index
+   */
   virtual Bool_t              ApplyParticleCuts(const AliVParticle* vp, UInt_t &rejectionReason) const;
+
+  /**
+   * @brief Select particle based on kinematic cuts
+   * @param[in] mom Momentum vector for which
+   * @param[out] rejectionReason  Bitmap with the reason why the particle was accepted.
+   * Note: The value is not set to 0 in the function in order to combine the information
+   * with other selection steps.
+   * @return True if the momentum vector was selected under the given cuts, false otherwise
+   * 
+   * Apply kinematical cuts to the momentum vector provided. In addition
+   * to the standard kinematical cuts in \f$ p_{t} \f$, \f$ \eta \f$ and
+   * \f$ \phi \f$, implemented in the AliEmcalContainer::ApplyKinematicCuts,
+   * also the distance to the TPC sector boundary is checked.
+   */
   virtual Bool_t              ApplyKinematicCuts(const AliTLorentzVector& mom, UInt_t &rejectionReason) const;
+
+  /**
+   * @brief Check whether particle at a given index is accepted
+   * @param i Index of the particle in the container
+   * @param[out] rejectionReason Bitmap containing selections criteria which were not passed
+   * @return True if the particle is accepted, false otherwise 
+   * 
+   * The function is used by AliEmcalContainer in order to select the particle at a given position 
+   */
   virtual Bool_t              AcceptObject(Int_t i, UInt_t &rejectionReason) const              { return AcceptParticle(i, rejectionReason);}
+
+  /**
+   * @brief Check whether a given particle is accepted
+   * @param obj Particle to be checked
+   * @param[out] rejectionReason Bitmap containing selections criteria which were not passed
+   * @return True if the particle is accepted, false otherwise 
+   * 
+   * The function is used by AliEmcalContainer in order to select a given particle
+   */
   virtual Bool_t              AcceptObject(const TObject* obj, UInt_t &rejectionReason) const   { return AcceptParticle(dynamic_cast<const AliVParticle*>(obj), rejectionReason);}
+
+  /**
+   * @brief Check whether a particle is selected among the selection cut defined for this container
+   * @param vp Particle for which to perform the selection
+   * @param rejectionReason Bitmap with the reason why the particle was accepted.
+   * Note: The value is not set to 0 in the function in order to combine the information
+   * with other selection steps.
+   * @return True if the particle is accepted, false otherwise.
+   * 
+   * Perform full particle selection consisting of kinematical and particle property
+   * selection on the particle provided. In case the particle is rejected, the
+   * reason for the rejection is encoded in the bitmap rejectionReason.
+   */
   virtual Bool_t              AcceptParticle(const AliVParticle* vp, UInt_t &rejectionReason) const        ;
+
+  /**
+   * @brief Check whether the particle at a given index in the container is selected among the selection cut defined for this container 
+   * @param[in] i Index of the particle to select.
+   * @param[out] rejectionReason Bitmap with the reason why the particle was accepted.
+   * Note: The value is not set to 0 in the function in order to combine the information
+   * with other selection steps.
+   * @return True if the particle was accepted, false otherwise
+   * 
+   * Perform full particle selection consisting of kinematical and particle property
+   * selection on the \f$ i^{th} \f$ particle in the array. In case the particle is
+   * rejected, the reason for the rejection is encoded in the bitmap rejectionReason.
+   */
   virtual Bool_t              AcceptParticle(Int_t i, UInt_t &rejectionReason) const                       ;
+
   Double_t                    GetParticlePtCut()                        const   { return GetMinPt()     ; }
   Double_t                    GetParticleEtaMin()                       const   { return GetMinEta()    ; }
   Double_t                    GetParticleEtaMax()                       const   { return GetMaxEta()    ; }
@@ -58,35 +167,192 @@ class AliParticleContainer : public AliEmcalContainer {
   void                        SetParticlePtCut(Double_t cut)                    { SetMinPt(cut)         ; }
   void                        SetParticleEtaLimits(Double_t min, Double_t max)  { SetEtaLimits(min, max); }
   void                        SetParticlePhiLimits(Double_t min, Double_t max)  { SetPhiLimits(min, max); }
+
+  /**
+   * @brief Get the leading particle in the container. 
+   * @param[in] opt Options for the selection of the leading particle
+   * @return Leading particle in the container
+   * 
+   * If "p" is contained in the parameter opt, 
+   * then the absolute momentum is use instead of the transverse momentum.
+   */
   virtual AliVParticle       *GetLeadingParticle(const char* opt="")         ;
+
+  /**
+   * @brief Get \f$ i^{th} \f$ particle in the container.
+   * @param[in] i Index of the particle to access
+   * @return Parrticle at the given index (NULL if the index is out of range)
+   */
   virtual AliVParticle       *GetParticle(Int_t i=-1)                   const;
+
+  /**
+   * @brief Get \f$ i^{th} \f$ particle in the container if it is accepted.
+   * @param[in] i Index of the particle
+   * @return Particle at the index if it is accepted, NULL otherwise
+   */
   virtual AliVParticle       *GetAcceptParticle(Int_t i=-1)             const;
+
+  /**
+   * @brief Get the next accepted particle in the array. 
+   * @return Next accepted particle in the array (NULL if the end is reached)
+   * @deprecated Only for backward compatibility - use accept_iterator instead
+   */
   virtual AliVParticle       *GetNextAcceptParticle()                        ;
+
+  /**
+   * @brief Get the next particle in the array.
+   * @return Next particle in the array (NULL if the end is reached)
+   * @deprecated Only for backward compatibility - use all_iterator instead.
+   */
   virtual AliVParticle       *GetNextParticle()                              ;
+
+  /**
+   * @brief Get particle momentum for a given particle under a user-defined mass hypothesis
+   * @param[out] mom Momentum vector to be filled
+   * @param[in] part Particle from which the momentum information is obtained.
+   * @param[in] mass (Optional) Mass hypothesis
+   * @return True if the particle is valid, false if it is invalid
+   * 
+   * Retrieve momentum information of a particle (part) and fill a TLorentzVector
+   * with it. In case the optional parameter mass is provided, it is used as mass
+   * hypothesis, otherwise the mass hypothesis from the particle itself is used.
+   */
   virtual Bool_t              GetMomentumFromParticle(TLorentzVector &mom, const AliVParticle* part, Double_t mass) const;
+
+  /**
+   * @brief Get the momentum vector for a given particle using the default mass hypothesis
+   * @param[out] mom Momentum vector of the particle provided
+   * @param[in] part Particle from which to obtain the momentum information
+   * @return Always true
+   * 
+   * Fills a TLorentzVector with the momentum information of the particle provided
+   * under a global mass hypothesis.
+   */
   virtual Bool_t              GetMomentumFromParticle(TLorentzVector &mom, const AliVParticle* part) const;
+
+  /**
+   * Get the momentum for the particle at a given index in the container
+   * @param[out] mom Momentum vector of the \f$ i^{th} \f$ particle in the array
+   * @param[in] i Index of th particle to check
+   * @return True if the request was successfull, false otherwise
+   * 
+   * Fills a TLorentzVector with the monentum infomation of the
+   * \f$ i^{th} \f$ particle in the container, using a global
+   * mass hypothesis. In case the provided index is out of
+   * range, false is returned as return value.
+   */
   virtual Bool_t              GetMomentum(TLorentzVector &mom, Int_t i) const;
+
+  /**
+   * @brief Get the momentum vector for the particle at a given position in the container if it is accepted
+   * @param[out] mom Momentum vector of the accepted particle
+   * @param[in] i Index to check
+   * @return True if the request was successfull, false otherwise
+   * 
+   * Fills a TLorentzVector with the monentum infomation of the
+   * \f$ i^{th} \f$ accepted particle in the container, using a
+   * global mass hypothesis. In case the provided index is out of
+   * range, or the particle under the index is not accepted, false
+   * is returned as return value.
+   */
   virtual Bool_t              GetAcceptMomentum(TLorentzVector &mom, Int_t i) const;
+
+  /**
+   * @brief Get momentum vector for the next particle in the container
+   * @param[out] mom Momentum vector of the next particle
+   * @return True if the request was successfull, false otherwise
+   * @deprecated Old style iterator - use all_iterator instead
+   * 
+   * Fills a TLorentzVector with the monentum infomation of the
+   * next particle in the container, using a global mass hypothesis.
+   * In case the iterator reached the end of the array, false
+   * is returned as return value.
+   */
   virtual Bool_t              GetNextMomentum(TLorentzVector &mom);
+
+  /**
+   * @brief Get the momentum vector of the next accepted particle in the container
+   * @param[out] mom Momentum vector of the next particle in the array
+   * @return True if the request was successfull, false (no more entries) otherwise
+   * @deprecated Old style iterator - use accept_iterator instead
+   * 
+   * Fills a TLorentzVector with the monentum infomation of the
+   * next accepted particle in the container, using a global
+   * mass hypothesis. In case the iteration reached the end of
+   * the array, false is returned as return value.
+   */
   virtual Bool_t              GetNextAcceptMomentum(TLorentzVector &mom);
+
+  /**
+   * @brief Get numebr of particles in this container
+   * @return Number of particles
+   */
   Int_t                       GetNParticles()                           const   {return GetNEntries();}
+
+  /**
+   * @brief Get number of accepted particles handled by this container 
+   * @return Number of selected particles under the given particle selection
+   * 
+   * In order to get this number, the selection has to be applied to each 
+   * particle within this function.
+   */
   Int_t                       GetNAcceptedParticles()                   const;
+
   void                        SetMinDistanceTPCSectorEdge(Double_t min)         { fMinDistanceTPCSectorEdge = min; }
   void                        SetCharge(EChargeCut_t c)                         { fChargeCut = c       ; }
   void                        SelectHIJING(Bool_t s)                            { if (s) fGeneratorIndex = 0; else fGeneratorIndex = -1; }
   void                        SetGeneratorIndex(Short_t i)                      { fGeneratorIndex = i  ; }
+
+  /**
+   * @brief Connect container to input event
+   * @param event Input event containing the array with content.
+   * 
+   * Connect the container to the array with content stored inside the virtual event.
+   * The object name in the event must match the name given in the constructor.
+   *
+   * Additionally register the array into the index map.
+   */
   void                        SetArray(const AliVEvent * event);
 
+  /**
+   * @brief Get title of the container
+   * @return Title of the container
+   * 
+   * Make a title of the container name based on the min \f$ p_{t} \f$ used
+   * in the particle selection process.
+   */
   const char*                 GetTitle() const;
 
 #if !(defined(__CINT__) || defined(__MAKECINT__))
   /// Get the EMCal container utils associated with particle containers
   static const AliEmcalContainerIndexMap <TClonesArray, AliVParticle>& GetEmcalContainerIndexMap() { return fgEmcalContainerIndexMap; }
 
+  /**
+   * @brief Create an iterable container interface over all objects in the
+   * EMCAL container.
+   * @return iterable container over all objects in the EMCAL container
+   */
   const AliParticleIterableContainer      all() const;
+
+  /**
+   * @brief Create an iterable container interface over accepted objects in the
+   * EMCAL container.
+   * @return iterable container over accepted objects in the EMCAL container
+   */
   const AliParticleIterableContainer      accepted() const;
 
+  /**
+   * @brief Create an iterable container interface over all objects in the
+   * EMCAL container.
+   * @return iterable container over all objects in the EMCAL container
+   */
   const AliParticleIterableMomentumContainer      all_momentum() const;
+
+  /**
+   * @brief Create an iterable container interface over accepted objects in the
+   * EMCAL container.
+   * @return iterable container over accepted objects in the EMCAL container
+   */
   const AliParticleIterableMomentumContainer      accepted_momentum() const;
 #endif
 
@@ -104,10 +370,7 @@ class AliParticleContainer : public AliEmcalContainer {
   AliParticleContainer(const AliParticleContainer& obj); // copy constructor
   AliParticleContainer& operator=(const AliParticleContainer& other); // assignment
 
-  /// \cond CLASSIMP
   ClassDef(AliParticleContainer,11);
-  /// \endcond
-
 };
 
 /**

--- a/PWG/EMCAL/EMCALbase/AliTrackContainer.cxx
+++ b/PWG/EMCAL/EMCALbase/AliTrackContainer.cxx
@@ -43,9 +43,7 @@
 #include "AliEmcalTrackSelResultHybrid.h"
 #include "AliTrackContainer.h"
 
-/// \cond CLASSIMP
 ClassImp(AliTrackContainer);
-/// \endcond
 
 TString AliTrackContainer::fgDefTrackCutsPeriod = "";
 
@@ -62,9 +60,6 @@ const std::map <std::string, AliEmcalTrackSelection::ETrackFilterType_t> AliTrac
   {"kHybridTracks2011woNoRefit", AliEmcalTrackSelection::kHybridTracks2011woNoRefit }
 };
 
-/**
- * Default constructor.
- */
 AliTrackContainer::AliTrackContainer():
   AliParticleContainer(),
   fTrackFilterType(AliEmcalTrackSelection::kHybridTracks),
@@ -82,11 +77,6 @@ AliTrackContainer::AliTrackContainer():
   fMassHypothesis = 0.139;
 }
 
-/**
- * Standard constructor.
- * @param[in] name Name of the container (= name of the array operated on)
- * @param[in] period Name of the period, needed for track cut selection
- */
 AliTrackContainer::AliTrackContainer(const char *name, const char *period):
   AliParticleContainer(name),
   fTrackFilterType(AliEmcalTrackSelection::kHybridTracks),
@@ -109,12 +99,6 @@ AliTrackContainer::AliTrackContainer(const char *name, const char *period):
   fMassHypothesis = 0.139;
 }
 
-/**
- * Get array from event. Also
- * creating the virtual track selection
- * for the period provided in the constructor.
- * @param[in] event Event from which the data is read
- */
 void AliTrackContainer::SetArray(const AliVEvent *event)
 {
   AliParticleContainer::SetArray(event);
@@ -176,11 +160,6 @@ void AliTrackContainer::SetArray(const AliVEvent *event)
   }
 }
 
-/**
- * Preparation for the next event: Run the track
- * selection of all bit and store the pointers to
- * selected tracks in a separate array.
- */
 void AliTrackContainer::NextEvent(const AliVEvent * event)
 {
   AliParticleContainer::NextEvent(event);
@@ -247,11 +226,6 @@ void AliTrackContainer::NextEvent(const AliVEvent * event)
   }
 }
 
-/**
- * Get track at index in the container
- * @param[in] i Index of the particle in the container
- * @return pointer to particle if particle is accepted, NULL otherwise
- */
 AliVTrack* AliTrackContainer::GetTrack(Int_t i) const
 {
   //Get i^th jet in array
@@ -261,11 +235,6 @@ AliVTrack* AliTrackContainer::GetTrack(Int_t i) const
   return vp;
 }
 
-/**
- * Get track at index in the container if accepted by the track selection provided
- * @param[in] i Index of the particle in the container
- * @return pointer to particle if particle is accepted, NULL otherwise
- */
 AliVTrack* AliTrackContainer::GetAcceptTrack(Int_t i) const
 {
   UInt_t rejectionReason;
@@ -279,11 +248,6 @@ AliVTrack* AliTrackContainer::GetAcceptTrack(Int_t i) const
   }
 }
 
-/**
- * Get next accepted particle in the container selected using the track cuts provided.
- * @deprecated Old style iterator - for compatibility reasons, use AliParticleContainer::accept_iterator instead
- * @return Next accepted particle (NULL if the end of the array is reached)
- */
 AliVTrack* AliTrackContainer::GetNextAcceptTrack()
 {
   const Int_t n = GetNEntries();
@@ -297,11 +261,6 @@ AliVTrack* AliTrackContainer::GetNextAcceptTrack()
   return p;
 }
 
-/**
- * Get next particle in the container
- * @deprecated Old style iterator - for compatibility reasons, use AliParticleContainer::all_iterator instead
- * @return Next track in the container (NULL if end of the container is reached)
- */
 AliVTrack* AliTrackContainer::GetNextTrack()
 {
   const Int_t n = GetNEntries();
@@ -315,12 +274,6 @@ AliVTrack* AliTrackContainer::GetNextTrack()
   return p;
 }
 
-/**
- * Retrieve the track type using the IndexOf method of the TClonesArray
- * to retrieve the index of the provided track.
- * @param track Track for which the type is requested.
- * @return The track type from fTrackTypes
- */
 Char_t AliTrackContainer::GetTrackType(const AliVTrack* track) const
 {
   Int_t id = fFilteredTracks.GetData()->IndexOf(track);
@@ -332,15 +285,6 @@ Char_t AliTrackContainer::GetTrackType(const AliVTrack* track) const
   }
 }
 
-/**
- * Retrieve momentum information of a track and fill a TLorentzVector
- * with it. In case the optional parameter mass is provided, it is used as mass
- * hypothesis, otherwise the mass hypothesis from the particle itself is used.
- * @param[out] mom Momentum vector to be filled
- * @param[in] track Track from which the momentum information is obtained.
- * @param[in] mass (Optional) Mass hypothesis
- * @return
- */
 Bool_t AliTrackContainer::GetMomentumFromTrack(TLorentzVector &mom, const AliVTrack* track, Double_t mass) const
 {
   if (track) {
@@ -370,27 +314,11 @@ Bool_t AliTrackContainer::GetMomentumFromTrack(TLorentzVector &mom, const AliVTr
   }
 }
 
-/**
- * Fills a TLorentzVector with the momentum information of the track provided
- * under a global mass hypothesis.
- * @param[out] mom Momentum vector of the particle provided
- * @param[in] track Track from which to obtain the momentum information
- * @return Always true
- */
 Bool_t AliTrackContainer::GetMomentumFromTrack(TLorentzVector &mom, const AliVTrack* part) const
 {
   return GetMomentumFromTrack(mom,part,fMassHypothesis);
 }
 
-/**
- * Fills a TLorentzVector with the momentum information of the
- * \f$ i^{th} \f$ particle in the container, using a global
- * mass hypothesis. In case the provided index is out of
- * range, false is returned as return value.
- * @param[out] mom Momentum vector of the \f$ i^{th} \f$ particle in the array
- * @param[in] i Index of the particle to check
- * @return True if the request was successful, false otherwise
- */
 Bool_t AliTrackContainer::GetMomentum(TLorentzVector &mom, Int_t i) const
 {
   Double_t mass = fMassHypothesis;
@@ -417,15 +345,6 @@ Bool_t AliTrackContainer::GetMomentum(TLorentzVector &mom, Int_t i) const
   }
 }
 
-/**
- * Fills a TLorentzVector with the momentum information of the
- * next particle in the container, using a global mass hypothesis.
- * In case the iterator reached the end of the array, false
- * is returned as return value.
- * @deprecated Old style iterator - use all_iterator instead
- * @param[out] mom Momentum vector of the next particle
- * @return True if the request was successful, false otherwise
- */
 Bool_t AliTrackContainer::GetNextMomentum(TLorentzVector &mom)
 {
   Double_t mass = fMassHypothesis;
@@ -451,16 +370,6 @@ Bool_t AliTrackContainer::GetNextMomentum(TLorentzVector &mom)
   }
 }
 
-/**
- * Fills a TLorentzVector with the monentum infomation of the
- * \f$ i^{th} \f$ accepted particle in the container, using a
- * global mass hypothesis. In case the provided index is out of
- * range, or the particle under the index is not accepted, false
- * is returned as return value.
- * @param[out] mom Momentum vector of the accepted particle
- * @param[in] i Index to check
- * @return True if the request was successfull, false otherwise
- */
 Bool_t AliTrackContainer::GetAcceptMomentum(TLorentzVector &mom, Int_t i) const
 {
 
@@ -489,15 +398,6 @@ Bool_t AliTrackContainer::GetAcceptMomentum(TLorentzVector &mom, Int_t i) const
   }
 }
 
-/**
- * Fills a TLorentzVector with the monentum infomation of the
- * next accepted particle in the container, using a global
- * mass hypothesis. In case the iteration reached the end of
- * the array, false is returned as return value.
- * @deprecated Old style iterator - use accept_iterator instead
- * @param[out] mom Momentum vector of the next particle in the array
- * @return True if the request was successfull, false (no more entries) otherwise
- */
 Bool_t AliTrackContainer::GetNextAcceptMomentum(TLorentzVector &mom)
 {
   Double_t mass = fMassHypothesis;
@@ -524,16 +424,6 @@ Bool_t AliTrackContainer::GetNextAcceptMomentum(TLorentzVector &mom)
   }
 }
 
-/**
- * Perform full track selection for the particle vp, consisting
- * of kinematical track selection and track quality
- * cut provided by the cuts assigned to this container
- * @param[in] vp Track to be checked
- * @param[in] rejectionReason Bitmap encoding the reason why the
- * track was rejected. Note: The variable is not set to NULL
- * inside this function before changing its value.
- * @return True if the track is accepted, false otherwise
- */
 Bool_t AliTrackContainer::AcceptTrack(const AliVTrack *vp, UInt_t &rejectionReason) const
 {
   Bool_t r = ApplyTrackCuts(vp, rejectionReason);
@@ -545,17 +435,6 @@ Bool_t AliTrackContainer::AcceptTrack(const AliVTrack *vp, UInt_t &rejectionReas
   return ApplyKinematicCuts(mom, rejectionReason);
 }
 
-/**
- * Perform full track selection for the particle in
- * the container stored at position i, consisting
- * of kinematical track selection and track quality
- * cut provided by the cuts assigned to this container
- * @param[in] i Index of the track to check
- * @param[in] rejectionReason Bitmap encoding the reason why the
- * track was rejected. Note: The variable is not set to NULL
- * inside this function before changing its value.
- * @return True if the track is accepted, false otherwise
- */
 Bool_t AliTrackContainer::AcceptTrack(Int_t i, UInt_t &rejectionReason) const
 {
   if(fTrackTypes[i] == kRejected) return false; // track was rejected by the track selection
@@ -568,24 +447,11 @@ Bool_t AliTrackContainer::AcceptTrack(Int_t i, UInt_t &rejectionReason) const
   return ApplyKinematicCuts(mom, rejectionReason);
 }
 
-/**
- * Perform track quality selection of the track vp using
- * the track cuts assigned to this container.
- * @param[in] vp Track to be checked
- * @param[out] rejectionReason Bitmap encoding the reason why the
- * track was rejected. Note: The variable is not set to NULL
- * inside this function before changing its value.
- * @return True if the particle was accepted, false otherwise
- */
 Bool_t AliTrackContainer::ApplyTrackCuts(const AliVTrack* vp, UInt_t &rejectionReason) const
 {
   return ApplyParticleCuts(vp, rejectionReason);
 }
 
-/**
- * Add new track cuts to the container.
- * @param[in] cuts Cuts to be  added
- */
 void AliTrackContainer::AddTrackCuts(AliVCuts *cuts)
 {
   if (!fListOfCuts) {
@@ -595,21 +461,12 @@ void AliTrackContainer::AddTrackCuts(AliVCuts *cuts)
   fListOfCuts->Add(cuts);
 }
 
-/**
- * Get number of track cut objects assigned to this container.
- * @return Number of track cut objects
- */
 Int_t AliTrackContainer::GetNumberOfCutObjects() const
 {
   if (!fListOfCuts) return 0;
   return fListOfCuts->GetEntries();
 }
 
-/**
- * Get the cut object at index (icut) assigned to this container.
- * @param[in] icut Index of the cut in the container
- * @return Cut object at the index if existing, NULL otherwise
- */
 AliVCuts* AliTrackContainer::GetTrackCuts(Int_t icut)
 {
   if (!fListOfCuts) return NULL;
@@ -678,48 +535,22 @@ Bool_t AliTrackContainer::CheckArrayConsistency() const {
   return teststatus;
 }
 
-/**
- * Create an iterable container interface over all objects in the
- * EMCAL container.
- * @return iterable container over all objects in the EMCAL container
- */
 const AliTrackIterableContainer AliTrackContainer::all() const {
   return AliTrackIterableContainer(this, false);
 }
 
-/**
- * Create an iterable container interface over accepted objects in the
- * EMCAL container.
- * @return iterable container over accepted objects in the EMCAL container
- */
 const AliTrackIterableContainer AliTrackContainer::accepted() const {
   return AliTrackIterableContainer(this, true);
 }
 
-/**
- * Create an iterable container interface over all objects in the
- * EMCAL container.
- * @return iterable container over all objects in the EMCAL container
- */
 const AliTrackIterableMomentumContainer AliTrackContainer::all_momentum() const {
   return AliTrackIterableMomentumContainer(this, false);
 }
 
-/**
- * Create an iterable container interface over accepted objects in the
- * EMCAL container.
- * @return iterable container over accepted objects in the EMCAL container
- */
 const AliTrackIterableMomentumContainer AliTrackContainer::accepted_momentum() const {
   return AliTrackIterableMomentumContainer(this, true);
 }
 
-/**
- * Build title of the container consisting of the container name
- * and a string encoding the minimum \f$ p_{t} \f$ cut applied
- * in the kinematic track selection.
- * @return Title of the container
- */
 const char* AliTrackContainer::GetTitle() const
 {
   static TString trackString;

--- a/PWG/EMCAL/EMCALbase/AliTrackContainer.h
+++ b/PWG/EMCAL/EMCALbase/AliTrackContainer.h
@@ -68,19 +68,71 @@ class AliTrackContainer : public AliParticleContainer {
    */
   class TrackOwnerHandler : public TObject {
   public:
+
+    /**
+     * @brief Default constructor
+     */
     TrackOwnerHandler();
+
+    /**
+     * @brief Constructor
+     * @param managedobject Object to be handled by this manager
+     * @param ownership Ownership status
+     */
     TrackOwnerHandler(TObjArray *managedobject, Bool_t ownership);
+
+    /**
+     * @brief Copy constructor
+     * @param other Other ownership handler to copy from
+     */
     TrackOwnerHandler(const TrackOwnerHandler &other);
+
+    /**
+     * @brief Assignment operator
+     * @param other Other ownership handler to assign from
+     * @return This ownership handler 
+     */
     TrackOwnerHandler &operator=(const TrackOwnerHandler &other);
+
+    /**
+     * @brief Destructor
+     */
     virtual ~TrackOwnerHandler();
 
+    /**
+     * @brief Set object to manage by the ownership handler
+     * @param obj Object to be managed
+     */
     void SetObject(TObjArray *obj);
+
+    /**
+     * @brief Set ownership of the object to be handled
+     * @param owner 
+     */
     void SetOwner(Bool_t owner);
 
+    /**
+     * @brief Access to data the ownership handler manages
+     * @return TObjArray* 
+     */
     TObjArray *GetData() const { return fManagedObject; }
+
+    /**
+     * @brief Check if this handler is the owner of the object it handles
+     * @return If true the object is owned by this handler
+     */
     Bool_t IsOwner() const { return fOwnership; }
 
+    /**
+     * @brief Transfer owership status over this object to other handler
+     * @param target Handler that will receive the ownership status
+     */
     void TransferOwnershipTo(TrackOwnerHandler &target);
+
+    /**
+     * @brief Receive ownership status from other handler
+     * @param source Handler from which to receive the ownership status
+     */
     void ReceiveOwnershipFrom(TrackOwnerHandler &source);
 
   private:
@@ -110,38 +162,275 @@ class AliTrackContainer : public AliParticleContainer {
     kHybridConstrainedNoITSrefit = 3,///< Track selected under the constrained hybrid track cuts without ITS refit
   };
 
+  /**
+   * @brief Default constructor.
+   */
   AliTrackContainer();
+
+  /**
+   * @brief Standard constructor.
+   * @param[in] name Name of the container (= name of the array operated on)
+   * @param[in] period Name of the period, needed for track cut selection
+   */
   AliTrackContainer(const char *name, const char *period = "");
+
+  /**
+   * @brief Destructor
+   */
   virtual ~AliTrackContainer(){;}
 
+  /**
+   * @brief Select track based on track cuts in container
+   * @param[in] vp Track to be checked
+   * @param[out] rejectionReason Bitmap encoding the reason why the
+   * track was rejected. Note: The variable is not set to NULL
+   * inside this function before changing its value.
+   * @return True if the particle was accepted, false otherwise
+   * 
+   * Perform track quality selection of the track vp using
+   * the track cuts assigned to this container.
+   */
   virtual Bool_t              ApplyTrackCuts(const AliVTrack* vp, UInt_t &rejectionReason) const;
+
+  /**
+   * @brief Check whether the track at a given index is accepted
+   * @param i Index of the track
+   * @param[out] rejectionReason Bitmap containing selections criteria which were not passed
+   * @return True if the track is accepted, false otherwise
+   * 
+   * The function is used by AliEmcalContainer in order to select the cluster at a given position
+   */
   virtual Bool_t              AcceptObject(Int_t i, UInt_t &rejectionReason) const                        { return AcceptTrack(i, rejectionReason)        ; }
+
+  /**
+   * @brief Check whether the track at a given index is accepted
+   * @param obj Object to be checked (must inherit from AliVTrack)
+   * @param[out] rejectionReason Bitmap containing selections criteria which were not passed
+   * @return True if the track is accepted, false otherwise
+   * 
+   * The function is used by AliEmcalContainer in order to select the cluster at a given position
+   */
   virtual Bool_t              AcceptObject(const TObject* obj, UInt_t &rejectionReason) const             { return AcceptTrack(dynamic_cast<const AliVTrack*>(obj), rejectionReason); }
+
+  /**
+   * @brief Check whether the track at a given index is accepted
+   * @param i Index of the track
+   * @param[out] rejectionReason Bitmap containing selections criteria which were not passed
+   * @return True if the track is accepted, false otherwise
+   */
   virtual Bool_t              AcceptParticle(Int_t i, UInt_t &rejectionReason) const                      { return AcceptTrack(i, rejectionReason); }
+
+  /**
+   * @brief Check whether the track at a given index is accepted
+   * @param obj Object to be checked (must inherit from AliVTrack)
+   * @param[out] rejectionReason Bitmap containing selections criteria which were not passed
+   * @return True if the track is accepted, false otherwise
+   */
   virtual Bool_t              AcceptParticle(const AliVParticle* vp, UInt_t &rejectionReason) const       { return AcceptTrack(dynamic_cast<const AliVTrack*>(vp), rejectionReason); }
+
+  /**
+   * @brief Get the particle at a given index in the container
+   * @param i Index of the particle in the container
+   * @return Particle at the index (nullptr if the index exceeds the number of particles in the container)
+   */
   virtual AliVParticle       *GetParticle(Int_t i=-1)                const { return GetTrack(i)           ; }
+
+  /**
+   * @brief Get the particle at a given index in the container if accepted
+   * @param i Index of the particle in the container
+   * @return Particle at the index (nullptr if particle is not accepted or the index exceeds the number of particles in the container)
+   */
   virtual AliVParticle       *GetAcceptParticle(Int_t i=-1)          const { return GetAcceptTrack(i)     ; }
+
+  /**
+   * @brief Get the next accepted particle in the container
+   * @return Next accepted particle in the container (null if there are no more accepted particles)
+   * @deprecated Use accepted() in order to iterate over particles 
+   * 
+   * Internal iterator over accepted tracks. Container must be reset
+   * at the beginning of the iteration via Reset().
+   */
   virtual AliVParticle       *GetNextAcceptParticle()                      { return GetNextAcceptTrack()  ; }
+  
+  /**
+   * @brief Get the next particle in the container
+   * @return Next particle in the container (null if there are no more particles)
+   * @deprecated Use all() in order to iterate over particles 
+   * 
+   * Internal iterator over all tracks. Container must be reset
+   * at the beginning of the iteration via Reset().
+   */
   virtual AliVParticle       *GetNextParticle()                            { return GetNextTrack()        ; }
+
+  /**
+   * @brief Select track based on track cuts in container
+   * @param[in] vp Track to be checked
+   * @param[in] rejectionReason Bitmap encoding the reason why the
+   * track was rejected. Note: The variable is not set to NULL
+   * inside this function before changing its value.
+   * @return True if the track is accepted, false otherwise
+   * 
+   * Perform full track selection for the particle vp, consisting
+   * of kinematical track selection and track quality
+   * cut provided by the cuts assigned to this container
+   */
   virtual Bool_t              AcceptTrack(const AliVTrack* vp, UInt_t &rejectionReason)  const;
+
+  /**
+   * @brief Select track at a given position based on track cuts in container
+   * @param[in] i Index of the track to check
+   * @param[in] rejectionReason Bitmap encoding the reason why the
+   * track was rejected. Note: The variable is not set to NULL
+   * inside this function before changing its value.
+   * @return True if the track is accepted, false otherwise
+   * 
+   * Perform full track selection for the particle in
+   * the container stored at position i, consisting
+   * of kinematical track selection and track quality
+   * cut provided by the cuts assigned to this container
+   */
   virtual Bool_t              AcceptTrack(Int_t i, UInt_t &rejectionReason) const;
+
+  /**
+   * @brief Get the leading track (highest energetic track) in the container 
+   * @param opt Option for the leading track selection 
+   * @return Leading track in the container
+   */
   virtual AliVTrack          *GetLeadingTrack(const char* opt="")          { return static_cast<AliVTrack*>(GetLeadingParticle(opt)); }
+
+  /**
+   * @brief Get track at index in the container
+   * @param[in] i Index of the particle in the container
+   * @return pointer to particle if particle is accepted, NULL otherwise
+   */
   virtual AliVTrack          *GetTrack(Int_t i=-1)                   const;
+
+  /**
+   * @brief Get track at index in the container if accepted by the track selection provided
+   * @param[in] i Index of the particle in the container
+   * @return pointer to particle if particle is accepted, NULL otherwise
+   */
   virtual AliVTrack          *GetAcceptTrack(Int_t i=-1)             const;
+
+  /**
+   * @brief Get next accepted particle in the container selected using the track cuts provided.
+   * @return Next accepted particle (NULL if the end of the array is reached)
+   * @deprecated Old style iterator - for compatibility reasons, use AliParticleContainer::accept_iterator instead
+   */
   virtual AliVTrack          *GetNextAcceptTrack()                        ;
-  virtual AliVTrack          *GetNextTrack()                              ;
+
+  /**
+   * @brief Get next particle in the container
+   * @return Next track in the container (NULL if end of the container is reached)
+   * @deprecated Old style iterator - for compatibility reasons, use AliParticleContainer::all_iterator instead
+   */
+   virtual AliVTrack          *GetNextTrack()                              ;
+
+  /**
+   * @brief Retrieve the track type using the IndexOf method of the TClonesArray
+   * to retrieve the index of the provided track.
+   * @param track Track for which the type is requested.
+   * @return The track type from fTrackTypes
+   */
   Char_t                      GetTrackType(const AliVTrack* track)   const;
+
+  /**
+   * @brief Calculate momentum vector for the input track under a user-defined mass hypothesis
+   * @param[out] mom Momentum vector to be filled
+   * @param[in] track Track from which the momentum information is obtained.
+   * @param[in] mass (Optional) Mass hypothesis
+   * @return True in case the track is valid, false otherwise
+   * 
+   * Retrieve momentum information of a track and fill a TLorentzVector
+   * with it. In case the optional parameter mass is provided, it is used as mass
+   * hypothesis, otherwise the mass hypothesis from the particle itself is used.
+   */
   virtual Bool_t              GetMomentumFromTrack(TLorentzVector &mom, const AliVTrack* track, Double_t mass) const;
+
+  /**
+   * @brief Fills a TLorentzVector with the momentum information of the track provided
+   * under a global mass hypothesis.
+   * @param[out] mom Momentum vector of the particle provided
+   * @param[in] track Track from which to obtain the momentum information
+   * @return Always true
+   */
   virtual Bool_t              GetMomentumFromTrack(TLorentzVector &mom, const AliVTrack* track) const;
+
+  /**
+   * @brief Get momentum vector of a track a given position in the container
+   * @param[out] mom Momentum vector of the \f$ i^{th} \f$ particle in the array
+   * @param[in] i Index of the particle to check
+   * @return True if the request was successful, false otherwise
+   * 
+   * Fills a TLorentzVector with the momentum information of the
+   * \f$ i^{th} \f$ particle in the container, using a global
+   * mass hypothesis. In case the provided index is out of
+   * range, false is returned as return value.
+   */
   virtual Bool_t              GetMomentum(TLorentzVector &mom, Int_t i) const;
+
+  /**
+   * @brief Get momentum vector of the track at given index in case the track was accepted
+   * @param[out] mom Momentum vector of the accepted particle
+   * @param[in] i Index to check
+   * @return True if the request was successfull, false otherwise
+   * 
+   * Fills a TLorentzVector with the monentum infomation of the
+   * \f$ i^{th} \f$ accepted particle in the container, using a
+   * global mass hypothesis. In case the provided index is out of
+   * range, or the particle under the index is not accepted, false
+   * is returned as return value.
+   */
   virtual Bool_t              GetAcceptMomentum(TLorentzVector &mom, Int_t i) const;
+
+  /**
+   * @brief Get momentum vector of the next track in the container
+   * @param[out] mom Momentum vector of the next particle
+   * @return True if the request was successful, false otherwise
+   * @deprecated Old style iterator - use all_iterator instead
+   * 
+   * Fills a TLorentzVector with the momentum information of the
+   * next particle in the container, using a global mass hypothesis.
+   * In case the iterator reached the end of the array, false
+   * is returned as return value.
+   */
   virtual Bool_t              GetNextMomentum(TLorentzVector &mom);
+
+  /**
+   * @brief Get momentum vector of the next accepted track
+   * @param[out] mom Momentum vector of the next particle in the array
+   * @return True if the request was successfull, false (no more entries) otherwise
+   * @deprecated Old style iterator - use accept_iterator instead
+   * 
+   * Fills a TLorentzVector with the monentum infomation of the
+   * next accepted particle in the container, using a global
+   * mass hypothesis. In case the iteration reached the end of
+   * the array, false is returned as return value.
+   */
   virtual Bool_t              GetNextAcceptMomentum(TLorentzVector &mom);
+
+  /**
+   * @brief Get the number of tracks handled by the container
+   * @return Number of tracks in the container
+   */
   Int_t                       GetNTracks()                              const   { return GetNParticles()         ; }
+
+  /**
+   * @brief Get the number of accepted tracks in the container
+   * @return Number of tracks in the container 
+   */
   Int_t                       GetNAcceptedTracks()                              { return GetNAcceptedParticles() ; }
+
   ETrackFilterType_t          GetTrackFilterType()                      const   { return fTrackFilterType; }
   Char_t                      GetTrackType(Int_t i)                     const   { return i >= 0 && i < fTrackTypes.GetSize() ? fTrackTypes[i] : (Char_t)kUndefined ; }
 
+  /**
+   * @brief Get array from event 
+   * @param[in] event Event from which the data is read
+   * 
+   * Also creating the virtual track selection
+   * for the period provided in the constructor.
+   */
   void                        SetArray(const AliVEvent *event);
 
   void                        SetTrackFilterType(ETrackFilterType_t f)          { fTrackFilterType = f; }
@@ -149,8 +438,24 @@ class AliTrackContainer : public AliParticleContainer {
   void                        SetITSHybridTrackDistinction(Bool_t doUse)        { fITSHybridTrackDistinction = doUse; }
 
   void                        SetTrackCutsPeriod(const char* period)            { fTrackCutsPeriod = period; }
+
+  /**
+   * @brief Add new track cuts to the container.
+   * @param[in] cuts Cuts to be  added
+   */
   void                        AddTrackCuts(AliVCuts *cuts);
+
+  /**
+   * @brief Get number of track cut objects assigned to this container.
+   * @return Number of track cut objects
+   */
   Int_t                       GetNumberOfCutObjects() const;
+
+  /**
+   * @brief Get the cut object at index (icut) assigned to this container.
+   * @param[in] icut Index of the cut in the container
+   * @return Cut object at the index if existing, NULL otherwise
+   */
   AliVCuts                   *GetTrackCuts(Int_t icut);
   void                        SetAODFilterBits(UInt_t bits)                     { fAODFilterBits   = bits  ; }
   void                        AddAODFilterBit(UInt_t bit)                       { fAODFilterBits  |= bit   ; }
@@ -160,36 +465,74 @@ class AliTrackContainer : public AliParticleContainer {
   void SetSelectionModeAny() { fSelectionModeAny = kTRUE ; }
   void SetSelectionModeAll() { fSelectionModeAny = kFALSE; }
 
+  /**
+   * @brief Preparation for the next event
+   * @param event Next event to be processed
+   * 
+   * Run the track selection of all bit and store the pointers to
+   * selected tracks in a separate array.
+   */
   void                        NextEvent(const AliVEvent* event);
 
   static void                 SetDefTrackCutsPeriod(const char* period)       { fgDefTrackCutsPeriod = period; }
   static TString              GetDefTrackCutsPeriod()                         { return fgDefTrackCutsPeriod  ; }
 
+  /**
+   * @brief Get the title of the track container
+   * @return Title of the container
+   * 
+   * Build title of the container consisting of the container name
+   * and a string encoding the minimum \f$ p_{t} \f$ cut applied
+   * in the kinematic track selection.
+   */
   const char*                 GetTitle() const;
 
   /**
    * @brief Test function checking whether the entries in the track array are the same as in the input array
-   * 
-   * @return Bool_t CheckArrayConsistency 
+   * @return If true entries are consistent 
    */
   Bool_t CheckArrayConsistency() const;
 
 #if !(defined(__CINT__) || defined(__MAKECINT__))
+
+  /**
+   * @brief Create an iterable container interface over all objects in the
+   * EMCAL container.
+   * @return iterable container over all objects in the EMCAL container
+   */
   const AliTrackIterableContainer      all() const;
+
+  /**
+   * @brief Create an iterable container interface over accepted objects in the
+   * EMCAL container.
+   * @return iterable container over accepted objects in the EMCAL container
+   */
   const AliTrackIterableContainer      accepted() const;
 
+  /**
+   * @brief Create an iterable container interface over all objects in the
+   * EMCAL container.
+   * @return iterable container over all objects in the EMCAL container
+   */
   const AliTrackIterableMomentumContainer      all_momentum() const;
+
+  /**
+   * @brief Create an iterable container interface over accepted objects in the
+   * EMCAL container.
+   * @return iterable container over accepted objects in the EMCAL container
+   */
   const AliTrackIterableMomentumContainer      accepted_momentum() const;
 #endif
 
  protected:
   /**
-   * Create default array name for the track container. The
-   * default array name will be
-   * - *tracks* in case of AOD event
-   * - *Tracks* in case of ESD event
+   * @brief Create default array name for the track container. 
    * @param[in] ev Input event, used for data type selection
    * @return Appropriate default array name
+   * 
+   * The default array name will be
+   * - *tracks* in case of AOD event
+   * - *Tracks* in case of ESD event
    */
   virtual TString             GetDefaultArrayName(const AliVEvent * const ev) const;
 
@@ -211,9 +554,7 @@ class AliTrackContainer : public AliParticleContainer {
   AliTrackContainer(const AliTrackContainer& obj); // copy constructor
   AliTrackContainer& operator=(const AliTrackContainer& other); // assignment
 
-  /// \cond CLASSIMP
   ClassDef(AliTrackContainer,1);
-  /// \endcond
 };
 
 #endif


### PR DESCRIPTION
Reasons:
- Source files are not always available
- Prevents splitting documentation over source
  and header file
- Modern tools (i.e. Xcode, Visual Studio Code, ...)
  can make use of the documentation in order to
  provide hints to the user while coding, but only
  the header files are checked for documentation