### PR TITLE
PWGGA/GammaConv: ElectronStudies TM changes

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskElectronStudies.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskElectronStudies.h
@@ -194,6 +194,7 @@ class AliAnalysisTaskElectronStudies : public AliAnalysisTaskSE{
     Int_t                       fTrackMatcherRunningMode; // CaloTrackMatcher running mode
 
     Float_t                     fIsoMaxRadius; //
+    Float_t                     fConversionTrackMatchR; // maximum dR at which conv photon is considered matched
     // tree
     UShort_t              fBuffer_NPrimaryTracks;
     UShort_t              fBuffer_NClus;
@@ -235,7 +236,7 @@ class AliAnalysisTaskElectronStudies : public AliAnalysisTaskSE{
     void ProcessCaloPhotons();
     void ProcessTracks(); // only needed for track effi
     Bool_t TrackIsSelectedAOD(AliAODTrack* lTrack);
-    void ProcessMatchedTrack(AliAODTrack* track, AliAODCaloCluster* clus, Bool_t isV0);
+    void ProcessMatchedTrack(AliAODTrack* track, AliAODCaloCluster* clus, Bool_t isV0, Float_t dEtaV0 = 99, Float_t dPhiV0 = 99);
     void ProcessMCParticles();
     void ProcessTrackMatching(AliAODCaloCluster* clus);
     Bool_t IsMatchedWithConv(AliAODCaloCluster* clus, AliCaloPhotonCuts* cuts);
@@ -254,7 +255,7 @@ class AliAnalysisTaskElectronStudies : public AliAnalysisTaskSE{
     std::pair<Double_t,Double_t> ProcessChargedIsolation(AliAODTrack* track);
     AliAnalysisTaskElectronStudies(const AliAnalysisTaskElectronStudies&); // Prevent copy-construction
     AliAnalysisTaskElectronStudies& operator=(const AliAnalysisTaskElectronStudies&); // Prevent assignment  
-    ClassDef(AliAnalysisTaskElectronStudies, 11);
+    ClassDef(AliAnalysisTaskElectronStudies, 12);
 
 };
 

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaIsoTree.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaIsoTree.cxx
@@ -3798,7 +3798,25 @@ void AliAnalysisTaskGammaIsoTree::ProcessTracks(){
   AliAODTrack *fCurrentTrack = NULL;
   for(Int_t t=0;t<fInputEvent->GetNumberOfTracks();t++){
       fCurrentTrack = static_cast<AliAODTrack*> (fInputEvent->GetTrack(t));
+      if(!fCurrentTrack) continue;
+      TLorentzVector v4track;
+      v4track.SetPxPyPzE(fCurrentTrack->Px(),fCurrentTrack->Py(),fCurrentTrack->Pz(),fCurrentTrack->E());
+      Double_t eta = v4track.Eta();
+      Double_t phi = v4track.Phi();
+      if (phi < 0) phi += 2*TMath::Pi();
+      if(TrackIsSelectedAOD(fCurrentTrack,kTRUE)){
+          fTrackPtHybridOnlyPosID->Fill(fCurrentTrack->Pt(),fWeightJetJetMC);
+          fTrackEtaHybridOnlyPosID->Fill(eta,fWeightJetJetMC);
+          fTrackPhiHybridOnlyPosID->Fill(phi,fWeightJetJetMC);
+      }
+
       if(!TrackIsSelectedAOD(fCurrentTrack)) continue;
+    
+
+      // for QA to check for dead TPC sectors
+      fTrackPt->Fill(fCurrentTrack->Pt(),fWeightJetJetMC);
+      fTrackEta->Fill(eta,fWeightJetJetMC);
+      fTrackPhi->Fill(phi,fWeightJetJetMC);
       prim++;
   }
   fBuffer_EventNPrimaryTracks = prim;
@@ -4232,19 +4250,7 @@ isoValues AliAnalysisTaskGammaIsoTree::ProcessChargedIsolation(AliAODCaloCluster
         Double_t trackPhi = v4track.Phi();
         if (trackPhi < 0) trackPhi += 2*TMath::Pi();
 
-        if(TrackIsSelectedAOD(aodt,kTRUE)){
-           fTrackPtHybridOnlyPosID->Fill(aodt->Pt(),fWeightJetJetMC);
-           fTrackEtaHybridOnlyPosID->Fill(trackEta,fWeightJetJetMC);
-           fTrackPhiHybridOnlyPosID->Fill(trackPhi,fWeightJetJetMC);
-        }
-
         if(!TrackIsSelectedAOD(aodt)) continue;
-      
-
-        // for QA to check for dead TPC sectors
-        fTrackPt->Fill(aodt->Pt(),fWeightJetJetMC);
-        fTrackEta->Fill(trackEta,fWeightJetJetMC);
-        fTrackPhi->Fill(trackPhi,fWeightJetJetMC);
 
         Double_t dEta = trackEta - clusterEta;
         Double_t dPhi = trackPhi - clusterPhi;

--- a/PWGGA/GammaConv/config/PWGGA_CF_config.yaml
+++ b/PWGGA/GammaConv/config/PWGGA_CF_config.yaml
@@ -150,6 +150,8 @@ Clusterizer:                                        # Clusterizer component
     recalDistToBadChannels: true
     recalShowerShape: true                          # True will recalculate the shower shape
     load1DBadChMap: true                            # ADDED !!!!
+    remapMcAod: false
+    diffEAggregation: 0.0
 ClusterExotics:                                     # Cluster exotics identification component (actual removal is handled by the cluster container)
     enabled: true                                   # Whether to enable the task
     createHistos: true                              # Whether the task should create outputhistograms

--- a/PWGGA/GammaConv/macros/AddTask_ElectronStudies.C
+++ b/PWGGA/GammaConv/macros/AddTask_ElectronStudies.C
@@ -28,7 +28,7 @@ void AddTask_ElectronStudies(
 
 
 
-  Int_t trackMatcherRunningMode = 0; // CaloTrackMatcher running mode
+  Int_t trackMatcherRunningMode = 7; // CaloTrackMatcher running mode
   TString sAdditionalTrainConfig      = cuts.GetSpecialSettingFromAddConfig(additionalTrainConfig, "", "", addTaskName);
   if (sAdditionalTrainConfig.Atoi() > 0){
     trainConfig = trainConfig + sAdditionalTrainConfig.Atoi();


### PR DESCRIPTION
- ElectronStudies: switched to runningmode=7 using all hybrid tracks for matching
- ElectronStudies: implemented proper matching of tracks from V0
- GammaIsoTree: fixed trackQA histos being filled at the wrong time
- CF Framework: data yaml file had slight inconsistency with data. Added    
    remapMcAod: false
    diffEAggregation: 0.0
