### PR TITLE
add a pT cut for the summed pTs of the pair

### DIFF
--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCollConfig.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCollConfig.cxx
@@ -47,7 +47,9 @@ AliFemtoDreamCollConfig::AliFemtoDreamCollConfig()
       fDeltaEtaMax(0.f),
       fDeltaPhiMax(0.f),
       fDoDeltaEtaDeltaPhiCut(false),
-      fCoutVariables(false) {
+      fCoutVariables(false),
+      fSummedPtLimit1(0.0),
+      fSummedPtLimit2(999.0) {
   //should not be used, since we need a name to deal with root objects
 }
 
@@ -92,7 +94,9 @@ AliFemtoDreamCollConfig::AliFemtoDreamCollConfig(
       fDeltaEtaMax(config.fDeltaEtaMax),
       fDeltaPhiMax(config.fDeltaPhiMax),
       fDoDeltaEtaDeltaPhiCut(config.fDoDeltaEtaDeltaPhiCut),
-      fCoutVariables(config.fCoutVariables) {
+      fCoutVariables(config.fCoutVariables),
+      fSummedPtLimit1(config.fSummedPtLimit1),
+      fSummedPtLimit2(config.fSummedPtLimit2) {
 }
 
 AliFemtoDreamCollConfig::AliFemtoDreamCollConfig(const char *name,
@@ -137,7 +141,9 @@ AliFemtoDreamCollConfig::AliFemtoDreamCollConfig(const char *name,
       fDeltaEtaMax(0.f),
       fDeltaPhiMax(0.f),
       fDoDeltaEtaDeltaPhiCut(false),
-      fCoutVariables(QACouts) {
+      fCoutVariables(QACouts),
+      fSummedPtLimit1(0.0),
+      fSummedPtLimit2(999.0) {
 }
 AliFemtoDreamCollConfig& AliFemtoDreamCollConfig::operator=(
     const AliFemtoDreamCollConfig& config) {
@@ -182,6 +188,8 @@ AliFemtoDreamCollConfig& AliFemtoDreamCollConfig::operator=(
     this->fDeltaPhiMax = config.fDeltaPhiMax;
     this->fDoDeltaEtaDeltaPhiCut = config.fDoDeltaEtaDeltaPhiCut;
     this->fCoutVariables = config.fCoutVariables;
+    this->fSummedPtLimit1 = config.fSummedPtLimit1;
+    this->fSummedPtLimit2 = config.fSummedPtLimit2;
   }
   return *this;
 }

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCollConfig.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCollConfig.h
@@ -278,10 +278,20 @@ class AliFemtoDreamCollConfig : public TNamed {
   bool GetDoDeltaEtaDeltaPhiCut() const {
     return fDoDeltaEtaDeltaPhiCut;
   }
-
+  void SetSummedPtCut(float limit1, float limit2){
+    fSummedPtLimit1 = limit1;
+    fSummedPtLimit2 = limit2;
+  }
+  float GetSummedPtLimit1(){
+    return fSummedPtLimit1;
+  }
+  float GetSummedPtLimit2(){
+    return fSummedPtLimit2;
+  }
   static std::vector<float> GetDefaultZbins();
   static std::vector<int> GetHMMultBins();
   static std::vector<int> GetMBMultBins();
+
 
  private:
   bool fMultBinning;            //
@@ -323,6 +333,8 @@ class AliFemtoDreamCollConfig : public TNamed {
   float fDeltaPhiMax;           //
   bool fDoDeltaEtaDeltaPhiCut;  //
   bool fCoutVariables;
+  float fSummedPtLimit1;
+  float fSummedPtLimit2;
   ClassDef(AliFemtoDreamCollConfig,17);
 };
 

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamControlSample.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamControlSample.cxx
@@ -20,7 +20,9 @@ AliFemtoDreamControlSample::AliFemtoDreamControlSample()
       fDeltaPhiMax(0.f),
       fDoDeltaEtaDeltaPhiCut(false),
       fMult(0),
-      fCent(0) {
+      fCent(0),
+      fSummedPtLimit1(0.0),
+      fSummedPtLimit2(999.0) {
   fRandom.SetSeed(0);
 }
 
@@ -39,7 +41,9 @@ AliFemtoDreamControlSample::AliFemtoDreamControlSample(
       fDeltaPhiMax(samp.fDeltaPhiMax),
       fDoDeltaEtaDeltaPhiCut(samp.fDoDeltaEtaDeltaPhiCut),
       fMult(samp.fMult),
-      fCent(samp.fCent) {
+      fCent(samp.fCent),
+      fSummedPtLimit1(samp.fSummedPtLimit1),
+      fSummedPtLimit2(samp.fSummedPtLimit2) {
   fRandom.SetSeed(0);
 }
 
@@ -58,7 +62,9 @@ AliFemtoDreamControlSample::AliFemtoDreamControlSample(
       fDeltaPhiMax(conf->GetDeltaPhiMax()),
       fDoDeltaEtaDeltaPhiCut(false),
       fMult(0),
-      fCent(0) {
+      fCent(0),
+      fSummedPtLimit1(conf->GetSummedPtLimit1()),
+      fSummedPtLimit2(conf->GetSummedPtLimit2()) {
   fRandom.SetSeed(0);
 }
 
@@ -79,6 +85,8 @@ AliFemtoDreamControlSample& AliFemtoDreamControlSample::operator=(
   this->fDoDeltaEtaDeltaPhiCut = samp.fDoDeltaEtaDeltaPhiCut;
   this->fMult = samp.fMult;
   this->fCent = samp.fCent;
+  this->fSummedPtLimit1 = samp.fSummedPtLimit1;
+  this->fSummedPtLimit2 = samp.fSummedPtLimit2;
   return *this;
 }
 
@@ -162,7 +170,7 @@ void AliFemtoDreamControlSample::CorrelatedSample(
       }
       RelativeK = fHigherMath->FillSameEvent(HistCounter, fMult, fCent,
                                              *itPart1, PDGPart1,
-                                             *itPart2, PDGPart2);
+                                             *itPart2, PDGPart2,fSummedPtLimit1,fSummedPtLimit2);
       fHigherMath->MassQA(HistCounter, RelativeK, *itPart1, PDGPart1,
                                                   *itPart2, PDGPart2);
       fHigherMath->SEDetaDPhiPlots(HistCounter, *itPart1, PDGPart1, *itPart2,

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamControlSample.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamControlSample.h
@@ -63,7 +63,10 @@ class AliFemtoDreamControlSample {
   float fDeltaPhiMax;
   bool fDoDeltaEtaDeltaPhiCut;
   int fMult;
-  float fCent;ClassDef(AliFemtoDreamControlSample, 4)
+  float fCent;
+  float fSummedPtLimit1;
+  float fSummedPtLimit2;
+  ClassDef(AliFemtoDreamControlSample, 4);
 };
 
 #endif

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamHigherPairMath.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamHigherPairMath.cxx
@@ -137,12 +137,12 @@ float AliFemtoDreamHigherPairMath::FillSameEvent(int iHC, int Mult, float cent,
                                                  AliFemtoDreamBasePart &part1,
                                                  int PDGPart1,
                                                  AliFemtoDreamBasePart &part2,
-                                                 int PDGPart2) {
+                                                 int PDGPart2, float PartSumPtLimit1 = 0.0, float PartSumPtLimit2 = 999.0) {
   if (PDGPart1 == 0 || PDGPart2 == 0) {
     AliError("Invalid PDG Code");
   }
   bool fillHists = fWhichPairs.at(iHC);
-  TLorentzVector PartOne, PartTwo;
+  TLorentzVector PartOne, PartTwo, PartSum;
   TVector3 Part1Momentum = part1.GetMomentum();
   TVector3 Part2Momentum = part2.GetMomentum();
 // Even if the Daughter tracks were switched up during PID doesn't play a role
@@ -152,8 +152,12 @@ float AliFemtoDreamHigherPairMath::FillSameEvent(int iHC, int Mult, float cent,
                   TDatabasePDG::Instance()->GetParticle(PDGPart1)->Mass());
   PartTwo.SetXYZM(Part2Momentum.X(), Part2Momentum.Y(), Part2Momentum.Z(),
                   TDatabasePDG::Instance()->GetParticle(PDGPart2)->Mass());
-
+  PartSum = PartOne + PartTwo;
+  float PartSumPt = PartSum.Pt();
   float RelativeK = RelativePairMomentum(PartOne, PartTwo);
+
+  if((PartSumPt > PartSumPtLimit1) && (PartSumPt < PartSumPtLimit2)){
+
   fHists->FillSameEventDist(iHC, RelativeK);
   if (fHists->GetDoMultBinning()) {
     fHists->FillSameEventMultDist(iHC, Mult + 1, RelativeK);
@@ -207,6 +211,7 @@ float AliFemtoDreamHigherPairMath::FillSameEvent(int iHC, int Mult, float cent,
     }
   }
   return RelativeK;
+  }
 }
 
 void AliFemtoDreamHigherPairMath::MassQA(int iHC, float RelK,

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamHigherPairMath.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamHigherPairMath.h
@@ -37,7 +37,7 @@ class AliFemtoDreamHigherPairMath {
   bool CommonAncestors(AliFemtoDreamBasePart& part1, AliFemtoDreamBasePart& part2);
   void RecalculatePhiStar(AliFemtoDreamBasePart &part);
   float FillSameEvent(int iHC, int Mult, float cent, AliFemtoDreamBasePart& part1,
-                      int PDGPart1, AliFemtoDreamBasePart& part2, int PDGPart2);
+                      int PDGPart1, AliFemtoDreamBasePart& part2, int PDGPart2, float PartSumPtLimit1, float PartSumPtLimit2);
   void MassQA(int iHC, float RelK, AliFemtoDreamBasePart &part1, int PDGPart1,
               AliFemtoDreamBasePart &part2, int PDGPart2);
   void MEMassQA(int iHC, float RelK, AliFemtoDreamBasePart &part1, int PDGPart1,

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamZVtxMultContainer.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamZVtxMultContainer.cxx
@@ -15,7 +15,9 @@ ClassImp(AliFemtoDreamPartContainer)
 AliFemtoDreamZVtxMultContainer::AliFemtoDreamZVtxMultContainer()
     : fPartContainer(0),
       fPDGParticleSpecies(0),
-      fWhichPairs(){
+      fWhichPairs(),
+      fSummedPtLimit1(0.0),
+      fSummedPtLimit2(999.0){
 }
 
 AliFemtoDreamZVtxMultContainer::AliFemtoDreamZVtxMultContainer(
@@ -23,7 +25,9 @@ AliFemtoDreamZVtxMultContainer::AliFemtoDreamZVtxMultContainer(
     : fPartContainer(conf->GetNParticles(),
                      AliFemtoDreamPartContainer(conf->GetMixingDepth())),
       fPDGParticleSpecies(conf->GetPDGCodes()),
-      fWhichPairs(conf->GetWhichPairs()){
+      fWhichPairs(conf->GetWhichPairs()),
+      fSummedPtLimit1(conf->GetSummedPtLimit1()),
+      fSummedPtLimit2(conf->GetSummedPtLimit2()){
   TDatabasePDG::Instance()->AddParticle("deuteron", "deuteron", 1.8756134,
                                         kTRUE, 0.0, 1, "Nucleus", 1000010020);
   TDatabasePDG::Instance()->AddAntiParticle("anti-deuteron", -1000010020);
@@ -100,7 +104,9 @@ void AliFemtoDreamZVtxMultContainer::PairParticlesSE(
                                                 part1,
                                                 *itPDGPar1,
                                                 part2,
-                                                *itPDGPar2);
+                                                *itPDGPar2,
+						fSummedPtLimit1,
+						fSummedPtLimit2);
           HigherMath->MassQA(HistCounter, RelativeK, *itPart1, *itPDGPar1,
                                                      *itPart2, *itPDGPar2);
           HigherMath->SEDetaDPhiPlots(HistCounter, *itPart1, *itPDGPar1,

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamZVtxMultContainer.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamZVtxMultContainer.h
@@ -49,7 +49,8 @@ class AliFemtoDreamZVtxMultContainer {
 //  float fDeltaEtaMax;
 //  float fDeltaPhiMax;
 //  float fDeltaPhiEtaMax;
-
+  float fSummedPtLimit1;
+  float fSummedPtLimit2;
 ClassDef(AliFemtoDreamZVtxMultContainer, 4)
   ;
 };


### PR DESCRIPTION
Hi there,
I have implemented a cut for the sum of the transverse momenta of the pair (pT1 + pT2). Only pairs within specified limits (limit1 < summed pT < limit2) will be used for the same-event distribution. The default values of the limits are: limit1 = 0.0 and limit2 = 999.0. These limits can be changed using "config->SetSummedPtCut(limit1,limit2)" in the AddTask.
regards
Michael