### PR TITLE
Adding TPC dE/dx identified pi, K, p jet hadron correlations analysis

### DIFF
--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHdEdxCorrelations.cxx
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHdEdxCorrelations.cxx
@@ -1,0 +1,1601 @@
+//////////
+//Measure Jet-hadron correlations
+//Does event Mixing using AliEventPoolManager
+/////////
+
+#include "AliAnalysisTaskEmcalJetHdEdxCorrelations.h"
+
+#include <bitset>
+
+#include <TH1F.h>
+#include <TH2F.h>
+#include <TH3F.h>
+#include <THnSparse.h>
+#include <TVector3.h>
+#include <TFile.h>
+#include <TGrid.h>
+#include <TList.h>
+
+#include <AliAnalysisManager.h>
+#include <AliInputEventHandler.h>
+#include <AliEventPoolManager.h>
+#include <AliLog.h>
+#include <AliVAODHeader.h>
+#include <AliVTrack.h>
+
+#include "AliEmcalJet.h"
+#include "AliTLorentzVector.h"
+#include "AliAODTrack.h"
+#include "AliBasicParticle.h"
+#include "AliEmcalContainerUtils.h"
+#include "AliClusterContainer.h"
+#include "AliTrackContainer.h"
+#include "AliJetContainer.h"
+#include "AliAnalysisTaskEmcalEmbeddingHelper.h"
+#include "AliAnalysisTaskEmcalJetHUtils.h"
+
+ClassImp(PWGJE::EMCALJetTasks::AliAnalysisTaskEmcalJetHdEdxCorrelations);
+using namespace std;
+namespace PWGJE {
+namespace EMCALJetTasks {
+
+/**
+ * Default constructor.
+ */
+AliAnalysisTaskEmcalJetHdEdxCorrelations::AliAnalysisTaskEmcalJetHdEdxCorrelations() :
+  AliAnalysisTaskEmcalJet("AliAnalysisTaskEmcalJetHdEdxCorrelations", kFALSE),
+  fYAMLConfig(),
+  fConfigurationInitialized(false),
+  fTrackBias(5),
+  fClusterBias(5),
+  fDoEventMixing(kFALSE),
+  fNMixingTracks(50000), fMinNTracksMixedEvents(5000), fMinNEventsMixedEvents(5), fNCentBinsMixedEvent(10),
+  fPoolMgr(nullptr),
+  fTriggerType(AliVEvent::kEMCEJE), fMixingEventType(AliVEvent::kMB | AliVEvent::kCentral | AliVEvent::kSemiCentral),
+  fDisableFastPartition(kFALSE),
+  fRandom(0),
+  fEfficiencyPeriodIdentifier(AliAnalysisTaskEmcalJetHUtils::kDisableEff),
+  fArtificialTrackInefficiency(1.0),
+  fNoMixedEventJESCorrection(kFALSE),
+  fJESCorrectionHist(nullptr),
+  fDoLessSparseAxes(kFALSE), fDoWiderTrackBin(kFALSE),
+  fRequireMatchedJetWhenEmbedding(kTRUE),
+  fMinSharedMomentumFraction(0.),
+  fRequireMatchedPartLevelJet(false),
+  fMaxMatchedJetDistance(-1),
+  fHistManager(),
+  fHistJetHTrackPt(nullptr),
+  fHistJetEtaPhi(nullptr),
+  fHistJetHEtaPhi(nullptr),
+  fhnMixedEvents(nullptr),
+  fhnJH(nullptr),
+  fhnTrigger(nullptr)
+{
+  // Default Constructor
+  InitializeArraysToZero();
+}
+
+/**
+ * Standard constructor
+ */
+AliAnalysisTaskEmcalJetHdEdxCorrelations::AliAnalysisTaskEmcalJetHdEdxCorrelations(const char *name) :
+  AliAnalysisTaskEmcalJet(name, kTRUE),
+  fYAMLConfig(),
+  fConfigurationInitialized(false),
+  fTrackBias(5),
+  fClusterBias(5),
+  fDoEventMixing(kFALSE),
+  fNMixingTracks(50000), fMinNTracksMixedEvents(5000), fMinNEventsMixedEvents(5), fNCentBinsMixedEvent(10),
+  fPoolMgr(nullptr),
+  fTriggerType(AliVEvent::kEMCEJE), fMixingEventType(AliVEvent::kMB | AliVEvent::kCentral | AliVEvent::kSemiCentral),
+  fDisableFastPartition(kFALSE),
+  fRandom(0),
+  fEfficiencyPeriodIdentifier(AliAnalysisTaskEmcalJetHUtils::kDisableEff),
+  fArtificialTrackInefficiency(1.0),
+  fNoMixedEventJESCorrection(kFALSE),
+  fJESCorrectionHist(nullptr),
+  fDoLessSparseAxes(kFALSE), fDoWiderTrackBin(kFALSE),
+  fRequireMatchedJetWhenEmbedding(kTRUE),
+  fMinSharedMomentumFraction(0.),
+  fRequireMatchedPartLevelJet(false),
+  fMaxMatchedJetDistance(-1),
+  fHistManager(name),
+  fHistJetHTrackPt(nullptr),
+  fHistJetEtaPhi(nullptr),
+  fHistJetHEtaPhi(nullptr),
+  fhnMixedEvents(nullptr),
+  fhnJH(nullptr),
+  fhnTrigger(nullptr)
+{
+  // Constructor
+  InitializeArraysToZero();
+  // Ensure that additional general histograms are created
+  SetMakeGeneralHistograms(kTRUE);
+}
+
+/**
+ * Initialize all member arrays to nullptr. Used as a convenience function in the constructors.
+ */
+void AliAnalysisTaskEmcalJetHdEdxCorrelations::InitializeArraysToZero()
+{
+  for(Int_t trackPtBin = 0; trackPtBin < kMaxTrackPtBins; trackPtBin++){
+    fHistTrackEtaPhi[trackPtBin] = nullptr;
+  }
+  for(Int_t centralityBin = 0; centralityBin < kMaxCentralityBins; ++centralityBin){
+    fHistJetPt[centralityBin] = nullptr;
+    fHistJetPtBias[centralityBin] = nullptr;
+  }
+}
+
+/**
+ * Initialize task.
+ */
+bool AliAnalysisTaskEmcalJetHdEdxCorrelations::Initialize()
+{
+  fConfigurationInitialized = false;
+
+  // Ensure that we have at least one configuration in the YAML config.
+  if (fYAMLConfig.DoesConfigurationExist(0) == false) {
+    // No configurations exist. Return immediately.
+    return fConfigurationInitialized;
+  }
+
+  // Always initialize for streaming purposes
+  fYAMLConfig.Initialize();
+
+  // Setup task based on the properties defined in the YAML config
+  AliDebugStream(2) << "Configuring task from the YAML configuration.\n";
+  RetrieveAndSetTaskPropertiesFromYAMLConfig();
+  AliDebugStream(2) << "Finished configuring via the YAML configuration.\n";
+
+  // Print the results of the initialization
+  // Print outside of the ALICE Log system to ensure that it is always available!
+  std::cout << *this;
+
+  fConfigurationInitialized = true;
+  return fConfigurationInitialized;
+}
+
+/**
+ * Perform task configuration via YAML.
+ */
+void AliAnalysisTaskEmcalJetHdEdxCorrelations::RetrieveAndSetTaskPropertiesFromYAMLConfig()
+{
+  // Base class options
+  // Task physics (trigger) selection.
+  std::string baseName = "eventCuts";
+  std::vector<std::string> physicsSelection;
+  bool res = fYAMLConfig.GetProperty(std::vector<std::string>({"eventCuts", "physicsSelection"}), physicsSelection, false);
+  if (res) {
+    fOfflineTriggerMask = AliEmcalContainerUtils::DeterminePhysicsSelectionFromYAML(physicsSelection);
+  }
+
+  // Event cuts
+  // If event cuts are enabled (which they exceptionally are by default), then we want to configure them here.
+  // If the event cuts are explicitly disabled, then we invert that value to enable the AliAnylsisTaskEmcal
+  // builtin event selection.
+  bool tempBool;
+  fYAMLConfig.GetProperty({baseName, "enabled"}, tempBool, false);
+  fUseBuiltinEventSelection = !tempBool;
+  if (fUseBuiltinEventSelection == false) {
+    // Need to include the namespace so that AliDebug will work properly...
+    std::string taskName = "PWGJE::EMCALJetTasks::";
+    taskName += GetName();
+    AliAnalysisTaskEmcalJetHUtils::ConfigureEventCuts(fAliEventCuts, fYAMLConfig, fOfflineTriggerMask, baseName, taskName);
+  }
+
+  // General task options
+  baseName = "general";
+  fYAMLConfig.GetProperty({baseName, "nCentBins"}, fNcentBins, false);
+
+  // Efficiency
+  std::string tempStr = "";
+  baseName = "efficiency";
+  res = fYAMLConfig.GetProperty({baseName, "periodIdentifier"}, tempStr, false);
+  if (res) {
+    fEfficiencyPeriodIdentifier = AliAnalysisTaskEmcalJetHUtils::fgkEfficiencyPeriodIdentifier.at(tempStr);
+  }
+}
+
+/**
+ * Perform run independent initializations, such as histograms and the event pool.
+ */
+void AliAnalysisTaskEmcalJetHdEdxCorrelations::UserCreateOutputObjects()
+{
+  // Called once
+  AliAnalysisTaskEmcalJet::UserCreateOutputObjects();
+
+  // Check that the task was initialized
+  if (!fConfigurationInitialized) {
+    AliFatal("Task was not initialized. Please ensure that Initialize() was called!");
+  }
+  // Reinitialize the YAML configuration
+  fYAMLConfig.Reinitialize();
+
+  // Create histograms
+  fHistJetHTrackPt = new TH1F("fHistJetHTrackPt", "P_{T} distribution", 1000, 0.0, 100.0);
+  fHistJetEtaPhi = new TH2F("fHistJetEtaPhi","Jet eta-phi",900,-1.8,1.8,720,-3.2,3.2);
+  fHistJetHEtaPhi = new TH2F("fHistJetHEtaPhi","Jet-Hadron deta-dphi",900,-1.8,1.8,720,-1.6,4.8);
+
+  fOutput->Add(fHistJetHTrackPt);
+  fOutput->Add(fHistJetEtaPhi);
+  fOutput->Add(fHistJetHEtaPhi);
+
+  TString name;
+  for(Int_t trackPtBin = 0; trackPtBin < kMaxTrackPtBins; ++trackPtBin){
+    name = Form("fHistTrackEtaPhi_%i", trackPtBin);
+    fHistTrackEtaPhi[trackPtBin] = new TH2F(name,name,400,-1,1,720,0.0,2.0*TMath::Pi());
+    fOutput->Add(fHistTrackEtaPhi[trackPtBin]);
+  }
+
+  for(Int_t centralityBin = 0; centralityBin < kMaxCentralityBins; ++centralityBin){
+    name = Form("fHistJetPt_%i",centralityBin);
+    fHistJetPt[centralityBin] = new TH1F(name,name,240,-40,200);
+    fOutput->Add(fHistJetPt[centralityBin]);
+
+    name = Form("fHistJetPtBias_%i",centralityBin);
+    fHistJetPtBias[centralityBin] = new TH1F(name,name,240,-40,200);
+    fOutput->Add(fHistJetPtBias[centralityBin]);
+  }
+
+  // Jet matching cuts
+  // Only need if we actually jet matching
+  if (fRequireMatchedJetWhenEmbedding) {
+    std::vector<std::string> binLabels = {"noMatch", "matchedJet", "sharedMomentumFraction", "partLevelMatchedJet", "jetDistance", "passedAllCuts"};
+    for (auto histName : std::vector<std::string>({"SameEvent", "MixedEvent"})) {
+      name = std::string("fHistJetMatching") + histName.c_str() + "Cuts";
+      std::string title = std::string("Jets which passed matching jet cuts for ") + histName;
+      auto histMatchedJetCuts = fHistManager.CreateTH1(name, title.c_str(), binLabels.size(), 0, binLabels.size());
+      // Set label names
+      for (unsigned int i = 1; i <= binLabels.size(); i++) {
+        histMatchedJetCuts->GetXaxis()->SetBinLabel(i, binLabels.at(i-1).c_str());
+      }
+      histMatchedJetCuts->GetYaxis()->SetTitle("Number of jets");
+    }
+  }
+
+  // NOTE: The bit encoding doesn't preserve the order defined here. It's
+  //       just using the bit values.
+  UInt_t cifras = 0; // bit coded, see GetDimParams() below
+  if(fDoLessSparseAxes) {
+    cifras = 1<<0 | 1<<1 | 1<<2 | 1<<3 | 1<<4 | 1<<5 | 1<<7 | 1<<11;
+  } else {
+    cifras = 1<<0 | 1<<1 | 1<<2 | 1<<3 | 1<<4 | 1<<5 | 1<<7 | 1<<8 | 1<<9 | 1<<11;
+  }
+  fhnJH = NewTHnSparseF("fhnJH", cifras);
+  fhnJH->Sumw2();
+  fOutput->Add(fhnJH);
+
+  if(fDoEventMixing){
+    // The event plane angle does not need to be included because the semi-central determined that the EP angle didn't change
+    // significantly for any of the EP orientations. However, it will be included so this can be demonstrated for the central
+    // analysis if so desired.
+    if(fDoLessSparseAxes) {
+      cifras = 1<<0 | 1<<1 | 1<<2 | 1<<3 | 1<<4 | 1<<5 | 1<<7;
+    } else {
+      cifras = 1<<0 | 1<<1 | 1<<2 | 1<<3 | 1<<4 | 1<<5 | 1<<7 | 1<<8 | 1<<9;
+    }
+    fhnMixedEvents = NewTHnSparseF("fhnMixedEvents", cifras);
+    fhnMixedEvents->Sumw2();
+    fOutput->Add(fhnMixedEvents);
+  }
+
+  // Trigger THnSparse
+  cifras = 1<<0 | 1<<1 | 1<<7;
+  fhnTrigger = NewTHnSparseF("fhnTrigger", cifras);
+  fhnTrigger->Sumw2();
+  fOutput->Add(fhnTrigger);
+
+  // Store hist manager output in the output list
+  TIter next(fHistManager.GetListOfHistograms());
+  TObject* obj = 0;
+  while ((obj = next())) {
+    fOutput->Add(obj);
+  }
+
+  PostData(1, fOutput);
+
+  // Event Mixing
+  Int_t poolSize = -1;  // Maximum number of events. Set to -1 to avoid limits on number of events
+  // ZVertex
+  Int_t nZVertexBins = 10;
+  Double_t* zVertexBins = GenerateFixedBinArray(nZVertexBins, -10, 10);
+  // Event activity (centrality of multiplicity)
+  Int_t nEventActivityBins = 8;
+  Double_t* eventActivityBins = 0;
+  // +1 to accomodate the fact that we define bins rather than array entries.
+  Double_t multiplicityBins[kMixedEventMultiplicityBins+1] = {0., 4., 9., 15., 25., 35., 55., 100., 500.};
+
+  // Cannot use GetBeamType() since it is not available until UserExec()
+  if (fForceBeamType != AliAnalysisTaskEmcal::kpp ) {   //all besides pp
+    // Event Activity is centrality in AA, pA
+    nEventActivityBins = fNCentBinsMixedEvent;
+    eventActivityBins = GenerateFixedBinArray(nEventActivityBins, 0, 100);
+  }
+  else if (fForceBeamType == AliAnalysisTaskEmcal::kpp) { //for pp only
+    // Event Activity is multiplicity in pp
+    eventActivityBins = multiplicityBins;
+  }
+
+  fPoolMgr = new AliEventPoolManager(poolSize, fNMixingTracks, nEventActivityBins, eventActivityBins, nZVertexBins, zVertexBins);
+
+  // Print pool properties
+  fPoolMgr->Validate();
+}
+
+/**
+ * User specific initializations to perform before the first event.
+ */
+void AliAnalysisTaskEmcalJetHdEdxCorrelations::UserExecOnce()
+{
+  // Base class.
+  AliAnalysisTaskEmcalJet::UserExecOnce();
+
+  // Ensure that the random number generator is seeded in each job.
+  fRandom.SetSeed(0);
+}
+
+/**
+ * Get the proper bin based on the track pt value.
+ *
+ * @param[in] pt Track pt value to be binned.
+ * @return Bin corresponding to the input value.
+ */
+Int_t AliAnalysisTaskEmcalJetHdEdxCorrelations::GetTrackPtBin(Double_t pt) const
+{
+  Int_t ptBin = -1;
+  if      (pt <  0.5) ptBin = 0;
+  else if (pt <  1  ) ptBin = 1;
+  else if (pt <  2  ) ptBin = 2;
+  else if (pt <  3  ) ptBin = 3;
+  else if (pt <  5  ) ptBin = 4;
+  else if (pt <  8  ) ptBin = 5;
+  else if (pt < 20  ) ptBin = 6;
+
+  return ptBin;
+}
+
+/**
+ * Retrieve the trigger mask from the input event or embedding helper as approapriate.
+ *
+ * @return The event trigger mask.
+ */
+UInt_t AliAnalysisTaskEmcalJetHdEdxCorrelations::RetrieveTriggerMask() const
+{
+  UInt_t eventTrigger = 0;
+  if (fIsEmbedded) {
+    auto embeddingHelper = AliAnalysisTaskEmcalEmbeddingHelper::GetInstance();
+    if (embeddingHelper) {
+      auto aodHeader = dynamic_cast<AliVAODHeader *>(embeddingHelper->GetEventHeader());
+      if (aodHeader) {
+        AliDebugStream(5) << "Retrieving trigger mask from embedded event\n";
+        eventTrigger = aodHeader->GetOfflineTrigger();
+      }
+      else {
+        AliErrorStream() << "Failed to retrieve requested AOD header from embedding helper\n";
+      }
+    }
+    else {
+      AliErrorStream() << "Failed to retrieve requested embedding helper\n";
+    }
+  }
+  else {
+    AliDebugStream(5) << "Retrieving trigger mask from internal event\n";
+    eventTrigger = ((AliInputEventHandler*)(AliAnalysisManager::GetAnalysisManager()->GetInputEventHandler()))->IsEventSelected();
+  }
+
+  return eventTrigger;
+}
+
+/**
+ * Main loop called for each event by AliAnalysisTaskEmcal.
+ */
+Bool_t AliAnalysisTaskEmcalJetHdEdxCorrelations::Run()
+{
+  // NOTE: Clusters are never used directly in the task, so the container is neither created not retrieved
+  // Retrieve tracks
+  AliTrackContainer * tracks = static_cast<AliTrackContainer * >(GetParticleContainer("tracksForCorrelations"));
+  if (!tracks) {
+    AliError(Form("%s: Unable to retrieve tracks!", GetName()));
+    return kFALSE;
+  }
+
+  // Retrieve jets
+  AliJetContainer * jets = GetJetContainer(0);
+  if (!jets) {
+    AliError(Form("%s: Unable to retrieve jets!", GetName()));
+    return kFALSE;
+  }
+
+  // Keep track of the tracks which are rejected with an aritificial track inefficiency
+  std::vector<unsigned int> rejectedTrackIndices;
+  bool useListOfRejectedIndices = false;
+
+  // Get z vertex
+  Double_t zVertex=fVertex[2];
+  // Flags
+  Bool_t biasedJet = kFALSE;
+  Bool_t leadJet = kFALSE;
+  // Jet pt
+  Double_t jetPt = 0;
+  // Rho
+  // NOTE: Defaults to 0 if rho was not specified.
+  Double_t rhoVal = jets->GetRhoVal();
+  // Relative angles and distances
+  Double_t deltaPhi = 0;
+  Double_t deltaEta = 0;
+  Double_t deltaR = 0;
+  Double_t epAngle = 0;
+  // Event activity (centrality or multipilicity)
+  Double_t eventActivity = 0;
+  // Efficiency correction
+  Double_t efficiency = -999;
+  // For comparison to the current jet
+  AliEmcalJet * leadingJet = jets->GetLeadingJet();
+  // For getting the proper properties of tracks
+  AliTLorentzVector track;
+  AliAODTrack* AODtrack=nullptr;
+
+  // Determine the trigger for the current event
+  UInt_t eventTrigger = RetrieveTriggerMask();
+
+  AliDebugStream(5) << "Beginning main processing. Number of jets: " << jets->GetNJets() << ", accepted jets: " << jets->GetNAcceptedJets() << "\n";
+
+  // Handle fast partition if selected
+  if ((eventTrigger & AliVEvent::kFastOnly) && fDisableFastPartition) {
+    AliDebugStream(4) << GetName() << ": Fast partition disabled\n";
+    if (fGeneralHistograms) {
+      fHistEventRejection->Fill("Fast Partition", 1);
+    }
+    return kFALSE;
+  }
+
+  for (auto jet : jets->accepted()) {
+    // Selects only events that we are interested in (ie triggered)
+    if (!(eventTrigger & fTriggerType)) {
+      // The two bitwise and to zero yet are still equal when both are 0, so we allow for that possibility
+      if (eventTrigger == fTriggerType && eventTrigger == 0) {
+        AliDebugStream(5) << "Event accepted because the physics selection is \"0\".\n";
+      }
+      else {
+        AliDebugStream(5) << "Rejected jets due to physics selection. Phys sel: " << std::bitset<32>(eventTrigger) << ", requested triggers: " << std::bitset<32>(fTriggerType) << " \n";
+        // We can break here - the physics selection is not going to change within an event.
+        break;
+      }
+    }
+
+    AliDebugStream(5) << "Jet passed event selection!\nJet: " << jet->toString().Data() << "\n";
+
+    // Require the found jet to be matched
+    // This match should be between detector and particle level MC
+    if (fIsEmbedded && fRequireMatchedJetWhenEmbedding) {
+      bool foundMatchedJet = CheckForMatchedJet(jets, jet, "fHistJetMatchingSameEventCuts");
+      if (foundMatchedJet == false) {
+        continue;
+      }
+    }
+
+    // Determine event activity
+    if (fBeamType == kAA || fBeamType == kpA) {
+      eventActivity = fCent;
+    }
+    else if (fBeamType == kpp) {
+      eventActivity = static_cast<Double_t>(tracks->GetNTracks());
+    }
+
+    // Jet properties
+    jetPt = AliAnalysisTaskEmcalJetHUtils::GetJetPt(jet, rhoVal);
+    // Determine if we have the lead jet
+    leadJet = kFALSE;
+    if (jet == leadingJet) leadJet = kTRUE;
+    biasedJet = BiasedJet(jet);
+    epAngle = PWGJE::EMCALJetTasks::AliAnalysisTaskEmcalJetHUtils::RelativeEPAngle(jet->Phi(), fEPV0);
+
+    // Fill jet properties
+    fHistJetEtaPhi->Fill(jet->Eta(), jet->Phi());
+    FillHist(fHistJetPt[fCentBin], jetPt);
+    if (biasedJet == kTRUE) {
+      FillHist(fHistJetPtBias[fCentBin], jetPt);
+
+      const double triggerInfo[] = {eventActivity, jetPt, epAngle};
+      fhnTrigger->Fill(triggerInfo);
+    }
+
+    // Cut on jet pt of 15 to reduce the size of the sparses
+    if (jetPt > 15) {
+
+      AliDebugStream(4) << "Passed min jet pt cut of 15. Jet: " << jet->toString().Data() << "\n";
+      AliDebugStream(4) << "N accepted tracks: " << tracks->GetNAcceptedTracks() << "\n";
+      auto tracksIter = tracks->accepted_momentum();
+      for (auto trackIter = tracksIter.begin(); trackIter != tracksIter.end(); trackIter++ ) {
+        // Get proper track properties
+        track.Clear();
+        track = trackIter->first;
+        AODtrack = dynamic_cast <AliAODTrack*>(trackIter->second);
+
+
+        // Artificial inefficiency
+        // Note that we already randomly rejected tracks so that the same tracks will be rejected for the mixed events
+        bool rejectParticle = CheckArtificialTrackEfficiency(trackIter.current_index(), rejectedTrackIndices, useListOfRejectedIndices);
+        if (rejectParticle) {
+          AliDebugStream(4) << "Track rejected in signal correlation loop.\n";
+          continue;
+        }
+
+        // Determine relative angles and distances and set the respective variables
+        GetDeltaEtaDeltaPhiDeltaR(track, jet, deltaEta, deltaPhi, deltaR);
+
+        // Float_t 1 = track.GetTPCsignal();
+
+        // Fill track properties
+        fHistJetHTrackPt->Fill(track.Pt());
+        fHistJetHEtaPhi->Fill(deltaEta, deltaPhi);
+
+        // Calculate single particle tracking efficiency for correlations
+        efficiency = EffCorrection(track.Eta(), track.Pt());
+        AliDebugStream(6) << "track eta: " << track.Eta() << ", track pt: " << track.Pt() << ", efficiency: " << efficiency << "\n";
+
+        if (biasedJet == kTRUE) {
+          if(fDoLessSparseAxes) { // check if we want all dimensions
+            double triggerEntries[] = {eventActivity, jetPt, track.Pt(), deltaEta, deltaPhi, static_cast<Double_t>(leadJet), epAngle, AODtrack->GetTPCsignal()};
+            FillHist(fhnJH, triggerEntries, 1.0/efficiency);
+          } else {
+            double triggerEntries[] = {eventActivity, jetPt, track.Pt(), deltaEta, deltaPhi, static_cast<Double_t>(leadJet), epAngle, zVertex, deltaR, AODtrack->GetTPCsignal()};
+            FillHist(fhnJH, triggerEntries, 1.0/efficiency);
+          }
+        }
+
+      } //track loop
+
+      // After one jet (and looping over whatever tracks are available in this event), we want to use the list of rejected indices,
+      // both for the next possible signal jet in the event and for the mixed events
+      AliDebugStream(4) << "Switching to list of rejected track indices. Number of indices: " << rejectedTrackIndices.size() << "\n";
+      useListOfRejectedIndices = true;
+
+    }//jet pt cut
+  }//jet loop
+
+  //Prepare to do event mixing
+
+  // create a list of reduced objects. This speeds up processing and reduces memory consumption for the event pool
+  TObjArray* tracksClone = 0;
+
+  if(fDoEventMixing == kTRUE){
+
+    // event mixing
+
+    // 1. First get an event pool corresponding in mult (cent) and
+    //    zvertex to the current event. Once initialized, the pool
+    //    should contain nMix (reduced) events. This routine does not
+    //    pre-scan the chain. The first several events of every chain
+    //    will be skipped until the needed pools are filled to the
+    //    specified depth. If the pool categories are not too rare, this
+    //    should not be a problem. If they are rare, you could lose
+    //    statistics.
+
+    // 2. Collect the whole pool's content of tracks into one TObjArray
+    //    (bgTracks), which is effectively a single background super-event.
+
+    // 3. The reduced and bgTracks arrays must both be passed into
+    //    FillCorrelations(). Also nMix should be passed in, so a weight
+    //    of 1./nMix can be applied.
+
+    AliEventPool *pool = 0;
+    if (fBeamType == kAA || fBeamType == kpA) {//everything but pp
+      pool = fPoolMgr->GetEventPool(fCent, zVertex);
+    }
+    else if (fBeamType == kpp) {//pp only
+      pool = fPoolMgr->GetEventPool(static_cast<Double_t>(tracks->GetNTracks()), zVertex);
+    }
+
+    if (!pool){
+      if (fBeamType == kAA || fBeamType == kpA) AliFatal(Form("No pool found for centrality = %f, zVertex = %f", fCent, zVertex));
+      else if (fBeamType == kpp) AliFatal(Form("No pool found for ntracks_pp = %d, zVertex = %f", tracks->GetNTracks(), zVertex));
+      return kTRUE;
+    }
+
+    // The number of events in the pool
+    Int_t nMix = pool->GetCurrentNEvents();
+
+    // The two bitwise and to zero yet are still equal when both are 0, so we allow for that possibility
+    if((eventTrigger & fTriggerType) || eventTrigger == fTriggerType) {
+      // check for a trigger jet
+      if (pool->IsReady() || pool->NTracksInPool() >= fMinNTracksMixedEvents || nMix >= fMinNEventsMixedEvents) {
+
+        for (auto jet : jets->accepted()) {
+          // Require the found jet to be matched
+          // This match should be between detector and particle level MC
+          if (fIsEmbedded && fRequireMatchedJetWhenEmbedding) {
+            bool foundMatchedJet = CheckForMatchedJet(jets, jet, "fHistJetMatchingMixedEventCuts");
+            if (foundMatchedJet == false) {
+              continue;
+            }
+          }
+
+          if (fBeamType == kAA || fBeamType == kpA) { //pA and AA
+            eventActivity = fCent;
+          }
+          else if (fBeamType == kpp) {
+            eventActivity = static_cast<Double_t>(tracks->GetNTracks());
+          }
+
+          // Jet properties
+          jetPt = AliAnalysisTaskEmcalJetHUtils::GetJetPt(jet, rhoVal);
+          // Determine if we have the lead jet
+          leadJet = kFALSE;
+          if (jet == leadingJet) { leadJet = kTRUE; }
+          biasedJet = BiasedJet(jet);
+          epAngle = PWGJE::EMCALJetTasks::AliAnalysisTaskEmcalJetHUtils::RelativeEPAngle(jet->Phi(), fEPV0);
+
+          // Make sure event contains a biased jet above our threshold (reduce stats of sparse)
+          if (jetPt < 15 || biasedJet == kFALSE) continue;
+
+          // Fill mixed-event histos here
+          for (Int_t jMix=0; jMix < nMix; jMix++) {
+            TObjArray* bgTracks = pool->GetEvent(jMix);
+
+            for (Int_t ibg=0; ibg < bgTracks->GetEntries(); ibg++){
+              AliBasicParticle *bgTrack = static_cast<AliBasicParticle*>(bgTracks->At(ibg));
+              if(!bgTrack) {
+                AliError(Form("%s:Failed to retrieve tracks from mixed events", GetName()));
+              }
+
+              // NOTE: We don't need to apply the artificial track inefficiency here because we already applied
+              //       it when will filling into the event pool (in CloneAndReduceTrackList()).
+
+              // Fill into TLorentzVector for use with functions below
+              track.Clear();
+              track.SetPtEtaPhiE(bgTrack->Pt(), bgTrack->Eta(), bgTrack->Phi(), 0);
+
+              // Calculate single particle tracking efficiency of mixed events for correlations
+              efficiency = EffCorrection(track.Eta(), track.Pt());
+
+              // Phi is [-0.5*TMath::Pi(), 3*TMath::Pi()/2.]
+              GetDeltaEtaDeltaPhiDeltaR(track, jet, deltaEta, deltaPhi, deltaR);
+
+              if (fDoLessSparseAxes) {  // check if we want all the axis filled
+                double triggerEntries[] = {eventActivity, jetPt, track.Pt(), deltaEta, deltaPhi, static_cast<Double_t>(leadJet), epAngle};
+                FillHist(fhnMixedEvents, triggerEntries, 1./(nMix*efficiency), fNoMixedEventJESCorrection);
+              } else {
+                double triggerEntries[] = {eventActivity, jetPt, track.Pt(), deltaEta, deltaPhi, static_cast<Double_t>(leadJet), epAngle, zVertex, deltaR};
+                FillHist(fhnMixedEvents, triggerEntries, 1./(nMix*efficiency), fNoMixedEventJESCorrection);
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // The two bitwise and to zero yet are still equal when both are 0, so we allow for that possibility
+    if ((eventTrigger & fMixingEventType) || eventTrigger == fMixingEventType) {
+      tracksClone = CloneAndReduceTrackList(rejectedTrackIndices, useListOfRejectedIndices);
+
+      //update pool if jet in event or not
+      pool->UpdatePool(tracksClone);
+    }
+
+  } // end of event mixing
+
+  return kTRUE;
+}
+
+/**
+ * Determine if a jet passes the track or cluster bias and is therefore a "biased" jet.
+ *
+ * @param[in] jet The jet to be checked.
+ * @return true if the jet is biased.
+ */
+Bool_t AliAnalysisTaskEmcalJetHdEdxCorrelations::BiasedJet(AliEmcalJet * jet)
+{
+  if ((jet->MaxTrackPt() > fTrackBias) || (jet->MaxClusterPt() > fClusterBias))
+  {
+    return kTRUE;
+  }
+  return kFALSE;
+}
+
+/**
+ * Get \f$\Delta\phi\f$, \f$\Delta\eta\f$, and \f$\Delta R\f$ between two given particles.
+ *
+ * @param[in] particleOne The first particle.
+ * @param[in] particleTwo The second particle.
+ * @param[out] deltaEta The calculated \f$\Delta\eta\f$ value.
+ * @param[out] deltaPhi The calculated \f$\Delta\phi\f$ value.
+ * @param[out] deltaR The calculated \f$\Delta R\f$ value.
+ */
+void AliAnalysisTaskEmcalJetHdEdxCorrelations::GetDeltaEtaDeltaPhiDeltaR(AliTLorentzVector & particleOne, AliVParticle * particleTwo, Double_t & deltaEta, Double_t & deltaPhi, Double_t & deltaR)
+{
+  // Define dPhi = jet.Phi() - particle.Phi() and similarly for dEta
+  // Returns deltaPhi in symmetric range so that we can calculate DeltaR.
+  deltaPhi = DeltaPhi(particleOne.Phi(), particleTwo->Phi(), -1.0*TMath::Pi(), TMath::Pi());
+  deltaEta = particleTwo->Eta() - particleOne.Eta();
+  deltaR = TMath::Sqrt(deltaPhi*deltaPhi + deltaEta*deltaEta);
+
+  // Adjust to the normal range after the DeltaR caluclation
+  deltaPhi = DeltaPhi(particleTwo->Phi(), particleOne.Phi(), -0.5*TMath::Pi(), 3*TMath::Pi()/2.);
+}
+
+/**
+ * Check whether a track should be rejected due to artificial track inefficiency.
+ *
+ * @param[in] trackIndex Index of the current track.
+ * @param[in] rejectedTrackIndices Vector of track indices which have been already rejected. Can be used to store the track index if rejected or reject a track if matched (depending on useRejectedList).
+ * @param[in] useRejectedList If true, check if the current track index is in the rejected index list and reject if so. If false, will randomly reject the track according to the track inefficiency.
+ * @return True if particle should be rejected
+ */
+bool AliAnalysisTaskEmcalJetHdEdxCorrelations::CheckArtificialTrackEfficiency(unsigned int trackIndex, std::vector<unsigned int> & rejectedTrackIndices, bool useRejectedList)
+{
+  bool returnValue = false;
+  if (fArtificialTrackInefficiency < 1.) {
+    if (useRejectedList) {
+      if (std::find(rejectedTrackIndices.begin(), rejectedTrackIndices.end(), trackIndex) != rejectedTrackIndices.end()) {
+        AliDebugStream(4) << "Track " << trackIndex << " rejected due to artificial tracking inefficiency (from list)\n";
+        returnValue = true;
+      }
+    }
+    else {
+      // Rejet randomly
+      Double_t rnd = fRandom.Rndm();
+      if (fArtificialTrackInefficiency < rnd) {
+        // Store index so we can reject it again if it is also filled for mixed events
+        rejectedTrackIndices.push_back(trackIndex);
+        AliDebugStream(4) << "Track " << trackIndex << " rejected due to artificial tracking inefficiency (from random)\n";
+        returnValue = true;
+      }
+    }
+  }
+
+  return returnValue;
+}
+
+/**
+ * Check for whether a matched jet should be accepted based on:
+ * - Jet being identified as matched to another jet
+ * - The shared momentum fraction being larger than some minimum value
+ * - Their matched distance being below the max matching distance
+ * - A particle level jet being matched to the detector level jet
+ *
+ * All of the above options are configurable and off by default (except for requiring a basic match).
+ *
+ * NOTE: AliEmcalJet::ClosestJet() is called instead of AliEmcalJet::MatchedJet() because ClosestJet() will work
+ * with both the EMCal Jet Tagger and the Response Maker, while MatchedJet() will only work with the Response Maker
+ * due to the design of the classes.
+ *
+ * @param[in] jets Jet container corresponding to the jet to be checked
+ * @param[in] jet Jet to be checked
+ * @param[in] histName Name of the hist in the hist manager where QA information will be filled
+ * @return true if the jet passes the criteria. false otherwise.
+ */
+bool AliAnalysisTaskEmcalJetHdEdxCorrelations::CheckForMatchedJet(AliJetContainer * jets, AliEmcalJet * jet, const std::string & histName)
+{
+  bool returnValue = false;
+  if (jet->ClosestJet()) {
+    fHistManager.FillTH1(histName.c_str(), "matchedJet");
+    returnValue = true;
+    // TODO: Can it be merged with the function in JetHPerformance?
+    AliDebugStream(4) << "Jet is matched!\nJet: " << jet->toString() << "\n";
+    // Check shared momentum fraction
+    // We explicitly want to use indices instead of geometric matching
+    double sharedFraction = jets->GetFractionSharedPt(jet, nullptr);
+    if (sharedFraction < fMinSharedMomentumFraction) {
+      AliDebugStream(4) << "Jet rejected due to shared momentum fraction of " << sharedFraction << ", which is smaller than the min momentum fraction of " << fMinSharedMomentumFraction << "\n";
+      returnValue = false;
+    }
+    else {
+      AliDebugStream(4) << "Passed shared momentum fraction with value of " << sharedFraction << "\n";
+      fHistManager.FillTH1(histName.c_str(), "sharedMomentumFraction");
+    }
+
+    if (fRequireMatchedPartLevelJet) {
+      AliEmcalJet * detLevelJet = jet->ClosestJet();
+      AliEmcalJet * partLevelJet = detLevelJet->ClosestJet();
+      if (!partLevelJet) {
+        AliDebugStream(4) << "Jet rejected due to no matching part level jet.\n";
+        returnValue = false;
+      }
+      else {
+        AliDebugStream(4) << "Det level jet has a required match to a part level jet.\n" << "Part level jet: " << partLevelJet->toString() << "\n";
+        fHistManager.FillTH1(histName.c_str(), "partLevelMatchedJet");
+      }
+    }
+
+    // Only check matched jet distance if a value has been set
+    if (fMaxMatchedJetDistance > 0) {
+      double matchedJetDistance = jet->ClosestJetDistance();
+      if (matchedJetDistance > fMaxMatchedJetDistance) {
+        AliDebugStream(4) << "Jet rejected due to matching distance of " << matchedJetDistance << ", which is larger than the max distance of " << fMaxMatchedJetDistance << "\n";
+        returnValue = false;
+      }
+      else {
+        AliDebugStream(4) << "Jet passed distance cut with distance of " << matchedJetDistance << "\n";
+        fHistManager.FillTH1(histName.c_str(), "jetDistance");
+      }
+    }
+
+    // Record all cuts passed
+    if (returnValue == true) {
+      fHistManager.FillTH1(histName.c_str(), "passedAllCuts");
+    }
+  }
+  else {
+    AliDebugStream(5) << "Rejected jet because it was not matched to a external event jet.\n";
+    fHistManager.FillTH1(histName.c_str(), "noMatch");
+    returnValue = false;
+  }
+
+  return returnValue;
+}
+
+/**
+ * Creates a new THnSparseF based on the desired number of entries. Note that the axes are defined in
+ * GetDimParams().
+ *
+ * @param[in] name Name of the new THnSparseF
+ * @param[in] entries Bits corresponding to entires to include in the THnSparseF, with the axis deteremined in GetDimParams().
+ */
+THnSparse* AliAnalysisTaskEmcalJetHdEdxCorrelations::NewTHnSparseF(const char* name, UInt_t entries)
+{
+  Int_t count = 0;
+  UInt_t tmp = entries;
+  while(tmp!=0){
+    count++;
+    tmp = tmp &~ -tmp;  // clear lowest bit
+  }
+
+  TString hnTitle(name);
+  const Int_t dim = count;
+  Int_t nbins[dim];
+  Double_t xmin[dim];
+  Double_t xmax[dim];
+
+  Int_t i=0;
+  Int_t c=0;
+  while(c<dim && i<32){
+    if(entries&(1<<i)){
+      TString label("");
+      GetDimParams(i, label, nbins[c], xmin[c], xmax[c]);
+      hnTitle += Form(";%s",label.Data());
+      c++;
+    }
+
+    i++;
+  }
+  hnTitle += ";";
+
+  return new THnSparseF(name, hnTitle.Data(), dim, nbins, xmin, xmax);
+}
+
+/**
+ * Stores labels and binning of axes for creating a new THnSparseF.
+ *
+ * @param[in] iEntry Which axis to pick out of the cases.
+ * @param[out] label Label of the axis.
+ * @param[out] nbins Number of bins for the axis.
+ * @param[out] xmin Minimum value of the axis.
+ * @param[out] xmax Maximum value of the axis.
+ */
+void AliAnalysisTaskEmcalJetHdEdxCorrelations::GetDimParams(Int_t iEntry, TString &label, Int_t &nbins, Double_t &xmin, Double_t &xmax)
+{
+  const Double_t pi = TMath::Pi();
+
+  switch(iEntry){
+
+    case 0:
+      label = "V0 centrality (%)";
+      nbins = 10;
+      xmin = 0.;
+      xmax = 100.;
+      // Adjust for pp, since we are retrieving multiplicity instead
+      if (fForceBeamType == AliAnalysisTaskEmcal::kpp) {
+        label = "Multiplicity";
+        xmax = 200.;
+      }
+      break;
+
+    case 1:
+      label = "Jet p_{T}";
+      nbins = 24;
+      xmin = -40.;
+      xmax = 200.;
+      break;
+
+    case 2:
+      if(fDoWiderTrackBin) {
+        label = "Track p_{T}";
+        nbins = 40;
+        xmin = 0.;
+        xmax = 10.;
+      } else {
+        label = "Track p_{T}";
+        nbins = 100;
+        xmin = 0.;
+        xmax = 10;
+      }
+      break;
+
+    case 3:
+      label = "#Delta#eta";
+      nbins = 28;
+      xmin = -1.4;
+      xmax = 1.4;
+      break;
+
+    case 4:
+      label = "#Delta#phi";
+      nbins = 72;
+      xmin = -0.5*pi;
+      xmax = 1.5*pi;
+      break;
+
+    case 5:
+      label = "Leading Jet";
+      nbins = 3;
+      xmin = -0.5;
+      xmax = 2.5;
+      break;
+
+    case 6:
+      label = "Trigger track";
+      nbins = 10;
+      xmin = 0;
+      xmax = 50;
+      break;
+
+    case 7:
+      label = "Event plane angle";
+      nbins = 3;
+      xmin = 0;
+      xmax = TMath::Pi()/2.;
+      break;
+
+    case 8:
+      label = "Z vertex (cm)";
+      nbins = 10;
+      xmin = -10;
+      xmax = 10;
+      break;
+
+    case 9:
+      label = "deltaR";
+      nbins = 10;
+      xmin = 0.;
+      xmax = 5.0;
+      break;
+
+    case 10:
+      label = "Leading track";
+      nbins = 20;
+      xmin = 0;
+      xmax = 50;
+      break;
+
+    case 11:
+      label = "TPC dE/dx";
+      nbins = 100;
+      xmin = 20.0;
+      xmax = 120.0;
+      break;
+  }
+}
+
+/**
+ * Clone tracks into a lighter object (AliBasicParticle) to store in the event pool. By using
+ * lighter objects, it reduces the event pool size in memory. Adapted from CF event mixing
+ * code PhiCorrelations.
+ *
+ * @return Array containing the lighter track objects.
+ */
+TObjArray* AliAnalysisTaskEmcalJetHdEdxCorrelations::CloneAndReduceTrackList(std::vector<unsigned int> & rejectedTrackIndices, const bool useRejectedList)
+{
+  // clones a track list by using AliBasicTrack which uses much less memory (used for event mixing)
+  TObjArray* tracksClone = new TObjArray;
+  tracksClone->SetOwner(kTRUE);
+
+  // Loop over all tracks
+  AliVParticle * particle = 0;
+  AliBasicParticle * clone = 0;
+  AliTrackContainer * tracks = GetTrackContainer("tracksForCorrelations");
+
+  auto particlesIter = tracks->accepted_momentum();
+  for (auto particleIter = particlesIter.begin(); particleIter != particlesIter.end(); particleIter++)
+  {
+    // Retrieve the particle
+    particle = particleIter->second;
+
+    // Artificial inefficiency
+    bool rejectParticle = CheckArtificialTrackEfficiency(particleIter.current_index(), rejectedTrackIndices, useRejectedList);
+    if (rejectParticle) {
+      AliDebugStream(4) << "Track rejected in CloneAndReduceTrackList()\n";
+      continue;
+    }
+
+    // Fill some QA information about the tracks
+    Int_t trackPtBin = GetTrackPtBin(particle->Pt());
+    if(trackPtBin > -1) fHistTrackEtaPhi[trackPtBin]->Fill(particle->Eta(),particle->Phi());
+
+    // Create new particle
+    clone = new AliBasicParticle(particle->Eta(), particle->Phi(), particle->Pt(), particle->Charge());
+    // Set so that we can do comparisons using the IsEqual() function.
+    clone->SetUniqueID(particle->GetUniqueID());
+
+    tracksClone->Add(clone);
+  }
+
+  return tracksClone;
+}
+
+/**
+ * Utility function to apply the determine the single track efficiency.
+ *
+ * @param trackEta Eta of the track
+ * @param trackPt pT of the track
+ *
+ * @return Track efficiency of the track (the entry in a histogram should be weighted as 1/(return value))
+ */
+Double_t AliAnalysisTaskEmcalJetHdEdxCorrelations::EffCorrection(Double_t trackEta, Double_t trackPt) const {
+  return AliAnalysisTaskEmcalJetHUtils::DetermineTrackingEfficiency(
+   trackPt, trackEta, fCentBin, fEfficiencyPeriodIdentifier,
+   "PWGJE::EMCALJetTasks::AliAnalysisTaskEmcalJetHdEdxCorrelations");
+}
+
+/**
+ * Utility function to fill a histogram with a given weight. If requested, it will also apply the JES correction derived weight
+ * to the hist.
+ *
+ * @param[in] hist Histogram to be filled.
+ * @param[in] fillValue The value to be filled into the hist.
+ * @param[in] weight The weight to be applied when filling the hist.
+ * @param[in] noCorrection True if the JES correction _should not_ be applied.
+ */
+void AliAnalysisTaskEmcalJetHdEdxCorrelations::FillHist(TH1 * hist, Double_t fillValue, Double_t weight, Bool_t noCorrection)
+{
+  if (fJESCorrectionHist == 0 || noCorrection == kTRUE)
+  {
+    AliDebugStream(3) << GetName() << ":" << hist->GetName() << ": " << std::boolalpha << "Using normal weights: JESHist: " << (fJESCorrectionHist ? fJESCorrectionHist->GetName() : "Null") << ", noCorrection: " << noCorrection << std::endl;
+    hist->Fill(fillValue, weight);
+  }
+  else
+  {
+    // Determine where to get the values in the correction hist
+    Int_t xBin = fJESCorrectionHist->GetXaxis()->FindBin(fillValue);
+
+    std::vector <Double_t> yBinsContent;
+    AliDebug(3, TString::Format("%s: Attempt to access weights from JES correction hist %s with jet pt %f!", GetName(), hist->GetName(), fillValue));
+    AccessSetOfYBinValues(fJESCorrectionHist, xBin, yBinsContent);
+    AliDebug(3, TString::Format("weights size: %zd", yBinsContent.size()));
+
+    // Loop over all possible bins to contribute.
+    // If content is 0 then calling Fill won't make a difference
+    for (Int_t index = 1; index <= fJESCorrectionHist->GetYaxis()->GetNbins(); index++)
+    {
+      // Don't bother trying to fill in the weight is 0
+      if (yBinsContent.at(index-1) > 0) {
+        // Determine the value to fill based on the center of the bins.
+        // This in principle allows the binning between the correction and hist to be different
+        Double_t fillLocation = fJESCorrectionHist->GetYaxis()->GetBinCenter(index);
+        AliDebug(4, TString::Format("fillLocation: %f, weight: %f", fillLocation, yBinsContent.at(index-1)));
+        // minus 1 since loop starts at 1
+        hist->Fill(fillLocation, weight*yBinsContent.at(index-1));
+      }
+    }
+
+    //TEMP
+    //hist->Draw();
+    //END TEMP
+  }
+}
+
+/**
+ * Utility function to fill a histogram with a given weight. If requested, it will also apply the JES correction
+ * derived weight to the hist. It assumes that the corrected jet pt value is located in the second element of the
+ * fillValue (as defined in GetDimParams()). If that is changed or the first entry is not included, then this
+ * function must be updated!
+ *
+ * @param[in] hist Histogram to be filled.
+ * @param[in] fillValue Array of values to be filled into the hist.
+ * @param[in] weight The weight to be applied when filling the hist.
+ * @param[in] noCorrection True if the JES correction _should not_ be applied.
+ */
+void AliAnalysisTaskEmcalJetHdEdxCorrelations::FillHist(THnSparse * hist, Double_t *fillValue, Double_t weight, Bool_t noCorrection)
+{
+  if (fJESCorrectionHist == 0 || noCorrection == kTRUE)
+  {
+    AliDebugStream(3) << GetName() << ":" << hist->GetName() << ": " << std::boolalpha << "Using normal weights: JESHist: " << (fJESCorrectionHist ? fJESCorrectionHist->GetName() : "Null") << ", noCorrection: " << noCorrection << std::endl;
+    hist->Fill(fillValue, weight);
+  }
+  else
+  {
+    // Jet pt is always located in the second position
+    Double_t jetPt = fillValue[1];
+
+    // Determine where to get the values in the correction hist
+    Int_t xBin = fJESCorrectionHist->GetXaxis()->FindBin(jetPt);
+
+    std::vector <Double_t> yBinsContent;
+    AliDebug(3, TString::Format("%s: Attempt to access weights from JES correction hist %s with jet pt %f!", GetName(), hist->GetName(), jetPt));
+    AccessSetOfYBinValues(fJESCorrectionHist, xBin, yBinsContent);
+    AliDebug(3, TString::Format("weights size: %zd", yBinsContent.size()));
+
+    // Loop over all possible bins to contribute.
+    // If content is 0 then calling Fill won't make a difference
+    for (Int_t index = 1; index <= fJESCorrectionHist->GetYaxis()->GetNbins(); index++)
+    {
+      // Don't bother trying to fill in the weight is 0
+      if (yBinsContent.at(index-1) > 0) {
+        // Determine the value to fill based on the center of the bins.
+        // This in principle allows the binning between the correction and hist to be different
+        fillValue[1] = fJESCorrectionHist->GetYaxis()->GetBinCenter(index);
+        AliDebug(4,TString::Format("fillValue[1]: %f, weight: %f", fillValue[1], yBinsContent.at(index-1)));
+        // minus 1 since loop starts at 1
+        hist->Fill(fillValue, weight*yBinsContent.at(index-1));
+      }
+    }
+  }
+}
+
+/**
+ * Access the array of y bin values for a given x bin. If the scaleFactor is greater than 0, then the values in yBinsContent will be set
+ * in the given histogram with the values scaled by the scale factor. This scaling can be used to normalize the histogram.
+ *
+ * @param[in] hist Histogram from which the bins should be extracted.
+ * @param[in] xBin X bin where the y bins should be extracted.
+ * @param[in,out] yBinsContent Array containing the y bins contents for the given x bin.
+ * @param[in] scaleFactor Scale factor to be applied to the
+ */
+void AliAnalysisTaskEmcalJetHdEdxCorrelations::AccessSetOfYBinValues(TH2D * hist, Int_t xBin, std::vector <Double_t> & yBinsContent, Double_t scaleFactor)
+{
+  for (Int_t index = 1; index <= hist->GetYaxis()->GetNbins(); index++)
+  {
+    //yBinsContent[index-1] = hist->GetBinContent(hist->GetBin(xBin,index));
+    yBinsContent.push_back(hist->GetBinContent(hist->GetBin(xBin,index)));
+
+    if (scaleFactor >= 0)
+    {
+      // -1 since index starts at 1
+      hist->SetBinContent(hist->GetBin(xBin,index), yBinsContent.at(index-1)/scaleFactor);
+    }
+  }
+}
+
+/**
+ * Attempt to retrieve and initialize the jet energy scale correction histogram with a given name.
+ * If successfully initialized, "_JESCorr" is added to the task name before the last underscore
+ * (which is usually the suffix).
+ *
+ * @param filename Name of file which contais the JES correction histogram.
+ * @param histName Name of the JES correction histogram in the file.
+ * @param trackBias The track bias used to create the JES correction histogram. Usually should match
+ *     the track bias set in the task. The string ("_track%.2f", trackBias) will be appended to the hist name
+ *     if this value is not set to be disabled.
+ * @param clusterBias The cluster bias used to create the JES correction histogram. Usually should match
+ *     the track bias set in the task. The string ("_clus%.2f", clusterBias) will be appended to the hist name
+ *     if this value is not set to be disabled.
+ *
+ * @return kTRUE if the histogram is successfully retrieve and initialized.
+ */
+Bool_t AliAnalysisTaskEmcalJetHdEdxCorrelations::RetrieveAndInitializeJESCorrectionHist(TString filename, TString histName, Double_t trackBias, Double_t clusterBias)
+{
+  // Initialize grid connection if necessary
+  if (filename.Contains("alien://") && !gGrid) {
+    TGrid::Connect("alien://");
+  }
+
+  // Setup hist name if a track or cluster bias was defined.
+  // NOTE: This can always be disabled by setting kDisableBias.
+  //       We arbitrarily add 0.1 to test since the values are doubles and cannot be
+  //       tested directly for equality. If we are still less than disable bins, then
+  //       it has been set and we should format it.
+  // NOTE: To ensure we can disable, we don't just take the member values!
+  // NOTE: The histBaseName will be attempted if the formatted name cannot be found.
+  TString histBaseName = histName;
+  if (trackBias + 0.1 < AliAnalysisTaskEmcalJetHdEdxCorrelations::kDisableBias) {
+    histName = TString::Format("%s_Track%.2f", histName.Data(), trackBias);
+  }
+  if (clusterBias + 0.1 < AliAnalysisTaskEmcalJetHdEdxCorrelations::kDisableBias) {
+    histName = TString::Format("%s_Clus%.2f", histName.Data(), clusterBias);
+  }
+
+  // Open file containing the correction
+  TFile * jesCorrectionFile = TFile::Open(filename);
+  if (!jesCorrectionFile || jesCorrectionFile->IsZombie()) {
+    AliError(TString::Format("%s: Could not open JES correction file %s", GetName(), filename.Data()));
+    return kFALSE;
+  }
+
+  // Retrieve the histogram containing the correction and safely add it to the task.
+  TH2D * JESCorrectionHist = dynamic_cast<TH2D*>(jesCorrectionFile->Get(histName.Data()));
+  if (JESCorrectionHist) {
+    AliInfo(TString::Format("%s: JES correction hist name \"%s\" loaded from file %s.", GetName(), histName.Data(), filename.Data()));
+  }
+  else {
+    AliError(TString::Format("%s: JES correction hist name \"%s\" not found in file %s.", GetName(), histName.Data(), filename.Data()));
+
+    // Attempt the base name instead of the formatted hist name
+    JESCorrectionHist = dynamic_cast<TH2D*>(jesCorrectionFile->Get(histBaseName.Data()));
+    if (JESCorrectionHist) {
+      AliInfo(TString::Format("%s: JES correction hist name \"%s\" loaded from file %s.", GetName(), histBaseName.Data(), filename.Data()));
+      histName = histBaseName;
+    }
+    else
+    {
+      AliError(TString::Format("%s: JES correction with base hist name %s not found in file %s.", GetName(), histBaseName.Data(), filename.Data()));
+      return kFALSE;
+    }
+  }
+
+  // Clone to ensure that the hist is available
+  TH2D * tempHist = static_cast<TH2D *>(JESCorrectionHist->Clone());
+  tempHist->SetDirectory(0);
+  SetJESCorrectionHist(tempHist);
+
+  // Close file
+  jesCorrectionFile->Close();
+
+  // Append to task name for clarity
+  // Unfortunately, this doesn't change the name of the output list (it would need to be
+  // changed in the AnalysisManager output container), so the suffix is still important
+  // if this correction is manually configured!
+  TString tempName = GetName();
+  TString tag = "_JESCorr";
+  // Append the tag if it isn't already included
+  if (tempName.Index(tag) == -1) {
+    // Insert before the suffix
+    Ssiz_t suffixLocation = tempName.Last('_');
+    tempName.Insert(suffixLocation, tag.Data());
+
+    // Set the new name
+    AliDebug(3, TString::Format("%s: Setting task name to %s", GetName(), tempName.Data()));
+    SetName(tempName.Data());
+  }
+
+  // Successful
+  return kTRUE;
+}
+
+/**
+ * AddTask for the jet-hadron task. We benefit for actually having compiled code, as opposed to
+ * struggling with CINT.
+ */
+AliAnalysisTaskEmcalJetHdEdxCorrelations * AliAnalysisTaskEmcalJetHdEdxCorrelations::AddTaskEmcalJetHdEdxCorrelations(
+   const char *nTracks,
+   const char *nCaloClusters,
+   // Jet options
+   const Double_t trackBias,
+   const Double_t clusterBias,
+   // Mixed event options
+   const Int_t nTracksMixedEvent,  // Additionally acts as a switch for enabling mixed events
+   const Int_t minNTracksMixedEvent,
+   const Int_t minNEventsMixedEvent,
+   const UInt_t nCentBinsMixedEvent,
+   // Triggers
+   UInt_t trigEvent,
+   UInt_t mixEvent,
+   // Options
+   const Bool_t lessSparseAxes,
+   const Bool_t widerTrackBin,
+   // Corrections
+   const Bool_t JESCorrection,
+   const char * JESCorrectionFilename,
+   const char * JESCorrectionHistName,
+   const char *suffix
+   )
+{
+  // Get the pointer to the existing analysis manager via the static access method.
+  //==============================================================================
+  AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
+  if (!mgr)
+  {
+    AliErrorClass("No analysis manager to connect to.");
+    return nullptr;
+  }
+
+  //-------------------------------------------------------
+  // Init the task and do settings
+  //-------------------------------------------------------
+
+  // Determine cluster and track names
+  TString trackName(nTracks);
+  TString clusName(nCaloClusters);
+
+  if (trackName == "usedefault") {
+    trackName = AliEmcalContainerUtils::DetermineUseDefaultName(AliEmcalContainerUtils::kTrack);
+  }
+
+  if (clusName == "usedefault") {
+    clusName = AliEmcalContainerUtils::DetermineUseDefaultName(AliEmcalContainerUtils::kCluster);
+  }
+
+  TString name("AliAnalysisTaskJetH");
+  if (!trackName.IsNull()) {
+    name += TString::Format("_%s", trackName.Data());
+  }
+  if (!clusName.IsNull()) {
+    name += TString::Format("_%s", clusName.Data());
+  }
+  if (strcmp(suffix, "") != 0) {
+    name += TString::Format("_%s", suffix);
+  }
+
+  AliAnalysisTaskEmcalJetHdEdxCorrelations *correlationTask = new AliAnalysisTaskEmcalJetHdEdxCorrelations(name);
+  // Set jet bias
+  correlationTask->SetTrackBias(trackBias);
+  correlationTask->SetClusterBias(clusterBias);
+  // Mixed events
+  correlationTask->SetEventMixing(static_cast<Bool_t>(nTracksMixedEvent));
+  correlationTask->SetNumberOfMixingTracks(nTracksMixedEvent);
+  correlationTask->SetMinNTracksForMixedEvents(minNTracksMixedEvent);
+  correlationTask->SetMinNEventsForMixedEvents(minNEventsMixedEvent);
+  correlationTask->SetNCentBinsMixedEvent(nCentBinsMixedEvent);
+  // Triggers
+  correlationTask->SetTriggerType(trigEvent);
+  correlationTask->SetMixedEventTriggerType(mixEvent);
+  // Options
+  correlationTask->SetNCentBins(5);
+  correlationTask->SetDoLessSparseAxes(lessSparseAxes);
+  correlationTask->SetDoWiderTrackBin(widerTrackBin);
+  // Corrections
+  if (JESCorrection == kTRUE)
+  {
+    Bool_t result = correlationTask->RetrieveAndInitializeJESCorrectionHist(JESCorrectionFilename, JESCorrectionHistName, correlationTask->GetTrackBias(), correlationTask->GetClusterBias());
+    if (!result) {
+      AliErrorClass("Failed to successfully retrieve and initialize the JES correction! Task initialization continuing without JES correction (can be set manually later).");
+    }
+  }
+
+  //-------------------------------------------------------
+  // Final settings, pass to manager and set the containers
+  //-------------------------------------------------------
+
+  mgr->AddTask(correlationTask);
+
+  // Create containers for input/output
+  mgr->ConnectInput (correlationTask, 0, mgr->GetCommonInputContainer() );
+  AliAnalysisDataContainer* cojeth =
+   mgr->CreateContainer(correlationTask->GetName(), TList::Class(), AliAnalysisManager::kOutputContainer,
+              Form("%s", AliAnalysisManager::GetCommonFileName()));
+  mgr->ConnectOutput(correlationTask, 1, cojeth);
+
+  return correlationTask;
+}
+
+/**
+ * Call after the AddTask to setup the standard Jet-h configuration.
+ *
+ * @return true if sucessfully configured for the standard configuration
+ */
+bool AliAnalysisTaskEmcalJetHdEdxCorrelations::ConfigureForStandardAnalysis(std::string trackName,
+    std::string clusName,
+    const double jetConstituentPtCut,
+    const double trackEta,
+    const double jetRadius)
+{
+  bool returnValue = false;
+  AliInfoStream() << "Configuring Jet-H Correlations task for a standard analysis.\n";
+
+  // Add Containers
+  // Clusters
+  if (clusName == "usedefault") {
+    clusName = AliEmcalContainerUtils::DetermineUseDefaultName(AliEmcalContainerUtils::kCluster);
+  }
+  // For jet finding
+  AliClusterContainer * clustersForJets = new AliClusterContainer(clusName.c_str());
+  clustersForJets->SetName("clustersForJets");
+  clustersForJets->SetMinE(jetConstituentPtCut);
+
+  // Tracks
+  // For jet finding
+  if (trackName == "usedefault") {
+    trackName = AliEmcalContainerUtils::DetermineUseDefaultName(AliEmcalContainerUtils::kTrack);
+  }
+  AliParticleContainer * particlesForJets = AliAnalysisTaskEmcalJetHUtils::CreateParticleOrTrackContainer(trackName.c_str());
+  particlesForJets->SetName("particlesForJets");
+  particlesForJets->SetMinPt(jetConstituentPtCut);
+  particlesForJets->SetEtaLimits(-1.0*trackEta, trackEta);
+
+
+  // Don't need to adopt the container - we'll just use it to find the right jet collection
+  // For correlations
+  AliParticleContainer * particlesForCorrelations = AliAnalysisTaskEmcalJetHUtils::CreateParticleOrTrackContainer(trackName.c_str());
+  if (particlesForCorrelations)
+  {
+
+    particlesForCorrelations->SetName("tracksForCorrelations");
+    particlesForCorrelations->SetMinPt(0.15);
+    particlesForCorrelations->SetEtaLimits(-1.0*trackEta, trackEta);
+    // Adopt the container
+    this->AdoptParticleContainer(particlesForCorrelations);
+  }
+  else {
+    AliWarningStream() << "No particle container was successfully created!\n";
+  }
+
+  // Jets
+  AliJetContainer * jetContainer = this->AddJetContainer(AliJetContainer::kFullJet,
+                              AliJetContainer::antikt_algorithm,
+                              AliJetContainer::pt_scheme,
+                              jetRadius,
+                              AliEmcalJet::kEMCALfid,
+                              particlesForJets,
+                              clustersForJets);
+  // 0.6 * jet area
+  jetContainer->SetJetAreaCut(jetRadius * jetRadius * TMath::Pi() * 0.6);
+  jetContainer->SetMaxTrackPt(100);
+  jetContainer->SetJetPtCut(0.1);
+
+  // Successfully configured
+  returnValue = true;
+
+  return returnValue;
+}
+
+/**
+ * Call after the AddTask to setup the embedded Jet-h configuration.
+ *
+ * @return true if successfully configured for embedding
+ */
+bool AliAnalysisTaskEmcalJetHdEdxCorrelations::ConfigureForEmbeddingAnalysis(std::string trackName,
+    std::string clusName,
+    const double jetConstituentPtCut,
+    const double trackEta,
+    const double jetRadius,
+    const std::string & jetTag,
+    const std::string & correlationsTracksCutsPeriod)
+{
+  bool returnValue = false;
+  AliInfoStream() << "Configuring Jet-H Correlations task for an embedding analysis.\n";
+
+  // Set the task to know it that is embedded
+  this->SetIsEmbedded(true);
+
+  // Add Containers
+  // Clusters
+  if (clusName == "usedefault") {
+    clusName = AliEmcalContainerUtils::DetermineUseDefaultName(AliEmcalContainerUtils::kCluster);
+  }
+  // For jet finding
+  AliClusterContainer * clustersForJets = new AliClusterContainer(clusName.c_str());
+  clustersForJets->SetName("clustersForJets");
+  clustersForJets->SetMinE(jetConstituentPtCut);
+  // We need the combined clusters, which should be available in the internal event.
+  // However, we don't need to adopt the container - we'll just use it to find the right jet collection
+  // For correlations
+  /*AliClusterContainer * clustersforCorrelations = new AliClusterContainer("usedefault");
+  clustersForCorrelations->SetName("clustersForCorrelations");
+  clustersForCorrelations->SetMinE(0.30);
+  clustersForCorrelations->SetIsEmbedding(true);
+  this->AdoptClusterContainer(clustersForCorrelations);*/
+
+  // Tracks
+  // For jet finding
+  if (trackName == "usedefault") {
+    trackName = AliEmcalContainerUtils::DetermineUseDefaultName(AliEmcalContainerUtils::kTrack);
+  }
+  AliParticleContainer * particlesForJets = AliAnalysisTaskEmcalJetHUtils::CreateParticleOrTrackContainer(trackName.c_str());
+  particlesForJets->SetName("particlesForJets");
+  particlesForJets->SetMinPt(jetConstituentPtCut);
+  particlesForJets->SetEtaLimits(-1.0*trackEta, trackEta);
+  // Don't need to adopt the container - we'll just use it to find the right jet collection
+  // For correlations
+  AliParticleContainer * particlesForCorrelations = AliAnalysisTaskEmcalJetHUtils::CreateParticleOrTrackContainer(trackName.c_str());
+  // Ensure that we don't operate on a null pointer
+  if (particlesForCorrelations)
+  {
+    particlesForCorrelations->SetName("tracksForCorrelations");
+    particlesForCorrelations->SetMinPt(0.15);
+    particlesForCorrelations->SetEtaLimits(-1.0*trackEta, trackEta);
+    particlesForCorrelations->SetIsEmbedding(true);
+    AliTrackContainer * trackCont = dynamic_cast<AliTrackContainer *>(particlesForCorrelations);
+    if (trackCont) {
+      // This option only exists for track containers
+      trackCont->SetTrackCutsPeriod(correlationsTracksCutsPeriod.c_str());
+    }
+    // Adopt the container
+    this->AdoptParticleContainer(particlesForCorrelations);
+  }
+  else {
+    AliWarningStream() << "No particle container was successfully created!\n";
+  }
+
+  // Jets
+  // The tag "hybridLevelJets" is defined in the jet finder
+  AliJetContainer * jetContainer = this->AddJetContainer(AliJetContainer::kFullJet,
+                              AliJetContainer::antikt_algorithm,
+                              AliJetContainer::pt_scheme,
+                              jetRadius,
+                              AliEmcalJet::kEMCALfid,
+                              particlesForJets,
+                              clustersForJets,
+                              jetTag);
+  // 0.6 * jet area
+  jetContainer->SetJetAreaCut(jetRadius * jetRadius * TMath::Pi() * 0.6);
+  jetContainer->SetMaxTrackPt(100);
+  jetContainer->SetJetPtCut(0.1);
+
+  // Successfully configured
+  returnValue = true;
+
+  return returnValue;
+}
+
+/**
+ * Prints information about the jet-hadron correlations task.
+ *
+ * @return std::string containing information about the task.
+ */
+std::string AliAnalysisTaskEmcalJetHdEdxCorrelations::toString() const
+{
+  std::stringstream tempSS;
+  tempSS << std::boolalpha;
+  tempSS << "Jet collections:\n";
+  TIter next(&fJetCollArray);
+  AliJetContainer * jetCont;
+  while ((jetCont = static_cast<AliJetContainer *>(next()))) {
+    tempSS << "\t" << jetCont->GetName() << ": " << jetCont->GetArrayName() << "\n";
+  }
+  tempSS << "Event selection\n";
+  tempSS << "\tUse AliEventCuts: " << !fUseBuiltinEventSelection << "\n";
+  tempSS << "\tTrigger event selection: " << std::bitset<32>(fTriggerType) << "\n";
+  tempSS << "\tMixed event selection: " << std::bitset<32>(fMixingEventType) << "\n";
+  tempSS << "\tEnabled only for non-fast partition: " << fDisableFastPartition << "\n";
+  tempSS << "Jet settings:\n";
+  tempSS << "\tTrack bias: " << fTrackBias << "\n";
+  tempSS << "\tCluster bias: " << fClusterBias << "\n";
+  tempSS << "Event mixing:\n";
+  tempSS << "\tEnabled: " << fDoEventMixing << "\n";
+  tempSS << "\tN mixed tracks: " << fNMixingTracks << "\n";
+  tempSS << "\tMin number of tracks for mixing: " << fMinNTracksMixedEvents << "\n";
+  tempSS << "\tMin number of events for mixing: " << fMinNEventsMixedEvents << "\n";
+  tempSS << "\tNumber of centrality bins for mixing: " << fNCentBinsMixedEvent << "\n";
+  tempSS << "Histogramming options:\n";
+  tempSS << "\tLess sparse axes: " << fDoLessSparseAxes << "\n";
+  tempSS << "\tWider associated track pt bins: " << fDoWiderTrackBin << "\n";
+  tempSS << "Jet matching options for embedding:\n";
+  tempSS << "\tRequire the jet to match to a embedded jets: " << fRequireMatchedJetWhenEmbedding << "\n";
+  tempSS << "\tRequire an additional match to a part level jet: " << fRequireMatchedPartLevelJet << "\n";
+  tempSS << "\tMinimum shared momentum fraction: " << fMinSharedMomentumFraction << "\n";
+  tempSS << "\tMax matched jet distance: " << fMaxMatchedJetDistance << "\n";
+  tempSS << "Efficiency\n";
+  tempSS << "\tSingle track efficiency identifier: " << fEfficiencyPeriodIdentifier << "\n";
+  tempSS << "\tArtifical track inefficiency: " << fArtificialTrackInefficiency << "\n";
+
+  return tempSS.str();
+}
+
+/**
+ * Print jet-hadron correlations task information on an output stream using the string representation provided by
+ * AliAnalysisTaskEmcalJetHdEdxCorrelations::toString. Used by operator<<
+ * @param in output stream stream
+ * @return reference to the output stream
+ */
+std::ostream & AliAnalysisTaskEmcalJetHdEdxCorrelations::Print(std::ostream & in) const {
+  in << toString();
+  return in;
+}
+
+/**
+ * Print basic jet-hadron correlations task information using the string representation provided by
+ * AliAnalysisTaskEmcalJetHdEdxCorrelations::toString
+ *
+ * @param[in] opt Unused
+ */
+void AliAnalysisTaskEmcalJetHdEdxCorrelations::Print(Option_t* opt) const
+{
+  Printf("%s", toString().c_str());
+}
+
+} /* namespace EMCALJetTasks */
+} /* namespace PWGJE */
+
+/**
+ * Implementation of the output stream operator for AliAnalysisTaskEmcalJetHdEdxCorrelations. Printing
+ * basic jet-hadron correlations task information provided by function toString
+ * @param in output stream
+ * @param myTask Task which will be printed
+ * @return Reference to the output stream
+ */
+std::ostream & operator<<(std::ostream & in, const PWGJE::EMCALJetTasks::AliAnalysisTaskEmcalJetHdEdxCorrelations & myTask)
+{
+  std::ostream & result = myTask.Print(in);
+  return result;
+}
+

--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHdEdxCorrelations.h
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHdEdxCorrelations.h
@@ -1,0 +1,260 @@
+#ifndef AliAnalysisTaskEmcalJetHdEdxCorrelations_H
+#define AliAnalysisTaskEmcalJetHdEdxCorrelations_H
+
+/**
+ * @class AliAnalysisTaskEmcalJetHdEdxCorrelations
+ * @brief Jet-hadron correlations analysis task for central Pb-Pb and pp
+ *
+ * %Analysis task for jet-hadron correlations in central Pb-Pb and pp.
+ * Includes the ability to weight entries by the efficiency, as well
+ * as utilize a jet energy scale correction in the form of a histogram.
+ *
+ * This code has been cross checked against the code used for the event
+ * plane dependent analysis (AliAnalysisTaskEmcalJetHadEPpid).
+ *
+ * @author Raymond Ehlers <raymond.ehlers@cern.ch>, Yale University
+ * @author Megan Connors, Georgia State University
+ * @date 1 Jan 2017
+ */
+
+#include <vector>
+
+#include <TRandom3.h>
+class TH1;
+class TH2;
+class TH3;
+class THnSparse;
+
+class AliEventPoolManager;
+
+#include "AliYAMLConfiguration.h"
+#include "THistManager.h"
+#include "AliAnalysisTaskEmcalJet.h"
+#include "AliAnalysisTaskEmcalJetHUtils.h"
+class AliTLorentzVector;
+class AliEmcalJet;
+class AliJetContainer;
+class AliParticleContainer;
+
+// operator<< has to be forward declared carefully to stay in the global namespace so that it works with CINT.
+// For generally how to keep the operator in the global namespace, See: https://stackoverflow.com/a/38801633
+namespace PWGJE { namespace EMCALJetTasks { class AliAnalysisTaskEmcalJetHdEdxCorrelations; } }
+std::ostream & operator<< (std::ostream &in, const PWGJE::EMCALJetTasks::AliAnalysisTaskEmcalJetHdEdxCorrelations &myTask);
+
+namespace PWGJE {
+namespace EMCALJetTasks {
+
+class AliAnalysisTaskEmcalJetHdEdxCorrelations : public AliAnalysisTaskEmcalJet {
+ public:
+  /**
+   * @enum jetBias_t
+   * @brief Default value used to disable constituent bias
+   */
+  enum jetBias_t {
+    kDisableBias = 10000            //!<! Arbitrarily large value which can be used to disable the constituent bias. Can be used for either tracks or clusters.
+  };
+
+  AliAnalysisTaskEmcalJetHdEdxCorrelations();
+  AliAnalysisTaskEmcalJetHdEdxCorrelations(const char *name);
+  virtual ~AliAnalysisTaskEmcalJetHdEdxCorrelations() {}
+
+  Double_t                GetTrackBias() const                       { return fTrackBias; }
+  Double_t                GetClusterBias() const                     { return fClusterBias; }
+
+  // Jet bias - setters
+  /// Require a track with pt > b in jet
+  virtual void            SetTrackBias(Double_t b)                   { fTrackBias    = b; }
+  /// Require a cluster with pt > b in jet
+  virtual void            SetClusterBias(Double_t b)                 { fClusterBias = b; }
+
+  // Event trigger/mixed selection - setters
+  /// Set the trigger event trigger selection
+  virtual void            SetTriggerType(UInt_t te)                  { fTriggerType = te; }
+  /// Set the mixed event trigger selection
+  virtual void            SetMixedEventTriggerType(UInt_t me)        { fMixingEventType = me; }
+  /// True if the task should be disabled for the fast partition
+  void                    SetDisableFastPartition(Bool_t b = kTRUE)  { fDisableFastPartition = b; }
+  Bool_t                  GetDisableFastPartition() const            { return fDisableFastPartition; }
+  /// Require jet to be matched when embedding
+  Bool_t                  GetRequireMatchedJetWhenEmbedding() const   { return fRequireMatchedJetWhenEmbedding; }
+  void                    SetRequireMatchedJetWhenEmbedding(Bool_t b) { fRequireMatchedJetWhenEmbedding = b; }
+  /// Mimimum shared momentum fraction for matched jet
+  double                  GetMinimumSharedMomentumFraction() const    { return fMinSharedMomentumFraction; }
+  void                    SetMinimumSharedMomentumFraction(double d)  { fMinSharedMomentumFraction = d; }
+  double                  GetMaximumMatchedJetDistance() const        { return fMaxMatchedJetDistance; }
+  void                    SetMaximumMatchedJetDistance(double d)      { fMaxMatchedJetDistance = d; }
+  bool                    GetRequireMatchedPartLevelJet() const       { return fRequireMatchedPartLevelJet; }
+  void                    SetRequireMatchedPartLevelJet(bool b)       { fRequireMatchedPartLevelJet = b; }
+
+  // Mixed events
+  virtual void            SetEventMixing(Bool_t enable)              { fDoEventMixing = enable;}
+  virtual void            SetNumberOfMixingTracks(Int_t tracks)      { fNMixingTracks = tracks; }
+  virtual void            SetMinNTracksForMixedEvents(Int_t nmt)     { fMinNTracksMixedEvents = nmt; }
+  virtual void            SetMinNEventsForMixedEvents(Int_t nme)     { fMinNEventsMixedEvents = nme; }
+  virtual void            SetNCentBinsMixedEvent(Bool_t centbins)    { fNCentBinsMixedEvent = centbins; }
+  // Switch to cut out some unneeded sparse axis
+  void                    SetDoLessSparseAxes(Bool_t dlsa)           { fDoLessSparseAxes = dlsa; }
+  void                    SetDoWiderTrackBin(Bool_t wtrbin)          { fDoWiderTrackBin = wtrbin; }
+  /// Artificial tracking inefficiency from 0 to 1. 1.0 (default) will disable it.
+  void                    SetArtificialTrackingInefficiency(double eff) { fArtificialTrackInefficiency = eff; }
+  // Setup JES correction
+  void                    SetJESCorrectionHist(TH2D * hist)          { fJESCorrectionHist = hist; }
+  void                    SetNoMixedEventJESCorrection(Bool_t b) { fNoMixedEventJESCorrection = b; }
+
+  Bool_t                  RetrieveAndInitializeJESCorrectionHist(TString filename, TString histName, Double_t trackBias = AliAnalysisTaskEmcalJetHdEdxCorrelations::kDisableBias, Double_t clusterBias = AliAnalysisTaskEmcalJetHdEdxCorrelations::kDisableBias);
+
+  virtual void            UserCreateOutputObjects();
+
+  // AddTask
+  static AliAnalysisTaskEmcalJetHdEdxCorrelations * AddTaskEmcalJetHdEdxCorrelations(
+     const char *nTracks              = "usedefault",
+     const char *nCaloClusters        = "usedefault",
+     // Jet options
+     const Double_t trackBias         = 5,
+     const Double_t clusterBias       = 5,
+     // Mixed event options
+     const Int_t nTracksMixedEvent    = 0,  // Additionally acts as a switch for enabling mixed events
+     const Int_t minNTracksMixedEvent = 5000,
+     const Int_t minNEventsMixedEvent = 5,
+     const UInt_t nCentBinsMixedEvent = 10,
+     // Triggers
+     UInt_t trigEvent                 = AliVEvent::kAny,
+     UInt_t mixEvent                  = AliVEvent::kAny,
+     // Options
+     const Bool_t lessSparseAxes      = kFALSE,
+     const Bool_t widerTrackBin       = kFALSE,
+     const Bool_t JESCorrection = kFALSE,
+     const char * JESCorrectionFilename = "alien:///alice/cern.ch/user/r/rehlersi/JESCorrection.root",
+     const char * JESCorrectionHistName = "JESCorrection",
+     const char *suffix               = "biased"
+   );
+
+  bool ConfigureForStandardAnalysis(std::string trackName = "usedefault",
+    std::string clusName = "usedefault",
+    const double jetConstituentPtCut = 3,
+    const double trackEta = 0.8,
+    const double jetRadius = 0.2);
+
+  bool ConfigureForEmbeddingAnalysis(std::string trackName = "usedefault",
+    std::string clusName = "caloClustersCombined",
+    const double jetConstituentPtCut = 3,
+    const double trackEta = 0.8,
+    const double jetRadius = 0.2,
+    const std::string & jetTag = "hybridLevelJets",
+    const std::string & correlationsTracksCutsPeriod = "lhc11a");
+
+  // Task configuration
+  void AddConfigurationFile(const std::string & configurationPath, const std::string & configName = "") { fYAMLConfig.AddConfiguration(configurationPath, configName); }
+  bool Initialize();
+
+  // Printing
+  std::string toString() const;
+  friend std::ostream & ::operator<<(std::ostream &in, const AliAnalysisTaskEmcalJetHdEdxCorrelations &myTask);
+  void Print(Option_t* opt = "") const;
+  std::ostream & Print(std::ostream &in) const;
+
+ protected:
+
+  // NOTE: This is not an ideal way to resolve the size of histogram initialization.
+  //       Will be resolved when we move fully to the THnSparse
+  /**
+   * @enum binArrayLimits_t
+   * @brief Define the number of elements in various arrays
+   */
+  enum binArrayLimits_t {
+    kMaxTrackPtBins = 7,             //!<! Number of elements in track pt binned arrays
+    kMaxCentralityBins = 5,          //!<! Number of elements in centrality binned arrays
+    kMixedEventMultiplicityBins = 8, //!<! Number of elements in mixed event multiplicity binned arrays
+  };
+
+  // EMCal framework functions
+  virtual void UserExecOnce();
+  Bool_t Run();
+
+  // Utility functions
+  // Determine if a jet has been matched
+  bool CheckForMatchedJet(AliJetContainer * jets, AliEmcalJet * jet, const std::string & histName);
+  // Apply artificial tracking inefficiency
+  bool CheckArtificialTrackEfficiency(unsigned int trackIndex, std::vector<unsigned int> & rejectedTrackIndices, bool useRejectedList);
+  // Reduce event mixing memory usage
+  TObjArray*             CloneAndReduceTrackList(std::vector<unsigned int> & rejectedTrackIndices, const bool useRejectedList);
+  // Histogram helper functions
+  virtual THnSparse*     NewTHnSparseF(const char* name, UInt_t entries);
+  virtual void           GetDimParams(Int_t iEntry,TString &label, Int_t &nbins, Double_t &xmin, Double_t &xmax);
+  // Binning helper functions
+  Int_t                  GetTrackPtBin(Double_t pt) const;
+  UInt_t                 RetrieveTriggerMask() const;
+  // Helper functions
+  void                   InitializeArraysToZero();
+  void                   GetDeltaEtaDeltaPhiDeltaR(AliTLorentzVector & particleOne, AliVParticle * particleTwo, Double_t & deltaEta, Double_t & deltaPhi, Double_t & deltaR);
+  Double_t               GetRelativeEPAngle(Double_t jetAngle, Double_t epAngle) const;
+  // Test for biased jet
+  Bool_t                 BiasedJet(AliEmcalJet * jet);
+  // Corrections
+  Double_t               EffCorrection(Double_t trackEta, Double_t trackPt) const;
+
+  // Fill methods which allow for the JES correction
+  void                   FillHist(TH1 * hist, Double_t fillValue, Double_t weight = 1.0, Bool_t noCorrection = kFALSE);
+  void                   FillHist(THnSparse * hist, Double_t *fillValue, Double_t weight = 1.0, Bool_t noCorrection = kFALSE);
+  void                   AccessSetOfYBinValues(TH2D * hist, Int_t xBin, std::vector <Double_t> & yBinsContent, Double_t scaleFactor = -1.0);
+
+  // Configuration
+  void RetrieveAndSetTaskPropertiesFromYAMLConfig();
+
+  // Configuration
+  PWG::Tools::AliYAMLConfiguration fYAMLConfig;   ///< YAML configuration file.
+  bool fConfigurationInitialized;                 ///<  True if the task configuration has been successfully initialized.
+  // Jet bias
+  Double_t               fTrackBias;               ///< Jet track bias
+  Double_t               fClusterBias;             ///< Jet cluster bias
+  // Event Mixing
+  Bool_t                 fDoEventMixing;           ///< flag to do event mixing
+  Int_t                  fNMixingTracks;           ///< size of track buffer for event mixing
+  Int_t                  fMinNTracksMixedEvents;   ///< threshold to use event pool # tracks
+  Int_t                  fMinNEventsMixedEvents;   ///< threshold to use event pool # events
+  UInt_t                 fNCentBinsMixedEvent;     ///< N cent bins for the event mixing pool
+  AliEventPoolManager   *fPoolMgr;                 //!<! Event pool manager
+  // Event selection types
+  UInt_t                 fTriggerType;             ///< Event selection for jets (ie triggered events).
+  UInt_t                 fMixingEventType;         ///< Event selection for mixed events
+  Bool_t                 fDisableFastPartition;    ///< True if task should be disabled for the fast partition, where the EMCal is not included.
+  // Efficiency correction
+  TRandom3 fRandom;                               //!<! Random number generator for artificial track inefficiency.
+  AliAnalysisTaskEmcalJetHUtils::EEfficiencyPeriodIdentifier_t fEfficiencyPeriodIdentifier;  ///<  Identifies the period for determining the efficiency correction to apply
+  Double_t               fArtificialTrackInefficiency; ///< Artificial track inefficiency. Enabled if < 1.0
+  // JES correction
+  Bool_t                 fNoMixedEventJESCorrection; ///< True if the jet energy scale correction should be applied to mixed event histograms
+  TH2D                  *fJESCorrectionHist;       ///< Histogram containing the jet energy scale correction
+  // Histogram binning variables
+  Bool_t                 fDoLessSparseAxes;        ///< True if there should be fewer THnSparse axes
+  Bool_t                 fDoWiderTrackBin;         ///< True if the track pt bins in the THnSparse should be wider
+  Bool_t                 fRequireMatchedJetWhenEmbedding; ///< True if jets are required to be matched (ie. jet->MatchedJet() != nullptr)
+  Double_t               fMinSharedMomentumFraction; ///< Minimum shared momentum with matched jet
+  bool                   fRequireMatchedPartLevelJet; ///< True if matched jets are required to be matched to a particle level jet
+  Double_t               fMaxMatchedJetDistance;  ///< Maximum distance between two matched jets
+
+  // Histograms
+  THistManager           fHistManager;             ///<  Histogram manager
+  TH1                   *fHistJetHTrackPt;         //!<! Track pt spectrum
+  TH2                   *fHistJetEtaPhi;           //!<! Jet eta-phi distribution
+  TH2                   *fHistTrackEtaPhi[7];      //!<! Track eta-phi distribution (the array corresponds to track pt)
+  TH2                   *fHistJetHEtaPhi;          //!<! Eta-phi distribution of jets which are in jet-hadron correlations
+
+  TH1                   *fHistJetPt[6];            //!<! Jet pt spectrum (the array corresponds to centrality bins)
+  TH1                   *fHistJetPtBias[6];        //!<! Jet pt spectrum of jets which meet the constituent bias criteria (the array corresponds to centrality bins)
+  THnSparse             *fhnMixedEvents;           //!<! Mixed events THnSparse
+  THnSparse             *fhnJH;                    //!<! JetH THnSparse
+  THnSparse             *fhnTrigger;               //!<! JetH trigger sparse
+
+ private:
+
+  AliAnalysisTaskEmcalJetHdEdxCorrelations(const AliAnalysisTaskEmcalJetHdEdxCorrelations&); // not implemented
+  AliAnalysisTaskEmcalJetHdEdxCorrelations& operator=(const AliAnalysisTaskEmcalJetHdEdxCorrelations&); // not implemented
+
+  ClassDef(AliAnalysisTaskEmcalJetHdEdxCorrelations, 20);
+};
+
+} /* namespace EMCALJetTasks */
+} /* namespace PWGJE */
+
+#endif

--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHdEdxPerformance.cxx
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHdEdxPerformance.cxx
@@ -1,0 +1,1540 @@
+/**
+ * Implemenation for AliAnalysisTaskEmcalJetHdEdxPerformance
+ */
+
+#include "AliAnalysisTaskEmcalJetHdEdxPerformance.h"
+
+#include <cmath>
+#include <map>
+#include <vector>
+#include <iostream>
+#include <bitset>
+
+#include <TObject.h>
+#include <TCollection.h>
+#include <TAxis.h>
+#include <THnSparse.h>
+
+#include <AliAnalysisManager.h>
+#include <AliInputEventHandler.h>
+#include <AliLog.h>
+
+#include "yaml-cpp/yaml.h"
+#include "AliAnalysisTaskEmcalEmbeddingHelper.h"
+#include "AliTrackContainer.h"
+#include "AliTLorentzVector.h"
+#include "AliClusterContainer.h"
+#include "AliEmcalContainerUtils.h"
+#include "AliJetContainer.h"
+#include "AliEmcalJet.h"
+#include "AliAnalysisTaskFlowVectorCorrections.h"
+#include "AliQnCorrectionsManager.h"
+#include "AliQnCorrectionsQnVector.h"
+
+#include "AliAnalysisTaskEmcalJetHUtils.h"
+
+ClassImp(PWGJE::EMCALJetTasks::AliAnalysisTaskEmcalJetHdEdxPerformance);
+
+namespace PWGJE {
+namespace EMCALJetTasks {
+
+/**
+ * Default constructor
+ */
+AliAnalysisTaskEmcalJetHdEdxPerformance::AliAnalysisTaskEmcalJetHdEdxPerformance():
+  AliAnalysisTaskEmcalJet("AliAnalysisTaskEmcalJetHdEdxPerformance", kFALSE),
+  fYAMLConfig(),
+  fConfigurationInitialized(false),
+  fHistManager(),
+  fEmbeddingQA(),
+  fCreateQAHists(false),
+  fCreateCellQAHists(false),
+  fPerformJetMatching(false),
+  fCreateResponseMatrix(false),
+  fEmbeddedCellsName("emcalCells"),
+  fPreviousEventTrigger(0),
+  fPreviousEmbeddedEventSelected(false),
+  fEfficiencyPeriodIdentifier(AliAnalysisTaskEmcalJetHUtils::kDisableEff),
+  fFlowQnVectorManager(nullptr),
+  fResponseMatrixFillMap(),
+  fResponseFromThreeJetCollections(true),
+  fMinFractionShared(0.),
+  fLeadingHadronBiasType(AliAnalysisTaskEmcalJetHUtils::kCharged)
+{
+}
+
+/**
+ * Standard constructor
+ */
+AliAnalysisTaskEmcalJetHdEdxPerformance::AliAnalysisTaskEmcalJetHdEdxPerformance(const char * name):
+  AliAnalysisTaskEmcalJet(name, kTRUE),
+  fYAMLConfig(),
+  fConfigurationInitialized(false),
+  fHistManager(name),
+  fEmbeddingQA(),
+  fCreateQAHists(false),
+  fCreateCellQAHists(false),
+  fPerformJetMatching(false),
+  fCreateResponseMatrix(false),
+  fEmbeddedCellsName("emcalCells"),
+  fPreviousEventTrigger(0),
+  fPreviousEmbeddedEventSelected(false),
+  fEfficiencyPeriodIdentifier(AliAnalysisTaskEmcalJetHUtils::kDisableEff),
+  fFlowQnVectorManager(nullptr),
+  fResponseMatrixFillMap(),
+  fResponseFromThreeJetCollections(true),
+  fMinFractionShared(0.),
+  fLeadingHadronBiasType(AliAnalysisTaskEmcalJetHUtils::kCharged)
+{
+  // Ensure that additional general histograms are created
+  SetMakeGeneralHistograms(kTRUE);
+}
+
+/**
+ * Copy constructor
+ */
+AliAnalysisTaskEmcalJetHdEdxPerformance::AliAnalysisTaskEmcalJetHdEdxPerformance(const AliAnalysisTaskEmcalJetHdEdxPerformance & other):
+  fYAMLConfig(other.fYAMLConfig),
+  fConfigurationInitialized(other.fConfigurationInitialized),
+  fHistManager(other.fHistManager.GetName()),
+  //fEmbeddingQA(other.fEmbeddingQA), // Cannot use because the THistManager (which is in the class) copy constructor is private.
+  fCreateQAHists(other.fCreateQAHists),
+  fCreateCellQAHists(other.fCreateCellQAHists),
+  fPerformJetMatching(other.fPerformJetMatching),
+  fCreateResponseMatrix(other.fCreateResponseMatrix),
+  fEmbeddedCellsName(other.fEmbeddedCellsName),
+  fPreviousEventTrigger(other.fPreviousEventTrigger),
+  fPreviousEmbeddedEventSelected(other.fPreviousEmbeddedEventSelected),
+  fEfficiencyPeriodIdentifier(other.fEfficiencyPeriodIdentifier),
+  fFlowQnVectorManager(other.fFlowQnVectorManager),
+  fResponseMatrixFillMap(other.fResponseMatrixFillMap),
+  fResponseFromThreeJetCollections(other.fResponseFromThreeJetCollections),
+  fMinFractionShared(other.fMinFractionShared),
+  fLeadingHadronBiasType(other.fLeadingHadronBiasType)
+{
+  TIter next(other.fHistManager.GetListOfHistograms());
+  TObject* obj = 0;
+  while ((obj = next())) {
+    fHistManager.SetObject(obj, obj->GetName());
+  }
+}
+
+/**
+ * Assignment operator. Note that we pass by _value_, so a copy is created and it is
+ * fine to swap the values with the created object!
+ */
+AliAnalysisTaskEmcalJetHdEdxPerformance & AliAnalysisTaskEmcalJetHdEdxPerformance::operator=(AliAnalysisTaskEmcalJetHdEdxPerformance other)
+{
+  swap(*this, other);
+  return *this;
+}
+
+/**
+ * Utility function to apply the determine the single track efficiency.
+ *
+ * @param trackEta Eta of the track
+ * @param trackPt pT of the track
+ *
+ * @return Track efficiency of the track (the entry in a histogram should be weighted as 1/(return value))
+ */
+double AliAnalysisTaskEmcalJetHdEdxPerformance::DetermineTrackingEfficiency(double trackPt, double trackEta)
+{
+  return AliAnalysisTaskEmcalJetHUtils::DetermineTrackingEfficiency(
+   trackPt, trackEta, fCentBin, fEfficiencyPeriodIdentifier,
+   "PWGJE::EMCALJetTasks::AliAnalysisTaskEmcalJetHdEdxPerformance");
+}
+
+/**
+ * Retrieve task properties from the YAML configuration.
+ */
+void AliAnalysisTaskEmcalJetHdEdxPerformance::RetrieveAndSetTaskPropertiesFromYAMLConfig()
+{
+  // Base class options
+  // Task physics (trigger) selection.
+  std::vector<std::string> physicsSelection;
+  bool res = fYAMLConfig.GetProperty(std::vector<std::string>({"eventCuts", "physicsSelection"}), physicsSelection, false);
+  if (res) {
+    fOfflineTriggerMask = AliEmcalContainerUtils::DeterminePhysicsSelectionFromYAML(physicsSelection);
+  }
+
+  // Same ordering as in the constructor (for consistency)
+  std::string baseName = "enable";
+  // These are disabled by default.
+  fYAMLConfig.GetProperty({baseName, "QAHists"}, fCreateQAHists, false);
+  fYAMLConfig.GetProperty({baseName, "CellQAHists"}, fCreateCellQAHists, false);
+  fYAMLConfig.GetProperty({baseName, "jetMatching"}, fPerformJetMatching, false);
+  fYAMLConfig.GetProperty({baseName, "responseMatrix"}, fCreateResponseMatrix, false);
+
+  // Event cuts
+  baseName = "eventCuts";
+  // If event cuts are enabled (which they exceptionally are by default), then we want to configure them here.
+  // If the event cuts are explicitly disabled, then we invert that value to enable the AliAnylsisTaskEmcal
+  // builtin event selection.
+  bool tempBool;
+  fYAMLConfig.GetProperty({baseName, "enabled"}, tempBool, false);
+  fUseBuiltinEventSelection = !tempBool;
+  if (fUseBuiltinEventSelection == false) {
+    // Need to include the namespace so that AliDebug will work properly...
+    std::string taskName = "PWGJE::EMCALJetTasks::";
+    taskName += GetName();
+    AliAnalysisTaskEmcalJetHUtils::ConfigureEventCuts(fAliEventCuts, fYAMLConfig, fOfflineTriggerMask, baseName, taskName);
+  }
+
+  // General task options
+  baseName = "general";
+  fYAMLConfig.GetProperty({baseName, "nCentBins"}, fNcentBins, false);
+
+  // QA options
+  baseName = "QA";
+  fYAMLConfig.GetProperty({baseName, "cellsName"}, fCaloCellsName, false);
+  // Defaults to "emcalCells" if not set.
+  fYAMLConfig.GetProperty({baseName, "embeddedCellsName"}, fEmbeddedCellsName, false);
+  // Efficiency
+  std::string tempStr = "";
+  baseName = "efficiency";
+  res = fYAMLConfig.GetProperty({baseName, "periodIdentifier"}, tempStr, false);
+  if (res) {
+    fEfficiencyPeriodIdentifier = AliAnalysisTaskEmcalJetHUtils::fgkEfficiencyPeriodIdentifier.at(tempStr);
+  }
+
+  // Jet matching
+  baseName = "jetMatching";
+  fYAMLConfig.GetProperty({baseName, "maxMatchingDistance"}, fMaxJetMatchingDistance, false);
+
+  // Response matrix properties
+  baseName = "responseMatrix";
+  fYAMLConfig.GetProperty({baseName, "useThreeJetCollections"}, fResponseFromThreeJetCollections, false);
+  fYAMLConfig.GetProperty({baseName, "minFractionSharedPt"}, fMinFractionShared, false);
+  std::string hadronBiasStr = "";
+  baseName = "jets";
+  res = fYAMLConfig.GetProperty({baseName, "leadingHadronBiasType"}, hadronBiasStr, false);
+  // Only attempt to set the property if it is retrieved successfully
+  if (res) {
+    fLeadingHadronBiasType = AliAnalysisTaskEmcalJetHUtils::fgkLeadingHadronBiasMap.at(hadronBiasStr);
+  }
+}
+
+/**
+ * Create jet containers based on the jet values defined in the YAML config.
+ */
+void AliAnalysisTaskEmcalJetHdEdxPerformance::SetupJetContainersFromYAMLConfig()
+{
+  std::string baseName = "jets";
+  std::vector <std::string> jetNames = {"hybridLevelJets", "detLevelJets", "partLevelJets", "analysisJets"};
+  for (const auto & jetName : jetNames) {
+    // Retrieve the node just to see if it is exists. If so, then we can proceed
+    YAML::Node node;
+    bool res = fYAMLConfig.GetProperty(std::vector<std::string>({baseName, jetName}), node, false);
+    if (res) {
+      // Retrieve jet container properties
+      std::string collectionName = "";
+      double R = -1;
+      fYAMLConfig.GetProperty({baseName, jetName, "collection"}, collectionName, true);
+      fYAMLConfig.GetProperty({baseName, jetName, "R"}, R, true);
+
+      // Determine the jet acceptance.
+      std::vector<std::string> jetAcceptances;
+      fYAMLConfig.GetProperty({baseName, jetName, "acceptance"}, jetAcceptances, true);
+      UInt_t jetAcceptance = AliAnalysisTaskEmcalJetHUtils::DetermineJetAcceptanceFromYAML(jetAcceptances);
+
+      // Create jet container and set the name
+      AliDebugStream(1) << "Creating jet from jet collection name " << collectionName << " with acceptance "
+               << jetAcceptance << " and R=" << R << "\n";
+      AliJetContainer* jetCont = AddJetContainer(collectionName.c_str(), jetAcceptance, R);
+      jetCont->SetName(jetName.c_str());
+
+      // Jet area cut percentage
+      double jetAreaCut = -1;
+      bool res = fYAMLConfig.GetProperty({ baseName, jetName, "areaCutPercentage" }, jetAreaCut, false);
+      if (res) {
+        AliDebugStream(1) << "Setting jet area cut percentage of " << jetAreaCut << " for jet cont " << jetName
+                 << "\n";
+        jetCont->SetPercAreaCut(jetAreaCut);
+      }
+
+      // Rho name
+      std::string tempStr = "";
+      res = fYAMLConfig.GetProperty({ baseName, jetName, "rhoName" }, tempStr, false);
+      if (res) {
+        AliDebugStream(1) << "Setting rho name of " << tempStr << " for jet cont " << jetName << "\n";
+        jetCont->SetRhoName(tempStr.c_str());
+      }
+
+      // Leading hadron type
+      int leadingHadronType = -1;
+      res = fYAMLConfig.GetProperty({ baseName, jetName, "leadingHadronType" }, leadingHadronType, false);
+      if (res) {
+        AliDebugStream(1) << "Setting leading hadron type of " << leadingHadronType << " for jet cont "
+                 << jetName << "\n";
+        jetCont->SetLeadingHadronType(leadingHadronType);
+      }
+
+      // Leading hadron cut
+      double leadingHadronBias = 0.;
+      res = fYAMLConfig.GetProperty({ baseName, jetName, "leadingHadronBias" }, leadingHadronBias, false);
+      if (res) {
+        AliDebugStream(1) << "Setting leading hadron bias of " << leadingHadronBias << " for jet cont "
+                 << jetName << "\n";
+        jetCont->SetMinTrackPt(leadingHadronBias);
+      }
+
+      // Max track pt
+      double maxTrackPt = 0.;
+      res = fYAMLConfig.GetProperty({ baseName, jetName, "maxTrackPt" }, maxTrackPt, false);
+      if (res) {
+        AliDebugStream(1) << "Setting max track pt of " << maxTrackPt << " for jet cont "
+                 << jetName << "\n";
+        jetCont->SetMinTrackPt(maxTrackPt);
+      }
+    }
+    else {
+      AliInfoStream() << "Unable to find definition of jet container corresponding to \"" << jetName << "\"\n";
+    }
+  }
+}
+
+/**
+ * Setup particle containers based on the provided YAML configuration.
+ */
+void AliAnalysisTaskEmcalJetHdEdxPerformance::SetupParticleContainersFromYAMLConfig()
+{
+  std::string baseName = "particles";
+  // Retrieve the node just to see if it is exists. If so, then we can proceed
+  YAML::Node node;
+  fYAMLConfig.GetProperty(baseName, node);
+  // Iterate over all of the particle and track containers
+  for (const auto & n : node) {
+    std::string containerName = n.first.as<std::string>();
+
+    // Create the container.
+    std::string branchName = "";
+    fYAMLConfig.GetProperty({baseName, containerName, "branchName"}, branchName, true);
+    if (branchName == "usedefault") {
+      branchName = AliEmcalContainerUtils::DetermineUseDefaultName(AliEmcalContainerUtils::kTrack);
+    }
+    AliParticleContainer * partCont = AliAnalysisTaskEmcalJetHUtils::CreateParticleOrTrackContainer(branchName);
+    this->AdoptParticleContainer(partCont);
+
+    // Configure the container
+    // Need to include the namespace so that AliDebug will work properly...
+    std::string taskName = "PWGJE::EMCALJetTasks::";
+    taskName += GetName();
+    std::vector<std::string> baseNameWithContainer = { baseName, containerName };
+    AliAnalysisTaskEmcalJetHUtils::ConfigureEMCalContainersFromYAMLConfig(baseNameWithContainer, containerName,
+                                       partCont, fYAMLConfig, taskName);
+
+    // Track specific properties
+    AliTrackContainer * trackCont = dynamic_cast<AliTrackContainer *>(partCont);
+    if (trackCont) {
+      AliAnalysisTaskEmcalJetHUtils::ConfigureTrackContainersFromYAMLConfig(baseNameWithContainer, trackCont,
+                                         fYAMLConfig, taskName);
+    }
+
+    AliDebugStream(2) << "Particle/track container: " << partCont->GetName()
+             << ", array class: " << partCont->GetClassName() << ", collection name: \""
+             << partCont->GetArrayName() << "\", min pt: " << partCont->GetMinPt() << "\n";
+  }
+}
+
+/**
+ * Setup cluster containers based on the provided YAML configuration.
+ */
+void AliAnalysisTaskEmcalJetHdEdxPerformance::SetupClusterContainersFromYAMLConfig()
+{
+  std::string baseName = "clusters";
+  // Retrieve the node just to see if it is exists. If so, then we can proceed
+  YAML::Node node;
+  fYAMLConfig.GetProperty(baseName, node);
+  // Iterate over all of the cluster containers
+  for (const auto & n : node) {
+    std::string containerName = n.first.as<std::string>();
+
+    // Create the container.
+    std::string branchName = "";
+    fYAMLConfig.GetProperty({baseName, containerName, "branchName"}, branchName, true);
+    if (branchName == "usedefault") {
+      branchName = AliEmcalContainerUtils::DetermineUseDefaultName(AliEmcalContainerUtils::kCluster);
+    }
+    AliClusterContainer * clusterCont = this->AddClusterContainer(branchName.c_str());
+
+    // Configure the container
+    // Need to include the namespace so that AliDebug will work properly...
+    std::string taskName = "PWGJE::EMCALJetTasks::";
+    taskName += GetName();
+    std::vector<std::string> baseNameWithContainer = { baseName, containerName };
+    AliAnalysisTaskEmcalJetHUtils::ConfigureEMCalContainersFromYAMLConfig(baseNameWithContainer, containerName,
+                                       clusterCont, fYAMLConfig, taskName);
+
+    // Cluster specific properties
+    AliAnalysisTaskEmcalJetHUtils::ConfigureClusterContainersFromYAMLConfig(baseNameWithContainer, clusterCont, fYAMLConfig, taskName);
+
+    AliDebugStream(2) << "Cluster container: " << clusterCont->GetName()
+             << ", array class: " << clusterCont->GetClassName() << ", collection name: \""
+             << clusterCont->GetArrayName() << "\", min pt: " << clusterCont->GetMinPt() << "\n";
+  }
+}
+
+/**
+ * Initialize task.
+ */
+bool AliAnalysisTaskEmcalJetHdEdxPerformance::Initialize()
+{
+  fConfigurationInitialized = false;
+
+  // Ensure that we have at least one configuration in the YAML config.
+  if (fYAMLConfig.DoesConfigurationExist(0) == false) {
+    // No configurations exist. Return immediately.
+    return fConfigurationInitialized;
+  }
+
+  // Always initialize for streaming purposes
+  fYAMLConfig.Initialize();
+
+  // Setup task based on the properties defined in the YAML config
+  AliDebugStream(2) << "Configuring task from the YAML configuration.\n";
+  RetrieveAndSetTaskPropertiesFromYAMLConfig();
+  SetupJetContainersFromYAMLConfig();
+  SetupParticleContainersFromYAMLConfig();
+  SetupClusterContainersFromYAMLConfig();
+  AliDebugStream(2) << "Finished configuring via the YAML configuration.\n";
+
+  // Print the results of the initialization
+  // Print outside of the ALICE Log system to ensure that it is always available!
+  std::cout << *this;
+
+  fConfigurationInitialized = true;
+  return fConfigurationInitialized;
+}
+
+/**
+ * Create output objects
+ */
+void AliAnalysisTaskEmcalJetHdEdxPerformance::UserCreateOutputObjects()
+{
+  // First call the base class
+  AliAnalysisTaskEmcalJet::UserCreateOutputObjects();
+
+  // Check that the task was initialized
+  if (!fConfigurationInitialized) {
+    AliFatal("Task was not initialized. Please ensure that Initialize() was called!");
+  }
+  // Reinitialize the YAML configuration
+  fYAMLConfig.Reinitialize();
+
+  // Create histograms
+  if (fCreateQAHists) {
+    SetupQAHists();
+  }
+  if (fPerformJetMatching) {
+    SetupJetMatchingQA();
+  }
+  if (fCreateResponseMatrix) {
+    SetupResponseMatrixHists();
+  }
+
+  // Store hist manager output in the output list
+  TIter next(fHistManager.GetListOfHistograms());
+  TObject* obj = 0;
+  while ((obj = next())) {
+    fOutput->Add(obj);
+  }
+
+  // Initialize
+  const AliAnalysisTaskEmcalEmbeddingHelper * embeddingHelper = AliAnalysisTaskEmcalEmbeddingHelper::GetInstance();
+  if (embeddingHelper) {
+    bool res = fEmbeddingQA.Initialize();
+    if (res) {
+      fEmbeddingQA.AddQAPlotsToList(fOutput);
+    }
+  }
+
+  // Post the data when finished
+  PostData(1, fOutput);
+}
+
+/**
+ * Setup cell QA histograms at a specific prefix within the histogram manager. This allows us to avoid repeating
+ * definitions for the same histograms in the embedded vs internal event. This function actually defines the histograms.
+ *
+ * @param[in] prefix Prefix under which the histograms will be created within the hist manager.
+ */
+void AliAnalysisTaskEmcalJetHdEdxPerformance::SetupCellQAHistsWithPrefix(const std::string & prefix)
+{
+  std::string name = prefix + "/fHistCellEnergy";
+  std::string title = name + ";\\mathit{E}_{\\mathrm{cell}} (\\mathrm{GeV});counts";
+  fHistManager.CreateTH1(name.c_str(), title.c_str(), 300, 0, 150);
+
+  name = prefix + "/fHistCellTime";
+  title = name + ";t (s);counts";
+  fHistManager.CreateTH1(name.c_str(), title.c_str(), 1000, -10e-6, 10e-6);
+
+  name = prefix + "/fHistNCells";
+  title = name + ";\\mathrm{N}_{\\mathrm{cells}};counts";
+  fHistManager.CreateTH1(name.c_str(), title.c_str(), 100, 0, 5000);
+
+  name = prefix + "/fHistCellID";
+  title = name + ";\\mathrm{N}_{\\mathrm{cell}};counts";
+  fHistManager.CreateTH1(name.c_str(), title.c_str(), 20000, 0, 20000);
+
+  // Histograms for embedding QA which use the cell timing to determine whether the
+  // embedded event has been double corrected.
+  if (prefix.find("embedding") != std::string::npos) {
+    name = prefix + "/fHistEmbeddedEventUsed";
+    title = name + ";Embedded event used";
+    fHistManager.CreateTH1(name.c_str(), title.c_str(), 2, 0, 2);
+
+    name = prefix + "/fHistInternalEventSelection";
+    title = name + ";Embedded event used;Trigger bit";
+    fHistManager.CreateTH2(name.c_str(), title.c_str(), 2, 0, 2, 32, -0.5, 31.5);
+  }
+}
+
+/**
+ * Directs the creation of Cell QA histograms for the internal and external events (if it exists).
+ */
+void AliAnalysisTaskEmcalJetHdEdxPerformance::SetupCellQAHists()
+{
+  // Only create and fill the cells QA if we've setup the cells name.
+  if (fCaloCellsName != "") {
+    std::string prefix = "QA/";
+    prefix += fCaloCellsName.Data();
+    SetupCellQAHistsWithPrefix(prefix);
+    auto embeddingInstance = AliAnalysisTaskEmcalEmbeddingHelper::GetInstance();
+    if (embeddingInstance) {
+      prefix = "QA/embedding/";
+      prefix += fEmbeddedCellsName;
+      SetupCellQAHistsWithPrefix(prefix);
+    }
+  }
+}
+
+/**
+ * Setup and allocate histograms related to QA histograms.
+ */
+void AliAnalysisTaskEmcalJetHdEdxPerformance::SetupQAHists()
+{
+  // Cell level QA
+  if (fCreateCellQAHists) {
+    SetupCellQAHists();
+  }
+
+  // Tracks
+  AliTrackContainer * trackCont = nullptr;
+  TIter nextTrackColl(&fParticleCollArray);
+  while ((trackCont = static_cast<AliTrackContainer*>(nextTrackColl()))) {
+    std::string name = "QA/%s/fHistTrackPtEtaPhi";
+    std::string title = name + ";#it{p}_{T} (GeV);#eta;#phi";
+    fHistManager.CreateTH3(TString::Format(name.c_str(), trackCont->GetName()),
+                TString::Format(title.c_str(), trackCont-> GetName()), 50, 0, 25, 40, -1, 1, 72, 0,
+                TMath::TwoPi());
+    name = "QA/%s/fHistTrackPtEtaPhiEfficiencyCorrected";
+    title = name + ";#it{p}_{T} (GeV);#eta;#phi";
+    fHistManager.CreateTH3(TString::Format(name.c_str(), trackCont->GetName()),
+                TString::Format(title.c_str(), trackCont-> GetName()), 50, 0, 25, 40, -1, 1, 72, 0,
+                TMath::TwoPi());
+  }
+
+  // Clusters
+  AliClusterContainer * clusterCont = nullptr;
+  TIter nextClusColl(&fClusterCollArray);
+  while ((clusterCont = static_cast<AliClusterContainer*>(nextClusColl()))) {
+    // Cluster time vs energy
+    std::string name = "QA/%s/fHistClusterEnergyVsTime";
+    std::string title = name + ";#it{E}_{cluster} (GeV);t_{cluster} (s);counts";
+    fHistManager.CreateTH2(TString::Format(name.c_str(), clusterCont->GetName()),
+                TString::Format(title.c_str(), clusterCont->GetName()), 1000, 0, 100, 300, -300e-9,
+                300e-9);
+    // Hadronically corrected energy (which is usually what we're using)
+    name = "QA/%s/fHistClusterHadCorrEnergy";
+    title = name + ";#it{E}_{cluster}^{had.corr.} (GeV);counts";
+    fHistManager.CreateTH1(TString::Format(name.c_str(), clusterCont->GetName()), TString::Format(title.c_str(), clusterCont->GetName()), 200, 0, 100);
+    // Cluster eta-phi
+    name = "QA/%s/fHistClusterEtaPhi";
+    title = name + ";#eta_{cluster};#phi_{cluster};counts";
+    fHistManager.CreateTH2(TString::Format(name.c_str(), clusterCont->GetName()), TString::Format(title.c_str(), clusterCont->GetName()), 28, -0.7, 0.7, 72, 0, TMath::TwoPi());
+  }
+
+  // Jets
+  AliJetContainer * jetCont = nullptr;
+  TIter nextJetColl(&fJetCollArray);
+  while ((jetCont = static_cast<AliJetContainer*>(nextJetColl()))) {
+    // Jet pT
+    std::string name = "QA/%s/fHistJetPt";
+    std::string title = name + ";p_{T} (GeV)";
+    fHistManager.CreateTH1(TString::Format(name.c_str(), jetCont->GetName()), TString::Format(title.c_str(), jetCont->GetName()), 600, -50, 250);
+  }
+
+  // Event plane resolution
+  // Only enable if the Qn vector corrections task is available.
+  auto qnVectorTask = dynamic_cast<AliAnalysisTaskFlowVectorCorrections*>(
+   AliAnalysisManager::GetAnalysisManager()->GetTask("FlowQnVectorCorrections"));
+  if (qnVectorTask) {
+    // Setup the Qn corrections manager.
+    fFlowQnVectorManager = qnVectorTask->GetAliQnCorrectionsManager();
+    // Then setup the resolution histograms.
+    // Resolution are calculated via TProfiles as a function of centrality.
+    std::map<std::string, std::string> resolutionNamesToTitles = {
+      std::make_pair("VZERO", R"(VZERO: $<\cos(R * (\Psi_{\mathrm{TPC_{Pos}}} - \Psi_{\mathrm{TPC_{Neg}}}))>$)"),
+      std::make_pair("TPC_Pos", R"(TPC $\eta$ > 0: $<\cos(R * (\Psi_{\mathrm{V0M}} - \Psi_{\mathrm{TPC_{Neg}}}))>$)"),
+      std::make_pair("TPC_Neg", R"(TPC $\eta$ < 0: $<\cos(R * (\Psi_{\mathrm{V0M}} - \Psi_{\mathrm{TPC_{Pos}}}))>$)")
+    };
+    for (const auto& nameAndTitle: resolutionNamesToTitles) {
+      for (unsigned int R = 2; R < 9; R++) {
+        std::string name = "QA/eventPlaneRes/%s/R%i";
+        std::string title = "%s event plane res;Centrality (%%);R_{%i}";
+        fHistManager.CreateTProfile(TString::Format(name.c_str(), nameAndTitle.first.c_str(), R),
+                      TString::Format(title.c_str(), nameAndTitle.second.c_str(), R),
+                      10, 0, 100);
+      }
+    }
+  }
+}
+
+/**
+ * Setup and allocate histograms related to jet matching.
+ */
+void AliAnalysisTaskEmcalJetHdEdxPerformance::SetupJetMatchingQA()
+{
+  // Setup
+  const int nBinsPt        = 40;
+  const int nBinsDPhi      = 72;
+  const int nBinsDEta      = 100;
+  const int nBinsDR        = 50;
+  const int nBinsFraction  = 101;
+
+  const double minPt       = -50.;
+  const double maxPt       = 150.;
+  const double minDPhi     = -0.5;
+  const double maxDPhi     =  0.5;
+  const double minDEta     = -0.5;
+  const double maxDEta     =  0.5;
+  const double minDR       =  0.;
+  const double maxDR       =  0.5;
+  const double minFraction =  -0.005;
+  const double maxFraction =  1.005;
+
+  // Create the histograms
+  // "s" ensures that Sumw2() is called
+  std::string name = "";
+  std::string title = "";
+  std::vector<std::string> matchingTypes = {"hybridToDet", "detToPart"};
+  for (auto matchingType : matchingTypes)
+  {
+    for (unsigned int centBin = 0; centBin < fNcentBins; centBin++)
+    {
+      // Jet 1 pt vs delta eta vs delta phi
+      name = "jetMatching/%s/fh3PtJet1VsDeltaEtaDeltaPhi_%d";
+      title = "fh3PtJet1VsDeltaEtaDeltaPhi_%d;#it{p}_{T,jet1};#it{#Delta#eta};#it{#Delta#varphi}";
+      fHistManager.CreateTH3(TString::Format(name.c_str(), matchingType.c_str(), centBin),
+                  TString::Format(title.c_str(), centBin), nBinsPt, minPt, maxPt, nBinsDEta,
+                  minDEta, maxDEta, nBinsDPhi, minDPhi, maxDPhi, "s");
+
+      // Jet pt 1 vs delta R
+      name = "jetMatching/%s/fh2PtJet1VsDeltaR_%d";
+      title = "fh2PtJet1VsDeltaR_%d;#it{p}_{T,jet1};#it{#Delta R}";
+      fHistManager.CreateTH2(TString::Format(name.c_str(), matchingType.c_str(), centBin),
+                  TString::Format(title.c_str(), centBin), nBinsPt, minPt, maxPt, nBinsDR, minDR,
+                  maxDR, "s");
+
+      // Jet pt 2 vs shared momentum fraction
+      name = "jetMatching/%s/fh2PtJet2VsFraction_%d";
+      title = "fh2PtJet2VsFraction_%d;#it{p}_{T,jet2};#it{f}_{shared}";
+      fHistManager.CreateTH2(TString::Format(name.c_str(), matchingType.c_str(), centBin),
+                  TString::Format(title.c_str(), centBin), nBinsPt, minPt, maxPt, nBinsFraction,
+                  minFraction, maxFraction, "s");
+
+      // Jet pt 1 vs lead pt before checking if the jet has a matched jet.
+      name = "jetMatching/%s/fh2PtJet1VsLeadPtAllSel_%d";
+      title = "fh2PtJet1VsLeadPtAllSel_%d;#it{p}_{T,jet1};#it{p}_{T,lead trk}";
+      fHistManager.CreateTH2(TString::Format(name.c_str(), matchingType.c_str(), centBin),
+                  TString::Format(title.c_str(), centBin), nBinsPt, minPt, maxPt, 20, 0., 20.,
+                  "s");
+
+      // Jet pt 1 vs lead pt after checking if the jet has a matched jet.
+      name = "jetMatching/%s/fh2PtJet1VsLeadPtTagged_%d";
+      title = "fh2PtJet1VsLeadPtTagged_%d;#it{p}_{T,jet1};#it{p}_{T,lead trk}";
+      fHistManager.CreateTH2(TString::Format(name.c_str(), matchingType.c_str(), centBin),
+                  TString::Format(title.c_str(), centBin), nBinsPt, minPt, maxPt, 20, 0., 20.,
+                  "s");
+
+      // Jet pt 1 vs jet pt 2.
+      name = "jetMatching/%s/fh2PtJet1VsPtJet2_%d";
+      title = "fh2PtJet1VsPtJet2_%d;#it{p}_{T,jet1};#it{p}_{T,jet2}";
+      fHistManager.CreateTH2(TString::Format(name.c_str(), matchingType.c_str(), centBin),
+                  TString::Format(title.c_str(), centBin), nBinsPt, minPt, maxPt, nBinsPt, minPt,
+                  maxPt, "s");
+
+      // Jet pt2 residual (aka. the jet energy scale).
+      name = "jetMatching/%s/fh2PtJet2VsRelPt_%d";
+      title = "fh2PtJet2VsRelPt_%d;#it{p}_{T,jet2};(#it{p}_{T,jet1}-#it{p}_{T,jet2})/#it{p}_{T,jet2}";
+      fHistManager.CreateTH2(TString::Format(name.c_str(), matchingType.c_str(), centBin),
+                  TString::Format(title.c_str(), centBin), nBinsPt, minPt, maxPt, 241, -2.41, 2.41,
+                  "s");
+    }
+
+    // Number of jets accepted.
+    name = "jetMatching/%s/fNAccJets";
+    title = "fNAccJets;N/ev";
+    fHistManager.CreateTH1(TString::Format(name.c_str(), matchingType.c_str()), title.c_str(), 11, -0.5, 9.5, "s");
+  }
+
+}
+
+/**
+ * Setup and allocate histograms related to creating a response matrix.
+ */
+void AliAnalysisTaskEmcalJetHdEdxPerformance::SetupResponseMatrixHists()
+{
+  // Main response matrix THnSparse
+  std::string name = "response/fHistResponseMatrix";
+  std::string title = name;
+
+  // Retrieve binning from the YAML configuration
+  std::vector<TAxis *> binning;
+  // This structure is designed to preserve the order of the axis in the YAML by using a YAML sequence (decoded into
+  // a vector), while defining a pair of the axis name and axis limts. Using this structure avoids the need to create
+  // a new object and conversion to retrieve the data
+  std::vector<std::pair<std::string, std::vector<double>>> sparseAxes;
+  std::string baseName = "responseMatrix";
+  fYAMLConfig.GetProperty({baseName, "axes"}, sparseAxes, true);
+  for (auto axis : sparseAxes) {
+    auto axisLimits = axis.second;
+    AliDebugStream(3) << "Creating axis " << axis.first << " with nBins " << axisLimits.at(0) << ", min: " << axisLimits.at(1) << ", max: " << axisLimits.at(2) << "\n";
+    binning.emplace_back(new TAxis(axisLimits.at(0), axisLimits.at(1), axisLimits.at(2)));
+  }
+
+  // "s" ensures that Sumw2() is called
+  // The explicit const_cast is required
+  THnSparse * hist = fHistManager.CreateTHnSparse(name.c_str(), title.c_str(), binning.size(), const_cast<const TAxis **>(binning.data()), "s");
+  // Set the axis titles
+  int axisNumber = 0;
+  for (auto axis = sparseAxes.begin(); axis != sparseAxes.end(); axis++) {
+    AliDebugStream(5) << "ResponseMatrix: Add axis " << axis->first << " to sparse\n";
+    hist->GetAxis(axisNumber)->SetTitle(axis->first.c_str());
+    axisNumber++;
+  }
+
+  // Define mapping from value name to value (including jet information)
+  for (unsigned int iJet = 1; iJet < 3; iJet++)
+  {
+    // pt
+    // ex: p_{T,1}
+    fResponseMatrixFillMap.insert(std::make_pair(std::string("p_{T,") + std::to_string(iJet) + "}", std::make_pair(iJet, &ResponseMatrixFillWrapper::fPt)));
+    // Area
+    // ex: A_{jet,1}
+    fResponseMatrixFillMap.insert(std::make_pair(std::string("A_{jet,") + std::to_string(iJet) + "}", std::make_pair(iJet, &ResponseMatrixFillWrapper::fArea)));
+    // EP angle
+    // ex: #theta_{jet,1}^{EP}
+    fResponseMatrixFillMap.insert(std::make_pair(std::string("#theta_{jet,") + std::to_string(iJet) + "}^{EP}", std::make_pair(iJet, &ResponseMatrixFillWrapper::fRelativeEPAngle)));
+    // Leading hadron
+    // ex: p_{T,particle,1}^{leading} (GeV/c)
+    fResponseMatrixFillMap.insert(std::make_pair(std::string("p_{T,particle,") + std::to_string(iJet) + "}^{leading} (GeV/c)", std::make_pair(iJet, &ResponseMatrixFillWrapper::fLeadingHadronPt)));
+  }
+  // Distance from one jet to another
+  fResponseMatrixFillMap.insert(std::make_pair("distance", std::make_pair(1, &ResponseMatrixFillWrapper::fDistance)) );
+  // Centrality
+  fResponseMatrixFillMap.insert(std::make_pair("centrality", std::make_pair(1, &ResponseMatrixFillWrapper::fCentrality)) );
+
+  // Shared momentum fraction
+  name = "fHistFractionSharedPt";
+  title = "Fraction of p_{T} shared between matched jets";
+  // Need to include the bin from 1-1.01 to ensure that jets which shared all of their momentum
+  // due not end up in the overflow bin!
+  fHistManager.CreateTH1(name.c_str(), title.c_str(), 101, 0, 1.01);
+}
+
+/**
+ * Main event loop
+ */
+Bool_t AliAnalysisTaskEmcalJetHdEdxPerformance::Run()
+{
+  // Only fill the embedding qa plots if:
+  //  - We are using the embedding helper
+  //  - The class has been initialized
+  if (fEmbeddingQA.IsInitialized()) {
+    fEmbeddingQA.RecordEmbeddedEventProperties();
+  }
+
+  // QA
+  if (fCreateQAHists) {
+    QAHists();
+  }
+
+  // Jet matching
+  if (fPerformJetMatching) {
+    // Setup
+    AliDebugStream(1) << "Performing jet matching\n";
+    // We don't perform any additional jet matching initialization because we will restrict
+    // the jets accepted via the jet acceptance cuts (ie. EMCal fiducial cuts)
+    // Retrieve the releveant jet collections
+    AliJetContainer * jetsHybrid = GetJetContainer("hybridLevelJets");
+    AliJetContainer * jetsDetLevel = GetJetContainer("detLevelJets");
+    AliJetContainer * jetsPartLevel = GetJetContainer("partLevelJets");
+    // Validation
+    if (!jetsHybrid) {
+      AliErrorStream() << "Could not retrieve hybrid jet collection.\n";
+      return kFALSE;
+    }
+    if (!jetsDetLevel) {
+      AliErrorStream() << "Could not retrieve det level jet collection.\n";
+      return kFALSE;
+    }
+    if (!jetsPartLevel) {
+      AliErrorStream() << "Could not retrieve part level jet collection.\n";
+      return kFALSE;
+    }
+
+    // Now, begin the actual matching.
+    // Hybrid <-> det first
+    AliDebugStream(2) << "Matching hybrid to detector level jets.\n";
+    // First, we reset the tagging
+    ResetMatching(*jetsHybrid);
+    ResetMatching(*jetsDetLevel);
+    // Next, we perform the matching
+    PerformGeometricalJetMatching(*jetsHybrid, *jetsDetLevel, fMaxJetMatchingDistance);
+    // Now, begin the next matching stage
+    // det <-> particle
+    AliDebugStream(2) << "Matching detector level to particle level jets.\n";
+    // First, we reset the tagging. We need to reset the det matching again to ensure
+    // that it doesn't accidentally keep some latent matches to the hybrid jets.
+    ResetMatching(*jetsDetLevel);
+    ResetMatching(*jetsPartLevel);
+    // Next, we perform the matching
+    PerformGeometricalJetMatching(*jetsDetLevel, *jetsPartLevel, fMaxJetMatchingDistance);
+
+    // Fill QA hists.
+    FillJetMatchingQA(*jetsHybrid, *jetsDetLevel, "hybridToDet");
+    FillJetMatchingQA(*jetsDetLevel, *jetsPartLevel, "detToPart");
+  }
+
+  // Response matrix
+  if (fCreateResponseMatrix) {
+    ResponseMatrix();
+  }
+
+  return kTRUE;
+}
+
+/**
+ * Process and fill QA hists
+ */
+void AliAnalysisTaskEmcalJetHdEdxPerformance::QAHists()
+{
+  // Continue on to filling the histograms
+  FillQAHists();
+}
+
+/**
+ * Helper function to fill cell QA into the defined histograms. This actually fills the histograms at a given prefix
+ * from the provided calo cells.
+ *
+ * @param[in] prefix Prefix under which the histograms will be created within the hist manager.
+ * @param[in] cells Cells from which the information should be extracted.
+ */
+void AliAnalysisTaskEmcalJetHdEdxPerformance::FillCellQAHists(const std::string & prefix, AliVCaloCells * cells)
+{
+  AliDebugStream(4) << "Storing cells with prefix \"" << prefix << "\". N cells: " << cells->GetNumberOfCells() << "\n";
+  short absId = -1;
+  double eCell = 0;
+  double tCell = 0;
+  double eFrac = 0;
+  int mcLabel = -1;
+
+  std::string energyName = prefix + "/fHistCellEnergy";
+  std::string timeName = prefix + "/fHistCellTime";
+  std::string idName = prefix + "/fHistCellID";
+  bool embeddedCellWithLateCellTime = false;
+  bool fillingEmbeddedCells = (prefix.find("embedding") != std::string::npos);
+  for (unsigned int iCell = 0; iCell < cells->GetNumberOfCells(); iCell++) {
+    cells->GetCell(iCell, absId, eCell, tCell, mcLabel, eFrac);
+
+    AliDebugStream(5) << "Cell " << iCell << ": absId: " << absId << ", E: " << eCell << ", t: " << tCell
+             << ", mcLabel: " << mcLabel << ", eFrac: " << eFrac << "\n";
+    fHistManager.FillTH1(energyName.c_str(), eCell);
+    fHistManager.FillTH1(timeName.c_str(), tCell);
+    fHistManager.FillTH1(idName.c_str(), absId);
+
+    // We will record the event selection if the time is less than -400 ns
+    // This corresponds to a doubly corrected embedded event, which shouldn't be possible, and therefore
+    // indicates that something has gone awry
+    // NOTE: We must also require that the time is greater than -1 because apparently some uncalibrated cells
+    //       will report their time as -1. We don't want to include those cells.
+    if (tCell < -400e-9 && tCell > -1 && fillingEmbeddedCells) {
+      embeddedCellWithLateCellTime = true;
+    }
+  }
+
+  // If we have one embedded cell with late cell time, then we want to fill out the QA to
+  // help identify the event.
+  std::string embeddedEventUsed = prefix + "/fHistEmbeddedEventUsed";
+  std::string embeddedInteranlEventSelection = prefix + "/fHistInternalEventSelection";
+  if (embeddedCellWithLateCellTime)
+  {
+    auto embeddingInstance = AliAnalysisTaskEmcalEmbeddingHelper::GetInstance();
+    if (embeddingInstance) {
+      fHistManager.FillTH1(embeddedEventUsed.c_str(),
+                 static_cast<double>(fPreviousEmbeddedEventSelected));
+
+      // Determine the physics selection. This isn't quite a perfect way to store it, as it mingles the
+      // selections between different events. But it is simple, which will let us investigate quickly.
+      // Plus, it's a reasonable bet that the event selection when be the same when it goes wrong.
+      std::bitset<sizeof(UInt_t) * 8> testBits = fPreviousEventTrigger;
+      for (unsigned int i = 0; i < 32; i++) {
+        if (testBits.test(i)) {
+          fHistManager.FillTH2(embeddedInteranlEventSelection.c_str(),
+                     static_cast<double>(fPreviousEmbeddedEventSelected), i);
+        }
+      }
+    }
+  }
+
+  std::string nCellsName = prefix + "/fHistNCells";
+  fHistManager.FillTH1(nCellsName.c_str(), cells->GetNumberOfCells());
+}
+
+/**
+ * Directs the filling of cell QA into the defined histograms.
+ */
+void AliAnalysisTaskEmcalJetHdEdxPerformance::FillCellQAHists()
+{
+  // Fill standard cell QA
+  std::string prefix = "QA/";
+  prefix += fCaloCellsName.Data();
+  FillCellQAHists(prefix, fCaloCells);
+
+  // Fill embedded cell QA it if's available.
+  auto embeddingInstance = AliAnalysisTaskEmcalEmbeddingHelper::GetInstance();
+  if (embeddingInstance) {
+    auto embeddedCells = dynamic_cast<AliVCaloCells*>(
+     embeddingInstance->GetExternalEvent()->FindListObject(fEmbeddedCellsName.c_str()));
+    if (embeddedCells) {
+      prefix = "QA/embedding/";
+      prefix += fEmbeddedCellsName;
+      FillCellQAHists(prefix, embeddedCells);
+    }
+  }
+}
+
+/**
+ * Fill QA histograms.
+ */
+void AliAnalysisTaskEmcalJetHdEdxPerformance::FillQAHists()
+{
+  if (fCreateCellQAHists) {
+    FillCellQAHists();
+  }
+
+  // Tracks
+  AliTrackContainer * trackCont = 0;
+  TIter nextTrackColl(&fParticleCollArray);
+  while ((trackCont = static_cast<AliTrackContainer*>(nextTrackColl()))) {
+    for (auto track : trackCont->accepted())
+    {
+      fHistManager.FillTH3(TString::Format("QA/%s/fHistTrackPtEtaPhi", trackCont->GetName()), track->Pt(),
+                 track->Eta(), track->Phi());
+      fHistManager.FillTH3(TString::Format("QA/%s/fHistTrackPtEtaPhiEfficiencyCorrected", trackCont->GetName()),
+                 track->Pt(), track->Eta(), track->Phi(),
+                 DetermineTrackingEfficiency(track->Pt(), track->Eta()));
+    }
+  }
+
+  // Clusters
+  AliClusterContainer* clusCont = 0;
+  TIter nextClusColl(&fClusterCollArray);
+  AliVCluster * cluster = 0;
+  while ((clusCont = static_cast<AliClusterContainer*>(nextClusColl()))) {
+    for (auto clusIter : clusCont->accepted_momentum())
+    {
+      AliTLorentzVector c = clusIter.first;
+      cluster = clusIter.second;
+      // Intentionally plotting against raw energy
+      fHistManager.FillTH2(TString::Format("QA/%s/fHistClusterEnergyVsTime", clusCont->GetName()), cluster->E(), cluster->GetTOF());
+      // Hadronically corrected energy (which is usually what we're using)
+      fHistManager.FillTH1(TString::Format("QA/%s/fHistClusterHadCorrEnergy", clusCont->GetName()),
+                 cluster->GetHadCorrEnergy());
+      fHistManager.FillTH2(TString::Format("QA/%s/fHistClusterEtaPhi", clusCont->GetName()), c.Eta(),
+                 c.Phi_0_2pi());
+    }
+  }
+
+  // Jets
+  AliJetContainer * jetCont = 0;
+  double jetPt = 0;
+  TIter nextJetColl(&fJetCollArray);
+  while ((jetCont = static_cast<AliJetContainer*>(nextJetColl()))) {
+    double rhoVal = jetCont->GetRhoVal();
+    for (auto jet : jetCont->accepted())
+    {
+      jetPt = AliAnalysisTaskEmcalJetHUtils::GetJetPt(jet, rhoVal);
+      fHistManager.FillTH1(TString::Format("QA/%s/fHistJetPt", jetCont->GetName()), jetPt);
+    }
+  }
+
+  // Event plane resolution
+  // Only attempt to fill the histogram if the corrected Qn vectors are available.
+  if (fFlowQnVectorManager) {
+    // Retrieve the Qn vectors
+    const AliQnCorrectionsQnVector * vzeroQnVector = fFlowQnVectorManager->GetDetectorQnVector("VZEROQoverM");
+    const AliQnCorrectionsQnVector * tpcPosQnVector = fFlowQnVectorManager->GetDetectorQnVector("TPCPosEtaQoverM");
+    const AliQnCorrectionsQnVector * tpcNegQnVector = fFlowQnVectorManager->GetDetectorQnVector("TPCNegEtaQoverM");
+    if (vzeroQnVector == nullptr || tpcPosQnVector == nullptr || tpcNegQnVector == nullptr) {
+      AliWarningStream() << "Q vector unavailable. Skipping.\n";
+    }
+    else {
+      // We need the centrality bin, but the bin provided by the base class isn't that fine grained
+      // (and may cause problems elsewhere if it is). So we just calculate the value here.
+      std::string name = "QA/eventPlaneRes/%s/R%i";
+      // The resolution is calculated by changing the leading term, but it is all with respect
+      // to the same harmonic. We measure with respect to the second order harmonic, so we retrieve
+      // that event plane.
+      double vzero = vzeroQnVector->EventPlane(2);
+      double tpcPos = tpcPosQnVector->EventPlane(2);
+      double tpcNeg = tpcNegQnVector->EventPlane(2);
+      for (unsigned int R = 2; R < 9; R++) {
+        fHistManager.FillProfile(TString::Format(name.c_str(), "VZERO", R), fCent,
+                     std::cos(R * (tpcPos - tpcNeg)));
+        fHistManager.FillProfile(TString::Format(name.c_str(), "TPC_Pos", R), fCent,
+                     std::cos(R * (vzero - tpcNeg)));
+        fHistManager.FillProfile(TString::Format(name.c_str(), "TPC_Neg", R), fCent,
+                     std::cos(R * (vzero - tpcPos)));
+      }
+    }
+  }
+
+  // Update the previous event trigger to the current event trigger so that it is available next event.
+  // This is stored for keeping track of when embedded events are double corrected.
+  // This must be updated after filling the relevant hists above!
+  fPreviousEventTrigger =
+   ((AliInputEventHandler*)(AliAnalysisManager::GetAnalysisManager()->GetInputEventHandler()))->IsEventSelected();
+  auto embeddingInstance = AliAnalysisTaskEmcalEmbeddingHelper::GetInstance();
+  if (embeddingInstance) {
+    fPreviousEmbeddedEventSelected = embeddingInstance->EmbeddedEventUsed();
+  }
+}
+
+/**
+ * Reset matching for the jet container.
+ *
+ * @params[in] c Jet container for the matching to be reset.
+ */
+void AliAnalysisTaskEmcalJetHdEdxPerformance::ResetMatching(const AliJetContainer &c) const
+{
+  for(auto j : c.all()){
+    j->ResetMatching();
+  }
+}
+
+/**
+ * Perform matching between jet collections.
+ *
+ * This code is basically combined from `AliAnalysisTaskEmcalJetTagger::MatchJetsGeo(...)`` and
+ * ``AliEmcalJetTaggerTaskFast::MatchJetsGeo(...)``. I mainly took the appraoch from the fast tagger,
+ * but I'm not using the KDTrees because they still need some additional work as of to properly wrap
+ * around at 2pi in phi. So for now we just use brute force matching at O(n^2).
+ *
+ * Why copy this code? It's a less than ideal thing to do, but for some unidentified, but well known reason
+ * (present from at least 2018), there is an issue that causes most jobs to fail when embedding into LHC15o
+ * for full jets when using one of the tagger tasks. This particularly seems to occur when embedding LHC16j5.
+ * This can be worked around by not running the standard or fast taggers. Thus, the code is copied.
+ *
+ * NOTE: This makes a number of assumptions about the jet containers that are specific to the jet-hadron analysis
+ *       for full jets. Among other factors, it expects that the acceptances are restricted to the EMCal fiducial
+ *       volume for detector level jets. If these assumptions are not true, matching may not work properly.
+ *
+ * @params[in] contBase Base jet container.
+ * @params[in] contTag Second jet container.
+ * @params[in] maxDist Max distance for matching.
+ * @returns True if the matching was successful.
+ */
+bool AliAnalysisTaskEmcalJetHdEdxPerformance::PerformGeometricalJetMatching(AliJetContainer& contBase,
+                                    AliJetContainer& contTag, double maxDist) const
+{
+  // Setup
+  const Int_t kNacceptedBase = contBase.GetNAcceptedJets(), kNacceptedTag = contTag.GetNAcceptedJets();
+  if (!(kNacceptedBase && kNacceptedTag)) {
+    return false;
+  }
+
+  // Build up vectors of jet pointers to use when assigning the closest jets.
+  // The storages are needed later for applying the tagging, in order to avoid multiple occurrence of jet selection
+  std::vector<AliEmcalJet*> jetsBase(kNacceptedBase), jetsTag(kNacceptedTag);
+
+  int countBase(0), countTag(0);
+  for (auto jb : contBase.accepted()) {
+    jetsBase[countBase] = jb;
+    countBase++;
+  }
+  for (auto jt : contTag.accepted()) {
+    jetsTag[countTag] = jt;
+    countTag++;
+  }
+
+  TArrayI faMatchIndexTag(kNacceptedBase), faMatchIndexBase(kNacceptedTag);
+  faMatchIndexBase.Reset(-1);
+  faMatchIndexTag.Reset(-1);
+
+  // find the closest distance to the base jet
+  countBase = 0;
+  for (auto jet1 : contBase.accepted()) {
+    double distance = maxDist;
+
+    // Loop over all accepted jets and brute force search for the closest jet.
+    // NOTE: current_index() returns the jet index in the underlying array, not
+    //       the index within the accepted jets that are returned.
+    int contTagAcceptedIndex = 0;
+    for (auto jet2 : contTag.accepted()) {
+      double dR = jet1->DeltaR(jet2);
+      if (dR < distance && dR < maxDist) {
+        faMatchIndexTag[countBase] = contTagAcceptedIndex;
+        distance = dR;
+      }
+      contTagAcceptedIndex++;
+    }
+
+    // Let us know whether a match was found successfully.
+    if (faMatchIndexTag[countBase] >= 0 && distance < maxDist) {
+      AliDebugStream(1) << "Found closest tag jet for " << countBase << " with match index "
+               << faMatchIndexTag[countBase] << " and distance " << distance << "\n";
+    } else {
+      AliDebugStream(1) << "Not found closest tag jet for " << countBase << ".\n";
+    }
+
+    countBase++;
+  }
+
+  // other way around
+  countTag = 0;
+  for (auto jet1 : contTag.accepted()) {
+    double distance = maxDist;
+
+    // Loop over all accepted jets and brute force search for the closest jet.
+    // NOTE: current_index() returns the jet index in the underlying array, not
+    //       the index within the accepted jets that are returned.
+    int contBaseAcceptedIndex = 0;
+    for (auto jet2 : contBase.accepted()) {
+      double dR = jet1->DeltaR(jet2);
+      if (dR < distance && dR < maxDist) {
+        faMatchIndexBase[countTag] = contBaseAcceptedIndex;
+        distance = dR;
+      }
+      contBaseAcceptedIndex++;
+    }
+
+    // Let us know whether a match was found successfully.
+    if (faMatchIndexBase[countTag] >= 0 && distance < maxDist) {
+      AliDebugStream(1) << "Found closest base jet for " << countTag << " with match index "
+               << faMatchIndexBase[countTag] << " and distance " << distance << "\n";
+    } else {
+      AliDebugStream(1) << "Not found closest base jet for " << countTag << ".\n";
+    }
+
+    countTag++;
+  }
+
+  // check for "true" correlations
+  // these are pairs where the base jet is the closest to the tag jet and vice versa
+  // As the lists are linear a loop over the outer base jet is sufficient.
+  AliDebugStream(1) << "Starting true jet loop: nbase(" << kNacceptedBase << "), ntag(" << kNacceptedTag << ")\n";
+  for (int ibase = 0; ibase < kNacceptedBase; ibase++) {
+    AliDebugStream(2) << "base jet " << ibase << ": match index in tag jet container " << faMatchIndexTag[ibase]
+             << "\n";
+    if (faMatchIndexTag[ibase] > -1) {
+      AliDebugStream(2) << "tag jet " << faMatchIndexTag[ibase] << ": matched base jet "
+               << faMatchIndexBase[faMatchIndexTag[ibase]] << "\n";
+    }
+    // We have a true correlation where each jet points to the other.
+    if (faMatchIndexTag[ibase] > -1 && faMatchIndexBase[faMatchIndexTag[ibase]] == ibase) {
+      AliDebugStream(2) << "found a true match \n";
+      AliEmcalJet *jetBase = jetsBase[ibase], *jetTag = jetsTag[faMatchIndexTag[ibase]];
+      // We have a valid pair of matched jets, so set the closest jet properties.
+      if (jetBase && jetTag) {
+        Double_t dR = jetBase->DeltaR(jetTag);
+        jetBase->SetClosestJet(jetTag, dR);
+        jetTag->SetClosestJet(jetBase, dR);
+      }
+    }
+  }
+  return true;
+}
+
+/**
+ * Fill jet matching QA histograms to describe the matching quality.
+ *
+ * @param[in] contBase Base jet container.
+ * @param[in] contTag Second jet container.
+ */
+void AliAnalysisTaskEmcalJetHdEdxPerformance::FillJetMatchingQA(AliJetContainer& contBase, AliJetContainer& contTag,
+                              const std::string& prefix)
+{
+  // Fill histograms.
+  std::string name = "";
+  std::string centBin = std::to_string(fCentBin);
+  AliDebugStream(2) << "Filling matching hists with prefix: " << prefix << "\n";
+  for (auto jet1 : contBase.accepted()) {
+    // Setup
+    Double_t ptJet1 = jet1->Pt() - contBase.GetRhoVal() * jet1->Area();
+    // Record jet 1 only properties
+    AliDebugStream(4) << "jet1: " << jet1->toString() << "\n";
+    name = "jetMatching/" + prefix + "/fh2PtJet1VsLeadPtAllSel_" + centBin;
+    fHistManager.FillTH2(name.c_str(), ptJet1, jet1->MaxTrackPt());
+
+    // Retrieve jet 2
+    AliEmcalJet * jet2 = jet1->ClosestJet();
+    if (!jet2) { continue; }
+    AliDebugStream(4) << "jet2: " << jet2->toString() << "\n";
+    Double_t ptJet2 = jet2->Pt() - contTag.GetRhoVal() * jet2->Area();
+    // This will retrieve the fraction of jet2's momentum in jet1.
+    Double_t fraction = contBase.GetFractionSharedPt(jet1);
+
+    name = "jetMatching/" + prefix + "/fh2PtJet2VsFraction_" + centBin;
+    fHistManager.FillTH2(name.c_str(), ptJet2, fraction);
+    AliDebugStream(5) << "Fraction: " << fraction << ", minimum: " << fMinFractionShared << "\n";
+    if (fraction < fMinFractionShared) {
+      continue;
+    }
+    name = "jetMatching/" + prefix + "/fh2PtJet1VsLeadPtTagged_" + centBin;
+    fHistManager.FillTH2(name.c_str(), ptJet1,jet1->MaxTrackPt());
+    name = "jetMatching/" + prefix + "/fh2PtJet1VsPtJet2_" + centBin;
+    fHistManager.FillTH2(name.c_str(), ptJet1, ptJet2);
+    if (ptJet2 > 0.) {
+      name = "jetMatching/" + prefix + "/fh2PtJet2VsRelPt_" + centBin;
+      fHistManager.FillTH2(name.c_str(), ptJet2, (ptJet1 - ptJet2) / ptJet2);
+    }
+
+    // Recall that the arguments are backwards of the expectation.
+    Double_t dPhi = DeltaPhi(jet2->Phi(), jet1->Phi());
+    if (dPhi > TMath::Pi()) {
+      dPhi -= TMath::TwoPi();
+    }
+    if (dPhi < (-1. * TMath::Pi())) {
+      dPhi += TMath::TwoPi();
+    }
+
+    name = "jetMatching/" + prefix + "/fh3PtJet1VsDeltaEtaDeltaPhi_" + centBin;
+    fHistManager.FillTH3(name.c_str(), ptJet1, jet1->Eta() - jet2->Eta(), dPhi);
+    name = "jetMatching/" + prefix + "/fh2PtJet1VsDeltaR_" + centBin;
+    fHistManager.FillTH2(name.c_str(), ptJet1, jet1->DeltaR(jet2));
+  }
+
+  // Number of accepted jets
+  name = "jetMatching/" + prefix + "/fNAccJets";
+  fHistManager.FillTH1(name.c_str(), contBase.GetNAcceptedJets());
+}
+
+/**
+ * Process the jets according to defined cuts and fill the response matrix.
+ */
+void AliAnalysisTaskEmcalJetHdEdxPerformance::ResponseMatrix()
+{
+  AliJetContainer * jetsHybrid = GetJetContainer("hybridLevelJets");
+  AliJetContainer * jetsDetLevel = GetJetContainer("detLevelJets");
+  AliJetContainer * jetsPartLevel = GetJetContainer("partLevelJets");
+  // NOTE: Defaults to 0 if rho was not specified.
+  double rhoHybrid = jetsHybrid->GetRhoVal();
+  if (!jetsHybrid) {
+    AliErrorStream() << "Could not retrieve hybrid jet collection.\n";
+    return;
+  }
+  if (!jetsDetLevel) {
+    AliErrorStream() << "Could not retrieve det level jet collection.\n";
+    return;
+  }
+  if (fResponseFromThreeJetCollections && !jetsPartLevel) {
+    AliErrorStream() << "Could not retrieve part level jet collection.\n";
+    return;
+  }
+
+  // Handle matching of jets.
+  for (auto jet1 : jetsHybrid->accepted())
+  {
+    AliDebugStream(4) << "jet1: " << jet1->toString() << "\n";
+    AliDebugStream(4) << "jet1 address: " << jet1 << "\n";
+
+    // Get jet the det level jet from the hybrid jet
+    AliEmcalJet * jet2 = jet1->ClosestJet();
+    if(!jet2) continue;
+
+    AliDebugStream(4) << "jet2: " << jet2->toString() << "\n";
+    AliDebugStream(4) << "jet2 address: " << jet2 << "\n";
+
+    // Check shared fraction
+    double sharedFraction = jetsHybrid->GetFractionSharedPt(jet1);
+    fHistManager.FillTH1("fHistFractionSharedPt", sharedFraction);
+    if (sharedFraction < fMinFractionShared) {
+      AliDebugStream(4) << "Rejecting jet due to momentum fraction of " << sharedFraction << ", smaller than the minimum.\n";
+      continue;
+    }
+    else {
+      AliDebugStream(4) << "Jet passed momentum fraction cut with value of " << sharedFraction << "\n";
+    }
+
+    // NOTE: We apply no explicit event selection to jet 2 because the matching in the tagger
+    // only matches jets which are accepted.
+
+    // Determine the jet to use to fill the response
+    // The jet that is passed may be the embedded detector level (for two stage matching), or it may
+    // be the embedded particle level (for direct matching).
+    AliEmcalJet * jetToPass = 0;
+    if (fResponseFromThreeJetCollections) {
+      // Retrieve the MC level jet
+      AliEmcalJet * jet3 = jet2->ClosestJet();
+      UInt_t rejectionReason = 0;
+      if (!jetsPartLevel->AcceptJet(jet3, rejectionReason)) {
+        // NOTE: This shouldn't ever happen because the tagger applies acceptance
+        //       cuts when matching. However, we keep the check here for good measure.
+        // NOTE: Could store rejection reasons if needed with below:
+        //fHistRejectionReason2->Fill(jets2->GetRejectionReasonBitPosition(rejectionReason), jet2->Pt());
+        continue;
+      }
+
+      AliDebugStream(4) << "jet3: " << jet3->toString() << "\n";
+      AliDebugStream(4) << "jet3 address: " << jet3 << "\n";
+
+      // Use for the response
+      AliDebugStream(4) << "Using part level jet for response (ie. two stage matching)\n";
+      jetToPass = jet3;
+    }
+    else {
+      // Use for the response
+      AliDebugStream(4) << "Using one stage matching for response\n";
+      jetToPass = jet2;
+    }
+
+    // Fill response
+    FillResponseMatrix(jet1, jetToPass, rhoHybrid);
+  }
+
+}
+
+/**
+ * If given multiple jet collections, handle creating a reasponse matrix
+ */
+void AliAnalysisTaskEmcalJetHdEdxPerformance::FillResponseMatrix(AliEmcalJet * jet1, AliEmcalJet * jet2, const double jet1Rho)
+{
+  if (!jet1 || !jet2) {
+    AliErrorStream() << "Null jet passed to fill response matrix";
+  }
+
+  AliDebugStream(3) << "About to create ResponseMatrixFillWrappers\n";
+  AliDebugStream(4) << "jet1: " << jet1->toString() << "\n";
+  AliDebugStream(4) << "jet2: " << jet2->toString() << "\n";
+  // Create map from jetNumber to jet and initialize the objects
+  std::map<unsigned int, ResponseMatrixFillWrapper> jetNumberToJet = {
+    std::make_pair(1, CreateResponseMatrixFillWrapper(jet1, jet1Rho)),
+    // We would never want to rho subtract the second jet, regardless of whether it's external
+    // detector level or particle level.
+    std::make_pair(2, CreateResponseMatrixFillWrapper(jet2, 0))
+  };
+
+  // Fill histograms
+  std::string histName = "response/fHistResponseMatrix";
+  std::vector<double> values;
+  THnSparse * response = static_cast<THnSparse*>(fHistManager.FindObject(histName.c_str()));
+  AliDebugStream(3) << "About to fill response matrix values\n";
+  AliDebugStream(4) << "jet1: " << jet1->toString() << "\n";
+  AliDebugStream(4) << "jet2: " << jet2->toString() << "\n";
+  for (unsigned int i = 0; i < response->GetNdimensions(); i++) {
+    std::string title = response->GetAxis(i)->GetTitle();
+
+    // Retrieve pair of jet and pointer to extract the fill value
+    auto jetPair = fResponseMatrixFillMap.find(title);
+    if (jetPair != fResponseMatrixFillMap.end()) {
+      auto wrapper = jetNumberToJet.at(jetPair->second.first);
+      auto member = jetPair->second.second;
+      AliDebugStream(4) << "Filling value " << wrapper.*member << " into axis " << title << "\n";
+      values.emplace_back(wrapper.*member);
+    }
+    else {
+      AliWarningStream() << "Unable to fill dimension " << title << "!\n";
+    }
+  }
+
+  fHistManager.FillTHnSparse(histName.c_str(), values.data());
+}
+
+/**
+ *
+ */
+AliAnalysisTaskEmcalJetHdEdxPerformance::ResponseMatrixFillWrapper AliAnalysisTaskEmcalJetHdEdxPerformance::CreateResponseMatrixFillWrapper(AliEmcalJet * jet, const double rho) const
+{
+  ResponseMatrixFillWrapper wrapper;
+  if (!jet) {
+    AliErrorStream() << "Must pass valid jet to create object.\n";
+    return wrapper;
+  }
+  wrapper.fPt = AliAnalysisTaskEmcalJetHUtils::GetJetPt(jet, rho);
+  wrapper.fArea = jet->Area();
+  wrapper.fPhi = jet->Phi();
+  wrapper.fDistance = jet->ClosestJetDistance();
+  wrapper.fCentrality = fCent;
+  wrapper.fRelativeEPAngle = AliAnalysisTaskEmcalJetHUtils::RelativeEPAngle(jet->Phi(), fEPV0);
+  wrapper.fLeadingHadronPt = AliAnalysisTaskEmcalJetHUtils::GetLeadingHadronPt(jet, fLeadingHadronBiasType);
+
+  return wrapper;
+}
+
+/**
+ * Add task to an existing analysis manager.
+ *
+ * @param[in] suffix Suffix string to attach to the task name
+ */
+AliAnalysisTaskEmcalJetHdEdxPerformance * AliAnalysisTaskEmcalJetHdEdxPerformance::AddTaskEmcalJetHdEdxPerformance(const char * suffix)
+{
+  // Get the pointer to the existing analysis manager via the static access method.
+  //==============================================================================
+  AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
+  if (!mgr)
+  {
+    AliErrorClass("No analysis manager to connect to.");
+    return nullptr;
+  }
+
+  // Setup task name
+  std::string taskName = "AliAnalysisTaskEmcalJetHdEdxPerformance";
+  std::string suffixName(suffix);
+  if (suffixName != "") {
+    taskName += "_";
+    taskName += suffixName;
+  }
+
+  // Create task and configure as desired.
+  AliAnalysisTaskEmcalJetHdEdxPerformance * task = new AliAnalysisTaskEmcalJetHdEdxPerformance(taskName.c_str());
+  // Set a few general default.
+  task->SetNCentBins(5);
+  // Configuration is via YAML.
+  mgr->AddTask(task);
+
+  // Create containers for input/output
+  mgr->ConnectInput(task, 0, mgr->GetCommonInputContainer() );
+  AliAnalysisDataContainer* outputContainer =
+   mgr->CreateContainer(task->GetName(), TList::Class(), AliAnalysisManager::kOutputContainer,
+              Form("%s", AliAnalysisManager::GetCommonFileName()));
+  mgr->ConnectOutput(task, 1, outputContainer);
+
+  return task;
+}
+
+/**
+ * Prints information about the jet-hadron performance task.
+ *
+ * @return std::string containing information about the task.
+ */
+std::string AliAnalysisTaskEmcalJetHdEdxPerformance::toString() const
+{
+  std::stringstream tempSS;
+  tempSS << std::boolalpha;
+  tempSS << "Particle collections:\n";
+  TIter nextParticleCont(&fParticleCollArray);
+  AliParticleContainer * particleCont;
+  while ((particleCont = static_cast<AliParticleContainer *>(nextParticleCont()))) {
+    tempSS << "\t" << particleCont->GetName() << ": " << particleCont->GetArrayName() << "\n";
+  }
+  tempSS << "Cluster collections:\n";
+  TIter nextClusterCont(&fClusterCollArray);
+  AliClusterContainer * clusterCont;
+  while ((clusterCont = static_cast<AliClusterContainer *>(nextClusterCont()))) {
+    tempSS << "\t" << clusterCont->GetName() << ": " << clusterCont->GetArrayName() << "\n";
+  }
+  tempSS << "Jet collections:\n";
+  TIter nextJetCont(&fJetCollArray);
+  AliJetContainer * jetCont;
+  while ((jetCont = static_cast<AliJetContainer *>(nextJetCont()))) {
+    tempSS << "\t" << jetCont->GetName() << ": " << jetCont->GetArrayName() << "\n";
+  }
+  // AliEventCuts
+  tempSS << "AliEventCuts\n";
+  tempSS << "\tEnabled: " << !fUseBuiltinEventSelection << "\n";
+  // Efficiency
+  tempSS << "Efficiency\n";
+  tempSS << "\tSingle track efficiency identifier: " << fEfficiencyPeriodIdentifier << "\n";
+  // QA
+  tempSS << "QA Hists:\n";
+  tempSS << "\tEnabled: " << fCreateQAHists << "\n";
+  tempSS << "\tCreate cell QA hists: " << fCreateCellQAHists << "\n";
+  // Use whether the pointer as null as a proxy. It's not ideal because it's not fully initialized
+  // until after UserCreateOutputObjects(). But it's good enough for these purposes.
+  tempSS << "\tCalculate event plane resolution (proxy of whether it's enabled - it may not be accurate): " << (fFlowQnVectorManager != nullptr) << "\n";
+  // Jet matching
+  tempSS << "Jet matching:\n";
+  tempSS << "\tEnabled: " << fPerformJetMatching << "\n";
+  tempSS << "\tMax matching distance: " << fMaxJetMatchingDistance << "\n";
+  // Response matrix
+  tempSS << "Response matrix:\n";
+  tempSS << "\tEnabled: " << fCreateResponseMatrix << "\n";
+  tempSS << "\tConstruct response from 3 jet collections: " << fResponseFromThreeJetCollections << "\n";
+  tempSS << "\tMin fraction shared pt: " << fMinFractionShared << "\n";
+  tempSS << "\tJet leading hadron bias type: " << fLeadingHadronBiasType << "\n";
+  tempSS << "\tResponse matrix fill map: \n";
+  for (auto el : fResponseMatrixFillMap) {
+    tempSS << "\t\tProperty " << el.first << " applied to jet " << el.second.first << "\n";
+  }
+
+  return tempSS.str();
+}
+
+/**
+ * Print jet-hadron performance task information on an output stream using the string representation provided by
+ * AliAnalysisTaskEmcalJetHdEdxPerformance::toString. Used by operator<<
+ * @param in output stream stream
+ * @return reference to the output stream
+ */
+std::ostream & AliAnalysisTaskEmcalJetHdEdxPerformance::Print(std::ostream & in) const {
+  in << toString();
+  return in;
+}
+
+/**
+ * Print basic jet-hadron performance task information using the string representation provided by
+ * AliAnalysisTaskEmcalJetHdEdxPerformance::toString
+ *
+ * @param[in] opt Unused
+ */
+void AliAnalysisTaskEmcalJetHdEdxPerformance::Print(Option_t* opt) const
+{
+  Printf("%s", toString().c_str());
+}
+
+} /* namespace EMCALJetTasks */
+} /* namespace PWGJE */
+
+/**
+ * Implementation of the output stream operator for AliAnalysisTaskEmcalJetHdEdxPerformance. Printing
+ * basic jet-hadron performance task information provided by function toString
+ * @param in output stream
+ * @param myTask Task which will be printed
+ * @return Reference to the output stream
+ */
+std::ostream & operator<<(std::ostream & in, const PWGJE::EMCALJetTasks::AliAnalysisTaskEmcalJetHdEdxPerformance & myTask)
+{
+  std::ostream & result = myTask.Print(in);
+  return result;
+}
+
+/**
+ * Swap function. Created using guide described here: https://stackoverflow.com/a/3279550.
+ *
+ * NOTE: We don't swap the base class values because the base class doesn't implement swap.
+ */
+void swap(PWGJE::EMCALJetTasks::AliAnalysisTaskEmcalJetHdEdxPerformance & first, PWGJE::EMCALJetTasks::AliAnalysisTaskEmcalJetHdEdxPerformance & second)
+{
+  using std::swap;
+
+  // Same ordering as in the constructors (for consistency)
+  swap(first.fYAMLConfig, second.fYAMLConfig);
+  swap(first.fConfigurationInitialized, second.fConfigurationInitialized);
+  //swap(first.fHistManager, second.fHistManager); // Skip here, because the THistManager copy constructor is private.
+  //swap(first.fEmbeddingQA, second.fEmbeddingQA); // Skip here, because the THistManager copy constructor is private.
+  swap(first.fCreateQAHists, second.fCreateQAHists);
+  swap(first.fCreateCellQAHists, second.fCreateCellQAHists);
+  swap(first.fPerformJetMatching, second.fPerformJetMatching);
+  swap(first.fCreateResponseMatrix, second.fCreateResponseMatrix);
+  swap(first.fEmbeddedCellsName, second.fEmbeddedCellsName);
+  swap(first.fPreviousEventTrigger, second.fPreviousEventTrigger);
+  swap(first.fPreviousEmbeddedEventSelected, second.fPreviousEmbeddedEventSelected);
+  swap(first.fEfficiencyPeriodIdentifier, second.fEfficiencyPeriodIdentifier);
+  swap(first.fFlowQnVectorManager, second.fFlowQnVectorManager);
+  swap(first.fResponseMatrixFillMap, second.fResponseMatrixFillMap);
+  swap(first.fResponseFromThreeJetCollections, second.fResponseFromThreeJetCollections);
+  swap(first.fMinFractionShared, second.fMinFractionShared);
+  swap(first.fLeadingHadronBiasType, second.fLeadingHadronBiasType);
+}

--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHdEdxPerformance.h
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHdEdxPerformance.h
@@ -1,0 +1,150 @@
+#ifndef ALIANALYSISTASKEMCALJETHDEDXPERFORMANCE_H
+#define ALIANALYSISTASKEMCALJETHDEDXPERFORMANCE_H
+
+/**
+ * @class AliAnalysisTaskEmcalJetHdEdxPerformance
+ * @brief Jet-hadron correlations task dedicated to performance of the analysis
+ *
+ * @author Raymond Ehlers <raymond.ehlers@cern.ch>, Yale University
+ * @date 23 Feb 2018
+ */
+
+#include <string>
+
+class AliJetContainer;
+class AliEmcalJet;
+class AliVCaloCells;
+class AliQnCorrectionsManager;
+#include "THistManager.h"
+#include "AliYAMLConfiguration.h"
+#include "AliAnalysisTaskEmcalJet.h"
+#include "AliEmcalEmbeddingQA.h"
+#include "AliAnalysisTaskEmcalJetHUtils.h"
+
+// operator<< has to be forward declared carefully to stay in the global namespace so that it works with CINT.
+// For generally how to keep the operator in the global namespace, See: https://stackoverflow.com/a/38801633
+namespace PWGJE { namespace EMCALJetTasks { class AliAnalysisTaskEmcalJetHdEdxPerformance; } }
+std::ostream & operator<< (std::ostream &in, const PWGJE::EMCALJetTasks::AliAnalysisTaskEmcalJetHdEdxPerformance &myTask);
+void swap(PWGJE::EMCALJetTasks::AliAnalysisTaskEmcalJetHdEdxPerformance & first, PWGJE::EMCALJetTasks::AliAnalysisTaskEmcalJetHdEdxPerformance & second);
+
+namespace PWGJE {
+namespace EMCALJetTasks {
+
+class AliAnalysisTaskEmcalJetHdEdxPerformance : public AliAnalysisTaskEmcalJet {
+ public:
+  /**
+   * Wrapper to contain the properties for a jet to simplify filling the response matrix histogram
+   */
+  struct ResponseMatrixFillWrapper {
+    double fPt;                 //!<! Jet pt
+    double fArea;               //!<! Jet area
+    double fPhi;                //!<! jet phi
+    double fRelativeEPAngle;    //!<! Angle relative to the event plane
+    double fLeadingHadronPt;    //!<! Leading hadron pt
+    double fDistance;           //!<! Distance to the matched jet
+    double fCentrality;         //!<! Centrality of the given jet (an event level property, but useful to here available here)
+  };
+
+  AliAnalysisTaskEmcalJetHdEdxPerformance();
+  AliAnalysisTaskEmcalJetHdEdxPerformance(const char * name);
+  // Additional constructors
+  AliAnalysisTaskEmcalJetHdEdxPerformance(const AliAnalysisTaskEmcalJetHdEdxPerformance & other);
+  AliAnalysisTaskEmcalJetHdEdxPerformance& operator=(AliAnalysisTaskEmcalJetHdEdxPerformance other);
+  friend void ::swap(AliAnalysisTaskEmcalJetHdEdxPerformance & first, AliAnalysisTaskEmcalJetHdEdxPerformance & second);
+  // Avoid implementing move since c++11 is not allowed in the header
+
+  void UserCreateOutputObjects();
+
+  // Initialize the task
+  // Configuration is handled via the YAML configuration file
+  bool Initialize();
+  void AddConfigurationFile(const std::string & configurationPath, const std::string & configName = "") { fYAMLConfig.AddConfiguration(configurationPath, configName); }
+
+  // Utility functions
+  // AddTask
+  static AliAnalysisTaskEmcalJetHdEdxPerformance * AddTaskEmcalJetHdEdxPerformance(const char * suffix = "");
+  // Printing
+  std::string toString() const;
+  friend std::ostream & ::operator<<(std::ostream &in, const AliAnalysisTaskEmcalJetHdEdxPerformance &myTask);
+  void Print(Option_t* opt = "") const;
+  std::ostream & Print(std::ostream &in) const;
+
+ private:
+
+  Bool_t Run();
+
+  // Helper functions
+  double DetermineTrackingEfficiency(double trackPt, double trackEta);
+
+  // Configuration
+  void RetrieveAndSetTaskPropertiesFromYAMLConfig();
+  void SetupJetContainersFromYAMLConfig();
+  void SetupParticleContainersFromYAMLConfig();
+  void SetupClusterContainersFromYAMLConfig();
+
+  // QA histograms
+  void SetupQAHists();
+  void QAHists();
+  void FillQAHists();
+  // Cell QA
+  void SetupCellQAHistsWithPrefix(const std::string & prefix);
+  void SetupCellQAHists();
+  void FillCellQAHists(const std::string & prefix, AliVCaloCells * cells);
+  void FillCellQAHists();
+
+  // Jet matching
+  void SetupJetMatchingQA();
+  void ResetMatching(const AliJetContainer & jetCont) const;
+  bool PerformGeometricalJetMatching(AliJetContainer& contBase, AliJetContainer& contTag, double maxDist) const;
+  void FillJetMatchingQA(AliJetContainer& contBase, AliJetContainer& contTag, const std::string& prefix);
+
+  // Response matrix functions
+  void SetupResponseMatrixHists();
+  void ResponseMatrix();
+  void FillResponseMatrix(AliEmcalJet* jet1, AliEmcalJet* jet2, const double jet1Rho);
+  ResponseMatrixFillWrapper CreateResponseMatrixFillWrapper(AliEmcalJet * jet, const double rho) const;
+
+  // Basic configuration
+  PWG::Tools::AliYAMLConfiguration fYAMLConfig; ///< YAML configuration file.
+  bool fConfigurationInitialized;     ///<  True if the task configuration has been successfully initialized.
+
+  // Histograms
+  THistManager fHistManager;          ///<  Histogram manager.
+  AliEmcalEmbeddingQA fEmbeddingQA;   //!<! Embedding QA hists (will only be added if embedding).
+
+  // Configuration options
+  bool fCreateQAHists;                ///<  If true, create QA histograms.
+  bool fCreateCellQAHists;            ///<  If true, create the Cell QA histograms. It doesn't gracefully turn off when not configured like the containers, so we have a switch.
+  bool fPerformJetMatching;           ///<  If true, enables jet matching.
+  bool fCreateResponseMatrix;         ///<  If true, create a response matrix with the available jet collections.
+
+  // QA variables
+  std::string fEmbeddedCellsName;                 ///<  Set the embedded cells collection name
+  UInt_t fPreviousEventTrigger;                   ///<  Physics selection (offline trigger) of the previous event for determine why a small number of embedded event are double counted.
+  bool fPreviousEmbeddedEventSelected;            ///<  True if the previous embedded event was selected. Used to determine why a small number of embedded event are double counted.
+  AliAnalysisTaskEmcalJetHUtils::EEfficiencyPeriodIdentifier_t fEfficiencyPeriodIdentifier;  ///<  Identifies the period for determining the efficiency correction to apply
+  AliQnCorrectionsManager *fFlowQnVectorManager;  //!<! Qn corrections framework manager.
+
+  // Jet matching
+  double fMaxJetMatchingDistance;                 ///<  Matx jet matching distance.
+
+  // Response matrix variables
+  // Response matrix fill map
+  // For whatever reason, it appears that CINT can't handle this definition
+  #if !(defined(__CINT__) || defined(__MAKECINT__))
+  // For some reason, root can't handle this typedef
+  //typedef double ResponseMatrixFillWrapper::*MP;
+  //std::map <std::string, std::pair<int, MP>> fResponseMatrixFillMap;   //!<!
+  std::map <std::string, std::pair<int, double ResponseMatrixFillWrapper::*>> fResponseMatrixFillMap;   //!<! Map from axis title to pair of (jet number, function to retrieve fill value)
+  #endif
+  bool fResponseFromThreeJetCollections; ///<  If true, the det level jets in collection 2 are only an intermediate step. They are used to get part level jets to match to hybrid jets
+  double fMinFractionShared;             ///<  Minimum fraction of shared jet pt required for matching a hybrid jet to detector level
+  AliAnalysisTaskEmcalJetHUtils::ELeadingHadronBiasType_t fLeadingHadronBiasType; ///<  Leading hadron in jet bias type (either charged, neutral, or both)
+
+  ClassDef(AliAnalysisTaskEmcalJetHdEdxPerformance, 7);
+};
+
+} /* namespace EMCALJetTasks */
+} /* namespace PWGJE */
+
+#endif /* AliAnalysisTaskEmcalJetHdEdxPerformance.h */

--- a/PWGJE/EMCALJetTasks/macros/AddTaskEmcalJetHdEdxCorrelations.C
+++ b/PWGJE/EMCALJetTasks/macros/AddTaskEmcalJetHdEdxCorrelations.C
@@ -1,0 +1,38 @@
+PWGJE::EMCALJetTasks::AliAnalysisTaskEmcalJetHdEdxCorrelations* AddTaskEmcalJetHdEdxCorrelations(
+   const char *nTracks              = "usedefault",
+   const char *nCaloClusters        = "usedefault",
+   // Jet options
+   const Double_t trackBias         = 5,
+   const Double_t clusterBias       = 5,
+   // Mixed event options
+   const Int_t nTracksMixedEvent    = 0,  // Additionally acts as a switch for enabling mixed events
+   const Int_t minNTracksMixedEvent = 5000,
+   const Int_t minNEventsMixedEvent = 5,
+   const UInt_t nCentBinsMixedEvent = 10,
+   // Triggers
+   UInt_t trigEvent                 = AliVEvent::kAny,
+   UInt_t mixEvent                  = AliVEvent::kAny,
+   // Options
+   const Bool_t lessSparseAxes      = 0,
+   const Bool_t widerTrackBin       = 0,
+   // Corrections
+   const Bool_t embeddingCorrection = kFALSE,
+   const char * embeddingCorrectionFilename = "alien:///alice/cern.ch/user/r/rehlersi/embeddingCorrection.root",
+   const char * embeddingCorrectionHistName = "embeddingCorrection",
+   const char *suffix               = "biased"
+)
+{
+  PWGJE::EMCALJetTasks::AliAnalysisTaskEmcalJetHdEdxCorrelations * task = PWGJE::EMCALJetTasks::AliAnalysisTaskEmcalJetHdEdxCorrelations::AddTaskEmcalJetHdEdxCorrelations(
+                          nTracks, nCaloClusters,
+                          trackBias, clusterBias,
+                          nTracksMixedEvent, minNTracksMixedEvent, minNEventsMixedEvent,
+                          nCentBinsMixedEvent,
+                          trigEvent, mixEvent,
+                          lessSparseAxes,
+                          widerTrackBin,
+                          embeddingCorrection,
+                          embeddingCorrectionFilename, embeddingCorrectionHistName,
+                          suffix
+                          );
+  return task;
+}

--- a/PWGJE/EMCALJetTasks/macros/AddTaskEmcalJetHdEdxPerformance.C
+++ b/PWGJE/EMCALJetTasks/macros/AddTaskEmcalJetHdEdxPerformance.C
@@ -1,0 +1,7 @@
+PWGJE::EMCALJetTasks::AliAnalysisTaskEmcalJetHdEdxPerformance* AddTaskEmcalJetHdEdxPerformance(
+    const char * suffix = ""
+)
+{  
+  PWGJE::EMCALJetTasks::AliAnalysisTaskEmcalJetHdEdxPerformance * task = PWGJE::EMCALJetTasks::AliAnalysisTaskEmcalJetHdEdxPerformance::AddTaskEmcalJetHdEdxPerformance(suffix);
+  return task;
+}


### PR DESCRIPTION
I am creating a new analysis which reuses almost all of AliAnalysisTaskEmcalJetHCorrelations and all of AliAnalysisTaskEmcalJetHCorrelations. Will be used as input to backend code which computes particle species identified yields in regions of the background-subtracted, efficiency and acceptance corrected, correlations function.