### PR TITLE
Add function ot obtain cross section weight from event header to AliAnalysisTaskEmcal

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.cxx
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.cxx
@@ -2336,6 +2336,15 @@ void AliAnalysisTaskEmcal::GeneratePythiaInfoObject(AliMCEvent* mcEvent)
     fPythiaInfo->SetPythiaEventWeight(ptWeight);}
 }
 
+double AliAnalysisTaskEmcal::GetCrossSectionFromHeader() const {
+  double crosssection = -1.;
+  if(fIsPythia || fIsHepMC) {
+    if(fIsPythia && fPythiaHeader) crosssection = fPythiaHeader->GetXsection();
+    if(fIsHepMC && fHepMCHeader) crosssection = fHepMCHeader->sigma_gen();
+  }
+  return crosssection;
+}
+
 AliAODInputHandler* AliAnalysisTaskEmcal::AddAODHandler()
 {
   AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();

--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.h
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.h
@@ -576,7 +576,16 @@ class AliAnalysisTaskEmcal : public AliAnalysisTaskSE {
   void                        SetTrigClass(const char *n)                           { fTrigClass         = n                              ; }
   void                        SetMinBiasTriggerClassName(const char *n)             { fMinBiasRefTrigger = n                              ; }
   void                        SetTriggerTypeSel(TriggerType t)                      { fTriggerTypeSel    = t                              ; } 
-  void                        SetUseAliAnaUtils(Bool_t b, Bool_t bRejPilup = kTRUE) { fUseAliAnaUtils    = b ; fRejectPileup = bRejPilup  ; }
+
+  /**
+   * @brief Use AliAnalysisUtils for event selection
+   * @param doUse If true AliAnalysisUtis are used for event selection (builtin event selection only)
+   * @param doRejectPilup If true pileup rejection is enabled
+   * @deprecated Event cuts work only for p-Pb 2013. Method should not be used. By default
+   * the AliAnalysisTaskEmcal uses AliEventCuts for event selection, which is adapted to all
+   * known datasets
+   */
+  void                        SetUseAliAnaUtils(Bool_t doUse, Bool_t doRejectPilup = kTRUE) { fUseAliAnaUtils    = doUse ; fRejectPileup = doRejectPilup  ; }
 
   /**
    * @brief Use internal (old) event selection
@@ -615,12 +624,53 @@ class AliAnalysisTaskEmcal : public AliAnalysisTaskSE {
   void                        SetUseSPDTrackletVsClusterBG(Bool_t b)                { fTklVsClusSPDCut   = b                              ; }
   void                        SetEMCalTriggerMode(EMCalTriggerMode_t m)             { fEMCalTriggerMode  = m                              ; }
   void                        SetUseNewCentralityEstimation(Bool_t b)               { fUseNewCentralityEstimation = b                     ; }
-  void                        SetGeneratePythiaInfoObject(Bool_t b)                 { fGeneratePythiaInfoObject = b                       ; }
-  void                        SetPythiaInfoName(const char *n)                      { fPythiaInfoName    = n                              ; }
-  void                        SetNameMCPartonInfo(const char *n)                    { fNameMCPartonInfo = n                               ; }
+
+  /**
+   * @brief Switch on building of the PYTHIA info object
+   * @param doUse If true the PYTHIA info object is built (accessible for this task only)
+   */
+  void                        SetGeneratePythiaInfoObject(Bool_t doBuild)           { fGeneratePythiaInfoObject = doBuild                 ; }
+
+  /**
+   * @brief Set name of the PYTHIA info object
+   * @param name Name of the pythis info object
+   */
+  void                        SetPythiaInfoName(const char *name)                   { fPythiaInfoName   = name                            ; }
+
+  /**
+   * @brief Set the name of the container with direct MC partons
+   * @param name Name of the MC parton info container
+   */
+  void                        SetNameMCPartonInfo(const char *name)                 { fNameMCPartonInfo = name                            ; }
+
+  /**
+   * @brief Get the name of the PYTHIA info object
+   * @return Name of the PYTHIA info object
+   */
   const TString&              GetPythiaInfoName()                             const { return fPythiaInfoName                              ; }
+
+  /**
+   * @brief Get the PYTHIA info object
+   * @return Object with hard partons from pt-hard productions 
+   * 
+   * The PYTHIA info object contains the partons from the initial hard scattering (stack postion 6 and 7).
+   * The object is only available for PYTHIA pt-hard productions
+   */
   const AliEmcalPythiaInfo   *GetPythiaInfo()                                 const { return fPythiaInfo                                  ; }
+
+  /**
+   * @brief Get container with direct partons produced from the colliding nucleons / nuclei (MC)
+   * @return Container with direct partons 
+   * 
+   * Method is currently implemented only for HepMC output
+   */
   const PWG::EMCAL::AliEmcalMCPartonInfo *GetMCPartonInfo()                   const { return fMCPartonInfo                                ; }
+
+  /**
+   * @brief Get the event cross section from the generator event header
+   * @return Cross section (-1 in not a PYTHIA- or HepMC based production)
+   */
+  double                      GetCrossSectionFromHeader()                     const;
 
   /**
    * @brief Switch on pt-hard bin scaling

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetEnergySpectrum.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetEnergySpectrum.cxx
@@ -69,6 +69,7 @@ AliAnalysisTaskEmcalJetEnergySpectrum::AliAnalysisTaskEmcalJetEnergySpectrum():
   fNameJetContainer("datajets"),
   fRequestTriggerClusters(true),
   fRequestCentrality(false),
+  fFillHistosWeighted(false),
   fUseRun1Range(false),
   fUseSumw2(false),
   fUseMuonCalo(false),
@@ -99,6 +100,7 @@ AliAnalysisTaskEmcalJetEnergySpectrum::AliAnalysisTaskEmcalJetEnergySpectrum(EMC
   fNameJetContainer("datajets"),
   fRequestTriggerClusters(true),
   fRequestCentrality(false),
+  fFillHistosWeighted(false),
   fUseRun1Range(false),
   fUseSumw2(false),
   fUseMuonCalo(false),
@@ -274,6 +276,13 @@ bool AliAnalysisTaskEmcalJetEnergySpectrum::Run(){
   Double_t weight = 1.;
   if(fUseDownscaleWeight) {
     weight = 1./PWG::EMCAL::AliEmcalDownscaleFactorsOCDB::Instance()->GetDownscaleFactorForTriggerClass(MatchTrigger(fInputEvent->GetFiredTriggerClasses().Data(), fTriggerSelectionString.Data(), fUseMuonCalo));
+  }
+  if(fFillHistosWeighted && isMC) {
+    // Get cross section weight from supported generator event header
+    auto crossSectionWeight = GetCrossSectionFromHeader();
+    if(crossSectionWeight > 0) {
+      weight *= crossSectionWeight;
+    }
   }
   AliDebugStream(2) << "Found downscale weight " << weight << " for trigger " << fTriggerSelectionString << std::endl;
   fHistos->FillTH1("hEventCounterAbs", 1.);

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetEnergySpectrum.h
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetEnergySpectrum.h
@@ -69,6 +69,7 @@ public:
   void SetRequestCentrality(bool doRequest) { fRequestCentrality = doRequest; }
   void SetRequestTriggerClusters(bool doRequest) { fRequestTriggerClusters = doRequest; }
   void SetCentralityEstimator(EMCAL_STRINGVIEW centest) { fCentralityEstimator = centest; }
+  void SetFillHistosWeighted(bool doFill)          { fFillHistosWeighted = doFill; }
   void SetFillHSparse(Bool_t doFill)               { fFillHSparse = doFill; }
   void SetUseMuonCalo(Bool_t doUse)                { fUseMuonCalo = doUse; }
   void SetEnergyScaleShfit(Double_t scaleshift)    { fScaleShift = scaleshift; } 
@@ -118,6 +119,7 @@ private:
   TString                       fNameJetContainer;              ///< Name of the jet container 
   Bool_t                        fRequestTriggerClusters;        ///< Request distinction of trigger clusters
   Bool_t                        fRequestCentrality;             ///< Request centrality
+  Bool_t                        fFillHistosWeighted;            ///< Fill histograms with cross section weight
   Bool_t                        fUseRun1Range;                  ///< Use run1 run range for trending plots     
   Bool_t                        fUseSumw2;                      ///< Switch for sumw2 option in THnSparse (should not be used when a downscale weight is applied)
   Bool_t                        fUseMuonCalo;                   ///< Use events from the (muon)-calo-(fast) cluster


### PR DESCRIPTION
- Add function to get the cross section weight in
  AliAnalysisTaskEmcal for the current event (PYTHIA
  or HepMC only)
- Add option in jet spectrum task to use the cross
  section weight to reweight the spectra on-the-fly