### PR TITLE
New 3D PsiPair Cut

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskGammaCaloDalitzV1.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaCaloDalitzV1.cxx
@@ -4189,7 +4189,7 @@ void AliAnalysisTaskGammaCaloDalitzV1::ProcessElectronCandidates(){
 				Double_t psiPair = GetPsiPair(positronCandidate,electronCandidate);
 				Double_t deltaPhi = magField * TVector2::Phi_mpi_pi( electronCandidate->GetConstrainedParam()->Phi()-positronCandidate->GetConstrainedParam()->Phi());
 
-				if( ((AliDalitzElectronCuts*)fElectronCutArray->At(fiCut))->IsFromGammaConversion(psiPair,deltaPhi ) ){
+				if( ((AliDalitzElectronCuts*)fElectronCutArray->At(fiCut))->IsFromGammaConversion(psiPair,deltaPhi,TMath::Sqrt(positronCandidate->Pt()*positronCandidate->Pt()+electronCandidate->Pt()*electronCandidate->Pt()))){//ALERT New update
 					lElectronPsiIndex[i] = kFALSE;
 					lPositronPsiIndex[j] = kFALSE;
 				}

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvDalitzV1.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvDalitzV1.cxx
@@ -1096,7 +1096,7 @@ void AliAnalysisTaskGammaConvDalitzV1::UserCreateOutputObjects()
         hESDEposEnegPsiPairpTEtaDPhi[iCut] = new TH3F("ESD_EposEneg_PsiPair_pTEta_DPhi","ESD_EposEneg_PsiPair_pTEta_DPhi",100,-1.0,1.0,100,-1.0,1.0,100,0,10);
         fQAFolder[iCut]->Add(hESDEposEnegPsiPairpTEtaDPhi[iCut]);
 
-        hESDEposEnegPsiPairpTPhotonDPhi[iCut] = new TH3F("ESD_EposEneg_PsiPair_pTPhoton_DPhi_DPhi","ESD_EposEneg_PsiPair_pTPhoton_DPhi",100,-1.0,1.0,100,-1.0,1.0,100,0,10);
+        hESDEposEnegPsiPairpTPhotonDPhi[iCut] = new TH3F("ESD_EposEneg_PsiPair_pTPhoton_DPhi","ESD_EposEneg_PsiPair_pTPhoton_DPhi",100,-1.0,1.0,100,-1.0,1.0,100,0,10);
         fQAFolder[iCut]->Add(hESDEposEnegPsiPairpTPhotonDPhi[iCut]);
 
         if (fIsMC > 1) {
@@ -2259,7 +2259,7 @@ void AliAnalysisTaskGammaConvDalitzV1::ProcessVirtualGammasCandidates(){
           hESDEposEnegTrueEtaDalitzInvMassPt[fiCut]->Fill(Vgamma->M(),Vgamma->Pt(),fWeightJetJetMC);
           hESDEposEnegTrueEtaDalitzPsiPairDPhi[fiCut]->Fill(deltaPhi,psiPair,fWeightJetJetMC);
           if ( fDoMesonQA > 1 ) {
-            hESDEposEnegPsiPairpTEtaDPhi[fiCut]->Fill(deltaPhi,psiPair,fWeightJetJetMC);
+            hESDEposEnegPsiPairpTEtaDPhi[fiCut]->Fill(deltaPhi,psiPair,Vgamma->Pt());
           }
           if( isMotherPrimary ) hESDEposEnegTruePrimEtaDalitzInvMass[fiCut]->Fill( Vgamma->M(),fWeightJetJetMC );
         } else if ( isTrueEposENeg && mcVgamma.get() ){

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvDalitzV1.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvDalitzV1.cxx
@@ -162,6 +162,12 @@ AliAnalysisTaskGammaConvDalitzV1::AliAnalysisTaskGammaConvDalitzV1():
   sESDMotherInvMassPtZM(NULL),
   hESDMotherBackInvMassPt(NULL),
   sESDMotherBackInvMassPtZM(NULL),
+  hESDInvMassElectronPositronPi0(NULL),
+  hESDInvMassElectronPositronPi0MC(NULL),
+//   hESDInvMassElectronPositronPi0Background(NULL),
+  hESDInvMassElectronPositronEta(NULL),
+  hESDInvMassElectronPositronEtaMC(NULL),
+//   hESDInvMassElectronPositronEtaBackground(NULL),
   hESDMotherPi0PtY(NULL),
   hESDMotherPi0PtAlpha(NULL),
   hESDMotherPi0PtOpenAngle(NULL),
@@ -398,6 +404,12 @@ AliAnalysisTaskGammaConvDalitzV1::AliAnalysisTaskGammaConvDalitzV1( const char* 
   sESDMotherInvMassPtZM(NULL),
   hESDMotherBackInvMassPt(NULL),
   sESDMotherBackInvMassPtZM(NULL),
+  hESDInvMassElectronPositronPi0(NULL),
+  hESDInvMassElectronPositronPi0MC(NULL),
+//   hESDInvMassElectronPositronPi0Background(NULL),
+  hESDInvMassElectronPositronEta(NULL),
+  hESDInvMassElectronPositronEtaMC(NULL),
+//   hESDInvMassElectronPositronEtaBackground(NULL),
   hESDMotherPi0PtY(NULL),
   hESDMotherPi0PtAlpha(NULL),
   hESDMotherPi0PtOpenAngle(NULL),
@@ -744,8 +756,14 @@ void AliAnalysisTaskGammaConvDalitzV1::UserCreateOutputObjects()
     hESDMotherPi0PtY         = new TH2F*[fnCuts];
     hESDMotherPi0PtAlpha         = new TH2F*[fnCuts];
     hESDMotherPi0PtOpenAngle       = new TH2F*[fnCuts];
-
-
+    hESDInvMassElectronPositronPi0  = new TH1F*[fnCuts];
+//     hESDInvMassElectronPositronPi0Background    = new TH1F*[fnCuts];
+    hESDInvMassElectronPositronEta  = new TH1F*[fnCuts];
+//     hESDInvMassElectronPositronEtaBackground    = new TH1F*[fnCuts];
+    if (fIsMC>0){
+        hESDInvMassElectronPositronPi0MC    = new TH1F*[fnCuts];
+        hESDInvMassElectronPositronEtaMC    = new TH1F*[fnCuts];
+    }
     if ( fDoMesonQA > 1 ){//QA 2 option
       sESDConvGammaZR       = new THnSparseF*[fnCuts];
       sESDConvGammaXY        = new THnSparseF*[fnCuts];
@@ -1125,6 +1143,18 @@ void AliAnalysisTaskGammaConvDalitzV1::UserCreateOutputObjects()
       hESDMotherPi0PtOpenAngle[iCut]   = new TH2F("ESD_MotherPi0_Pt_OpenAngle","ESD_MotherPi0_Pt_OpenAngle",150,0.03,15.,100,0,TMath::Pi());//TODO
       SetLogBinningXTH2(hESDMotherPi0PtOpenAngle[iCut]);
       fESDList[iCut]->Add(hESDMotherPi0PtOpenAngle[iCut]);
+        hESDInvMassElectronPositronPi0[iCut]  =  new TH1F("ESD_InvMassElectronPositron_Pi0", "ESD_InvMassElectronPositron_Pi0",120,0.05,0.17);
+//         hESDInvMassElectronPositronPi0Background[iCut]    =  new TH1F("ESD_InvMassElectronPositron_Pi0Background", "ESD_InvMassElectronPositron_Pi0Background",120,0.05,0.17);
+        hESDInvMassElectronPositronEta[iCut]  = new TH1F("ESD_InvMassElectronPositron_Eta", "ESD_InvMassElectronPositron_Eta",100,0.500,0.580);
+//         hESDInvMassElectronPositronEtaBackground[iCut]    =  new TH1F("ESD_InvMassElectronPositron_EtaBackground", "ESD_InvMassElectronPositron_EtaBackground",100,0.500,0.580);
+        fESDList[iCut]->Add(hESDInvMassElectronPositronPi0[iCut]);
+        fESDList[iCut]->Add(hESDInvMassElectronPositronEta[iCut]);
+        if (fIsMC>0){
+            hESDInvMassElectronPositronPi0MC[iCut]    = new TH1F("ESD_InvMassElectronPositron_Pi0MC", "ESD_InvMassElectronPositron_Pi0MC",120,0.05,0.17);
+            hESDInvMassElectronPositronEtaMC[iCut]    = new TH1F("ESD_InvMassElectronPositron_EtaMC", "ESD_InvMassElectronPositron_EtaMC",80,0.500,0.580);
+            fESDList[iCut]->Add(hESDInvMassElectronPositronPi0MC[iCut]);
+            fESDList[iCut]->Add(hESDInvMassElectronPositronEtaMC[iCut]);
+        }
         if (fIsMC > 1) {
             hESDMotherPi0PtOpenAngle[iCut]->Sumw2();
             hESDMotherPi0PtAlpha[iCut]->Sumw2();
@@ -2410,7 +2440,7 @@ void AliAnalysisTaskGammaConvDalitzV1::ProcessElectronCandidates(){
         Double_t psiPair = GetPsiPair(positronCandidate.get(),electronCandidate.get());
         Double_t deltaPhi = GetdeltaPhi(electronCandidate.get(),positronCandidate.get());
 
-        if( ((AliDalitzElectronCuts*)fCutElectronArray->At(fiCut))->IsFromGammaConversion(psiPair,deltaPhi) ){
+        if( ((AliDalitzElectronCuts*)fCutElectronArray->At(fiCut))->IsFromGammaConversion(psiPair,deltaPhi,0.0) ){
           lElectronPsiIndex[i] = kFALSE;
           lPositronPsiIndex[j] = kFALSE;
         }
@@ -2650,8 +2680,18 @@ void AliAnalysisTaskGammaConvDalitzV1::CalculatePi0DalitzCandidates(){
                 hESDMotherInvMassOpeningAngleGammaElectron[fiCut]->Fill(vGamma.Angle(vPositron),fWeightJetJetMC);
                 hESDMotherInvMassOpeningAngleGammaElectron[fiCut]->Fill(vGamma.Angle(vElectron),fWeightJetJetMC);
 
-                if ( pi0cand->M() > 0.05 && pi0cand->M() < 0.17){
 
+                if ( pi0cand->M() > 0.500 && pi0cand->M() < 0.580){
+                    hESDInvMassElectronPositronEta[fiCut]->Fill(Vgamma->M());
+                    if(fMCEvent){
+                        hESDInvMassElectronPositronEtaMC[fiCut]->Fill(Vgamma->M());
+                  }
+                }
+                if ( pi0cand->M() > 0.05 && pi0cand->M() < 0.17){
+                hESDInvMassElectronPositronPi0[fiCut]->Fill(Vgamma->M());
+                    if(fMCEvent){
+                        hESDInvMassElectronPositronPi0MC[fiCut]->Fill(Vgamma->M());
+                    }
                   if( fDoMesonQA > 1 ){
                     TLorentzVector electronCandidateTLV(vElectron,TDatabasePDG::Instance()->GetParticle(  ::kElectron   )->Mass());
                     TLorentzVector positronCandidateTLV(vPositron,TDatabasePDG::Instance()->GetParticle(  ::kPositron   )->Mass());

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvDalitzV1.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvDalitzV1.h
@@ -198,6 +198,12 @@ class AliAnalysisTaskGammaConvDalitzV1: public AliAnalysisTaskSE {
     THnSparseF                        **sESDMotherInvMassPtZM;
     TH2F                              **hESDMotherBackInvMassPt;
     THnSparseF                        **sESDMotherBackInvMassPtZM;
+    TH1F                              **hESDInvMassElectronPositronPi0;
+    TH1F                              **hESDInvMassElectronPositronPi0MC;
+//     TH1F                              **hESDInvMassElectronPositronPi0Background;
+    TH1F                              **hESDInvMassElectronPositronEta;
+    TH1F                              **hESDInvMassElectronPositronEtaMC;
+//     TH1F                              **hESDInvMassElectronPositronEtaBackground;
     TH2F                              **hESDMotherPi0PtY;
     TH2F                              **hESDMotherPi0PtAlpha;
     TH2F                              **hESDMotherPi0PtOpenAngle;

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvDalitzV1_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvDalitzV1_pp.C
@@ -400,6 +400,16 @@ void AddTask_GammaConvDalitzV1_pp(  Int_t trainConfig = 1,  //change different s
     //New Standard+0.5 single pt cut
     cuts.AddCutPCMDalitz("0008d113", "0dm00009f9730000dge0404000", "204c6420263202223010", "0152103500000000");
     //New Standard+Low Rejection for pions kaons and protons
+   } else if (trainConfig == 430) {//Psipair Optimization.
+    cuts.AddCutPCMDalitz("00010113", "0dm00009f9730000dge0404000", "204c6400863202223710", "0152103500000000");//Standard with kBoth on electrons
+    cuts.AddCutPCMDalitz("00010113", "0dm00009f9730000dge0404000", "204c6400263202223710", "0152103500000000");//Standard
+    cuts.AddCutPCMDalitz("00010113", "0dm00009f9730000dge0404000", "204c6400263702223710", "0152103500000000");//kAny 5% GG
+    cuts.AddCutPCMDalitz("00010113", "0dm00009f9730000dge0404000", "204c6400263802223710", "0152103500000000");//kAny 8% GG
+    } else if (trainConfig == 431) {//Psipair Optimization.
+    cuts.AddCutPCMDalitz("00010113", "0dm00009f9730000dge0404000", "204c6400863e02223710", "0152103500000000");//kBoth 5 % GG
+    cuts.AddCutPCMDalitz("00010113", "0dm00009f9730000dge0404000", "204c6400863f02223710", "0152103500000000");//kBoth 8 % GG
+    cuts.AddCutPCMDalitz("00010113", "0dm00009f9730000dge0404000", "204c6400863h02223710", "0152103500000000");//kBoth pt dependance
+    cuts.AddCutPCMDalitz("00010113", "0dm00009f9730000dge0404000", "204c6400263g02223710", "0152103500000000");//kAny pt dependance
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 ///////////////////  6XX for lowB,    65X  lowB and MBW ////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -481,28 +491,19 @@ void AddTask_GammaConvDalitzV1_pp(  Int_t trainConfig = 1,  //change different s
     cuts.AddCutPCMDalitz("00010113", "0dh00009266300008850404000", "20475400254202321710", "0263103100900000");
     cuts.AddCutPCMDalitz("00010113", "0di00009266300008850404000", "20475400254202321710", "0263103100900000");
   } else if (trainConfig == 770) {  //New standar?
-    cuts.AddCutPCMDalitz("00010113", "0d200009f9730000dge0404000", "204c6400263202223710", "0152103500000000");
+    cuts.AddCutPCMDalitz("00010113", "0d200009f9730000dge0404000", "204c6400863b02223710", "0152103500000000");
   } else if (trainConfig == 771) {  //Study on range of TPC
-    cuts.AddCutPCMDalitz("00010113", "0da00009f9730000dge0404000", "204c6400263202223710", "0152103500000000");
-    //Range TPC 5-33.5
-    cuts.AddCutPCMDalitz("00010113", "0db00009f9730000dge0404000", "204c6400263202223710", "0152103500000000");
-    //Range TPC 33.5-72
-    cuts.AddCutPCMDalitz("00010113", "0dc00009f9730000dge0404000", "204c6400263202223710", "0152103500000000");
-    //Range TPC 72-180
+    cuts.AddCutPCMDalitz("00010113", "0da00009f9730000dge0404000", "204c6400863b02223710", "0152103500000000");//Range TPC 5-33.5i
+    cuts.AddCutPCMDalitz("00010113", "0db00009f9730000dge0404000", "204c6400863b02223710", "0152103500000000");//Range TPC 33.5-72
+    cuts.AddCutPCMDalitz("00010113", "0dc00009f9730000dge0404000", "204c6400863b02223710", "0152103500000000");//Range TPC 72-180
   } else if (trainConfig == 772) {  //still Study on range of TPC
-    cuts.AddCutPCMDalitz("00010113", "0dh00009f9730000dge0404000", "204c6400263202223710", "0152103500000000");
-    //Range TPC 5-13
-    cuts.AddCutPCMDalitz("00010113", "0di00009f9730000dge0404000", "204c6400263202223710", "0152103500000000");
-    //Range TPC 13-33.5
-    cuts.AddCutPCMDalitz("00010113", "0dj00009f9730000dge0404000", "204c6400263202223710", "0152103500000000");
-    //Range TPC 33.5-55
+    cuts.AddCutPCMDalitz("00010113", "0dh00009f9730000dge0404000", "204c6400863b02223710", "0152103500000000");//Range TPC 5-13
+    cuts.AddCutPCMDalitz("00010113", "0di00009f9730000dge0404000", "204c6400863b02223710", "0152103500000000");//Range TPC 13-33.5
+    cuts.AddCutPCMDalitz("00010113", "0dj00009f9730000dge0404000", "204c6400863b02223710", "0152103500000000");//Range TPC 33.5-55
   } else if (trainConfig == 773) {  //still still Study on range of TPC
-    cuts.AddCutPCMDalitz("00010113", "0dk00009f9730000dge0404000", "204c6400263202223710", "0152103500000000");
-    //Range TPC 55-72
-    cuts.AddCutPCMDalitz("00010113", "0dl00009f9730000dge0404000", "204c6400263202223710", "0152103500000000");
-    //Range TPC 72-95
-    cuts.AddCutPCMDalitz("00010113", "0dg00009f9730000dge0404000", "204c6400263202223710", "0152103500000000");
-    //Range TPC 95-180
+    cuts.AddCutPCMDalitz("00010113", "0dk00009f9730000dge0404000", "204c6400863b02223710", "0152103500000000");//Range TPC 55-72
+    cuts.AddCutPCMDalitz("00010113", "0dl00009f9730000dge0404000", "204c6400863b02223710", "0152103500000000");//Range TPC 72-95
+    cuts.AddCutPCMDalitz("00010113", "0dg00009f9730000dge0404000", "204c6400863b02223710", "0152103500000000");//Range TPC 95-180
 ///////////////////////////////////////////////////////////////////////////////////
 ///////////////////////////Study region of R on LowB Field/////////////////////////
 ///////////////////////////////////////////////////////////////////////////////////
@@ -537,28 +538,30 @@ void AddTask_GammaConvDalitzV1_pp(  Int_t trainConfig = 1,  //change different s
     cuts.AddCutPCMDalitz("00010113", "0dm00089f9730000iih0424000", "204c6400263202263710", "0152103500000000"); // eta < 0.8  // Test improved cuts
     cuts.AddCutPCMDalitz("00010113", "0dm00089f9730000iih0454000", "204c6400263202263710", "0152103500000000"); // eta < 0.8  // Test improved cuts
     cuts.AddCutPCMDalitz("00010113", "0dm00089f9730000iih0404000", "204c6400263202263710", "0152103520000000"); // eta < 0.8  // Test improved cuts
-
+  } else if (trainConfig == 930) { // Study Low B Field kBoth for New PsiPair and kBoth, Optimization at 5 and 8 % of contamiantion.
+    cuts.AddCutPCMDalitz("00010113", "0dm00089f9730000iih0404000", "204c6400863a02263710", "0152103500000000"); //kBoth 5 % of contamination from photons
+    cuts.AddCutPCMDalitz("00010113", "0dm00089f9730000iih0404000", "204c6400863b02263710", "0152103500000000"); //kBoth 8 % of contamination from photons
+    cuts.AddCutPCMDalitz("00010113", "0dm00089f9730000iih0404000", "204c6400263c02263710", "0152103500000000"); //kAny 5 % of contamination from photons
+    cuts.AddCutPCMDalitz("00010113", "0dm00089f9730000iih0404000", "204c6400263d02263710", "0152103500000000"); //kAny 8 % of contamination from photons
     //-----------------same as 6XX to be used with MBW extracted from 5TeV Nch
-
-
   } else if (trainConfig == 969) { // R 5-180 and remove r bin 55-72
     cuts.AddCutPCMDalitz("00010113", "0d200089f9730000iih0404000", "204c6400263202263710", "0152101500000000"); // eta < 0.8  // Test alpha meson pT dependent
     cuts.AddCutPCMDalitz("00010113", "0dm00089f9730000iih0404000", "204c6400263202263710", "0152103500000000"); // eta < 0.8  // remove  55-72 bin
     cuts.AddCutPCMDalitz("00010113", "0dd00089f9730000iih0404000", "204c6400263202263710", "0152103500000000"); // eta < 0.8  // use 5-55 bin only
   } else if (trainConfig == 970) { // R 5-180
-    cuts.AddCutPCMDalitz("00010113", "0d200089f9730000iih0404000", "204c6400263202263710", "0152103500000000"); // eta < 0.8  // Test improved cuts
+    cuts.AddCutPCMDalitz("00010113", "0d200089f9730000iih0404000", "204c6400863b02263710", "0152103500000000"); // all range 0 to 180
   } else if (trainConfig == 971) { // R 5-180
-    cuts.AddCutPCMDalitz("00010113", "0da00089f9730000iih0404000", "204c6400263202263710", "0152103500000000"); // eta < 0.8  // Test improved cuts
-    cuts.AddCutPCMDalitz("00010113", "0db00089f9730000iih0404000", "204c6400263202263710", "0152103500000000"); // eta < 0.8  // Test improved cuts
-    cuts.AddCutPCMDalitz("00010113", "0dc00089f9730000iih0404000", "204c6400263202263710", "0152103500000000"); // eta < 0.8  // Test improved cuts
+    cuts.AddCutPCMDalitz("00010113", "0da00089f9730000iih0404000", "204c6400863b02263710", "0152103500000000"); // Range TPC 5-33.5
+    cuts.AddCutPCMDalitz("00010113", "0db00089f9730000iih0404000", "204c6400863b02263710", "0152103500000000"); // Range TPC 33.5-72
+    cuts.AddCutPCMDalitz("00010113", "0dc00089f9730000iih0404000", "204c6400863b02263710", "0152103500000000"); // Range TPC 72-180
   } else if (trainConfig == 972) { // R 5-180
-    cuts.AddCutPCMDalitz("00010113", "0dh00089f9730000iih0404000", "204c6400263202263710", "0152103500000000"); // eta < 0.8  // Test improved cuts
-    cuts.AddCutPCMDalitz("00010113", "0di00089f9730000iih0404000", "204c6400263202263710", "0152103500000000"); // eta < 0.8  // Test improved cuts
-    cuts.AddCutPCMDalitz("00010113", "0dj00089f9730000iih0404000", "204c6400263202263710", "0152103500000000"); // eta < 0.8  // Test improved cuts
+    cuts.AddCutPCMDalitz("00010113", "0dh00089f9730000iih0404000", "204c6400863b02263710", "0152103500000000"); // Range TPC 5-13
+    cuts.AddCutPCMDalitz("00010113", "0di00089f9730000iih0404000", "204c6400863b02263710", "0152103500000000"); // Range TPC 13-33.5
+    cuts.AddCutPCMDalitz("00010113", "0dj00089f9730000iih0404000", "204c6400863b02263710", "0152103500000000"); // Range TPC 33.5-55
   } else if (trainConfig == 973) { // R 5-180
-    cuts.AddCutPCMDalitz("00010113", "0dk00089f9730000iih0404000", "204c6400263202263710", "0152103500000000"); // eta < 0.8  // Test improved cuts
-    cuts.AddCutPCMDalitz("00010113", "0dl00089f9730000iih0404000", "204c6400263202263710", "0152103500000000"); // eta < 0.8  // Test improved cuts
-    cuts.AddCutPCMDalitz("00010113", "0dg00089f9730000iih0404000", "204c6400263202263710", "0152103500000000"); // eta < 0.8  // Test improved cuts
+    cuts.AddCutPCMDalitz("00010113", "0dk00089f9730000iih0404000", "204c6400863b02263710", "0152103500000000"); // Range TPC 55-72
+    cuts.AddCutPCMDalitz("00010113", "0dl00089f9730000iih0404000", "204c6400863b02263710", "0152103500000000"); // Range TPC 72-95
+    cuts.AddCutPCMDalitz("00010113", "0dg00089f9730000iih0404000", "204c6400863b02263710", "0152103500000000"); // Range TPC 95-180
   } else if (trainConfig == 978) { // R 5-180  // Cat 1, cat 2+3, Meson Cat >= 2
     cuts.AddCutPCMDalitz("00010113", "0d200089f9730000iih0424000", "204c6400263202263710", "0152103500000000"); // eta < 0.8  // Test improved cuts
     cuts.AddCutPCMDalitz("00010113", "0d200089f9730000iih0454000", "204c6400263202263710", "0152103500000000"); // eta < 0.8  // Test improved cuts

--- a/PWGGA/GammaConvBase/AliDalitzElectronCuts.h
+++ b/PWGGA/GammaConvBase/AliDalitzElectronCuts.h
@@ -121,7 +121,7 @@ class AliDalitzElectronCuts : public AliAnalysisCuts {
   Bool_t dEdxCuts(AliVTrack * track);
   Bool_t PIDProbabilityCut(AliConversionPhotonBase *photon, AliVEvent * event);
   Bool_t RejectSharedElecGamma(TList *photons, Int_t indexEle);
-  Bool_t IsFromGammaConversion( Double_t psiPair, Double_t deltaPhi );
+  Bool_t IsFromGammaConversion( Double_t psiPair, Double_t deltaPhi , Double_t pT);
   Bool_t MassCut(Double_t pi0CandidatePt,Double_t vphotonCandidateMass);
 
   // Event Cuts
@@ -190,6 +190,13 @@ class AliDalitzElectronCuts : public AliAnalysisCuts {
   Double_t fPsiPairCut;
   Double_t fDeltaPhiCutMin;
   Double_t fDeltaPhiCutMax;
+  Int_t    fDoDifferentCut;
+  Double_t* fPsiPairCutArray;
+  Double_t* fDeltaPhiCutArray;
+  Double_t* fpTDependanceCutArray;
+  Double_t* fPsiPairpTDependanceCut;
+  Double_t* fDeltaPhipTDependanceCutMin;
+  Double_t* fDeltaPhipTDependanceCutMax;
   Double_t fMaxDCAVertexz;
   Double_t fMaxDCAVertexxy;
   TString fDCAVertexPt;//Conversion from coordenates to momentum.


### PR DESCRIPTION
New implementation in the Psipair, Optimization at 5 and 8 %, plus histograms to study the invariant mass of the electron-positron coming from the primary vertex