### PR TITLE
PWGGA/GammaConv: Fixing problem for a case 1 in PsiPair

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvDalitzV1.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvDalitzV1.cxx
@@ -164,10 +164,10 @@ AliAnalysisTaskGammaConvDalitzV1::AliAnalysisTaskGammaConvDalitzV1():
   sESDMotherBackInvMassPtZM(NULL),
   hESDInvMassElectronPositronPi0(NULL),
   hESDInvMassElectronPositronPi0MC(NULL),
-//   hESDInvMassElectronPositronPi0Background(NULL),
+  hESDInvMassElectronPositronPi0Background(NULL),
   hESDInvMassElectronPositronEta(NULL),
   hESDInvMassElectronPositronEtaMC(NULL),
-//   hESDInvMassElectronPositronEtaBackground(NULL),
+  hESDInvMassElectronPositronEtaBackground(NULL),
   hESDMotherPi0PtY(NULL),
   hESDMotherPi0PtAlpha(NULL),
   hESDMotherPi0PtOpenAngle(NULL),
@@ -406,10 +406,10 @@ AliAnalysisTaskGammaConvDalitzV1::AliAnalysisTaskGammaConvDalitzV1( const char* 
   sESDMotherBackInvMassPtZM(NULL),
   hESDInvMassElectronPositronPi0(NULL),
   hESDInvMassElectronPositronPi0MC(NULL),
-//   hESDInvMassElectronPositronPi0Background(NULL),
+  hESDInvMassElectronPositronPi0Background(NULL),
   hESDInvMassElectronPositronEta(NULL),
   hESDInvMassElectronPositronEtaMC(NULL),
-//   hESDInvMassElectronPositronEtaBackground(NULL),
+  hESDInvMassElectronPositronEtaBackground(NULL),
   hESDMotherPi0PtY(NULL),
   hESDMotherPi0PtAlpha(NULL),
   hESDMotherPi0PtOpenAngle(NULL),
@@ -757,9 +757,9 @@ void AliAnalysisTaskGammaConvDalitzV1::UserCreateOutputObjects()
     hESDMotherPi0PtAlpha         = new TH2F*[fnCuts];
     hESDMotherPi0PtOpenAngle       = new TH2F*[fnCuts];
     hESDInvMassElectronPositronPi0  = new TH1F*[fnCuts];
-//     hESDInvMassElectronPositronPi0Background    = new TH1F*[fnCuts];
+    hESDInvMassElectronPositronPi0Background    = new TH1F*[fnCuts];
     hESDInvMassElectronPositronEta  = new TH1F*[fnCuts];
-//     hESDInvMassElectronPositronEtaBackground    = new TH1F*[fnCuts];
+    hESDInvMassElectronPositronEtaBackground    = new TH1F*[fnCuts];
     if (fIsMC>0){
         hESDInvMassElectronPositronPi0MC    = new TH1F*[fnCuts];
         hESDInvMassElectronPositronEtaMC    = new TH1F*[fnCuts];
@@ -1074,6 +1074,27 @@ void AliAnalysisTaskGammaConvDalitzV1::UserCreateOutputObjects()
 
       hESDEposEnegLikeSignBackInvMassPt[iCut]  = new TH2F("ESD_EposEneg_LikeSignBack_InvMassPt","ESD_EposEneg_LikeSignBack_InvMassPt",1000,0.0,2.,100,0.,10.);//TODO
       fQAFolder[iCut]->Add(hESDEposEnegLikeSignBackInvMassPt[iCut]);
+
+      hESDInvMassElectronPositronPi0[iCut]  =  new TH1F("ESD_InvMassElectronPositron_Pi0", "ESD_InvMassElectronPositron_Pi0",120,0.05,0.17);
+      fQAFolder[iCut]->Add(hESDInvMassElectronPositronPi0[iCut]);
+
+      hESDInvMassElectronPositronPi0Background[iCut]    =  new TH1F("ESD_InvMassElectronPositron_Pi0Background", "ESD_InvMassElectronPositron_Pi0Background",120,0.05,0.17);
+      fQAFolder[iCut]->Add(hESDInvMassElectronPositronPi0Background[iCut]);
+
+      hESDInvMassElectronPositronEta[iCut]  = new TH1F("ESD_InvMassElectronPositron_Eta", "ESD_InvMassElectronPositron_Eta",100,0.500,0.580);
+      fQAFolder[iCut]->Add(hESDInvMassElectronPositronEta[iCut]);
+
+      hESDInvMassElectronPositronEtaBackground[iCut]    =  new TH1F("ESD_InvMassElectronPositron_EtaBackground", "ESD_InvMassElectronPositron_EtaBackground",100,0.500,0.580);
+      fQAFolder[iCut]->Add(hESDInvMassElectronPositronEtaBackground[iCut]);
+
+      if (fIsMC>0){
+        hESDInvMassElectronPositronPi0MC[iCut]    = new TH1F("ESD_InvMassElectronPositron_Pi0MC", "ESD_InvMassElectronPositron_Pi0MC",120,0.05,0.17);
+        fQAFolder[iCut]->Add(hESDInvMassElectronPositronPi0MC[iCut]);
+
+        hESDInvMassElectronPositronEtaMC[iCut]    = new TH1F("ESD_InvMassElectronPositron_EtaMC", "ESD_InvMassElectronPositron_EtaMC",80,0.500,0.580);
+        fQAFolder[iCut]->Add(hESDInvMassElectronPositronEtaMC[iCut]);
+      }
+
         if (fIsMC > 1) {
             hESDEposEnegPsiPairDPhi[iCut]->Sumw2();
             hESDEposEnegPsiPairEta[iCut]->Sumw2();
@@ -1143,18 +1164,6 @@ void AliAnalysisTaskGammaConvDalitzV1::UserCreateOutputObjects()
       hESDMotherPi0PtOpenAngle[iCut]   = new TH2F("ESD_MotherPi0_Pt_OpenAngle","ESD_MotherPi0_Pt_OpenAngle",150,0.03,15.,100,0,TMath::Pi());//TODO
       SetLogBinningXTH2(hESDMotherPi0PtOpenAngle[iCut]);
       fESDList[iCut]->Add(hESDMotherPi0PtOpenAngle[iCut]);
-        hESDInvMassElectronPositronPi0[iCut]  =  new TH1F("ESD_InvMassElectronPositron_Pi0", "ESD_InvMassElectronPositron_Pi0",120,0.05,0.17);
-//         hESDInvMassElectronPositronPi0Background[iCut]    =  new TH1F("ESD_InvMassElectronPositron_Pi0Background", "ESD_InvMassElectronPositron_Pi0Background",120,0.05,0.17);
-        hESDInvMassElectronPositronEta[iCut]  = new TH1F("ESD_InvMassElectronPositron_Eta", "ESD_InvMassElectronPositron_Eta",100,0.500,0.580);
-//         hESDInvMassElectronPositronEtaBackground[iCut]    =  new TH1F("ESD_InvMassElectronPositron_EtaBackground", "ESD_InvMassElectronPositron_EtaBackground",100,0.500,0.580);
-        fESDList[iCut]->Add(hESDInvMassElectronPositronPi0[iCut]);
-        fESDList[iCut]->Add(hESDInvMassElectronPositronEta[iCut]);
-        if (fIsMC>0){
-            hESDInvMassElectronPositronPi0MC[iCut]    = new TH1F("ESD_InvMassElectronPositron_Pi0MC", "ESD_InvMassElectronPositron_Pi0MC",120,0.05,0.17);
-            hESDInvMassElectronPositronEtaMC[iCut]    = new TH1F("ESD_InvMassElectronPositron_EtaMC", "ESD_InvMassElectronPositron_EtaMC",80,0.500,0.580);
-            fESDList[iCut]->Add(hESDInvMassElectronPositronPi0MC[iCut]);
-            fESDList[iCut]->Add(hESDInvMassElectronPositronEtaMC[iCut]);
-        }
         if (fIsMC > 1) {
             hESDMotherPi0PtOpenAngle[iCut]->Sumw2();
             hESDMotherPi0PtAlpha[iCut]->Sumw2();
@@ -2683,15 +2692,9 @@ void AliAnalysisTaskGammaConvDalitzV1::CalculatePi0DalitzCandidates(){
 
                 if ( pi0cand->M() > 0.500 && pi0cand->M() < 0.580){
                     hESDInvMassElectronPositronEta[fiCut]->Fill(Vgamma->M());
-                    if(fMCEvent){
-                        hESDInvMassElectronPositronEtaMC[fiCut]->Fill(Vgamma->M());
-                  }
                 }
                 if ( pi0cand->M() > 0.05 && pi0cand->M() < 0.17){
                 hESDInvMassElectronPositronPi0[fiCut]->Fill(Vgamma->M());
-                    if(fMCEvent){
-                        hESDInvMassElectronPositronPi0MC[fiCut]->Fill(Vgamma->M());
-                    }
                   if( fDoMesonQA > 1 ){
                     TLorentzVector electronCandidateTLV(vElectron,TDatabasePDG::Instance()->GetParticle(  ::kElectron   )->Mass());
                     TLorentzVector positronCandidateTLV(vPositron,TDatabasePDG::Instance()->GetParticle(  ::kPositron   )->Mass());
@@ -2810,6 +2813,12 @@ void AliAnalysisTaskGammaConvDalitzV1::CalculateBackground(){
               if( ((AliDalitzElectronCuts*) fCutElectronArray->At(fiCut))->MassCut( backgroundCandidate->Pt() , currentEventGoodV0.M() ) == kTRUE ){
 
                 hESDMotherBackInvMassPt[fiCut]->Fill(backgroundCandidate->M(),backgroundCandidate->Pt(),fWeightJetJetMC);
+                if ((backgroundCandidate->M()>0.05) && (backgroundCandidate->M()<0.17)){
+                        hESDInvMassElectronPositronPi0Background[fiCut]->Fill(currentEventGoodV0.M());
+                }
+                if ((backgroundCandidate->M()>0.500) && (backgroundCandidate->M()<0.580)){
+                        hESDInvMassElectronPositronEtaBackground[fiCut]->Fill(currentEventGoodV0.M());
+                }
                 if(fDoTHnSparse){
                 Double_t sparesFill[4] = {backgroundCandidate->M(),backgroundCandidate->Pt(),(Double_t)zbin,(Double_t)mbin};
                 sESDMotherBackInvMassPtZM[fiCut]->Fill(sparesFill,1);
@@ -2998,7 +3007,7 @@ void AliAnalysisTaskGammaConvDalitzV1::ProcessTrueMesonCandidates(AliAODConversi
             hESDTruePi0PtY[fiCut]->Fill(Pi0Candidate->Pt(),Pi0Candidate->Rapidity()-((AliConvEventCuts*)fCutEventArray->At(fiCut))->GetEtaShift());
             hESDTruePi0PtAlpha[fiCut]->Fill(Pi0Candidate->Pt(),TMath::Abs(Pi0Candidate->GetAlpha()));
             hESDTruePi0PtOpenAngle[fiCut]->Fill(Pi0Candidate->Pt(),Pi0Candidate->GetOpeningAngle());
-
+            hESDInvMassElectronPositronPi0MC[fiCut]->Fill(TrueVirtualGammaCandidate->M());
             if( fDoMesonQA > 1 ) {
               std::unique_ptr<AliDalitzAODESD> positronVgamma = std::unique_ptr<AliDalitzAODESD>(fAODESDEvent->GetTrack(TrueVirtualGammaCandidate->GetTrackLabelPositive()));
              // AliESDtrack* positronVgamma = fESDEvent->GetTrack( TrueVirtualGammaCandidate->GetTrackLabelPositive() );
@@ -3025,7 +3034,11 @@ void AliAnalysisTaskGammaConvDalitzV1::ProcessTrueMesonCandidates(AliAODConversi
             }
           }
         }
-
+        if (isTrueEta && fDoMesonQA > 0) {
+            if ( Pi0Candidate->M() > 0.500 && Pi0Candidate->M() < 0.580){
+                hESDInvMassElectronPositronEtaMC[fiCut]->Fill(TrueVirtualGammaCandidate->M());
+            }
+        }
         if( ((AliDalitzElectronCuts*) fCutElectronArray->At(fiCut))->DoWeights() ) {
           if(((AliConvEventCuts*)fCutEventArray->At(fiCut))->IsParticleFromBGEvent(gammaMotherLabel, fMCEvent,fInputEvent)){
             if (TempgammaMotherLabel->PtG()>0.005){

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvDalitzV1.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvDalitzV1.h
@@ -200,10 +200,10 @@ class AliAnalysisTaskGammaConvDalitzV1: public AliAnalysisTaskSE {
     THnSparseF                        **sESDMotherBackInvMassPtZM;
     TH1F                              **hESDInvMassElectronPositronPi0;
     TH1F                              **hESDInvMassElectronPositronPi0MC;
-//     TH1F                              **hESDInvMassElectronPositronPi0Background;
+    TH1F                              **hESDInvMassElectronPositronPi0Background;
     TH1F                              **hESDInvMassElectronPositronEta;
     TH1F                              **hESDInvMassElectronPositronEtaMC;
-//     TH1F                              **hESDInvMassElectronPositronEtaBackground;
+    TH1F                              **hESDInvMassElectronPositronEtaBackground;
     TH2F                              **hESDMotherPi0PtY;
     TH2F                              **hESDMotherPi0PtAlpha;
     TH2F                              **hESDMotherPi0PtOpenAngle;

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvDalitzV1.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvDalitzV1.h
@@ -351,7 +351,7 @@ class AliAnalysisTaskGammaConvDalitzV1: public AliAnalysisTaskSE {
     AliAnalysisTaskGammaConvDalitzV1( const AliAnalysisTaskGammaConvDalitzV1& ); // Not implemented
     AliAnalysisTaskGammaConvDalitzV1& operator=( const AliAnalysisTaskGammaConvDalitzV1& ); // Not implemented
 
-  ClassDef( AliAnalysisTaskGammaConvDalitzV1, 56 );
+  ClassDef( AliAnalysisTaskGammaConvDalitzV1, 9 );
 };
 
 #endif // ALIANALYSISTASKGAMMACONVDALITZV1_H

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvDalitzV1.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvDalitzV1.h
@@ -351,7 +351,7 @@ class AliAnalysisTaskGammaConvDalitzV1: public AliAnalysisTaskSE {
     AliAnalysisTaskGammaConvDalitzV1( const AliAnalysisTaskGammaConvDalitzV1& ); // Not implemented
     AliAnalysisTaskGammaConvDalitzV1& operator=( const AliAnalysisTaskGammaConvDalitzV1& ); // Not implemented
 
-  ClassDef( AliAnalysisTaskGammaConvDalitzV1, 8 );
+  ClassDef( AliAnalysisTaskGammaConvDalitzV1, 56 );
 };
 
 #endif // ALIANALYSISTASKGAMMACONVDALITZV1_H

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvDalitzV1.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvDalitzV1.h
@@ -108,199 +108,199 @@ class AliAnalysisTaskGammaConvDalitzV1: public AliAnalysisTaskSE {
     Bool_t IsPi0DalitzDaughter( Int_t label ) const;
     Bool_t CheckVectorForDoubleCount(vector<Int_t> &vec, Int_t tobechecked);
 
-    AliV0ReaderV1                     *fV0Reader;
+    AliV0ReaderV1                     *fV0Reader;               //
     TString                           fV0ReaderName;
-    AliDalitzElectronSelector         *fElecSelector;
-    AliGammaConversionAODBGHandler    **fBGHandler;
-    AliVEvent                         *fDataEvent;
-    AliDalitzData                     *fAODESDEvent;
-    AliESDEvent                       *fESDEvent;
-    AliMCEvent                        *fMCEvent;
-    AliAODEvent                       *fAODEvent;
-    AliDalitzEventMC                  *fAODESDEventMC;
-    TList                             **fCutFolder;
-    TList                             **fESDList;
-    TList                             **fBackList;
-    TList                             **fMotherList;
-    TList                             **fTrueList;
-    TList                             **fMCList;
-    TList                             **fQAFolder;
+    AliDalitzElectronSelector         *fElecSelector;           //
+    AliGammaConversionAODBGHandler    **fBGHandler;             //
+    AliVEvent                         *fDataEvent;              //
+    AliDalitzData                     *fAODESDEvent;            //
+    AliESDEvent                       *fESDEvent;               //
+    AliMCEvent                        *fMCEvent;                //
+    AliAODEvent                       *fAODEvent;               //
+    AliDalitzEventMC                  *fAODESDEventMC;          //
+    TList                             **fCutFolder;             //
+    TList                             **fESDList;               //
+    TList                             **fBackList;              //
+    TList                             **fMotherList;            //
+    TList                             **fTrueList;              //
+    TList                             **fMCList;                //
+    TList                             **fQAFolder;              //
     TList                             *fOutputContainer;
-    TClonesArray                      *fReaderGammas;
-    vector<Int_t>                     fSelectorElectronIndex;
-    vector<Int_t>                     fSelectorPositronIndex;
-    TList                             *fGoodGammas;
-    TList                             *fGoodVirtualGammas;
-    TList                             *fGoodElectrons;
-    TList                             *fGoodPositrons;
-    TList                             *fCutEventArray;
-    TList                             *fCutGammaArray;
-    TList                             *fCutElectronArray;
-    TList                             *fCutMesonArray;
-    //TList                           **fGammasPool;
-    AliConvEventCuts                  *fEventCuts;
-    AliConversionPhotonCuts           *fConversionCuts;
-    TH1F                              **hESDConvGammaPt;
-    TH1F                              **hESDConvGammaEta;
-    //TH2F                            **hESDConvGammaZR;
-    THnSparseF                        **sESDConvGammaZR;
-    THnSparseF                        **sESDConvGammaXY;
-    TH1F                              **hESDDalitzElectronPt;
-    TH1F                              **hESDDalitzPositronPt;
-    TH1F                              **hESDDalitzElectronPhi;
-    TH1F                              **hESDDalitzPositronPhi;
-    TH1F                              **hESDDalitzElectronAfterPt;
-    TH1F                              **hESDDalitzPositronAfterPt;
-    TH1F                              **hESDDalitzElectronAfterEta;
-    TH1F                              **hESDDalitzElectronAfterEtaPCut;
-    TH1F                              **hESDDalitzPositronAfterEta;
-    TH1F                              **hESDDalitzPositronAfterEtaPCut;
-    TH1F                              **hESDDalitzElectronAfterPhi;
-    TH1F                              **hESDDalitzPositronAfterPhi;
-    TH1F                              **hESDDalitzElectronAfterNClsITS;
-    TH1F                              **hESDDalitzElectronAfterNClsITSPCut;
-    TH1F                              **hESDDalitzPositronAfterNClsITS;
-    TH1F                              **hESDDalitzPositronAfterNClsITSPCut;
-    TH2F                              **hESDDalitzElectronAfterNFindClsTPC;
-    TH1F                              **hESDDalitzElectronAfterNFindClsTPCPCut;
-    TH2F                              **hESDDalitzPositronAfterNFindClsTPC;
-    TH1F                              **hESDDalitzPositronAfterNFindClsTPCPCut;
-    TH2F                              **hESDDalitzElectronAfterNClsTPC;
-    TH1F                              **hESDDalitzElectronAfterNClsTPCPCut;
-    TH2F                              **hESDDalitzPositronAfterNClsTPC;
-    TH1F                              **hESDDalitzPositronAfterNClsTPCPCut;
-    TH2F                              **hESDDalitzElectronAfterNCrossedRowsTPC;
-    TH1F                              **hESDDalitzElectronAfterNCrossedRowsTPCPCut;
-    TH2F                              **hESDDalitzPositronAfterNCrossedRowsTPC;
-    TH1F                              **hESDDalitzPositronAfterNCrossedRowsTPCPCut;
-    TH2F                              **hESDDalitzPosEleAfterDCAxy;
-    TH2F                              **hESDDalitzPosEleAfterDCAz;
-    TH2F                              **hESDDalitzElectronAfterTPCdEdxVsP;
-    TH2F                              **hESDDalitzPositronAfterTPCdEdxVsP;
-    TH2F                              **hESDDalitzElectronAfterTPCdEdxSignalVsP;
-    TH2F                              **hESDDalitzPositronAfterTPCdEdxSignalVsP;
-    TH2F                              **hESDDalitzElectronAfterTPCdEdxVsEta;
-    TH2F                              **hESDDalitzPositronAfterTPCdEdxVsEta;
-    TH2F                              **hESDDalitzElectronAfterTPCdEdxVsPhi;
-    TH2F                              **hESDDalitzPositronAfterTPCdEdxVsPhi;
-    TH2F                              **hESDEposEnegPsiPairDPhi;
-    TH2F                              **hESDEposEnegPsiPairEta;
-    TH2F                              **hESDEposEnegDPhiEta;
-    TH2F                              **hESDEposEnegInvMassPt;
-    TH2F                              **hESDTruePi0EposEnegInvMassPi0Pt;
-    TH2F                              **hESDEposEnegLikeSignBackInvMassPt;
-    TH2F                              **hESDMotherInvMassPt;
-    TH2F                              **hESDPi0MotherInvMassPt;
-    TH2F                              **hESDPi0MotherDiffInvMassPt;
-    TH2F                              **hESDPi0MotherDiffLimInvMassPt;
-    TH2F                              **hESDEposEnegInvMassPi0MotherPt;
-    TH1F                              **hESDMotherInvMassOpeningAngleGammaElectron;
-    THnSparseF                        **sESDMotherInvMassPtZM;
-    TH2F                              **hESDMotherBackInvMassPt;
-    THnSparseF                        **sESDMotherBackInvMassPtZM;
-    TH1F                              **hESDInvMassElectronPositronPi0;
-    TH1F                              **hESDInvMassElectronPositronPi0MC;
-    TH1F                              **hESDInvMassElectronPositronPi0Background;
-    TH1F                              **hESDInvMassElectronPositronEta;
-    TH1F                              **hESDInvMassElectronPositronEtaMC;
-    TH1F                              **hESDInvMassElectronPositronEtaBackground;
-    TH2F                              **hESDMotherPi0PtY;
-    TH2F                              **hESDMotherPi0PtAlpha;
-    TH2F                              **hESDMotherPi0PtOpenAngle;
-    THnSparseF                        **sESDMotherDalitzPlot;
-    TH1F                              **hMCAllGammaPt;
-    TH1F                              **hMCAllGammaPi0Pt;
-    TH1F                              **hMCConvGammaPt;
-    TH2F                              **hMCConvGammaPtR;
-    TH1F                              **hMCConvGammaRSPt;
-    TH1F                              **hMCConvGammaPi0Pt;
-    TH1F                              **hMCAllPositronsPt;
-    TH1F                              **hMCDecayPositronPi0Pt;
-    TH1F                              **hMCAllElectronsPt;
-    TH1F                              **hMCDecayElectronPi0Pt;
-    TH1F                              **hMCConvGammaEta;
-    TH1F                              **hMCConvGammaR;
-    TH1F                              **hMCAllPositronsEta;
-    TH1F                              **hMCAllElectronsEta;
-    TH1F                              **hMCPi0DalitzGammaPt;
-    TH1F                              **hMCPi0DalitzElectronPt;
-    TH1F                              **hMCPi0DalitzPositronPt;
-    TH1F                              **hMCPi0Pt;
-    TH1F                              **hMCPi0WOWeightPt;
-    TH1F                              **hMCPi0GGPt;
-    TH1F                              **hMCEtaPt;
-    TH1F                              **hMCEtaWOWeightPt;
-    TH1F                              **hMCEtaGGPt;
-    TH1F                              **hMCPi0InAccPt;
-    TH1F                              **hMCPi0WOWeightInAccPt;
-    TH1F                              **hMCPi0InAccOpeningAngleGammaElectron;
-    THnSparseF                        **sMCPi0DalitzPlot;
-    TH1F                              **hMCEtaInAccPt;
-    TH1F                              **hMCEtaWOWeightInAccPt;
-    TH1F                              **hMCChiCPt;
-    TH1F                              **hMCChiCInAccPt;
-    TH2F                              **hMCPi0EposEnegInvMassPt;
-    TH2F                              **hMCEtaEposEnegInvMassPt;
-    TH2F                              **hESDEposEnegTruePi0DalitzInvMassPt;
-    TH1F                              **hESDEposEnegTruePrimPi0DalitzInvMass;
-    TH2F                              **hESDEposEnegTruePi0DalitzPsiPairDPhi;
-    TH1F                              **hESDEposEnegTruePi0DalitzPsiPairMC;
-    TH2F                              **hESDEposEnegTruePi0DalitzPsiPairEta;
-    TH2F                              **hESDEposEnegTruePi0DalitzDPhiEta;
-    TH2F                              **hESDEposEnegTrueEtaDalitzInvMassPt;
-    TH1F                              **hESDEposEnegTruePrimEtaDalitzInvMass;
-    TH2F                              **hESDEposEnegTrueEtaDalitzPsiPairDPhi;
-    TH2F                              **hESDEposEnegTruePhotonInvMassPt;
-    TH2F                              **hESDEposEnegTrueInvMassPt;
-    TH2F                              **hESDEposEnegTrueMotherInvMassPt;
-    TH2F                              **hESDEposEnegTruePhotonPsiPairDPhi;
-    TH2F                              **hESDEposEnegTruePhotonPsiPairDPhiPtCut;
-    TH2F                              **hESDEposEnegTrueJPsiInvMassPt;
-    TH2F                              **hESDTrueMotherChiCInvMassPt;
-    TH2F                              **hESDTrueMotherChiCDiffInvMassPt;
-    TH2F                              **hESDTrueMotherInvMassPt;
-    TH2F                              **hESDTrueMotherW0WeightsInvMassPt;
-    TH2F                              **hESDTrueMotherDalitzInvMassPt;
-    TH2F                              **hESDTrueMotherPi0GGInvMassPt;
-    TH2F                              **hESDTrueMotherPi0GGW0WeightsInvMassPt;
-    TH2F                              **hESDTruePi0PtY;
-    TH2F                              **hESDTruePi0PtAlpha;
-    TH2F                              **hESDTruePi0PtOpenAngle;
-    THnSparseF                        **sESDTruePi0DalitzPlot;
-    TH2F                              **hESDTruePrimaryMotherPi0GGInvMassPt;
-    TH2F                              **hESDTrueSecondaryMotherPi0GGInvMassPt;
-    TH2F                              **hESDTruePrimaryMotherInvMassMCPt;
-    TH2F                              **hESDTruePrimaryMotherInvMassPt;
-    TH2F                              **hESDTruePrimaryMotherW0WeightingInvMassPt;
-    TH2F                              **hESDTruePrimaryPi0DalitzESDPtMCPt;
-    TH2F                              **hESDTrueSecondaryMotherInvMassPt;
-    TH2F                              **hESDTrueSecondaryMotherFromK0sInvMassPt;
-    TH2F                              **hESDTrueBckGGInvMassPt;
-    TH2F                              **hESDTrueBckContInvMassPt;
-    TH2F                              **hESDTrueMotherGGInvMassPt;
-    TH1F                              **hESDTrueConvGammaPt;
-    TH1F                              **hESDTrueConvGammaPtMC;
-    TH1F                              **hESDTrueConvGammaR;
-    TH1F                              **hESDTrueConvGammaRMC;
-    TH1F                              **hESDTruePositronPt;
-    TH1F                              **hESDTrueElectronPt;
-    TH1F                              **hESDTrueSecConvGammaPt;
-    TH1F                              **hESDTrueSecPositronPt;
-    TH1F                              **hESDTrueSecElectronPt;
-    TH1F                              **hESDTruePi0DalitzConvGammaPt;
-    TH1F                              **hESDTruePi0DalitzConvGammaR;
-    TH1F                              **hESDTruePi0DalitzPositronPt;
-    TH1F                              **hESDTruePi0DalitzPositronPtMB;
-    TH1F                              **hESDTruePi0DalitzElectronPt;
-    TH1F                              **hESDTruePi0DalitzElectronPtMB;
-    TH1F                              **hESDTruePi0DalitzSecConvGammaPt;
-    TH1F                              **hESDTruePi0DalitzSecPositronPt;
-    TH1F                              **hESDTruePi0DalitzSecElectronPt;
-    TH1F                              **hNEvents;
-    TH1F                              **hNEventsWOWeight;
-    TH1I                              **hNGoodESDTracks;
-    TH2F                              **hNGoodESDTracksVsNGoodGammas;
-    TH2F                              **hNGoodESDTracksVsNGoodVGammas;
+    TClonesArray                      *fReaderGammas;               //
+    vector<Int_t>                     fSelectorElectronIndex;       //
+    vector<Int_t>                     fSelectorPositronIndex;       //
+    TList                             *fGoodGammas;                 //
+    TList                             *fGoodVirtualGammas;          //
+    TList                             *fGoodElectrons;              //
+    TList                             *fGoodPositrons;              //
+    TList                             *fCutEventArray;              //
+    TList                             *fCutGammaArray;              //
+    TList                             *fCutElectronArray;           //
+    TList                             *fCutMesonArray;              //
+    //TList                           **fGammasPool;                //
+    AliConvEventCuts                  *fEventCuts;                  //
+    AliConversionPhotonCuts           *fConversionCuts;             //
+    TH1F                              **hESDConvGammaPt;            //!
+    TH1F                              **hESDConvGammaEta;           //!
+    //TH2F                            **hESDConvGammaZR;            //!
+    THnSparseF                        **sESDConvGammaZR;            //!
+    THnSparseF                        **sESDConvGammaXY;            //!
+    TH1F                              **hESDDalitzElectronPt;       //!
+    TH1F                              **hESDDalitzPositronPt;       //!
+    TH1F                              **hESDDalitzElectronPhi;      //!
+    TH1F                              **hESDDalitzPositronPhi;      //!
+    TH1F                              **hESDDalitzElectronAfterPt;  //!
+    TH1F                              **hESDDalitzPositronAfterPt;  //!
+    TH1F                              **hESDDalitzElectronAfterEta; //!
+    TH1F                              **hESDDalitzElectronAfterEtaPCut;             //!
+    TH1F                              **hESDDalitzPositronAfterEta;                 //!
+    TH1F                              **hESDDalitzPositronAfterEtaPCut;             //!
+    TH1F                              **hESDDalitzElectronAfterPhi;                 //!
+    TH1F                              **hESDDalitzPositronAfterPhi;                 //!
+    TH1F                              **hESDDalitzElectronAfterNClsITS;             //!
+    TH1F                              **hESDDalitzElectronAfterNClsITSPCut;         //!
+    TH1F                              **hESDDalitzPositronAfterNClsITS;             //!
+    TH1F                              **hESDDalitzPositronAfterNClsITSPCut;         //!
+    TH2F                              **hESDDalitzElectronAfterNFindClsTPC;         //!
+    TH1F                              **hESDDalitzElectronAfterNFindClsTPCPCut;     //!
+    TH2F                              **hESDDalitzPositronAfterNFindClsTPC;         //!
+    TH1F                              **hESDDalitzPositronAfterNFindClsTPCPCut;     //!
+    TH2F                              **hESDDalitzElectronAfterNClsTPC;             //!
+    TH1F                              **hESDDalitzElectronAfterNClsTPCPCut;         //!
+    TH2F                              **hESDDalitzPositronAfterNClsTPC;             //!
+    TH1F                              **hESDDalitzPositronAfterNClsTPCPCut;         //!
+    TH2F                              **hESDDalitzElectronAfterNCrossedRowsTPC;     //!
+    TH1F                              **hESDDalitzElectronAfterNCrossedRowsTPCPCut; //!
+    TH2F                              **hESDDalitzPositronAfterNCrossedRowsTPC;     //!
+    TH1F                              **hESDDalitzPositronAfterNCrossedRowsTPCPCut; //!
+    TH2F                              **hESDDalitzPosEleAfterDCAxy;                 //!
+    TH2F                              **hESDDalitzPosEleAfterDCAz;                  //!
+    TH2F                              **hESDDalitzElectronAfterTPCdEdxVsP;          //!
+    TH2F                              **hESDDalitzPositronAfterTPCdEdxVsP;          //!
+    TH2F                              **hESDDalitzElectronAfterTPCdEdxSignalVsP;    //!
+    TH2F                              **hESDDalitzPositronAfterTPCdEdxSignalVsP;    //!
+    TH2F                              **hESDDalitzElectronAfterTPCdEdxVsEta;        //!
+    TH2F                              **hESDDalitzPositronAfterTPCdEdxVsEta;        //!
+    TH2F                              **hESDDalitzElectronAfterTPCdEdxVsPhi;        //!
+    TH2F                              **hESDDalitzPositronAfterTPCdEdxVsPhi;        //!
+    TH2F                              **hESDEposEnegPsiPairDPhi;                    //!
+    TH2F                              **hESDEposEnegPsiPairEta;                     //!
+    TH2F                              **hESDEposEnegDPhiEta;                        //!
+    TH2F                              **hESDEposEnegInvMassPt;                      //!
+    TH2F                              **hESDTruePi0EposEnegInvMassPi0Pt;            //!
+    TH2F                              **hESDEposEnegLikeSignBackInvMassPt;          //!
+    TH2F                              **hESDMotherInvMassPt;                        //!
+    TH2F                              **hESDPi0MotherInvMassPt;                     //!
+    TH2F                              **hESDPi0MotherDiffInvMassPt;                 //!
+    TH2F                              **hESDPi0MotherDiffLimInvMassPt;              //!
+    TH2F                              **hESDEposEnegInvMassPi0MotherPt;             //!
+    TH1F                              **hESDMotherInvMassOpeningAngleGammaElectron; //!
+    THnSparseF                        **sESDMotherInvMassPtZM;                      //!
+    TH2F                              **hESDMotherBackInvMassPt;                    //!
+    THnSparseF                        **sESDMotherBackInvMassPtZM;                  //!
+    TH1F                              **hESDInvMassElectronPositronPi0;             //!
+    TH1F                              **hESDInvMassElectronPositronPi0MC;           //!
+    TH1F                              **hESDInvMassElectronPositronPi0Background;   //!
+    TH1F                              **hESDInvMassElectronPositronEta;             //!
+    TH1F                              **hESDInvMassElectronPositronEtaMC;           //!
+    TH1F                              **hESDInvMassElectronPositronEtaBackground;   //!
+    TH2F                              **hESDMotherPi0PtY;                           //!
+    TH2F                              **hESDMotherPi0PtAlpha;                       //!
+    TH2F                              **hESDMotherPi0PtOpenAngle;                   //!
+    THnSparseF                        **sESDMotherDalitzPlot;                       //!
+    TH1F                              **hMCAllGammaPt;                              //!
+    TH1F                              **hMCAllGammaPi0Pt;                           //!
+    TH1F                              **hMCConvGammaPt;                             //!
+    TH2F                              **hMCConvGammaPtR;                            //!
+    TH1F                              **hMCConvGammaRSPt;                           //!
+    TH1F                              **hMCConvGammaPi0Pt;                          //!
+    TH1F                              **hMCAllPositronsPt;                          //!
+    TH1F                              **hMCDecayPositronPi0Pt;                      //!
+    TH1F                              **hMCAllElectronsPt;                          //!
+    TH1F                              **hMCDecayElectronPi0Pt;                      //!
+    TH1F                              **hMCConvGammaEta;                            //!
+    TH1F                              **hMCConvGammaR;                              //!
+    TH1F                              **hMCAllPositronsEta;                         //!
+    TH1F                              **hMCAllElectronsEta;                         //!
+    TH1F                              **hMCPi0DalitzGammaPt;                        //!
+    TH1F                              **hMCPi0DalitzElectronPt;                     //!
+    TH1F                              **hMCPi0DalitzPositronPt;                     //!
+    TH1F                              **hMCPi0Pt;                                   //!
+    TH1F                              **hMCPi0WOWeightPt;                           //!
+    TH1F                              **hMCPi0GGPt;                                 //!
+    TH1F                              **hMCEtaPt;                                   //!
+    TH1F                              **hMCEtaWOWeightPt;                           //!
+    TH1F                              **hMCEtaGGPt;                                 //!
+    TH1F                              **hMCPi0InAccPt;                              //!
+    TH1F                              **hMCPi0WOWeightInAccPt;                      //!
+    TH1F                              **hMCPi0InAccOpeningAngleGammaElectron;       //!
+    THnSparseF                        **sMCPi0DalitzPlot;                           //!
+    TH1F                              **hMCEtaInAccPt;                              //!
+    TH1F                              **hMCEtaWOWeightInAccPt;                      //!
+    TH1F                              **hMCChiCPt;                                  //!
+    TH1F                              **hMCChiCInAccPt;                             //!
+    TH2F                              **hMCPi0EposEnegInvMassPt;                    //!
+    TH2F                              **hMCEtaEposEnegInvMassPt;                    //!
+    TH2F                              **hESDEposEnegTruePi0DalitzInvMassPt;         //!
+    TH1F                              **hESDEposEnegTruePrimPi0DalitzInvMass;       //!
+    TH2F                              **hESDEposEnegTruePi0DalitzPsiPairDPhi;       //!
+    TH1F                              **hESDEposEnegTruePi0DalitzPsiPairMC;         //!
+    TH2F                              **hESDEposEnegTruePi0DalitzPsiPairEta;        //!
+    TH2F                              **hESDEposEnegTruePi0DalitzDPhiEta;           //!
+    TH2F                              **hESDEposEnegTrueEtaDalitzInvMassPt;         //!
+    TH1F                              **hESDEposEnegTruePrimEtaDalitzInvMass;       //!
+    TH2F                              **hESDEposEnegTrueEtaDalitzPsiPairDPhi;       //!
+    TH2F                              **hESDEposEnegTruePhotonInvMassPt;            //!
+    TH2F                              **hESDEposEnegTrueInvMassPt;                  //!
+    TH2F                              **hESDEposEnegTrueMotherInvMassPt;            //!
+    TH2F                              **hESDEposEnegTruePhotonPsiPairDPhi;          //!
+    TH2F                              **hESDEposEnegTruePhotonPsiPairDPhiPtCut;     //!
+    TH2F                              **hESDEposEnegTrueJPsiInvMassPt;              //!
+    TH2F                              **hESDTrueMotherChiCInvMassPt;                //!
+    TH2F                              **hESDTrueMotherChiCDiffInvMassPt;            //!
+    TH2F                              **hESDTrueMotherInvMassPt;                    //!
+    TH2F                              **hESDTrueMotherW0WeightsInvMassPt;           //!
+    TH2F                              **hESDTrueMotherDalitzInvMassPt;              //!
+    TH2F                              **hESDTrueMotherPi0GGInvMassPt;               //!
+    TH2F                              **hESDTrueMotherPi0GGW0WeightsInvMassPt;      //!
+    TH2F                              **hESDTruePi0PtY;                             //!
+    TH2F                              **hESDTruePi0PtAlpha;                         //!
+    TH2F                              **hESDTruePi0PtOpenAngle;                     //!
+    THnSparseF                        **sESDTruePi0DalitzPlot;                      //!
+    TH2F                              **hESDTruePrimaryMotherPi0GGInvMassPt;        //!
+    TH2F                              **hESDTrueSecondaryMotherPi0GGInvMassPt;      //!
+    TH2F                              **hESDTruePrimaryMotherInvMassMCPt;           //!
+    TH2F                              **hESDTruePrimaryMotherInvMassPt;             //!
+    TH2F                              **hESDTruePrimaryMotherW0WeightingInvMassPt;  //!
+    TH2F                              **hESDTruePrimaryPi0DalitzESDPtMCPt;          //!
+    TH2F                              **hESDTrueSecondaryMotherInvMassPt;           //!
+    TH2F                              **hESDTrueSecondaryMotherFromK0sInvMassPt;    //!
+    TH2F                              **hESDTrueBckGGInvMassPt;                     //!
+    TH2F                              **hESDTrueBckContInvMassPt;                   //!
+    TH2F                              **hESDTrueMotherGGInvMassPt;                  //!
+    TH1F                              **hESDTrueConvGammaPt;                        //!
+    TH1F                              **hESDTrueConvGammaPtMC;                      //!
+    TH1F                              **hESDTrueConvGammaR;                         //!
+    TH1F                              **hESDTrueConvGammaRMC;                       //!
+    TH1F                              **hESDTruePositronPt;                         //!
+    TH1F                              **hESDTrueElectronPt;                         //!
+    TH1F                              **hESDTrueSecConvGammaPt;                     //!
+    TH1F                              **hESDTrueSecPositronPt;                      //!
+    TH1F                              **hESDTrueSecElectronPt;                      //!
+    TH1F                              **hESDTruePi0DalitzConvGammaPt;               //!
+    TH1F                              **hESDTruePi0DalitzConvGammaR;                //!
+    TH1F                              **hESDTruePi0DalitzPositronPt;                //!
+    TH1F                              **hESDTruePi0DalitzPositronPtMB;              //!
+    TH1F                              **hESDTruePi0DalitzElectronPt;                //!
+    TH1F                              **hESDTruePi0DalitzElectronPtMB;              //!
+    TH1F                              **hESDTruePi0DalitzSecConvGammaPt;            //!
+    TH1F                              **hESDTruePi0DalitzSecPositronPt;             //!
+    TH1F                              **hESDTruePi0DalitzSecElectronPt;             //!
+    TH1F                              **hNEvents;                                   //!
+    TH1F                              **hNEventsWOWeight;                           //!
+    TH1I                              **hNGoodESDTracks;                            //!
+    TH2F                              **hNGoodESDTracksVsNGoodGammas;               //!
+    TH2F                              **hNGoodESDTracksVsNGoodVGammas;              //!
     TH2F                              **fHistoSPDClusterTrackletBackground;        //! array of histos with SPD tracklets vs SPD clusters for background rejection
     TH1I                              **hNV0Tracks;
     //TH3F                              **hESDEposEnegPsiPairpTleptonsDPhi;
@@ -317,8 +317,8 @@ class AliAnalysisTaskGammaConvDalitzV1: public AliAnalysisTaskSE {
     vector<Int_t>                     fVectorDoubleCountTrueEtas;            //! vector containing labels of validated eta
     vector<Int_t>                     fVectorDoubleCountTrueConvGammas;          //! vector containing labels of validated photons
 
-    TRandom3                          fRandom;
-    Double_t                          fEventPlaneAngle;
+    TRandom3                          fRandom;                                      //
+    Double_t                          fEventPlaneAngle;                             //
     Double_t                          *fUnsmearedPx;
     Double_t                          *fUnsmearedPy;
     Double_t                          *fUnsmearedPz;
@@ -328,24 +328,24 @@ class AliAnalysisTaskGammaConvDalitzV1: public AliAnalysisTaskSE {
     Double_t                          *fUnsmearedVPz;
     Double_t                          *fUnsmearedVE;
 
-    Int_t                             fnCuts;
-    Int_t                             fiCut;
-    Int_t                             fNumberOfESDTracks;
-    Int_t                             fNumberOfESDTrackskBoth;
-    Int_t                             fNVirtualGammas;
-    Bool_t                            fMoveParticleAccordingToVertex;
-    Int_t                             fIsHeavyIon;
-    Bool_t                            fDoMesonAnalysis;
-    Bool_t                            fDoChicAnalysis;
-    Int_t                             fDoMesonQA;
-    Bool_t                            fSetProductionVertextoVGamma;
-    Bool_t                            fIsFromMBHeader;
-    Int_t                             fIsMC;
-    Bool_t                            fDoTHnSparse;
-    Double_t                          fWeightJetJetMC;
-    Bool_t                            fDoHistoDalitzMassLog;
-    Bool_t                            fDoMaterialBudgetWeightingOfGammasForTrueMesons;
-    Bool_t                            fDoLightVersion;
+    Int_t                             fnCuts;                                       //
+    Int_t                             fiCut;                                        //
+    Int_t                             fNumberOfESDTracks;                           //
+    Int_t                             fNumberOfESDTrackskBoth;                      //
+    Int_t                             fNVirtualGammas;                              //
+    Bool_t                            fMoveParticleAccordingToVertex;               //
+    Int_t                             fIsHeavyIon;                                  //
+    Bool_t                            fDoMesonAnalysis;                             //
+    Bool_t                            fDoChicAnalysis;                              //
+    Int_t                             fDoMesonQA;                                   //
+    Bool_t                            fSetProductionVertextoVGamma;                 //
+    Bool_t                            fIsFromMBHeader;                              //
+    Int_t                             fIsMC;                                        //
+    Bool_t                            fDoTHnSparse;                                 //
+    Double_t                          fWeightJetJetMC;                              //
+    Bool_t                            fDoHistoDalitzMassLog;                        //
+    Bool_t                            fDoMaterialBudgetWeightingOfGammasForTrueMesons;  //
+    Bool_t                            fDoLightVersion;                              //
 
   private:
     AliAnalysisTaskGammaConvDalitzV1( const AliAnalysisTaskGammaConvDalitzV1& ); // Not implemented

--- a/PWGGA/GammaConvBase/AliDalitzElectronCuts.cxx
+++ b/PWGGA/GammaConvBase/AliDalitzElectronCuts.cxx
@@ -1073,12 +1073,11 @@ Bool_t AliDalitzElectronCuts::IsFromGammaConversion( Double_t psiPair, Double_t 
     }
     else if (fDoDifferentCut==1){
         for(Int_t ii=0;ii<5;ii++){
-            if (deltaPhi >= fDeltaPhiCutArray[ii] && deltaPhi < fDeltaPhiCutArray[ii+1] ){
-                if(psiPair<fPsiPairCutArray[ii]){
-                return kTRUE;
-                }
+            if ( (deltaPhi >= fDeltaPhiCutArray[ii] && deltaPhi < fDeltaPhiCutArray[ii+1]) && (psiPair<fPsiPairCutArray[ii]) ){
+             return kTRUE;
             }
         }
+        return kFALSE;
     }
     else if (fDoDifferentCut==2){//pT Dependace, triangular
         for(Int_t ii=0;ii<3;ii++){
@@ -1087,10 +1086,7 @@ Bool_t AliDalitzElectronCuts::IsFromGammaConversion( Double_t psiPair, Double_t 
             }
         }
     }
-//     else {
-//         return kFALSE;
-//     }
-    return kTRUE;
+    return kTRUE;//Warning correction.
 }
 
 ///________________________________________________________________________

--- a/PWGGA/GammaConvBase/AliDalitzElectronCuts.h
+++ b/PWGGA/GammaConvBase/AliDalitzElectronCuts.h
@@ -178,41 +178,41 @@ class AliDalitzElectronCuts : public AliAnalysisCuts {
 
   protected:
 
-  TList *fHistograms;
-  AliPIDResponse *fPIDResponse;
-  AliESDtrackCuts *fesdTrackCuts;
+  TList *fHistograms;   //
+  AliPIDResponse *fPIDResponse; //
+  AliESDtrackCuts *fesdTrackCuts;   //
 
-  Double_t fEtaCut; //eta cutç
-  Bool_t   fDoEtaCut;
-  Double_t fPtMinCut;
-  Double_t fPtMaxCut;
-  Double_t fRadiusCut; // radius cut
-  Double_t fPsiPairCut;
-  Double_t fDeltaPhiCutMin;
-  Double_t fDeltaPhiCutMax;
-  Int_t    fDoDifferentCut;
+  Double_t fEtaCut; //eta cut
+  Bool_t   fDoEtaCut;   // flag for eta cut
+  Double_t fPtMinCut;   //  min pt cut
+  Double_t fPtMaxCut;   //  max pt cut
+  Double_t fRadiusCut;  // radius cut
+  Double_t fPsiPairCut; //
+  Double_t fDeltaPhiCutMin; //
+  Double_t fDeltaPhiCutMax; //
+  Int_t    fDoDifferentCut; //
   Double_t* fPsiPairCutArray;
   Double_t* fDeltaPhiCutArray;
   Double_t* fpTDependanceCutArray;
   Double_t* fPsiPairpTDependanceCut;
   Double_t* fDeltaPhipTDependanceCutMin;
   Double_t* fDeltaPhipTDependanceCutMax;
-  Double_t fMaxDCAVertexz;
-  Double_t fMaxDCAVertexxy;
-  TString fDCAVertexPt;//Conversion from coordenates to momentum.
-  Double_t fMinClsTPC; // minimum clusters in the TPC
-  Double_t fMinClsTPCToF; // minimum clusters to findable clusters
-  Bool_t   fDodEdxSigmaITSCut; // flag to use the dEdxCut ITS based on sigmas
-  Bool_t   fDodEdxSigmaTPCCut; // flag to use the dEdxCut TPC based on sigmas
-  Bool_t   fDoTOFsigmaCut; // flag to use TOF pid cut RRnewTOF
+  Double_t fMaxDCAVertexz;  //
+  Double_t fMaxDCAVertexxy; //
+  TString fDCAVertexPt; //Conversion from coordenates to momentum.
+  Double_t fMinClsTPC;  // minimum clusters in the TPC
+  Double_t fMinClsTPCToF;   // minimum clusters to findable clusters
+  Bool_t   fDodEdxSigmaITSCut;  // flag to use the dEdxCut ITS based on sigmas
+  Bool_t   fDodEdxSigmaTPCCut;  // flag to use the dEdxCut TPC based on sigmas
+  Bool_t   fDoTOFsigmaCut;  // flag to use TOF pid cut RRnewTOF
   Bool_t   fDoRejectSharedElecGamma; //Reject electrons from the gammas with Radius < RadiusCut
   Bool_t   fDoPsiPairCut; // PsiPair Cut
   Double_t fPIDnSigmaAboveElectronLineITS; // sigma cut
   Double_t fPIDnSigmaBelowElectronLineITS; // sigma cut
-  Double_t fPIDnSigmaAboveElectronLineTPC; // sigma cut
-  Double_t fPIDnSigmaBelowElectronLineTPC; // sigma cut
-  Double_t fPIDnSigmaAbovePionLineTPC;
-  Double_t fPIDnSigmaAbovePionLineTPCHighPt;
+  Double_t fPIDnSigmaAboveElectronLineTPC; // sigma electron TPC cut
+  Double_t fPIDnSigmaBelowElectronLineTPC; // sigma electron TPC cut
+  Double_t fPIDnSigmaAbovePionLineTPC;  // sigma pion TPC cut
+  Double_t fPIDnSigmaAbovePionLineTPCHighPt;    // sigma pt pion cut
   Double_t fTofPIDnSigmaAboveElectronLine; // sigma cut RRnewTOF
   Double_t fTofPIDnSigmaBelowElectronLine; // sigma cut RRnewTOF
   Double_t fPIDMinPnSigmaAbovePionLineTPC; // sigma cut
@@ -229,18 +229,18 @@ class AliDalitzElectronCuts : public AliAnalysisCuts {
 
   Bool_t   fUseCorrectedTPCClsInfo; // flag to use corrected tpc cl info
   Bool_t   fUseCrossedRows;  //UseCrossedRows 2011
-  Int_t    fITSCut;
+  Int_t    fITSCut; // flag to ITS
   Bool_t   fUseTOFpid; // flag to use tof pid
   Bool_t   fRequireTOF; //flg to analyze only tracks with TOF signal
-  Bool_t   fDoMassCut;
-  Bool_t   fDoMassMinCut;
-  Double_t fMassCutLowPt;
-  Double_t fMassCutHighPt;
-  Double_t fMassCutPtMin;
-  Double_t fMassMinCut;
-  Bool_t   fDoWeights;
-  Bool_t   fUseVPhotonMCPSmearing;
-  Bool_t   fUseElectronMCPSmearing;
+  Bool_t   fDoMassCut;  //
+  Bool_t   fDoMassMinCut;   //
+  Double_t fMassCutLowPt;   //
+  Double_t fMassCutHighPt;  //
+  Double_t fMassCutPtMin;   //
+  Double_t fMassMinCut; //
+  Bool_t   fDoWeights;  //
+  Bool_t   fUseVPhotonMCPSmearing;  //
+  Bool_t   fUseElectronMCPSmearing; //
   Bool_t   fDoElecDeDxPostCalibrationPrimaryPair; //flg to use Post Calibration on primary Pair.
   Bool_t   fIsRecalibDepTPCClPrimaryPair;  //flg that always is kTRUE
   Int_t    fRecalibCurrentRunPrimaryPair;                   ///< runnumber for correct loading of recalib from OADB
@@ -263,16 +263,16 @@ class AliDalitzElectronCuts : public AliAnalysisCuts {
   TH2F *hTPCdEdxSignalafter; //TPC dEdx signal  after
   TH2F *hTOFbefore; // TOF after cuts
   TH2F *hTOFafter; // TOF after cuts
-  TH2F *hTrackDCAxyPtbefore;
-  TH2F *hTrackDCAxyPtafter;
-  TH2F *hTrackDCAzPtbefore;
-  TH2F *hTrackDCAzPtafter;
-  TH2F *hTrackNFindClsPtTPCbefore;
-  TH2F *hTrackNFindClsPtTPCafter;
-  TH1F *hTrackPosEtabeforeDedx;
-  TH1F *hTrackNegEtabeforeDedx;
-  TH1F *hTrackPosEtaafterDedx;
-  TH1F *hTrackNegEtaafterDedx;
+  TH2F *hTrackDCAxyPtbefore;    //
+  TH2F *hTrackDCAxyPtafter; //
+  TH2F *hTrackDCAzPtbefore; //
+  TH2F *hTrackDCAzPtafter;  //
+  TH2F *hTrackNFindClsPtTPCbefore;  //
+  TH2F *hTrackNFindClsPtTPCafter;   //
+  TH1F *hTrackPosEtabeforeDedx; //
+  TH1F *hTrackNegEtabeforeDedx; //
+  TH1F *hTrackPosEtaafterDedx;  //
+  TH1F *hTrackNegEtaafterDedx;  //
 
 
 

--- a/PWGGA/GammaConvBase/AliDalitzElectronCuts.h
+++ b/PWGGA/GammaConvBase/AliDalitzElectronCuts.h
@@ -282,7 +282,7 @@ private:
   AliDalitzElectronCuts& operator=(const AliDalitzElectronCuts&); // not implemented
 
 
-  ClassDef(AliDalitzElectronCuts,3)
+  ClassDef(AliDalitzElectronCuts,86)
 };
 
 

--- a/PWGGA/GammaConvBase/AliDalitzElectronCuts.h
+++ b/PWGGA/GammaConvBase/AliDalitzElectronCuts.h
@@ -282,7 +282,7 @@ private:
   AliDalitzElectronCuts& operator=(const AliDalitzElectronCuts&); // not implemented
 
 
-  ClassDef(AliDalitzElectronCuts,86)
+  ClassDef(AliDalitzElectronCuts,4)
 };
 
 


### PR DESCRIPTION
Correction to Background histograms in terms of the invariant mass of the electron-positron pair and correction to lineal dependence in PsiPair.