### PR TITLE
solved problem on missing generated particles + merged trees of Omega and Xi

### DIFF
--- a/PWGLF/STRANGENESS/Ratios/AliAnalysisTaskStrangenessRatios.h
+++ b/PWGLF/STRANGENESS/Ratios/AliAnalysisTaskStrangenessRatios.h
@@ -90,8 +90,7 @@ private:
   AliAnalysisTaskStrangenessRatios &operator=(const AliAnalysisTaskStrangenessRatios &source);
 
   TList*          fList = nullptr;             //!<! List of the output histograms
-  TTree*          fTreeXi = nullptr;           //!<! Tree for Xis
-  TTree*          fTreeOmega = nullptr;        //!<! Tree for Omegas
+  TTree*          fTree = nullptr;           //!<! Tree for Xis and Omegas
 
   MiniCascade* fRecCascade = nullptr;          //!<! Transient fRecCascade
   MiniCascadeMC fGenCascade;


### PR DESCRIPTION
Not all the generated particles were filled into the tree (check performed locally on single AliAOD.root files). In addition the trees of Omega and Xi have been merged to reduce the output size especially on data (expected a 20% reduction) even if the present solution is not yet optimal (in my opinion)

