### PR TITLE
PWGGA/GammaConv: GammaIsoTree added iso correction for cone outside TPC

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskGammaIsoTree.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaIsoTree.h
@@ -808,9 +808,10 @@ class AliAnalysisTaskGammaIsoTree : public AliAnalysisTaskSE{
     Bool_t IsWithinRadiusEMCal(Double_t eta, Double_t phi, Double_t riso);
     Bool_t IsWithinRadiusTPC(Double_t eta, Double_t phi, Double_t riso);
     Int_t GetProperLabel(AliAODMCParticle* mcpart);
+    Float_t CalculateIsoCorrectionFactor(Double_t cEta, Double_t maxEta, Double_t r);
     AliAnalysisTaskGammaIsoTree(const AliAnalysisTaskGammaIsoTree&); // Prevent copy-construction
     AliAnalysisTaskGammaIsoTree& operator=(const AliAnalysisTaskGammaIsoTree&); // Prevent assignment  
-    ClassDef(AliAnalysisTaskGammaIsoTree, 37);
+    ClassDef(AliAnalysisTaskGammaIsoTree, 38);
 
 };
 

--- a/PWGGA/GammaConv/macros/AddTask_GammaIsoTree.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaIsoTree.C
@@ -344,7 +344,7 @@ void AddTask_GammaIsoTree(
       fAntiIsolation[1] = 20;
 
 
-  // pPb 8 TeV
+  // pPb 8 TeV (EMC)
   // ────────────────────────────────────────────────────────────────────────────────
   } else if(trainConfig == 50){  // pPb INT7
       TaskEventCutnumber                = "80010103";
@@ -401,14 +401,17 @@ void AddTask_GammaIsoTree(
       doTagging = kFALSE;
       doCellIso = kFALSE;
 
-// Anti isolation variation
-  } else if(trainConfig == 60){  // pPb INT7
+   //
+   // ─── PPB 8TEV DCAL ONLY ─────────────────────────────────────────────────────────
+   //
+
+   } else if(trainConfig == 60){  // pPb INT7
       TaskEventCutnumber                = "80010103";
-      TaskClusterCutnumberEMC           = "1111132060032000000";
-      TaskTMCut = TaskClusterCutnumberEMC.Data();
+      TaskClusterCutnumberEMC           = "3885532060032000000";
+            TaskTMCut = TaskClusterCutnumberEMC.Data();
       TaskTMCut.Replace(9,1,"5");
-      TaskClusterCutnumberIsolationEMC  = "111113206f022000000";
-      TaskClusterCutnumberTaggingEMC    = "111113206f000000000";
+      TaskClusterCutnumberIsolationEMC  = "388553206f022000000";
+      TaskClusterCutnumberTaggingEMC    = "388553206f000000000";
       TaskClusterCutnumberPHOS          = "2444411044013300000";
       TaskConvCutnumber                 = "0dm00009f9730000dge0404000";
 
@@ -420,16 +423,13 @@ void AddTask_GammaIsoTree(
       doChargedIso = kTRUE;
       doTagging = kFALSE;
       doCellIso = kFALSE;
-
-      fAntiIsolation[0] = 4;
-      fAntiIsolation[1] = 10;
-  } else if(trainConfig == 61){  // EG2
-      TaskEventCutnumber                = "80085103";
-      TaskClusterCutnumberEMC           = "1111132060032000000";
+  } else if(trainConfig == 61){  // DG2
+      TaskEventCutnumber                = "80089103";
+      TaskClusterCutnumberEMC           = "3885532060032000000";
       TaskTMCut = TaskClusterCutnumberEMC.Data();
       TaskTMCut.Replace(9,1,"5");
-      TaskClusterCutnumberIsolationEMC  = "111113206f022000000";
-      TaskClusterCutnumberTaggingEMC    = "111113206f000000000";
+      TaskClusterCutnumberIsolationEMC  = "388553206f022000000";
+      TaskClusterCutnumberTaggingEMC    = "388553206f000000000";
       TaskClusterCutnumberPHOS          = "2444411044013300000";
       TaskConvCutnumber                 = "0dm00009f9730000dge0404000";
 
@@ -441,98 +441,13 @@ void AddTask_GammaIsoTree(
       doChargedIso = kTRUE;
       doTagging = kFALSE;
       doCellIso = kFALSE;
-      fAntiIsolation[0] = 4;
-      fAntiIsolation[1] = 10;
-  } else if(trainConfig == 62){  // EG1
-      TaskEventCutnumber                = "80083103";
-      TaskClusterCutnumberEMC           = "1111132060032000000";
+  } else if(trainConfig == 62){  // DG1
+      TaskEventCutnumber                = "8008b103";
+      TaskClusterCutnumberEMC           = "3885532060032000000";
       TaskTMCut = TaskClusterCutnumberEMC.Data();
       TaskTMCut.Replace(9,1,"5");
-      TaskClusterCutnumberIsolationEMC  = "111113206f022000000";
-      TaskClusterCutnumberTaggingEMC    = "111113206f000000000";
-      TaskClusterCutnumberPHOS          = "2444411044013300000";
-      TaskConvCutnumber                 = "0dm00009f9730000dge0404000";
-
-      minSignalM02 = 0.1;
-      maxSignalM02 = 0.5;
-
-      backgroundTrackMatching = kFALSE; // obsolete
-      doNeutralIso = kFALSE;
-      doChargedIso = kTRUE;
-      doTagging = kFALSE;
-      doCellIso = kFALSE;
-      fAntiIsolation[0] = 4;
-      fAntiIsolation[1] = 10;
-
- } else if(trainConfig == 63){  // pPb INT7
-      TaskEventCutnumber                = "80010103";
-      TaskClusterCutnumberEMC           = "1111132060032000000";
-      TaskTMCut = TaskClusterCutnumberEMC.Data();
-      TaskTMCut.Replace(9,1,"5");
-      TaskClusterCutnumberIsolationEMC  = "111113206f022000000";
-      TaskClusterCutnumberTaggingEMC    = "111113206f000000000";
-      TaskClusterCutnumberPHOS          = "2444411044013300000";
-      TaskConvCutnumber                 = "0dm00009f9730000dge0404000";
-
-      minSignalM02 = 0.1;
-      maxSignalM02 = 0.5;
-
-      backgroundTrackMatching = kFALSE; // obsolete
-      doNeutralIso = kFALSE;
-      doChargedIso = kTRUE;
-      doTagging = kFALSE;
-      doCellIso = kFALSE;
-
-      fAntiIsolation[0] = 5;
-      fAntiIsolation[1] = 20;
-  } else if(trainConfig == 64){  // EG2
-      TaskEventCutnumber                = "80085103";
-      TaskClusterCutnumberEMC           = "1111132060032000000";
-      TaskTMCut = TaskClusterCutnumberEMC.Data();
-      TaskTMCut.Replace(9,1,"5");
-      TaskClusterCutnumberIsolationEMC  = "111113206f022000000";
-      TaskClusterCutnumberTaggingEMC    = "111113206f000000000";
-      TaskClusterCutnumberPHOS          = "2444411044013300000";
-      TaskConvCutnumber                 = "0dm00009f9730000dge0404000";
-
-      minSignalM02 = 0.1;
-      maxSignalM02 = 0.5;
-
-      backgroundTrackMatching = kFALSE; // obsolete
-      doNeutralIso = kFALSE;
-      doChargedIso = kTRUE;
-      doTagging = kFALSE;
-      doCellIso = kFALSE;
-      fAntiIsolation[0] = 5;
-      fAntiIsolation[1] = 20;
-  } else if(trainConfig == 65){  // EG1
-      TaskEventCutnumber                = "80083103";
-      TaskClusterCutnumberEMC           = "1111132060032000000";
-      TaskTMCut = TaskClusterCutnumberEMC.Data();
-      TaskTMCut.Replace(9,1,"5");
-      TaskClusterCutnumberIsolationEMC  = "111113206f022000000";
-      TaskClusterCutnumberTaggingEMC    = "111113206f000000000";
-      TaskClusterCutnumberPHOS          = "2444411044013300000";
-      TaskConvCutnumber                 = "0dm00009f9730000dge0404000";
-
-      minSignalM02 = 0.1;
-      maxSignalM02 = 0.5;
-
-      backgroundTrackMatching = kFALSE; // obsolete
-      doNeutralIso = kFALSE;
-      doChargedIso = kTRUE;
-      doTagging = kFALSE;
-      doCellIso = kFALSE;
-      fAntiIsolation[0] = 5;
-      fAntiIsolation[1] = 20;
-
-  } else if(trainConfig == 70){  // min bias (cuts from PCMEMC 84 + loose iso)
-      TaskEventCutnumber                = "00000000";
-      TaskClusterCutnumberEMC           = "1111132060032000000";
-      TaskTMCut = TaskClusterCutnumberEMC.Data();
-      TaskTMCut.Replace(9,1,"5");
-      TaskClusterCutnumberIsolationEMC  = "111113206f022000000";
-      TaskClusterCutnumberTaggingEMC    = "111113206f000000000";
+      TaskClusterCutnumberIsolationEMC  = "388553206f022000000";
+      TaskClusterCutnumberTaggingEMC    = "388553206f000000000";
       TaskClusterCutnumberPHOS          = "2444411044013300000";
       TaskConvCutnumber                 = "0dm00009f9730000dge0404000";
 

--- a/PWGGA/GammaConvBase/AliConvEventCuts.cxx
+++ b/PWGGA/GammaConvBase/AliConvEventCuts.cxx
@@ -4872,6 +4872,12 @@ Bool_t AliConvEventCuts::IsJetJetMCEventAccepted(AliMCEvent *mcEvent, Double_t& 
               weight = weightsBins[pthardbin-1];
               if(fUseAdditionalOutlierRejection && ((ptHard < ptHardBinRanges[pthardbin-1]) || (ptHard > ptHardBinRanges[pthardbin]))) eventAccepted= kFALSE;
             }
+        } else{ // smaller than lowest border
+            weight = weightsBins[0];
+            if(fUseFilePathForPthard && (pthardbin > -1)){
+            weight = weightsBins[pthardbin-1];
+            if(fUseAdditionalOutlierRejection && ((ptHard < ptHardBinRanges[pthardbin-1]) || (ptHard > ptHardBinRanges[pthardbin]))) eventAccepted= kFALSE;
+            }
         }
       } else if ( fPeriodEnum == kLHC17g5c ){ // preliminary weights obtained from local running
         Double_t ptHardBinRanges[9]  = { 8, 10, 14, 19, 26, 35, 48, 66, 10000};
@@ -4883,6 +4889,12 @@ Bool_t AliConvEventCuts::IsJetJetMCEventAccepted(AliMCEvent *mcEvent, Double_t& 
           if(fUseFilePathForPthard && (pthardbin > -1)){
               weight = weightsBins[pthardbin-1];
               if(fUseAdditionalOutlierRejection && ((ptHard < ptHardBinRanges[pthardbin-1]) || (ptHard > ptHardBinRanges[pthardbin]))) eventAccepted= kFALSE;
+            }
+        } else{ // smaller than lowest border
+            weight = weightsBins[0];
+            if(fUseFilePathForPthard && (pthardbin > -1)){
+            weight = weightsBins[pthardbin-1];
+            if(fUseAdditionalOutlierRejection && ((ptHard < ptHardBinRanges[pthardbin-1]) || (ptHard > ptHardBinRanges[pthardbin]))) eventAccepted= kFALSE;
             }
         }
       } else if ( fPeriodEnum == kLHC17g6b2a ){ // preliminary weights obtained from local running
@@ -4896,6 +4908,12 @@ Bool_t AliConvEventCuts::IsJetJetMCEventAccepted(AliMCEvent *mcEvent, Double_t& 
               weight = weightsBins[pthardbin-1];
               if(fUseAdditionalOutlierRejection && ((ptHard < ptHardBinRanges[pthardbin-1]) || (ptHard > ptHardBinRanges[pthardbin]))) eventAccepted= kFALSE;
             }
+        } else{ // smaller than lowest border
+          weight = weightsBins[0];
+          if(fUseFilePathForPthard && (pthardbin > -1)){
+          weight = weightsBins[pthardbin-1];
+          if(fUseAdditionalOutlierRejection && ((ptHard < ptHardBinRanges[pthardbin-1]) || (ptHard > ptHardBinRanges[pthardbin]))) eventAccepted= kFALSE;
+          }
         }
       } else if ( fPeriodEnum == kLHC17g6b2b ){ // preliminary weights obtained from local running
         Double_t ptHardBinRanges[7]  = { 5, 7, 9, 12, 16, 21, 10000};
@@ -4908,6 +4926,12 @@ Bool_t AliConvEventCuts::IsJetJetMCEventAccepted(AliMCEvent *mcEvent, Double_t& 
               weight = weightsBins[pthardbin-1];
               if(fUseAdditionalOutlierRejection && ((ptHard < ptHardBinRanges[pthardbin-1]) || (ptHard > ptHardBinRanges[pthardbin]))) eventAccepted= kFALSE;
             }
+        } else{ // smaller than lowest border
+          weight = weightsBins[0];
+          if(fUseFilePathForPthard && (pthardbin > -1)){
+          weight = weightsBins[pthardbin-1];
+          if(fUseAdditionalOutlierRejection && ((ptHard < ptHardBinRanges[pthardbin-1]) || (ptHard > ptHardBinRanges[pthardbin]))) eventAccepted= kFALSE;
+          }
         }
       } else if ( fPeriodEnum == kLHC17g6b3a ){ // preliminary weights obtained from local running
         Double_t ptHardBinRanges[9]  = { 8, 10, 14, 19, 26, 35, 48, 66, 10000};
@@ -4920,6 +4944,12 @@ Bool_t AliConvEventCuts::IsJetJetMCEventAccepted(AliMCEvent *mcEvent, Double_t& 
               weight = weightsBins[pthardbin-1];
               if(fUseAdditionalOutlierRejection && ((ptHard < ptHardBinRanges[pthardbin-1]) || (ptHard > ptHardBinRanges[pthardbin]))) eventAccepted= kFALSE;
             }
+        } else{ // smaller than lowest border
+          weight = weightsBins[0];
+          if(fUseFilePathForPthard && (pthardbin > -1)){
+          weight = weightsBins[pthardbin-1];
+          if(fUseAdditionalOutlierRejection && ((ptHard < ptHardBinRanges[pthardbin-1]) || (ptHard > ptHardBinRanges[pthardbin]))) eventAccepted= kFALSE;
+          }
         }
       } else if ( fPeriodEnum == kLHC17g6b3b ){ // preliminary weights obtained from local running
         Double_t ptHardBinRanges[9]  = { 8, 10, 14, 19, 26, 35, 48, 66, 10000};
@@ -4932,6 +4962,12 @@ Bool_t AliConvEventCuts::IsJetJetMCEventAccepted(AliMCEvent *mcEvent, Double_t& 
               weight = weightsBins[pthardbin-1];
               if(fUseAdditionalOutlierRejection && ((ptHard < ptHardBinRanges[pthardbin-1]) || (ptHard > ptHardBinRanges[pthardbin]))) eventAccepted= kFALSE;
             }
+        } else{ // smaller than lowest border
+          weight = weightsBins[0];
+          if(fUseFilePathForPthard && (pthardbin > -1)){
+          weight = weightsBins[pthardbin-1];
+          if(fUseAdditionalOutlierRejection && ((ptHard < ptHardBinRanges[pthardbin-1]) || (ptHard > ptHardBinRanges[pthardbin]))) eventAccepted= kFALSE;
+          }
         }
     } else {
       weight = 1;


### PR DESCRIPTION
- added geometrical correction to properly account for missing energy in cone when outside TPC acceptance
- added fixes to AliConvEventCuts to ensure that edge cases where  pthard is below lowest threshold get treated properly