### PR TITLE
Added cut variations for DCA_{xy} and PID

### DIFF
--- a/PWGLF/NUCLEX/Nuclei/Nuclei_UE/AliAnalysisTaskDeuteronsRT.cxx
+++ b/PWGLF/NUCLEX/Nuclei/Nuclei_UE/AliAnalysisTaskDeuteronsRT.cxx
@@ -95,6 +95,8 @@ hnsigmaTPC_deuterons_Syst(nullptr),
 hnsigmaTPC_antideuterons_Syst(nullptr),
 hnsigmaTOF_deuterons_Syst(nullptr),
 hnsigmaTOF_antideuterons_Syst(nullptr),
+hDCAxy_deuterons_Syst(nullptr),
+hDCAxy_antideuterons_Syst(nullptr),
 hnsigmaTPC_deuterons_rap(nullptr),
 hnsigmaTPC_antideuterons_rap(nullptr),
 hnsigmaTOF_deuterons_rap(nullptr),
@@ -167,6 +169,8 @@ hnsigmaTPC_deuterons_Syst(nullptr),
 hnsigmaTPC_antideuterons_Syst(nullptr),
 hnsigmaTOF_deuterons_Syst(nullptr),
 hnsigmaTOF_antideuterons_Syst(nullptr),
+hDCAxy_deuterons_Syst(nullptr),
+hDCAxy_antideuterons_Syst(nullptr),
 hnsigmaTPC_deuterons_rap(nullptr),
 hnsigmaTPC_antideuterons_rap(nullptr),
 hnsigmaTOF_deuterons_rap(nullptr),
@@ -237,6 +241,8 @@ AliAnalysisTaskDeuteronsRT::~AliAnalysisTaskDeuteronsRT()  {
     delete hnsigmaTPC_antideuterons_Syst;
     delete hnsigmaTOF_deuterons_Syst;
     delete hnsigmaTOF_antideuterons_Syst;
+    delete hDCAxy_deuterons_Syst;
+    delete hDCAxy_antideuterons_Syst;
     delete hnsigmaTPC_deuterons_rap;
     delete hnsigmaTPC_antideuterons_rap;
     delete hnsigmaTOF_deuterons_rap;
@@ -492,6 +498,26 @@ void AliAnalysisTaskDeuteronsRT::UserCreateOutputObjects()  {
          hnsigmaTOF_antideuterons_Syst -> Sumw2();
          fOutputList -> Add (hnsigmaTOF_deuterons_Syst);
          fOutputList -> Add (hnsigmaTOF_antideuterons_Syst);
+        
+        
+        //***************************       Nch_Transverse,      DCA_{xy},                 pt_DCA,   isyst *******************************************
+        Int_t    bins_DCA_syst[4] = {         nBins_Nch_Tr,  nBins_dca_xy,           nBins_pt_DCA,    50 };
+        Double_t xmin_DCA_syst[4] = {            Nch_Tr[0],          -1.0,              pt_DCA[0],     0 };
+        Double_t xmax_DCA_syst[4] = { Nch_Tr[nBins_Nch_Tr],          +1.0,   pt_DCA[nBins_pt_DCA],    50 };
+        //***************************************************************************************************************************************
+
+        hDCAxy_deuterons_Syst     = new THnSparseF ("hDCAxy_deuterons_Syst","",4, bins_DCA_syst, xmin_DCA_syst, xmax_DCA_syst);
+        hDCAxy_antideuterons_Syst = new THnSparseF ("hDCAxy_antideuterons_Syst","",4, bins_DCA_syst, xmin_DCA_syst, xmax_DCA_syst);
+        hDCAxy_deuterons_Syst -> GetAxis(0) -> Set(nBins_Nch_Tr, Nch_Tr);
+        hDCAxy_deuterons_Syst -> GetAxis(1) -> Set(nBins_dca_xy, dca_xy);
+        hDCAxy_deuterons_Syst -> GetAxis(2) -> Set(nBins_pt_DCA, pt_DCA);
+        hDCAxy_antideuterons_Syst -> GetAxis(0) -> Set(nBins_Nch_Tr, Nch_Tr);
+        hDCAxy_antideuterons_Syst -> GetAxis(1) -> Set(nBins_dca_xy, dca_xy);
+        hDCAxy_antideuterons_Syst -> GetAxis(2) -> Set(nBins_pt_DCA, pt_DCA);
+        hDCAxy_deuterons_Syst     -> Sumw2();
+        hDCAxy_antideuterons_Syst -> Sumw2();
+        fOutputList -> Add(hDCAxy_deuterons_Syst);
+        fOutputList -> Add(hDCAxy_antideuterons_Syst);
     }
     
     
@@ -533,10 +559,11 @@ void AliAnalysisTaskDeuteronsRT::UserCreateOutputObjects()  {
         
         h_deuterons_Gen              = new TH1F ("h_deuterons_Gen","",900,0.5,5.0);
         h_antideuterons_Gen          = new TH1F ("h_antideuterons_Gen","",900,0.5,5.0);
-        hnsigmaTPC_deuterons_Rec     = new TH1F ("hnsigmaTPC_deuterons_Rec","",900,0.5,5.0);
-        hnsigmaTPC_antideuterons_Rec = new TH1F ("hnsigmaTPC_antideuterons_Rec","",900,0.5,5.0);
-        hnsigmaTOF_deuterons_Rec     = new TH1F ("hnsigmaTOF_deuterons_Rec","",900,0.5,5.0);
-        hnsigmaTOF_antideuterons_Rec = new TH1F ("hnsigmaTOF_antideuterons_Rec","",900,0.5,5.0);
+        hnsigmaTPC_deuterons_Rec     = new TH2F ("hnsigmaTPC_deuterons_Rec","",900,0.5,5.0,100,-5,5);
+        hnsigmaTPC_antideuterons_Rec = new TH2F ("hnsigmaTPC_antideuterons_Rec","",900,0.5,5.0,100,-5,5);
+        hnsigmaTOF_deuterons_Rec     = new TH2F ("hnsigmaTOF_deuterons_Rec","",900,0.5,5.0,100,-5,5);
+        hnsigmaTOF_antideuterons_Rec = new TH2F ("hnsigmaTOF_antideuterons_Rec","",900,0.5,5.0,100,-5,5);
+
         h_deuterons_Gen              -> Sumw2();
         h_antideuterons_Gen          -> Sumw2();
         hnsigmaTPC_deuterons_Rec     -> Sumw2();
@@ -586,8 +613,8 @@ void AliAnalysisTaskDeuteronsRT::UserCreateOutputObjects()  {
     fESDtrackCuts_Deuteron -> SetMaxChi2PerClusterITS(36);
     fESDtrackCuts_Deuteron -> SetMaxChi2PerClusterTPC(5);
     fESDtrackCuts_Deuteron -> SetEtaRange(-0.8,0.8);
-    fESDtrackCuts_Deuteron -> SetMaxDCAToVertexXY(1);
-    fESDtrackCuts_Deuteron -> SetMaxDCAToVertexZ(1);
+    fESDtrackCuts_Deuteron -> SetMaxDCAToVertexXY(2);
+    fESDtrackCuts_Deuteron -> SetMaxDCAToVertexZ(2);
     fESDtrackCuts_Deuteron -> SetDCAToVertex2D(kFALSE);
     fESDtrackCuts_Deuteron -> SetRequireSigmaToVertex(kFALSE);
     
@@ -831,12 +858,10 @@ void AliAnalysisTaskDeuteronsRT::ProcessRealEvent ()  {
     hRt_NchTot                -> Fill (Rt,(mult_Transverse+mult_Toward+mult_Away));
     hNchTransv_MultPercentile -> Fill (mult_Transverse,mult_percentile);
     hRt_MultPercentile        -> Fill (Rt,mult_percentile);
-
     
     //Number of Deuteron Candidates
     Int_t nDeuterons = (Int_t)deuteron_ID.size();
     hNumberOfDeuterons -> Fill (nDeuterons);
-    
     
     //Loop over Deuteron Candidates
     for (Int_t i=0 ; i<nDeuterons ; i++)  {
@@ -1104,26 +1129,27 @@ Bool_t AliAnalysisTaskDeuteronsRT::PassedBasicTrackQualityCuts_NoRapidityCut (Al
 //__________________________________________________________________________________________________________________________________________________
 void AliAnalysisTaskDeuteronsRT::FillHistograms_StandardCuts (Int_t mult_Transverse, Int_t leading_track_ID, AliESDtrack *track)  {
     
-    
     //Variables
     Double_t nsigmaTPC = fPIDResponse -> NumberOfSigmasTPC (track,AliPID::kDeuteron);
     Double_t nsigmaTOF = fPIDResponse -> NumberOfSigmasTOF (track,AliPID::kDeuteron);
     Double_t pt        = track->Pt();
     Double_t charge    = track->Charge();
     Double_t DCAxy     = GetTransverseDCA (track);
+    Double_t DCAz      = GetLongitudinalDCA (track);
     Bool_t   hasTOFhit = (track->GetStatus() & AliVTrack::kTOFout) && (track->GetStatus() & AliVTrack::kTIME);
     Double_t length    = track->GetIntegratedLength();
     Double_t Rt        = static_cast<Double_t>(mult_Transverse)/fAverage_Nch_Transv;
     
-    //Track Track Quality Cuts
+    //Track Quality Cuts
     if (!PassedTrackQualityCuts_Syst(track,0)) return;
        
+    //DCA_{z} Cut
+    if (TMath::Abs(DCAz)>1.0) return;
         
     //Vectors
     Double_t xTPC[3] = { Rt, nsigmaTPC, pt };
     Double_t xTOF[3] = { Rt, nsigmaTOF, pt };
     Double_t xDCA[3] = { Rt, DCAxy, pt };
-
     
     //DCA_{xy} Histograms
     if (IsCleanDeuteron (track))  {
@@ -1141,10 +1167,8 @@ void AliAnalysisTaskDeuteronsRT::FillHistograms_StandardCuts (Int_t mult_Transve
         }
     }
     
-    
     //DCA_{xy} Cut
     if (TMath::Abs(DCAxy)>0.1) return;
-
     
     //TPC-Only Analysis
     if (pt<1.5)  {
@@ -1161,7 +1185,6 @@ void AliAnalysisTaskDeuteronsRT::FillHistograms_StandardCuts (Int_t mult_Transve
             if (IsTrackInTransverseRegion(track,leading_track_ID)) hnsigmaTPC_antideuterons_Transverse -> Fill (xTPC);
         }
     }
-        
         
         
     //TOF Analysis
@@ -1255,6 +1278,7 @@ void AliAnalysisTaskDeuteronsRT::FillHistograms_StandardCuts_Sim (AliESDtrack *t
     Double_t pt        = track->Pt();
     Double_t charge    = track->Charge();
     Double_t DCAxy     = GetTransverseDCA (track);
+    Double_t DCAz      = GetLongitudinalDCA (track);
     Bool_t   hasTOFhit = (track->GetStatus() & AliVTrack::kTOFout) && (track->GetStatus() & AliVTrack::kTIME);
     Double_t length    = track->GetIntegratedLength();
 
@@ -1264,6 +1288,9 @@ void AliAnalysisTaskDeuteronsRT::FillHistograms_StandardCuts_Sim (AliESDtrack *t
     //Track Track Quality Cuts
     if (!PassedTrackQualityCuts_Syst(track,0)) return;
     
+    //DCA_{z} Cut
+    if (TMath::Abs(DCAz)>1.0) return;
+
     //DCA_{xy} Distributions
     if (particle->IsPhysicalPrimary())       hDCAxy_deuterons_Prim -> Fill (pt,DCAxy);
     if (particle->IsSecondaryFromMaterial()) hDCAxy_deuterons_Sec  -> Fill (pt,DCAxy);
@@ -1273,25 +1300,29 @@ void AliAnalysisTaskDeuteronsRT::FillHistograms_StandardCuts_Sim (AliESDtrack *t
     if (!particle->IsPhysicalPrimary()) return;
     
     //TPC-Only Analysis
-    if (pt<1.5 && TMath::Abs(nsigmaTPC)<3.0)  {
+    if (pt<1.5)  {
        
-        if (charge>0)  hnsigmaTPC_deuterons_Rec     -> Fill (pt);
-        if (charge<0)  hnsigmaTPC_antideuterons_Rec -> Fill (pt);
+        if (charge>0)  hnsigmaTPC_deuterons_Rec     -> Fill (pt,nsigmaTPC);
+        if (charge<0)  hnsigmaTPC_antideuterons_Rec -> Fill (pt,nsigmaTPC);
     }
         
     //TOF Analysis
     if (!hasTOFhit) return;
     if (length<350.0) return;
     if (TMath::Abs(nsigmaTPC)>3.0) return;
-    if (TMath::Abs(nsigmaTOF)>3.0) return;
     if (pt<1.0) return;
             
-    if (charge>0) hnsigmaTOF_deuterons_Rec     -> Fill(pt);
-    if (charge<0) hnsigmaTOF_antideuterons_Rec -> Fill(pt);
+    if (charge>0) hnsigmaTOF_deuterons_Rec     -> Fill(pt,nsigmaTOF);
+    if (charge<0) hnsigmaTOF_antideuterons_Rec -> Fill(pt,nsigmaTOF);
 
 }
 //__________________________________________________________________________________________________________________________________________________
 void AliAnalysisTaskDeuteronsRT::FillHistograms_Systematics  (Int_t mult_Transverse, Int_t leading_track_ID, AliESDtrack *track, Int_t isyst)  {
+    
+    
+    Double_t DCAxy_max[]={0.0800,0.1200,0.1600,0.1400,0.1000,0.1000,0.1200,0.1400,0.1000,0.1200,0.1400,0.1400,0.1200,0.1200,0.1200,0.1600,0.1000,0.1000,0.1200,0.1000,0.1000,0.1200,0.1000,0.1200,0.1000,0.1400,0.1400,0.1400,0.0800,0.1600,0.1400,0.1000,0.1200,0.1400,0.1400,0.0800,0.1200,0.1200,0.1600,0.1000,0.1000,0.1600,0.1200,0.1400,0.1200,0.1600,0.1000,0.1200,0.1000,0.1400};
+
+    Double_t DCAz_max[]={0.9113,0.9840,1.0381,0.8747,1.4862,0.9562,1.3854,1.2460,1.0332,1.3982,0.8442,0.9277,1.3835,0.9963,1.2933,1.3615,1.3876,1.4857,1.2432,1.0957,1.1053,0.9439,0.9174,1.4443,0.9351,1.3539,0.8032,0.9003,1.2470,1.3777,1.3049,1.4598,1.0615,1.3109,0.8874,0.9497,0.8719,0.8165,1.0398,1.3376,0.8662,1.1053,1.0806,1.2371,0.9518,1.4904,1.0039,1.0135,0.8318,1.3350};
     
     
     //Variables
@@ -1300,22 +1331,35 @@ void AliAnalysisTaskDeuteronsRT::FillHistograms_Systematics  (Int_t mult_Transve
     Double_t pt        = track->Pt();
     Double_t charge    = track->Charge();
     Double_t DCAxy     = GetTransverseDCA (track);
+    Double_t DCAz      = GetLongitudinalDCA (track);
     Bool_t   hasTOFhit = (track->GetStatus() & AliVTrack::kTOFout) && (track->GetStatus() & AliVTrack::kTIME);
     Double_t length    = track->GetIntegratedLength();
     Double_t Rt        = static_cast<Double_t>(mult_Transverse)/fAverage_Nch_Transv;
 
     
-    //Track Track Quality Cuts
+    //Track Quality Cuts
     if (!PassedTrackQualityCuts_Syst(track,isyst)) return;
-       
         
+    //DCA_{z} Cut
+    if (TMath::Abs(DCAz)>DCAz_max[isyst]) return;
+    
+    
     //Vectors
     Double_t xTPC[4] = { Rt, nsigmaTPC, pt, static_cast<Double_t>(isyst) };
     Double_t xTOF[4] = { Rt, nsigmaTOF, pt, static_cast<Double_t>(isyst) };
+    Double_t xDCA[4] = { Rt, DCAxy, pt, static_cast<Double_t>(isyst) };
+    
+    
+    //DCA_{xy} Histograms
+    if (IsCleanDeuteron (track))  {
+              
+        if (charge>0) hDCAxy_deuterons_Syst     -> Fill (xDCA);
+        if (charge<0) hDCAxy_antideuterons_Syst -> Fill (xDCA);
+    }
 
         
-    //DCA_{xy} cut
-    if (TMath::Abs(DCAxy)>0.1) return;
+    //DCA cuts
+    if (TMath::Abs(DCAxy)>DCAxy_max[isyst]) return;
 
     
     //TPC-Only Analysis
@@ -1340,6 +1384,9 @@ void AliAnalysisTaskDeuteronsRT::FillHistograms_Systematics  (Int_t mult_Transve
 //__________________________________________________________________________________________________________________________________________________
 void AliAnalysisTaskDeuteronsRT::FillHistograms_Systematics_Sim  (AliESDtrack *track, Int_t isyst)  {
     
+    Double_t DCAxy_max[]={0.0800,0.1200,0.1600,0.1400,0.1000,0.1000,0.1200,0.1400,0.1000,0.1200,0.1400,0.1400,0.1200,0.1200,0.1200,0.1600,0.1000,0.1000,0.1200,0.1000,0.1000,0.1200,0.1000,0.1200,0.1000,0.1400,0.1400,0.1400,0.0800,0.1600,0.1400,0.1000,0.1200,0.1400,0.1400,0.0800,0.1200,0.1200,0.1600,0.1000,0.1000,0.1600,0.1200,0.1400,0.1200,0.1600,0.1000,0.1200,0.1000,0.1400};
+
+    Double_t DCAz_max[]={0.9113,0.9840,1.0381,0.8747,1.4862,0.9562,1.3854,1.2460,1.0332,1.3982,0.8442,0.9277,1.3835,0.9963,1.2933,1.3615,1.3876,1.4857,1.2432,1.0957,1.1053,0.9439,0.9174,1.4443,0.9351,1.3539,0.8032,0.9003,1.2470,1.3777,1.3049,1.4598,1.0615,1.3109,0.8874,0.9497,0.8719,0.8165,1.0398,1.3376,0.8662,1.1053,1.0806,1.2371,0.9518,1.4904,1.0039,1.0135,0.8318,1.3350};
     
     //Variables
     Double_t nsigmaTPC = fPIDResponse -> NumberOfSigmasTPC (track,AliPID::kDeuteron);
@@ -1347,6 +1394,7 @@ void AliAnalysisTaskDeuteronsRT::FillHistograms_Systematics_Sim  (AliESDtrack *t
     Double_t pt        = track->Pt();
     Double_t charge    = track->Charge();
     Double_t DCAxy     = GetTransverseDCA (track);
+    Double_t DCAz      = GetLongitudinalDCA(track);
     Bool_t   hasTOFhit = (track->GetStatus() & AliVTrack::kTOFout) && (track->GetStatus() & AliVTrack::kTIME);
     Double_t length    = track->GetIntegratedLength();
 
@@ -1358,8 +1406,9 @@ void AliAnalysisTaskDeuteronsRT::FillHistograms_Systematics_Sim  (AliESDtrack *t
        
         
     //DCA_{xy} cut
-    if (TMath::Abs(DCAxy)>0.1) return;
-    if (!particle->IsPhysicalPrimary()) return;
+    if (TMath::Abs(DCAz)>DCAz_max[isyst])   return;
+    if (TMath::Abs(DCAxy)>DCAxy_max[isyst]) return;
+    if (!particle->IsPhysicalPrimary())     return;
 
     
     //TPC-Only Analysis
@@ -1374,7 +1423,8 @@ void AliAnalysisTaskDeuteronsRT::FillHistograms_Systematics_Sim  (AliESDtrack *t
     if (!hasTOFhit) return;
     if (length<350.0) return;
     if (TMath::Abs(nsigmaTPC)>3.0) return;
-    if (TMath::Abs(nsigmaTOF)>3.0) return;
+    if (nsigmaTOF<-3.0) return;
+    if (nsigmaTOF>+3.5) return;
     if (pt<1.0) return;
        
     if (charge>0) hnsigmaTOF_deuterons_Rec_Syst     -> Fill (pt,isyst);
@@ -1428,6 +1478,17 @@ Double_t AliAnalysisTaskDeuteronsRT::GetTransverseDCA (AliESDtrack *track)  {
     Double_t DCAxy = impactParameter[0];
             
     return DCAxy;
+}
+//__________________________________________________________________________________________________________________________________________________
+Double_t AliAnalysisTaskDeuteronsRT::GetLongitudinalDCA (AliESDtrack *track)  {
+         
+    Double_t impactParameter[2];
+    Double_t covarianceMatrix[3];
+    if (!track->PropagateToDCA (fESDevent->GetPrimaryVertex(),fESDevent->GetMagneticField(),10000,impactParameter,covarianceMatrix)) return -999;
+            
+    Double_t DCAz = impactParameter[1];
+            
+    return DCAz;
 }
 //__________________________________________________________________________________________________________________________________________________
 void AliAnalysisTaskDeuteronsRT::Terminate(Option_t *)  {

--- a/PWGLF/NUCLEX/Nuclei/Nuclei_UE/AliAnalysisTaskDeuteronsRT.h
+++ b/PWGLF/NUCLEX/Nuclei/Nuclei_UE/AliAnalysisTaskDeuteronsRT.h
@@ -70,6 +70,7 @@ public:
     Bool_t   IsDeuteronCandidate                 (AliESDtrack *track);
     Bool_t   PassedTrackQualityCuts_Syst         (AliESDtrack *track, Int_t isyst);
     Double_t GetTransverseDCA                    (AliESDtrack *track);
+    Double_t GetLongitudinalDCA                  (AliESDtrack *track);
     Double_t GetRapidity (AliESDtrack *track);
 
     //Standard Event Cuts
@@ -85,6 +86,8 @@ private:
     AliPIDResponse    *fPIDResponse;//!
     TList             *fOutputList;//!
     TList             *fQAList;//!
+    
+   
     
     //Input from AddTask
     UInt_t    fTriggerType;//
@@ -144,6 +147,9 @@ private:
     THnSparseF *hnsigmaTPC_antideuterons_Syst;//!
     THnSparseF *hnsigmaTOF_deuterons_Syst;//!
     THnSparseF *hnsigmaTOF_antideuterons_Syst;//!
+    THnSparseF *hDCAxy_deuterons_Syst;//!
+    THnSparseF *hDCAxy_antideuterons_Syst;//!
+
     
     //3-Dimensional Histograms for Deuterons vs. y
     THnSparseF *hnsigmaTPC_deuterons_rap;//!
@@ -158,12 +164,12 @@ private:
     TH1F *h_antideuterons_Gen;//!
 
     //Reconstructed p_{T} Spectra (low p_{T})
-    TH1F *hnsigmaTPC_deuterons_Rec;//!
-    TH1F *hnsigmaTPC_antideuterons_Rec;//!
+    TH2F *hnsigmaTPC_deuterons_Rec;//!
+    TH2F *hnsigmaTPC_antideuterons_Rec;//!
         
     //Reconstructed p_{T} Spectra (high p_{T})
-    TH1F *hnsigmaTOF_deuterons_Rec;//!
-    TH1F *hnsigmaTOF_antideuterons_Rec;//!
+    TH2F *hnsigmaTOF_deuterons_Rec;//!
+    TH2F *hnsigmaTOF_antideuterons_Rec;//!
 
     //DCA_{xy} Distributions
     TH2F *hDCAxy_deuterons_Prim;//!
@@ -177,7 +183,8 @@ private:
     
     //****************************************************************************************
 
-
+    
+    
     
     
     AliAnalysisTaskDeuteronsRT(const AliAnalysisTaskDeuteronsRT&);


### PR DESCRIPTION
Added extra dimension for PID systematics (TPC & TOF).
Added DCA_{xy} variations into track cuts
Successfully tested on the GRID.