### PR TITLE
Make pt-dependent matching params in had corr. settable

### DIFF
--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterHadronicCorrection.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterHadronicCorrection.cxx
@@ -50,6 +50,12 @@ AliEmcalCorrectionClusterHadronicCorrection::AliEmcalCorrectionClusterHadronicCo
   fHistNMatchCent(0),
   fHistNClusMatchCent(0)
 {
+  fMomDepMatchingParamEta[0] = 0.04;
+  fMomDepMatchingParamEta[1] = 0.010;
+  fMomDepMatchingParamEta[2] = 2.5;
+  fMomDepMatchingParamPhi[0] = 0.09; 
+  fMomDepMatchingParamPhi[1] = 0.015;
+  fMomDepMatchingParamPhi[2] = 2.;
   for(Int_t i=0; i<10; i++) {
     fHistEsubPch[i]    = 0;
     fHistEsubPchRat[i] = 0;
@@ -104,6 +110,12 @@ Bool_t AliEmcalCorrectionClusterHadronicCorrection::Initialize()
   GetProperty("useM02SubtractionScheme", fUseM02SubtractionScheme);
   GetProperty("useConstantSubtraction", fUseConstantSubtraction);
   GetProperty("constantSubtractionValue", fConstantSubtractionValue);
+  GetProperty("momDepMatchingParamEta0", fMomDepMatchingParamEta[0]);
+  GetProperty("momDepMatchingParamEta1", fMomDepMatchingParamEta[1]);
+  GetProperty("momDepMatchingParamEta2", fMomDepMatchingParamEta[2]);
+  GetProperty("momDepMatchingParamPhi0", fMomDepMatchingParamPhi[0]);
+  GetProperty("momDepMatchingParamPhi1", fMomDepMatchingParamPhi[1]);
+  GetProperty("momDepMatchingParamPhi2", fMomDepMatchingParamPhi[2]);
 
   return kTRUE;
 }
@@ -579,9 +591,9 @@ void AliEmcalCorrectionClusterHadronicCorrection::DoMatchedTracksLoop(Int_t iclu
   //https://alice-notes.web.cern.ch/node/411  Fig. 46   for mom<3GeV these cuts are wider than the standard cuts
   //these values were extracted in the 2012 pp8 TeV MonteCarlo and apparently showed robustness throughout different periods
   TF1 funcPtDepEta("func", "[1] + 1 / pow(x + pow(1 / ([0] - [1]), 1 / [2]), [2])");
-  funcPtDepEta.SetParameters(0.04, 0.010, 2.5);
+  funcPtDepEta.SetParameters(fMomDepMatchingParamEta[0], fMomDepMatchingParamEta[1], fMomDepMatchingParamEta[2]);
   TF1 funcPtDepPhi("func", "[1] + 1 / pow(x + pow(1 / ([0] - [1]), 1 / [2]), [2])");
-  funcPtDepPhi.SetParameters(0.09, 0.015, 2.);
+  funcPtDepPhi.SetParameters(fMomDepMatchingParamPhi[0], fMomDepMatchingParamPhi[1], fMomDepMatchingParamPhi[2]);
   
   // loop over matched tracks
   Int_t Ntrks = cluster->GetNTracksMatched();

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterHadronicCorrection.h
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterHadronicCorrection.h
@@ -59,6 +59,8 @@ protected:
   Double_t               fEtaMatch;                  ///< eta match value (pp=0.025)
   Bool_t                 fDoTrackClus;               ///< loop over tracks first
   Bool_t                 fDoMomDepMatching;          ///< set the values fPhiMatch and fEtaMatch depending on the track momentum
+  Double_t               fMomDepMatchingParamEta[3]; ///< Momemtum-dependent matching params for eta
+  Double_t               fMomDepMatchingParamPhi[3]; ///< Momemtum-dependent matching params for phi
   Double_t               fHadCorr;                   ///< hadronic correction (fraction)
   Double_t               fEexclCell;                 ///< energy/cell that we cannot subtract from the clusters
   Bool_t                 fPlotOversubtractionHistograms; ///< compute and plot oversubtracted energy from embedded/signal matches (embedding only)

--- a/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
+++ b/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
@@ -276,6 +276,12 @@ ClusterHadronicCorrection:                          # Cluster hadronic correctio
     phiMatch: 0.030                                 # Phi match value
     etaMatch: 0.015                                 # Eta match value
     doMomDepMatching: false                         # This enables a momentum dependent eta/phi window for track matching
+    momDepMatchingParamEta0: 0.04                   # Param 0 in eta for pt-dependent matching
+    momDepMatchingParamEta1: 0.010                  # Param 1 in eta for pt-dependent matching
+    momDepMatchingParamEta2: 2.5                    # Param 2 in eta for pt-dependent matching
+    momDepMatchingParamPhi0: 0.09                   # Param 0 in phi for pt-dependent matching
+    momDepMatchingParamPhi1: 0.015                  # Param 1 in phi for pt-dependent matching
+    momDepMatchingParamPhi2: 2.                     # Param 2 in phi for pt-dependent matching
     hadCorr: 2.                                     # Sets the fraction f of track p to subtract from matched cluster. To subtract all tracks within the eta-phi cut set hadCorr = 1+f. To subtract only one track set 0<hadCorr<1 where hadCorr=f.
     Eexcl: 0                                        # Cell energy that cannot be subtracted
     doTrackClus: true                               # Loop over tracks first


### PR DESCRIPTION
Make parameters for cut function settable in order
to be able to vary them for systematics studies.