### PR TITLE
Fixing naming of AliHFSystErr objects

### DIFF
--- a/PWGHF/vertexingHF/AliHFSystErr.cxx
+++ b/PWGHF/vertexingHF/AliHFSystErr.cxx
@@ -10618,6 +10618,7 @@ void AliHFSystErr::InitD0toKpi2018PbPb010() {
   // D0->Kpi syst errors. Responsible: S. Trogolo
   //   2018 PbPb sample, 010 CC
   // On 17/04/2019: the syst. unc. values are still those from 2015 analysis [TO BE UPDATED].
+  SetNameTitle("AliHFSystErr","SystErrD0toKpi2018PbPb010");
 
   // Normalization
   fNorm = new TH1F("fNorm","fNorm",100,0,50);
@@ -10745,7 +10746,7 @@ void AliHFSystErr::InitD0toKpi2018PbPb3050() {
   //   2018 PbPb sample, 30-50 CC
   // On 17/04/2019: the syst. unc. values are still those from 2015 analysis [TO BE UPDATED].
 
-  SetNameTitle("AliHFSystErr","SystErrD0toKpi2015PbPb3050");
+  SetNameTitle("AliHFSystErr","SystErrD0toKpi2018PbPb3050");
   // Normalization
   fNorm = new TH1F("fNorm","fNorm",72,0,36);
   for(Int_t i=1;i<=72;i++) fNorm->SetBinContent(i,0.04); // TAA and pp norm

--- a/PWGHF/vertexingHF/AliHFSystErr.h
+++ b/PWGHF/vertexingHF/AliHFSystErr.h
@@ -22,7 +22,7 @@ class AliHFSystErr : public TNamed
 {
  public:
 
-  AliHFSystErr(const Char_t* name="HFSystErr", const Char_t* title="");
+  AliHFSystErr(const Char_t* name="AliHFSystErr", const Char_t* title="");
 
   virtual ~AliHFSystErr();
 


### PR DESCRIPTION
1. In the first commit as discussed and agreed with @fgrosa, the default name of AliHFSystErr object in the constructor is moved to "AliHFSystErr" that is the default used in all macros.
2. In the second commit the naming of D0 syst err has been fixed