### PR TITLE
Bugfix for DMC7 and DG1 trigger + support for mixed trigger

### DIFF
--- a/PWG/EMCAL/EMCALtasks/AliAnalysisTaskEmcalTriggerNormalization.h
+++ b/PWG/EMCAL/EMCALtasks/AliAnalysisTaskEmcalTriggerNormalization.h
@@ -324,11 +324,6 @@ protected:
   std::string MatchTrigger(EMCAL_STRINGVIEW triggerstring, const std::vector<std::string> &triggers) const;
 
   /**
-   * @brief Reset downscale factor cache for all EMCAL triggers
-   */
-  void ResetDownscaleFactors();
-
-  /**
    * @brief Check whether run number is from a p-Pb run from 2013
    * @param runnumber Run number to check
    * @return true in case runs from p-Pb 2013 are processed, false otherwise 


### PR DESCRIPTION
- Bugfix in filling norm hist and cluster counter for
  DMC7 and DG1 (missing "," in trigger class vector)
- Add mixed triggers to trigger downscale factor
  cache if at least one trigger (EMCAL or DCAL) is
  present. If both are found the downscale factor
  is taken from the EMCAL side.