### PR TITLE
Adding option for DeltPhi bins, isMC

### DIFF
--- a/PWGHF/hfe/AliAnalysisTaskEHCorrel.cxx
+++ b/PWGHF/hfe/AliAnalysisTaskEHCorrel.cxx
@@ -157,6 +157,7 @@ AliAnalysisTaskEHCorrel::AliAnalysisTaskEHCorrel(const char *name)
   fEMCClsTimeCut(kFALSE),
   fMCarray(0),
   fMCHeader(0),
+  fIsMC(kFALSE),
   fApplyElectronEffi(kFALSE),
   fEffi(1.0),
   fWeight(1.0),
@@ -174,6 +175,7 @@ AliAnalysisTaskEHCorrel::AliAnalysisTaskEHCorrel(const char *name)
   fNpureMC(0),
   fNembMCpi0(0),
   fNembMCeta(0),
+  fNDelPhiBins(32),
   fOutputList(0),
   fNevents(0),
   fVtxZ(0),
@@ -349,6 +351,7 @@ AliAnalysisTaskEHCorrel::AliAnalysisTaskEHCorrel()
   fEMCClsTimeCut(kFALSE),
   fMCarray(0),
   fMCHeader(0),
+  fIsMC(kFALSE),
   fApplyElectronEffi(kFALSE),
   fEffi(1.0),
   fWeight(1.0),
@@ -366,6 +369,7 @@ AliAnalysisTaskEHCorrel::AliAnalysisTaskEHCorrel()
   fNpureMC(0),
   fNembMCpi0(0),
   fNembMCeta(0),
+  fNDelPhiBins(32),
   fOutputList(0),
   fNevents(0),
   fVtxZ(0),
@@ -980,7 +984,7 @@ if(fFlagFillMECorr){
   // Int_t bin[6] = {30,20,32,50,nZvtxBins,nCentralityBinsPbPb}; //ptElec, ptHad,Dphi, Deta
   // Double_t xmin[6] = {0,0,-TMath::Pi()/2,-1.8,0,0};
   // Double_t xmax[6] = {30,20,(3*TMath::Pi())/2,1.8,6,6};
-  Int_t bin[4] = {30,20,32,50}; //ptElec, ptHad,Dphi, Deta
+  Int_t bin[4] = {30,20,fNDelPhiBins,50}; //ptElec, ptHad,Dphi, Deta
   Double_t xmin[4] = {0,0,-TMath::Pi()/2,-1.8};
   Double_t xmax[4] = {30,20,(3*TMath::Pi())/2,1.8};
 
@@ -1293,13 +1297,16 @@ void AliAnalysisTaskEHCorrel::UserExec(Option_t*)
       if(fFlagClsTypeDCAL && !fFlagClsTypeEMC)
         if(!fClsTypeDCAL) continue; //selecting only DCAL clusters
         
-      if(clustMatch->GetIsExotic()) continue; //remove exotic clusters
+      if(!fIsMC)
+          if(clustMatch->GetIsExotic()) continue; //remove exotic clusters
 
       Double_t clustTime = clustMatch->GetTOF()*1e+9; // ns;
 
-      if(fEMCClsTimeCut)
-        if(TMath::Abs(clustTime) > 50) continue;
-
+      if(fEMCClsTimeCut){
+        if(!fIsMC)
+            if(TMath::Abs(clustTime) > 50) continue;
+      }
+        
       ////////////////////////////////////////////////////////////////////////////////
       //Properties of tracks matched to the EMCAL//
       ////////////////////////////////////////////////////////////////////////////////
@@ -2005,7 +2012,7 @@ void AliAnalysisTaskEHCorrel::EMCalClusterInfo()
   Int_t Nclust = -999;
   TVector3 clustpos;
   Float_t  emcx[3]; // cluster pos
-  Double_t clustE=-999, emcphi = -999, emceta=-999;
+  Double_t clustE=-999, emcphi = -999, emceta=-999, m02=-999;
   Float_t tof=-999;
 
   if(!fUseTender) Nclust = fVevent->GetNumberOfCaloClusters();
@@ -2020,7 +2027,12 @@ void AliAnalysisTaskEHCorrel::EMCalClusterInfo()
     Bool_t fClsTypeEMC = kFALSE, fClsTypeDCAL = kFALSE;  
     if(clust && clust->IsEMCAL())
     {
-      if(clust->GetIsExotic()) continue;
+        //Removing exotic clusters using IsExotic function in data and using M02 min cut
+      if(!fIsMC)
+          if(clust->GetIsExotic()) continue;
+      m02 = clust->GetM02();
+        if(m02 < 0.02) continue;
+        
       clustE = clust->E();
       if(clustE < 0.3) continue;
 
@@ -2042,8 +2054,10 @@ void AliAnalysisTaskEHCorrel::EMCalClusterInfo()
       if(fFlagClsTypeDCAL && !fFlagClsTypeEMC)
         if(!fClsTypeDCAL) continue; //selecting only DCAL clusters
 
-      if(fEMCClsTimeCut)
-        if(TMath::Abs(tof) > 50) continue;
+      if(fEMCClsTimeCut){
+        if(!fIsMC)
+            if(TMath::Abs(tof) > 50) continue;
+      }
 
       fHistClustE->Fill(clustE);
       fEMCClsEtaPhi->Fill(emceta,emcphi);

--- a/PWGHF/hfe/AliAnalysisTaskEHCorrel.h
+++ b/PWGHF/hfe/AliAnalysisTaskEHCorrel.h
@@ -119,7 +119,7 @@ class AliAnalysisTaskEHCorrel : public AliAnalysisTaskSE {
     void    IsMC(Bool_t isMC) {fIsMC = isMC;};
 
     void    SwitchFillEHCorrel(Bool_t fSwitch){fFillEHCorrel = fSwitch;};
-    void    SetNDeltaPhiBins(Int_t nbins){fNDelPhiBins = nbins};
+    void    SetNDeltaPhiBins(Int_t nbins){fNDelPhiBins = nbins;};
 
     void    GetHadronTrackingEfficiency();
     void    SwitchHadTrackEffi(Bool_t fSwitch) {fCalcHadronTrackEffi = fSwitch;};

--- a/PWGHF/hfe/AliAnalysisTaskEHCorrel.h
+++ b/PWGHF/hfe/AliAnalysisTaskEHCorrel.h
@@ -116,8 +116,10 @@ class AliAnalysisTaskEHCorrel : public AliAnalysisTaskSE {
     void    IsPbPb(Bool_t isPbPb) {fIsPbPb = isPbPb;};
     void    Ispp(Bool_t ispp) {fIspp = ispp;};
     void    IspPb(Bool_t ispPb) {fIspPb = ispPb;};
+    void    IsMC(Bool_t isMC) {fIsMC = isMC;};
 
     void    SwitchFillEHCorrel(Bool_t fSwitch){fFillEHCorrel = fSwitch;};
+    void    SetNDeltaPhiBins(Int_t nbins){fNDelPhiBins = nbins};
 
     void    GetHadronTrackingEfficiency();
     void    SwitchHadTrackEffi(Bool_t fSwitch) {fCalcHadronTrackEffi = fSwitch;};
@@ -196,6 +198,7 @@ class AliAnalysisTaskEHCorrel : public AliAnalysisTaskSE {
     Bool_t              fEMCClsTimeCut;//
     TClonesArray        *fMCarray;//!
     AliAODMCHeader      *fMCHeader;//!
+    Bool_t              fIsMC;// Is MC
     Bool_t              fApplyElectronEffi;//
     Double_t            fEffi;//!
     Double_t            fWeight;//!
@@ -215,6 +218,7 @@ class AliAnalysisTaskEHCorrel : public AliAnalysisTaskSE {
     Int_t               fNembMCpi0; //! N > fNembMCpi0 = particles from pi0 generator
     Int_t               fNembMCeta; //! N > fNembMCeta = particles from eta generator
 
+    Int_t               fNDelPhiBins; //number of bins to be used for deltaphi distribution
     TList       	   	*fOutputList;		//!output list
     TH1F                *fNevents;		//!no of events
     TH1F                *fVtxZ;//!

--- a/PWGHF/hfe/AliAnalysisTaskHFEBESpectraEMC.cxx
+++ b/PWGHF/hfe/AliAnalysisTaskHFEBESpectraEMC.cxx
@@ -1651,10 +1651,11 @@ void AliAnalysisTaskHFEBESpectraEMC::UserExec(Option_t *)
             if(fFlagClsTypeDCAL && !fFlagClsTypeEMC)
                 if(!fClsTypeDCAL) continue; //selecting only DCAL clusters
             
-            if(clustMatch->GetIsExotic()) continue; //remove exotic clusters
-            
             Double_t clustTime = clustMatch->GetTOF()*1e+9; // ns;
-            if(TMath::Abs(clustTime) > 50) continue; //50ns time cut to remove pileup
+            if(!fIsMC){
+                if(clustMatch->GetIsExotic()) continue; //remove exotic clusters
+                if(TMath::Abs(clustTime) > 50) continue; //50ns time cut to remove pileup
+            }
             
             /////////////////////////////
             //Reconstruction efficiency//
@@ -2066,7 +2067,12 @@ void AliAnalysisTaskHFEBESpectraEMC::GetEMCalClusterInfo()
         
         if(clust && clust->IsEMCAL())
         {
-            if(clust->GetIsExotic()) continue;
+            //Removing exotic clusters using IsExotic function in data and using M02 min cut
+            if(!fIsMC)
+                if(clust->GetIsExotic()) continue;
+            Double_t m02 = clust->GetM02();
+            if(m02 < 0.02) continue;
+            
             Double_t clustE_NL = clust->GetNonLinCorrEnergy();
             Double_t clustE = clust->E();
             if(clustE < 0.3) continue;
@@ -2093,7 +2099,8 @@ void AliAnalysisTaskHFEBESpectraEMC::GetEMCalClusterInfo()
             
             Float_t tof = clust->GetTOF()*1e+9; // ns
             fHistoTimeEMC->Fill(clustE,tof);
-            if(TMath::Abs(tof) > 50) continue;
+            if(!fIsMC)
+                if(TMath::Abs(tof) > 50) continue;
             
             fHistClustE->Fill(clust->E());
             fHistNonLinClustE->Fill(clustE_NL);

--- a/PWGHF/hfe/macros/AddTaskEHCorrel.C
+++ b/PWGHF/hfe/macros/AddTaskEHCorrel.C
@@ -13,7 +13,7 @@ AliAnalysisTask *AddTaskEHCorrel(TString ContNameExt = "", Bool_t isPbPb=kFALSE,
     Bool_t ClsTypeEMC=kTRUE, Bool_t ClsTypeDCAL=kTRUE,
     Int_t AddPileUpCut=kFALSE, Int_t hadCutCase=2,  Bool_t FillEHCorrel=kTRUE,
     Bool_t  CalcHadronTrackEffi=kFALSE, Bool_t CalculateNonHFEEffi=kFALSE, Bool_t CalPi0EtaWeight=kFALSE,
-    Bool_t applyEleEffi=kFALSE)
+    Bool_t applyEleEffi=kFALSE, Int_t nBins=32, Bool_t isMC=kFALSE)
 {
   //get the current analysis manager
   AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
@@ -83,6 +83,8 @@ AliAnalysisTask *AddTaskEHCorrel(TString ContNameExt = "", Bool_t isPbPb=kFALSE,
     taskHFEeh->SwitchFillEHCorrel(FillEHCorrel);
     taskHFEeh->SetWeightCal(CalPi0EtaWeight);
     taskHFEeh->SetNonHFEEffi(CalculateNonHFEEffi);
+    taskHFEeh->SetNDeltaPhiBins(nBins);
+    taskHFEeh->IsMC(isMC);
 
     TString containerName = mgr->GetCommonFileName();
     TString SubcontainerName = ContNameExt;
@@ -106,6 +108,7 @@ AliAnalysisTask *AddTaskEHCorrel(TString ContNameExt = "", Bool_t isPbPb=kFALSE,
     taskHFEehGA01->SetTriggerElePtCut(trigElePtcut);
     taskHFEehGA01->SetClusterTypeEMC(ClsTypeEMC);
     taskHFEehGA01->SetClusterTypeDCAL(ClsTypeDCAL);
+    taskHFEeh->SetNDeltaPhiBins(nBins);
 
     TString containerName01 = mgr->GetCommonFileName();
     TString SubcontainerName01 = ContNameExt;


### PR DESCRIPTION
EH Correlation:
- Add switch to change DeltaPhi bins in THnsparse
- Add switch for MC to apply exotic cluster removal, EMCal cluster TOF cut only in data

HFEBEtask:
- Add switch for MC to apply exotic cluster removal, EMCal cluster TOF cut only in data
