### PR TITLE
Update AliAnalysisTaskEmcalJetEnergyFlow.cxx

### DIFF
--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetEnergyFlow.cxx
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetEnergyFlow.cxx
@@ -55,7 +55,7 @@ AliAnalysisTaskEmcalJetEnergyFlow::AliAnalysisTaskEmcalJetEnergyFlow(const char*
 AliAnalysisTaskEmcalJet(name, kTRUE),
 fHistManager(name) // ,fOutput{0}
 {
-	SetMakeGeneralHistograms(kFALSE);
+	SetMakeGeneralHistograms(kTRUE);
 //	DefineInput(0, TChain::Class());
 //	DefineOutput(1,TList::Class());
 


### PR DESCRIPTION
Enabled the SetMakeGeneralHistograms option in order to get the Nevents histogram but also to facilitate scaling with pt hard binning when running om Pythia productions