### PR TITLE
Registering output container connected to AO2D.root file.

### DIFF
--- a/RUN3/AliAnalysisTaskAO2Dconverter.cxx
+++ b/RUN3/AliAnalysisTaskAO2Dconverter.cxx
@@ -471,6 +471,8 @@ AliAnalysisTaskAO2Dconverter *AliAnalysisTaskAO2Dconverter::AddTask(TString suff
   mgr->ConnectInput(task, 0, mgr->GetCommonInputContainer());
   // same for the output
   mgr->ConnectOutput(task, 1, mgr->CreateContainer("QAlist", TList::Class(), AliAnalysisManager::kOutputContainer, fileName.Data()));
+  // we need to register an unconnected output container to register the output file in the lego system
+  mgr->CreateContainer("AO2D", TTree::Class(), AliAnalysisManager::kOutputContainer, "AO2D.root");
   // for (Int_t i = 0; i < kTrees; i++)
   //   mgr->ConnectOutput(task, 2 + i, mgr->CreateContainer(TreeName[i], TTree::Class(), AliAnalysisManager::kOutputContainer, fileName.Data()));
   // in the end, this macro returns a pointer to your task. this will be convenient later on


### PR DESCRIPTION
Due to the non-standard way to handle the output file in the AO2D conversion task, we need to create an un-connected output container having as output file AO2D.root. This helps the system in the lego environment understand that this file needs to be registered, which is not the case when running the wagon standalone in a train.