### PR TITLE
PWG/EMCAL: Added new function for NCell efficiency and modified energy fine tuning for 1 cell clusters

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.cxx
@@ -1662,6 +1662,11 @@ void AliEMCALRecoUtils::InitNCellEfficiencyParam()
     fNCellEfficiencyParams[1] = 1.28118;
     fNCellEfficiencyParams[2] = 0.583403;
   }
+  else if (fNCellEfficiencyFunction == kNCePi0TaggedPCMEMC) {
+    fNCellEfficiencyParams[0] = -0.0377925;
+    fNCellEfficiencyParams[1] = 0.160758;
+    fNCellEfficiencyParams[2] = -0.00357992;
+  }
 
 }
 
@@ -1732,7 +1737,7 @@ Bool_t AliEMCALRecoUtils::GetIsNCellCorrected(AliVCluster* cluster, AliVCaloCell
 
     case kNCeGammaAndElec:
     {
-      // based on clusters which are part of a cluster pair with a mass of: [M(Pi0) - 0.05;M(Pi0) + 0.02]
+      // based on clusters which are part of a (EMC-EMC) cluster pair with a mass of: [M(Pi0) - 0.05;M(Pi0) + 0.02]
       // mostly photon clusters and electron(conversion) clusters (purity about 95%)
       // exotics should be nearly cancled by that
       // fNCellEfficiencyParams[0] = 0.0901375;
@@ -1741,6 +1746,22 @@ Bool_t AliEMCALRecoUtils::GetIsNCellCorrected(AliVCluster* cluster, AliVCaloCell
       Float_t val = fNCellEfficiencyParams[0]*exp(
                     -0.5*((energy-fNCellEfficiencyParams[1])/fNCellEfficiencyParams[2])*
                     ((energy-fNCellEfficiencyParams[1])/fNCellEfficiencyParams[2]));
+      if(randNr < val) return kTRUE;
+      else return kFALSE;
+      break;
+    }
+
+    case kNCePi0TaggedPCMEMC:
+    {
+      // based on clusters which are part of a (PCM-EMC) cluster pair with a mass of: [M(Pi0) - 0.05;M(Pi0) + 0.02]
+      // mostly photon clusters and electron(conversion) clusters (purity about 95%)
+      // exotics should be nearly cancled by that
+      // fNCellEfficiencyParams[0] = -0.0377925;
+      // fNCellEfficiencyParams[1] = 0.160758;
+      // fNCellEfficiencyParams[2] = -0.00357992;
+      Float_t val = fNCellEfficiencyParams[0]*energy*energy +
+                    fNCellEfficiencyParams[1]*energy +
+                    fNCellEfficiencyParams[2];
       if(randNr < val) return kTRUE;
       else return kFALSE;
       break;

--- a/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.h
+++ b/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.h
@@ -100,10 +100,11 @@ public:
   /// Recomended setting:
   enum     NCellEfficiencyFunctions
   {
-    kNCeNoCorrection   = 0,
-    kNCeAllClusters    = 1,
-    kNCeTestBeam       = 2,
-    kNCeGammaAndElec   = 3
+    kNCeNoCorrection    = 0,
+    kNCeAllClusters     = 1,
+    kNCeTestBeam        = 2,
+    kNCeGammaAndElec    = 3,
+    kNCePi0TaggedPCMEMC = 4
   };
 
   /// Cluster position enum list of possible algoritms

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterLowEnergyEfficiency.h
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterLowEnergyEfficiency.h
@@ -43,6 +43,7 @@ protected:
   TH1F                  *fNCellDistAfter;           //!<!number of cells distribution after
 
   Bool_t                fRejectNextToClus;          //!<!Switch waether to reject 1 cell clusters with direct neighbours
+  Bool_t                fApplyToGammaOnly;          //!<!Switch waether to apply correction to only photon clusters
 
  private:
   AliEmcalCorrectionClusterLowEnergyEfficiency(const AliEmcalCorrectionClusterLowEnergyEfficiency &);               // Not implemented
@@ -52,7 +53,7 @@ protected:
   static RegisterCorrectionComponent<AliEmcalCorrectionClusterLowEnergyEfficiency> reg;
 
   /// \cond CLASSIMP
-  ClassDef(AliEmcalCorrectionClusterLowEnergyEfficiency, 1); // EMCal cluster non-linearity correction component
+  ClassDef(AliEmcalCorrectionClusterLowEnergyEfficiency, 2); // EMCal cluster low energy efficiency correction component
   /// \endcond
 };
 

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterNonLinearityMCAfterburner.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterNonLinearityMCAfterburner.cxx
@@ -68,9 +68,9 @@ Bool_t AliEmcalCorrectionClusterNonLinearityMCAfterburner::Initialize()
  * Create run-independent objects for output. Called before running over events.
  */
 void AliEmcalCorrectionClusterNonLinearityMCAfterburner::UserCreateOutputObjects()
-{   
+{
   AliEmcalCorrectionComponent::UserCreateOutputObjects();
-  
+
   // Create my user objects.
   if (fCreateHisto){
     fEnergyDistBefore = new TH1F("hEnergyDistBefore","hEnergyDistBefore;E_{clus} (GeV)",1500,0,150);
@@ -81,7 +81,7 @@ void AliEmcalCorrectionClusterNonLinearityMCAfterburner::UserCreateOutputObjects
     fOutput->Add(fEnergyDistAfter);
     fEnergyTimeHistAfter = new TH2F("hEnergyTimeDistAfter","hEnergyTimeDistAfter;E_{clus} (GeV);time (s)",1500,0,150,500,-1e-6,1e-6);
     fOutput->Add(fEnergyTimeHistAfter);
-    
+
     // Take ownership of output list
     fOutput->SetOwner(kTRUE);
   }
@@ -148,9 +148,13 @@ Bool_t AliEmcalCorrectionClusterNonLinearityMCAfterburner::Run()
        // like function 1 but divided by constant factor
        if (fNonLinearityAfterburnerFunction == 4) {
           newEnergy = oldEnergy;
-
-          newEnergy/= fNLAfterburnerPara[0] + TMath::Exp( fNLAfterburnerPara[1] + (fNLAfterburnerPara[2] * newEnergy));
-          newEnergy/= fNLAfterburnerPara[3];
+          
+          if(clus->GetNCells() == 1){ // 1 cell clusters need to be treated differently
+            newEnergy/= fNLAfterburnerPara[4];
+          } else {
+            newEnergy/= fNLAfterburnerPara[0] + TMath::Exp( fNLAfterburnerPara[1] + (fNLAfterburnerPara[2] * newEnergy));
+            newEnergy/= fNLAfterburnerPara[3];
+          }
           AliDebugStream(2) << "Using non-lin afterburner function No.4" << std::endl;
           AliDebugStream(2) << "old Energy: "<< oldEnergy<<", new Energy: "<<newEnergy<< std::endl;
        }
@@ -384,7 +388,7 @@ void AliEmcalCorrectionClusterNonLinearityMCAfterburner::InitNonLinearityParam(T
         fNLAfterburnerPara[2] = -0.273207;
         //Iteration-2 parameters
         fNLAfterburnerPara[3] = 1.0;
-        fNLAfterburnerPara[4] = 0;
+        fNLAfterburnerPara[4] = 1.008614; // factor to be applied on 1 cell clusters only
         fNLAfterburnerPara[5] = 0;
       }
       else if( !namePeriod.CompareTo("kTestBeamFinalMCRun213TeV")) {
@@ -396,7 +400,7 @@ void AliEmcalCorrectionClusterNonLinearityMCAfterburner::InitNonLinearityParam(T
         fNLAfterburnerPara[2] = -0.273207;
         //Iteration-2 parameters
         fNLAfterburnerPara[3] = 1.00349; // additional factor from average to improve agreement
-        fNLAfterburnerPara[4] = 0;
+        fNLAfterburnerPara[4] = 1.008614; // factor to be applied on 1 cell clusters only
         fNLAfterburnerPara[5] = 0;
       }
       else if( !namePeriod.CompareTo("kTestBeamFinalMCRun1")) {
@@ -408,7 +412,7 @@ void AliEmcalCorrectionClusterNonLinearityMCAfterburner::InitNonLinearityParam(T
         fNLAfterburnerPara[2] = -0.273207;
         //Iteration-2 parameters
         fNLAfterburnerPara[3] = 1.0125; // Run1 additional correction factor of 1.25%
-        fNLAfterburnerPara[4] = 0;
+        fNLAfterburnerPara[4] = 1.008614; // factor to be applied on 1 cell clusters only
         fNLAfterburnerPara[5] = 0;
       }
       // pp 5.02 TeV (2015) - LHC15n

--- a/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
+++ b/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
@@ -245,6 +245,7 @@ ClusterLowEnergyEfficiency:                         # Cluster number of cell eff
     createHistos: false                             # Whether the task should create output histograms
     nCellFunct: kGammaAndElec                       # Sets the probabiliyt function for the ncell efficiency
     setRejectNextToClus: true                       # Set if 1 cell clusters which are directly next to another cluster should be considered for the ncell efficiency (Should be enabled)
+    setApplyToGammaOnly: true                       # Set if correction should be applied on all clusters (false) or only on photon clusters (true)
     cellsNames:                                     # Names of the cells input objects which should be attached to the correction
         - defaultCells                              # This object is defined above in the cells section of the input objects
     clusterContainersNames:                         # Names of the cluster input objects which should be attached to the correction

--- a/PWGGA/GammaConv/macros/AddTask_GammaCalo_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaCalo_pp.C
@@ -3284,15 +3284,18 @@ void AddTask_GammaCalo_pp(
 
     // multiple configs for different settings in the correction framework
   } else if (trainConfig == 2513) { // NCellEfficiency calculated in the correction framework
-    cuts.AddCutCalo("00010113","411792109fe3y220000","0r631031000000d0"); // INT7 NL 12 + TB
+    cuts.AddCutCalo("00010113","411790009fe3y220000","0r631031000000d0"); // INT7 TB and NL applied in CF!
   } else if (trainConfig == 2514) { // NCellEfficiency calculated in the correction framework
-    cuts.AddCutCalo("00010113","411792109fe3y220000","0r631031000000d0"); // INT7 NL 12 + TB
+    cuts.AddCutCalo("00010113","411790009fe3y220000","0r631031000000d0"); // INT7 TB and NL applied in CF!
   } else if (trainConfig == 2515) { // NCellEfficiency calculated in the correction framework
-    cuts.AddCutCalo("00010113","411792109fe3y220000","0r631031000000d0"); // INT7 NL 12 + TB
+    cuts.AddCutCalo("00010113","411790009fe3y220000","0r631031000000d0"); // INT7 TB and NL applied in CF!
   } else if (trainConfig == 2516) { // NCellEfficiency calculated in the correction framework
-    cuts.AddCutCalo("00010113","411792109fe3y220000","0r631031000000d0"); // INT7 NL 12 + TB
+    cuts.AddCutCalo("00010113","411790009fe3y220000","0r631031000000d0"); // INT7 TB and NL applied in CF!
   } else if (trainConfig == 2517) { // NCellEfficiency calculated in the correction framework
-    cuts.AddCutCalo("00010113","411792109fe3y220000","0r631031000000d0"); // INT7 NL 12 + TB
+    cuts.AddCutCalo("00010113","411790009fe3y220000","0r631031000000d0"); // INT7 TB and NL applied in CF!
+  // with standard NCell 2 cut
+  } else if (trainConfig == 2518) { // NCellEfficiency calculated in the correction framework
+    cuts.AddCutCalo("00010113","411790009fe32220000","0r631031000000d0"); // INT7 TB and NL applied in CF!
 
   // 3x3 clusterizer
   } else if (trainConfig == 2520) { // 3x3 clusterizer

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_pp.C
@@ -2821,20 +2821,20 @@ void AddTask_GammaConvCalo_pp(
     cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411790109fl3m220000","0163103100000010"); //  Exotics > 6 GeV
 
     // NCell effi from correction framework
-  } else if (trainConfig == 2150){ // std. cuts
-    cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411792109fe32220000","0163103100000010"); // NCell from CF
+  } else if (trainConfig == 2150){ // std. cuts no NL (to be applied in the CF)
+    cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411790009fe32220000","0163103100000010"); // std but no NL
   } else if (trainConfig == 2151){ // no NCell cut
-    cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411792109fe30220000","0163103100000010"); // NCell from CF
+    cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411790009fe30220000","0163103100000010"); // no NCell cut and no NL
   } else if (trainConfig == 2152){ // NCell from correction framework
-    cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411792109fe3y220000","0163103100000010"); // NCell from CF
+    cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411790009fe3y220000","0163103100000010"); // NCell from CF
   } else if (trainConfig == 2153){ // NCell from correction framework
-    cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411792109fe3y220000","0163103100000010"); // NCell from CF
+    cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411790009fe3y220000","0163103100000010"); // NCell from CF
   } else if (trainConfig == 2154){ // NCell from correction framework
-    cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411792109fe3y220000","0163103100000010"); // NCell from CF
+    cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411790009fe3y220000","0163103100000010"); // NCell from CF
   } else if (trainConfig == 2155){ // NCell from correction framework
-    cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411792109fe3y220000","0163103100000010"); // NCell from CF
+    cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411790009fe3y220000","0163103100000010"); // NCell from CF
   } else if (trainConfig == 2156){ // NCell from correction framework
-    cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411792109fe3y220000","0163103100000010"); // NCell from CF
+    cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411790009fe3y220000","0163103100000010"); // NCell from CF
 
   // PCM-EDC systematics
   } else if (trainConfig == 2200){ // PCM based systematics

--- a/PWGGA/GammaConvBase/AliCaloPhotonCuts.cxx
+++ b/PWGGA/GammaConvBase/AliCaloPhotonCuts.cxx
@@ -6940,10 +6940,10 @@ void AliCaloPhotonCuts::ApplyNonLinearity(AliVCluster* cluster, Int_t isMC, AliV
         if(isMC){
           energy /= FunctionNL_OfficialTB_100MeV_MC_V2(energy);
           // fine tuning based on gaussian fits on PCMEMC in pPb5TeV
-          energy /= FunctionNL_kSDM(energy, 0.987912, -2.94105, -0.273207) ;
-          if(cluster->GetNCells() == 1){ // additional fine tuning for 1 cell clusters
-            energy /= FunctionNL_kSDM(energy,0, -0.002069903, -0.00669839);
-            energy /= 0.995;
+          if(cluster->GetNCells() == 1){ // different fine tuning for 1 cell clusters
+            energy /= 1.0086142771;
+          } else {
+            energy /= FunctionNL_kSDM(energy, 0.987912, -2.94105, -0.273207) ;
           }
         } else {
           energy /= FunctionNL_OfficialTB_100MeV_Data_V2(energy);
@@ -7142,10 +7142,11 @@ void AliCaloPhotonCuts::ApplyNonLinearity(AliVCluster* cluster, Int_t isMC, AliV
           }
           if(fClusterType==1 || fClusterType==3 || fClusterType==4){
             energy /= FunctionNL_OfficialTB_100MeV_MC_V2(energy);
-            energy /= FunctionNL_kSDM(energy, 0.987912, -2.94105, -0.273207) ;
-            if(cluster->GetNCells() == 1){ // additional fine tuning for 1 cell clusters
-              energy /= FunctionNL_kSDM(energy,0, -0.002069903, -0.00669839);
-              energy /= 0.995;
+            // fine tuning based on gaussian fits on PCMEMC in pPb5TeV
+            if(cluster->GetNCells() == 1){ // different fine tuning for 1 cell clusters
+              energy /= 1.0086142771;
+            } else {
+              energy /= FunctionNL_kSDM(energy, 0.987912, -2.94105, -0.273207) ;
             }
           }
 
@@ -7156,11 +7157,12 @@ void AliCaloPhotonCuts::ApplyNonLinearity(AliVCluster* cluster, Int_t isMC, AliV
           }
           if(fClusterType==4){
               energy /= FunctionNL_OfficialTB_100MeV_MC_V2(energy);
-              energy /= FunctionNL_kSDM(energy, 1.02451, -3.49297, -0.420027);
-              energy /= FunctionNL_kSDM(energy, 0.986634, -4.12191, -0.321714);
-              if(cluster->GetNCells() == 1){ // additional fine tuning for 1 cell clusters
-                energy /= FunctionNL_kSDM(energy,0, -0.002069903, -0.00669839);
-                energy /= 0.995;
+              // fine tuning based on gaussian fits on PCMEMC in pPb5TeV
+              if(cluster->GetNCells() == 1){ // different fine tuning for 1 cell clusters
+                energy /= 1.0086142771;
+              } else {
+                energy /= FunctionNL_kSDM(energy, 1.02451, -3.49297, -0.420027);
+                energy /= FunctionNL_kSDM(energy, 0.986634, -4.12191, -0.321714);
               }
           }
         } else fPeriodNameAvailable = kFALSE;
@@ -7252,11 +7254,12 @@ void AliCaloPhotonCuts::ApplyNonLinearity(AliVCluster* cluster, Int_t isMC, AliV
           if(fClusterType==1) energy /= FunctionNL_kSDM(energy, 0.957323, -3.55283, -0.608886);
           if(fClusterType==4){
               energy /= FunctionNL_OfficialTB_100MeV_MC_V2(energy);
-              energy /= FunctionNL_kSDM(energy, 1.01591,-3.07414,-0.297182);
-              energy /= FunctionNL_kSDM(energy, 0.978507, -3.71687, -0.0796175);
-              if(cluster->GetNCells() == 1){ // additional fine tuning for 1 cell clusters
-                energy /= FunctionNL_kSDM(energy,0, -0.002069903, -0.00669839);
-                energy /= 0.995;
+              // fine tuning based on gaussian fits on PCMEMC in pPb5TeV
+              if(cluster->GetNCells() == 1){ // different fine tuning for 1 cell clusters
+                energy /= 1.0086142771;
+              } else {
+                energy /= FunctionNL_kSDM(energy, 1.01591,-3.07414,-0.297182);
+                energy /= FunctionNL_kSDM(energy, 0.978507, -3.71687, -0.0796175);
               }
           }
         } else if ( fCurrentMC==kPP13T16P1Pyt8 || fCurrentMC==kPP13T17P1Pyt8 || fCurrentMC==kPP13T18P1Pyt8 || fCurrentMC==kPP13T16P1JJ || fCurrentMC==kPP13T17P1JJ || fCurrentMC==kPP13T18P1JJ || fCurrentMC==kPP13T16P1JJTrigger || fCurrentMC==kPP13T17P1JJTrigger || fCurrentMC==kPP13T18P1JJTrigger){
@@ -7267,11 +7270,12 @@ void AliCaloPhotonCuts::ApplyNonLinearity(AliVCluster* cluster, Int_t isMC, AliV
           }
           if(fClusterType==1 || fClusterType==3 || fClusterType==4){
             energy /= FunctionNL_OfficialTB_100MeV_MC_V2(energy);
-            energy /= FunctionNL_kSDM(energy, 0.987912, -2.94105, -0.273207) ;
-            energy /= 1.007;
-            if(cluster->GetNCells() == 1){ // additional fine tuning for 1 cell clusters
-              energy /= FunctionNL_kSDM(energy,0, -0.002069903, -0.00669839);
-              energy /= 0.995;
+            // fine tuning based on gaussian fits on PCMEMC in pPb5TeV
+            if(cluster->GetNCells() == 1){ // different fine tuning for 1 cell clusters
+              energy /= 1.0086142771;
+            } else {
+              energy /= FunctionNL_kSDM(energy, 0.987912, -2.94105, -0.273207) ;
+              energy /= 1.007;
             }
           }
 
@@ -7490,11 +7494,12 @@ void AliCaloPhotonCuts::ApplyNonLinearity(AliVCluster* cluster, Int_t isMC, AliV
           if(fClusterType==2) energy /= (FunctionNL_DPOW(energy, 0.9893461252, 0.0541088219, -0.4999999904, 1.0204701327, 0.0010000000, 1.7769590236));
           if(fClusterType==1 || fClusterType==3 || fClusterType==4){
             energy /= FunctionNL_OfficialTB_100MeV_MC_V2(energy);
-            energy /= FunctionNL_kSDM(energy, 0.987912, -2.94105, -0.273207) ;
-            energy /= 1.00349;
-            if(cluster->GetNCells() == 1){ // additional fine tuning for 1 cell clusters
-              energy /= FunctionNL_kSDM(energy,0, -0.002069903, -0.00669839);
-              energy /= 0.995;
+            // fine tuning based on gaussian fits on PCMEMC in pPb5TeV
+            if(cluster->GetNCells() == 1){ // different fine tuning for 1 cell clusters
+              energy /= 1.0086142771;
+            } else {
+              energy /= FunctionNL_kSDM(energy, 0.987912, -2.94105, -0.273207) ;
+              energy /= 1.00349;
             }
           }
 
@@ -7503,11 +7508,12 @@ void AliCaloPhotonCuts::ApplyNonLinearity(AliVCluster* cluster, Int_t isMC, AliV
           if(fClusterType==2) energy /= (FunctionNL_DPOW(energy, 1.0167588250, 0.0501002307, -0.8336787497, 0.9500009312, 0.0944118922, -0.1043983134));
           if(fClusterType==4){
               energy /= FunctionNL_OfficialTB_100MeV_MC_V2(energy);
-              energy /= FunctionNL_DPOW(energy, 1.0184615336, -0.0425198632, -0.5000000000, 1.0143887128, -0.0810648326, -0.4123125379);
-              energy /= FunctionNL_DPOW(energy, 1.0108477805, -0.0458091673, -0.4999999999, 1.1674873897, -0.1999999997, -0.1094442490);
-              if(cluster->GetNCells() == 1){ // additional fine tuning for 1 cell clusters
-                energy /= FunctionNL_kSDM(energy,0, -0.002069903, -0.00669839);
-                energy /= 0.995;
+              // fine tuning based on gaussian fits on PCMEMC in pPb5TeV
+              if(cluster->GetNCells() == 1){ // different fine tuning for 1 cell clusters
+                energy /= 1.0086142771;
+              } else {
+                energy /= FunctionNL_DPOW(energy, 1.0184615336, -0.0425198632, -0.5000000000, 1.0143887128, -0.0810648326, -0.4123125379);
+                energy /= FunctionNL_DPOW(energy, 1.0108477805, -0.0458091673, -0.4999999999, 1.1674873897, -0.1999999997, -0.1094442490);
               }
           }
         } else fPeriodNameAvailable = kFALSE;
@@ -7584,11 +7590,12 @@ void AliCaloPhotonCuts::ApplyNonLinearity(AliVCluster* cluster, Int_t isMC, AliV
         } else if ( fCurrentMC==kPP13T16P1Pyt8 || fCurrentMC==kPP13T17P1Pyt8 || fCurrentMC==kPP13T18P1Pyt8 || fCurrentMC==kPP13T16P1JJ || fCurrentMC==kPP13T17P1JJ || fCurrentMC==kPP13T18P1JJ || fCurrentMC==kPP13T16P1JJTrigger  || fCurrentMC==kPP13T17P1JJTrigger || fCurrentMC==kPP13T18P1JJTrigger){
           if(fClusterType==1 || fClusterType==3 || fClusterType==4){
             energy /= FunctionNL_OfficialTB_100MeV_MC_V2(energy);
-            energy /= FunctionNL_kSDM(energy, 0.987912, -2.94105, -0.273207);
-            energy /= 1.002;
-            if(cluster->GetNCells() == 1){ // additional fine tuning for 1 cell clusters
-              energy /= FunctionNL_kSDM(energy,0, -0.002069903, -0.00669839);
-              energy /= 0.995;
+            // fine tuning based on gaussian fits on PCMEMC in pPb5TeV
+            if(cluster->GetNCells() == 1){ // different fine tuning for 1 cell clusters
+              energy /= 1.0086142771;
+            } else {
+              energy /= FunctionNL_kSDM(energy, 0.987912, -2.94105, -0.273207);
+              energy /= 1.002;
             }
           }
 
@@ -7596,11 +7603,12 @@ void AliCaloPhotonCuts::ApplyNonLinearity(AliVCluster* cluster, Int_t isMC, AliV
           if(fClusterType==1) energy /= (FunctionNL_DPOW(energy, 1.0187401756, -0.0857332791, -0.5000000000, 1.1585209386, -0.1999999989, -0.2646540338));
           if(fClusterType==4){
             energy /= FunctionNL_OfficialTB_100MeV_MC_V2(energy);
-            energy /= FunctionNL_DExp(energy, 0.9997473385, 1.3660748813, -2.2265702768, 0.9705245932, 0.9837532668, -2.1275549381);
-            energy /= FunctionNL_DExp(energy, 0.9671163390, 1.1263515545, -2.1208302530, 0.9784342471, 0.7207198365, -2.2726375529);
-            if(cluster->GetNCells() == 1){ // additional fine tuning for 1 cell clusters
-              energy /= FunctionNL_kSDM(energy,0, -0.002069903, -0.00669839);
-              energy /= 0.995;
+            // fine tuning based on gaussian fits on PCMEMC in pPb5TeV
+            if(cluster->GetNCells() == 1){ // different fine tuning for 1 cell clusters
+              energy /= 1.0086142771;
+            } else {
+              energy /= FunctionNL_DExp(energy, 0.9997473385, 1.3660748813, -2.2265702768, 0.9705245932, 0.9837532668, -2.1275549381);
+              energy /= FunctionNL_DExp(energy, 0.9671163390, 1.1263515545, -2.1208302530, 0.9784342471, 0.7207198365, -2.2726375529);
             }
           }
 


### PR DESCRIPTION
New function for NCell efficiency based on (PCM-EMC) pi0 tagged photon clusters. 
Added a switch for th NCell efficiency to apply it only on photon clusters if wanted.
Added special treatment for 1 cell clusters in the MC cluster energy fine tuning, because non-linearity for 1 cell clusters different than for >= 2 cell clusters.

In PWGGA/GammaConv: 
Modified configs for PCM-EMC and EMC to check implementation in CF vs in AliCaloPhotonCuts
Modified (and simplified) Non-Linearity for 1 cell clusters in AliCaloPhotonCuts