### PR TITLE
Add ITS/TPC/TPC chi2 cuts for AODS + use AliESDtrackCuts for AODs

### DIFF
--- a/PWGLF/RESONANCES/AliRsnCutTrackQuality.h
+++ b/PWGLF/RESONANCES/AliRsnCutTrackQuality.h
@@ -68,6 +68,7 @@ public:
    AliESDtrackCuts  *GetESDtrackCuts() {return fESDtrackCuts;}
    Double_t   GetPtRange(Bool_t max) {return fPt[max];}
    Double_t   GetEtaRange(Bool_t max) {return fEta[max];}
+   void      SetAODTrackCuts(Bool_t useTPCCrossedRows = kTRUE);
    
    virtual Bool_t IsSelected(TObject *obj);
    virtual void   Print(const Option_t *option = "") const;


### PR DESCRIPTION
- Add ITS/TPC Chi2 per cluster and TPC Chi2 constrained Vs global cuts for AODs in CheckAOD()
- Add a function (SetAODTrackCuts) to extract cut info from fESDtrackCuts to use them also for AOD (useful in particular in all SetDefaults methods to make them compatible with AODs)