### PR TITLE
Switch off trigger selection for runs where the trigger was disabled in the CTP

### DIFF
--- a/PWG/EMCAL/EMCALtasks/AliAnalysisTaskEmcalTriggerSelection.h
+++ b/PWG/EMCAL/EMCALtasks/AliAnalysisTaskEmcalTriggerSelection.h
@@ -45,6 +45,7 @@ std::ostream & operator<< (std::ostream &in, const PWG::EMCAL::AliAnalysisTaskEm
 namespace PWG{
 namespace EMCAL {
 
+class AliEmcalTriggerAlias;
 class AliEmcalTriggerDecision;
 class AliEmcalTriggerDecisionContainer;
 class AliEmcalTriggerSelection;
@@ -258,6 +259,12 @@ public:
    * @return Name of the trigger decision container
    */
   const TString  &GetGlobalDecisionContainerName() const { return fGlobalDecisionContainerName; }
+
+  /**
+   * @brief Perform trigger selection only if the trigger was active in CTP
+   * @param doRequire If true the trigger is required to be active in CTP 
+   */
+  void SetRequireTriggerActiveInCTP(bool doRequire) { fRequireTriggerActiveInCTP = doRequire; }
 
   /**
    * @brief Configure task using YAML configuration file
@@ -830,6 +837,16 @@ protected:
   virtual Bool_t Run();
 
   /**
+   * @brief Actions to be performed when the run changed
+   * @param newrun Number of the new run
+   * 
+   * Load CTP configuration for the new run in case the 
+   * trigger selection is implemented to require that the
+   * triggers are active in the CTP. 
+   */
+  virtual void RunChanged(Int_t newrun);
+
+  /**
    * @brief Filling basic QA Histograms of the trigger selection task
    *
    * The QA histograms are connected to the main patch and monitor
@@ -876,6 +893,8 @@ protected:
   Bool_t Is2017PP5TeV(const char *dataset) const;
   Bool_t Is2017MCPP5TeV(const char *dataset) const;
   Bool_t IsSupportedMCSample(const char *period, std::vector<TString> &supportedProductions) const;
+  Bool_t IsTriggerActive(const char *triggerclass);
+  Bool_t IsAliasActive(const AliEmcalTriggerAlias *alias);
  
   AliEmcalTriggerSelectionCuts::AcceptanceType_t  DecodeAcceptanceString(const std::string &acceptancestring);
   AliEmcalTriggerSelectionCuts::PatchType_t       DecodePatchTypeString(const std::string &patchtypestring);
@@ -893,8 +912,10 @@ protected:
   AliEmcalTriggerDecisionContainer          *fTriggerDecisionContainer;        ///< Trigger decision container objects
   TString                                    fGlobalDecisionContainerName;     ///< Name of the global trigger selection
   TList                                      fTriggerSelections;               ///< List of trigger selections
+  TList                                      fActiveTriggerCTP;                ///< List of active trigger classes in CTP
   TList                                      fSelectionQA;                     ///< Trigger selection QA
   Bool_t                                     fUseRho;                          //!<! Check if any of teh trigger selections is requiring rho calculation
+  Bool_t                                     fRequireTriggerActiveInCTP;       ///< Require trigger class to be active in the CTP in data
 
 private:
 

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerAlias.cxx
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerAlias.cxx
@@ -25,6 +25,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
  ************************************************************************************/
 #include <iostream>
+#include <sstream>
 #include <memory>
 #include <TObjArray.h>
 #include <TObjString.h>
@@ -77,6 +78,10 @@ void AliEmcalTriggerAlias::SetTriggerClasses(const TList &triggernames) {
   }
 }
 
+void AliEmcalTriggerAlias::AddTriggerClass(const char *name) {
+  fTriggerClasses.Add(new TObjString(name));
+}
+
 void AliEmcalTriggerAlias::DecodeTriggerClasses(const char *triggernames) {
   TString tmpstring(triggernames);
   std::unique_ptr<TObjArray> separated(tmpstring.Tokenize(";"));
@@ -85,6 +90,19 @@ void AliEmcalTriggerAlias::DecodeTriggerClasses(const char *triggernames) {
   while((triggerstring = static_cast<TObjString *>(listiter()))){
     fTriggerClasses.Add(new TObjString(*triggerstring));
   }
+}
+
+std::string AliEmcalTriggerAlias::BuildAliasString() const {
+  std::stringstream result;
+  TIter listiter(&fTriggerClasses);
+  TObjString *tmpstring(nullptr);
+  bool first = true;
+  while((tmpstring = static_cast<TObjString *>(listiter()))) {
+    if(!first) result << ";";
+    result << tmpstring->String();
+    if(first) first = false;
+  }
+  return result.str();
 }
 
 bool AliEmcalTriggerAlias::HasTriggerClass(const char *triggername) const {

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerAlias.h
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerAlias.h
@@ -28,6 +28,7 @@
 #define ALIEMCALTRIGGERALIAS_H
 
 #include <iosfwd>
+#include <string>
 #include <TObject.h>
 #include <TList.h>
 
@@ -101,6 +102,24 @@ public:
    * @param triggernames List of trigger classes handled
    */
   void SetTriggerClasses(const TList &triggernames);
+
+  /**
+   * @brief Add trigger class to trigger alias
+   * @param name Name of the trigger class
+   */
+  void AddTriggerClass(const char *name);
+
+  /**
+   * @brief Get list of trigger classes handled by this alias
+   * @return List of trigger classes handled by this alias 
+   */
+  const TList &GetTriggerClasses() const { return fTriggerClasses; }
+
+  /**
+   * @brief Build string representation of trigger alias
+   * @return Trigger alias string 
+   */
+  std::string BuildAliasString() const;
 
   /**
    * @brief Print trigger alias on a stream

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerDecisionContainer.cxx
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerDecisionContainer.cxx
@@ -40,6 +40,7 @@ AliEmcalTriggerDecisionContainer::AliEmcalTriggerDecisionContainer():
   fContainer()
 {
   fContainer.SetOwner(kTRUE);
+  fActiveTriggerClasses.SetOwner(kTRUE);
 }
 
 AliEmcalTriggerDecisionContainer::AliEmcalTriggerDecisionContainer(const char* name):
@@ -47,14 +48,24 @@ AliEmcalTriggerDecisionContainer::AliEmcalTriggerDecisionContainer(const char* n
   fContainer()
 {
   fContainer.SetOwner(kTRUE);
+  fActiveTriggerClasses.SetOwner(kTRUE);
 }
 
 void AliEmcalTriggerDecisionContainer::Reset() {
   if(fContainer.GetEntries()) fContainer.Clear();
+  if(fActiveTriggerClasses.GetEntries()) fActiveTriggerClasses.Clear();
+}
+
+void AliEmcalTriggerDecisionContainer::CleanActiveTriggerClasses() {
+  if(fActiveTriggerClasses.GetEntries()) fActiveTriggerClasses.Clear();
 }
 
 void AliEmcalTriggerDecisionContainer::AddTriggerDecision(AliEmcalTriggerDecision* const decision) {
   fContainer.Add(decision);
+}
+
+void AliEmcalTriggerDecisionContainer::AddActiveTriggerClass(const char* alias) {
+  fActiveTriggerClasses.Add(new AliEmcalTriggerAlias(alias));
 }
 
 const AliEmcalTriggerDecision* AliEmcalTriggerDecisionContainer::FindTriggerDecision(const char* decname) const {
@@ -83,6 +94,25 @@ bool AliEmcalTriggerDecisionContainer::IsEventSelected(const char *name)  const 
   const AliEmcalTriggerDecision *trg = FindTriggerDecision(name);
   if(trg) return trg->IsSelected();
   return false;
+}
+
+bool AliEmcalTriggerDecisionContainer::IsTriggerClassActive(const char *name) const {
+  bool result = false;
+  TIter triggerIter(&fActiveTriggerClasses);
+  AliEmcalTriggerAlias *tmp(nullptr);
+  while((tmp = static_cast<AliEmcalTriggerAlias *>(triggerIter()))) {
+    if(tmp) {
+      if(tmp->HasTriggerClass(name)) {
+        result = true;
+        break;
+      }
+    }
+  }
+  return result;
+}
+
+bool AliEmcalTriggerDecisionContainer::HasActiveEMCALTrigger() const {
+  return fActiveTriggerClasses.GetEntries() > 0;
 }
 
 }

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerDecisionContainer.h
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerDecisionContainer.h
@@ -145,6 +145,11 @@ public:
   virtual void Clear(Option_t *option="") { Reset(); }
 
   /**
+   * @brief Clean list of active trigger classes
+   */
+  void CleanActiveTriggerClasses();
+
+  /**
    * @brief Add trigger decision to the container
    * 
    * The name of the trigger decision corresponds to the name of the
@@ -207,8 +212,34 @@ public:
    */
   bool IsEventSelected(const char *name)  const;
 
+  /**
+   * @brief Add trigger to the list of active trigger classes
+   * @param alias Trigger alias containing the trigger classes (string of trigger classes separated by ";")
+   */
+  void AddActiveTriggerClass(const char *alias);
+
+  /**
+   * @brief Check whether trigger class was active for the given run
+   * @param name Name of the trigger class
+   * @return True if the trigger was found in the list of triggers, false otherwise 
+   */
+  bool IsTriggerClassActive(const char *name) const;
+
+  /**
+   * @brief Get list of active trigger classes
+   * @return Active trigger classes
+   */
+  const TList *GetListOfActiveTriggers() const { return &fActiveTriggerClasses; }
+
+  /**
+   * @brief Check whether the container was filled for events with active EMCAL trigger selection
+   * @return True if at least 1 EMCAL trigger was active, false otherwise
+   */
+  bool HasActiveEMCALTrigger() const;
+
 protected:
-  TList     fContainer;         ///< List of trigger decisions
+  TList     fContainer;               ///< List of trigger decisions
+  TList     fActiveTriggerClasses;    ///< List of active trigger classes
 
   /// \cond CLASSIMP
   ClassDef(AliEmcalTriggerDecisionContainer, 1);    // Container for trigger decisions


### PR DESCRIPTION
- Skip trigger for runs where the trigger was not active
  in data, as the acceptance of these runs should not
  be taken into account
- Check made optional
- Add information of active trigger classes for event in
  the trigger decision object so that analysis task
  utilizing the trigger selection can make use of this in
  the trigger efficiency calculation