### PR TITLE
Add include unistd.h for compilation on MacOS

### DIFF
--- a/PWG/FLOW/Tasks/AliAnalysisTaskMuPa.cxx
+++ b/PWG/FLOW/Tasks/AliAnalysisTaskMuPa.cxx
@@ -25,6 +25,8 @@
 #include "AliMultSelection.h"
 #include <TFile.h>
 
+#include <unistd.h>
+
 using std::cout;
 using std::endl;
 


### PR DESCRIPTION
The compilation on MacOS was failing because of the missing "#include <unistd.h>". 
This compilation issue is fixed after including unistd.h in the .cxx of the task.
