### PR TITLE
Attempt to fix memory leak in event-wise CS

### DIFF
--- a/PWGJE/EMCALJetTasks/AliFJWrapper.h
+++ b/PWGJE/EMCALJetTasks/AliFJWrapper.h
@@ -1256,6 +1256,9 @@ Int_t AliFJWrapper::DoEventConstituentSubtraction() {
   //Do constituent subtraction
 #ifdef FASTJET_VERSION
   CreateEventConstituentSub();
+  // Clear consituents from the previous event. RE and LH suspect (in May 2021) that this may leak
+  // memory for some allocators (namely, we're worried about jemalloc).
+  fEventSubCorrectedVectors.clear();
   fEventSubCorrectedVectors = fEventConstituentSubtractor->subtract_event(fEventSubInputVectors,fMaxRap); //second argument max rap?
   //clear constituent subtracted jets
   if(fEventConstituentSubtractor) { delete fEventConstituentSubtractor; fEventConstituentSubtractor = NULL; }


### PR DESCRIPTION
It seems to only occur with jemalloc (ie. on the grid)

@lhavener 