### PR TITLE
Add simple analysis task monitoring the patch position of online patches from STU data

### DIFF
--- a/PWGJE/EMCALJetTasks/CMakeLists.txt
+++ b/PWGJE/EMCALJetTasks/CMakeLists.txt
@@ -162,6 +162,7 @@ set(SRCS
     Tracks/AliAnalysisTaskEmcalJetIterativeDeclustering.cxx
     Tracks/AliAnalysisTaskEmcalFastorMultiplicity.cxx
     Tracks/AliAnalysisTaskEmcalTriggerSelectionTest.cxx
+    Tracks/AliAnalysisTaskEmcalRawSTU.cxx
     Tracks/AliEmcalTRDTrackingTask.cxx
     UserTasks/AliAnalysisTaskJetUEStudies.cxx
     UserTasks/AliAnalysisTaskBackFlucRandomCone.cxx

--- a/PWGJE/EMCALJetTasks/PWGJEEMCALJetTasksLinkDef.h
+++ b/PWGJE/EMCALJetTasks/PWGJEEMCALJetTasksLinkDef.h
@@ -244,6 +244,7 @@
 #pragma link C++ class PWGJE::EMCALJetTasks::AliAnalysisTaskEmcalTriggerCorrelationMC+;
 #pragma link C++ class PWGJE::EMCALJetTasks::AliAnalysisTaskEmcalEG1Correlation+;
 #pragma link C++ class PWGJE::EMCALJetTasks::AliAnalysisTaskEmcalTriggerBackground+;
+#pragma link C++ class PWGJE::EMCALJetTasks::AliAnalysisTaskEmcalRawSTU+;
 #pragma link C++ namespace PWGJE::EMCALJetTasks::Test;
 #pragma link C++ class PWGJE::EMCALJetTasks::Test::AliAnalysisTaskEmcalTriggerSelectionTest+;
 

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalRawSTU.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalRawSTU.cxx
@@ -1,0 +1,139 @@
+/************************************************************************************
+ * Copyright (C) 2021, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+#include <bitset>
+#include <map>
+
+#include <THistManager.h>
+#include <TString.h>
+
+#include "AliAnalysisManager.h"
+#include "AliAnalysisTaskEmcalRawSTU.h"
+#include "AliEMCALTriggerTypes.h"
+#include "AliInputEventHandler.h"
+#include "AliLog.h"
+#include "AliVCaloTrigger.h"
+#include "AliVEvent.h"
+
+ClassImp(PWGJE::EMCALJetTasks::AliAnalysisTaskEmcalRawSTU)
+
+using namespace PWGJE::EMCALJetTasks;
+
+AliAnalysisTaskEmcalRawSTU::AliAnalysisTaskEmcalRawSTU():
+    AliAnalysisTaskEmcal(),
+    fHistos(nullptr)
+{
+
+}
+
+AliAnalysisTaskEmcalRawSTU::AliAnalysisTaskEmcalRawSTU(const char *name):
+    AliAnalysisTaskEmcal(name, true),
+    fHistos(nullptr)
+{
+    SetCaloTriggersName("usedefault");
+}
+
+void AliAnalysisTaskEmcalRawSTU::UserCreateOutputObjects(){
+    AliAnalysisTaskEmcal::UserCreateOutputObjects();
+
+    fHistos = new THistManager("STUhistos");
+    std::vector<std::string> triggers = {"EG1", "EG2", "DG1", "DG2", "EDG1", "EDG2", "EG1noDG1", "EG1andDG1", "EG2noDG2", "EG2andDG2", "DG1noEG1", "DG2noEG2"};
+    for(const auto &trg : triggers) {
+        fHistos->CreateTH2(Form("hRowCol%s", trg.data()), Form("Patch row-col %s", trg.data()), 48, -0.5, 47.5, 104, -0.5, 103.5);
+    }
+
+    for(auto hist : *fHistos->GetListOfHistograms()) fOutput->Add(hist);
+    PostData(1, fOutput);
+}
+
+bool AliAnalysisTaskEmcalRawSTU::Run(){
+
+    auto triggers = fInputEvent->GetFiredTriggerClasses();
+    bool isEG1 = (fInputHandler->IsEventSelected() & AliVEvent::kEMCEGA) && triggers.Contains("EG1"),
+         isEG2 = (fInputHandler->IsEventSelected() & AliVEvent::kEMCEGA) && triggers.Contains("EG2"),
+         isDG1 = (fInputHandler->IsEventSelected() & AliVEvent::kEMCEGA) && triggers.Contains("DG1"),
+         isDG2 = (fInputHandler->IsEventSelected() & AliVEvent::kEMCEGA) && triggers.Contains("DG2");
+    if(!(isEG1 || isEG2 || isDG1 || isDG2)) return false;
+
+    fCaloTriggers->Reset();
+    int col, row, triggerbitsRaw;
+    while(fCaloTriggers->Next()) {
+        fCaloTriggers->GetTriggerBits(triggerbitsRaw);
+        if(!triggerbitsRaw) continue;
+        std::bitset<sizeof(triggerbitsRaw)> triggerbits;
+        fCaloTriggers->GetPosition(col, row);
+
+        if(triggerbits.test(kL1GammaHigh) || (triggerbits.test(kL1GammaHigh + kTriggerTypeEnd))) {
+            // Gamma high
+            bool filledCombined = false;
+            if(isEG1) {
+                fHistos->FillTH1("hRowColEG1", col, row);
+                fHistos->FillTH1("hRowColEDG1", col, row);
+                filledCombined = true;
+                if(isDG1) fHistos->FillTH1("hRowColEG1andDG1", col, row);
+                else fHistos->FillTH1("hRowColEG1noDG1", col, row);
+            }
+            if(isDG1) {
+                fHistos->FillTH1("hRowColDG1", col, row);
+                if(!filledCombined) fHistos->FillTH1("hRowColEDG1", col, row);
+                if(!isEG1) fHistos->FillTH1("hRowColDG1noEG1", col, row);
+            }
+        }
+        if(triggerbits.test(kL1GammaLow) || (triggerbits.test(kL1GammaLow + kTriggerTypeEnd))) {
+            // Gamma low
+            bool filledCombined = false;
+            if(isEG2) {
+                fHistos->FillTH1("hRowColEG2", col, row);
+                fHistos->FillTH1("hRowColEDG2", col, row);
+                filledCombined = true;
+                if(isDG2) fHistos->FillTH1("hRowColEG2andDG2", col, row);
+                else fHistos->FillTH1("hRowColEG2noDG2", col, row);
+            }
+            if(isDG2) {
+                fHistos->FillTH1("hRowColDG2", col, row);
+                if(!filledCombined) fHistos->FillTH1("hRowColEDG2", col, row);
+                if(!isEG2) fHistos->FillTH1("hRowColDG2noEG2", col, row);
+            }
+        }
+    }
+    
+    return true;
+}
+
+AliAnalysisTaskEmcalRawSTU *AliAnalysisTaskEmcalRawSTU::AddTaskEmcalRawSTU(const char *name) {
+   auto mgr = AliAnalysisManager::GetAnalysisManager(); 
+
+   if(!mgr) {
+        AliFatalGeneral("AliAnalysisTaskEmcalRawSTU::AddTaskEmcalRawSTU", "No analysis manager created");
+   }
+
+   auto task = new AliAnalysisTaskEmcalRawSTU(name);
+   mgr->AddTask(task);
+
+   mgr->ConnectInput(task, 0, mgr->GetCommonInputContainer());
+   mgr->ConnectOutput(task, 1, mgr->CreateContainer("RawSTUHistos", TList::Class(), AliAnalysisManager::kOutputContainer, mgr->GetCommonFileName()));
+   return task;
+}

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalRawSTU.h
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalRawSTU.h
@@ -1,0 +1,63 @@
+/************************************************************************************
+ * Copyright (C) 2021, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+#ifndef __ALIANALYSISTASKEMCALRAWSTU_H__
+#define __ALIANALYSISTASKEMCALRAWSTU_H__
+
+#include "AliAnalysisTaskEmcal.h"
+
+class THistManager;
+
+namespace PWGJE {
+
+namespace EMCALJetTasks {
+
+class AliAnalysisTaskEmcalRawSTU : public AliAnalysisTaskEmcal {
+public:
+
+    AliAnalysisTaskEmcalRawSTU();
+    AliAnalysisTaskEmcalRawSTU(const char *name);
+    virtual ~AliAnalysisTaskEmcalRawSTU() {}
+
+    static AliAnalysisTaskEmcalRawSTU *AddTaskEmcalRawSTU(const char *name);
+
+protected:
+
+    virtual void UserCreateOutputObjects();
+    virtual bool Run();
+
+private:
+
+    THistManager *fHistos;              //!<! Historgams
+
+    ClassDef(AliAnalysisTaskEmcalRawSTU, 1);
+};
+
+}
+
+}
+
+#endif

--- a/PWGJE/EMCALJetTasks/macros/AddTaskEmcalRawSTU.C
+++ b/PWGJE/EMCALJetTasks/macros/AddTaskEmcalRawSTU.C
@@ -1,0 +1,3 @@
+PWGJE::EMCALJetTasks::AliAnalysisTaskEmcalRawSTU *AddTaskEmcalRawSTU(const char *name){
+    return PWGJE::EMCALJetTasks::AliAnalysisTaskEmcalRawSTU::AddTaskEmcalRawSTU(name);
+}


### PR DESCRIPTION
Mainly in order to check the acceptance of the
trigger at L1
- Purely rely on information in AliVCaloTrigger
- Monitor trigger classes and
  combined/mixed/exclusive classes between
  EMCAL and DCAL (no distinction between high
  and low threshold)