### PR TITLE
Fix masking of DCAL TRUs

### DIFF
--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerTask.cxx
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerTask.cxx
@@ -450,6 +450,7 @@ void AliEmcalTriggerMakerTask::InitializeFastORMaskingFromOCDB(){
     for(int itru = 0; itru < 32; itru++) {
       if(!sturegion.test(itru)) {
         // TRU disabled
+        std::cout << "Disable EMCAL TRU " << itru << "(" << itru << ")" << std::endl;
         for(int ichannel = 0; ichannel < 96; ichannel++) {
           fGeom->GetTriggerMapping()->GetAbsFastORIndexFromTRU(itru, ichannel, fastOrAbsID);
           fTriggerMaker->AddFastORBadChannel(fastOrAbsID); 
@@ -459,12 +460,14 @@ void AliEmcalTriggerMakerTask::InitializeFastORMaskingFromOCDB(){
   }
 
   if(dcalstu){
-    std::bitset<sizeof(int) * 8> sturegion(emcalstu->GetRegion());
+    std::bitset<sizeof(int) * 8> sturegion(dcalstu->GetRegion());
     for(int itru = 0; itru < 14; itru++) {
       if(!sturegion.test(itru)) {
         // TRU disabled
+        auto globTRUindex = fGeom->GetTriggerMapping()->GetTRUIndexFromSTUIndex(itru, 1);
+        std::cout << "Disable DCAL TRU " << itru << "(" << globTRUindex << ")" << std::endl;
         for(int ichannel = 0; ichannel < 96; ichannel++) {
-          fGeom->GetTriggerMapping()->GetAbsFastORIndexFromTRU(itru, ichannel, fastOrAbsID);
+          fGeom->GetTriggerMapping()->GetAbsFastORIndexFromTRU(globTRUindex, ichannel, fastOrAbsID);
           fTriggerMaker->AddFastORBadChannel(fastOrAbsID); 
         }
       }


### PR DESCRIPTION
In case a DCAL TRU is masked in the STU the global
TRU index need to be used. The global TRU index  is
including TRUs in EMCAL STU region and virtual TRUs
in PHOS region. As luckly the only the EMCAL TRUs
were masked by mistake, and the DCAL 1/3rd
supermodules were dead in readout as well the bug
did not harm so far.