### PR TITLE
Add container class for offline trigger mask

### DIFF
--- a/PWG/EMCAL/CMakeLists.txt
+++ b/PWG/EMCAL/CMakeLists.txt
@@ -35,3 +35,11 @@ add_subdirectory(EMCALtriggerPart)
 # Installing the macros
 install (DIRECTORY macros DESTINATION PWG/EMCAL)
 install (DIRECTORY config DESTINATION PWG/EMCAL)
+
+add_test(func_PWGEMCALtrigger_AliEmcalTriggerMaskContainer
+    env
+    PATH=$ENV{PATH}
+    LD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/lib:$ENV{LD_LIBRARY_PATH}
+    DYLD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/lib:$ENV{DYLD_LIBRARY_PATH}
+    ROOT_HIST=0
+    root -n -l -b -q "${CMAKE_INSTALL_PREFIX}/PWG/EMCAL/macros/TestAliEmcalFastorMaskContainer.C")

--- a/PWG/EMCAL/Doxymodules.h
+++ b/PWG/EMCAL/Doxymodules.h
@@ -65,6 +65,12 @@
  */
  
  /**
+  * \defgroup EMCALTESTS Unit tests for classes in the EMCAL framework
+  * \ingroup EMCALFW
+  * \brief Unit tests for classes in the EMCAL framework
+  */
+ 
+ /**
  * \defgroup EMCALJETFW Jet finding framework
  * \ingroup EMCALFW
  * \brief Framework for jet finding and analysis of jet-related observables

--- a/PWG/EMCAL/EMCALbase/AliEmcalAODHybridTrackCuts.h
+++ b/PWG/EMCAL/EMCALbase/AliEmcalAODHybridTrackCuts.h
@@ -107,7 +107,7 @@ private:
 /**
  * @class TestAliEmcalAODFilterBitCuts
  * @brief Unit test for AOD hybrid track cuts
- * @ingroup EMCALCOREFW
+ * @ingroup EMCALTESTS
  * @author Markus Fasel <markus.fasel@cern.ch>, Oak Ridge National Laboratory
  * @since Dec 18, 2017
  * 

--- a/PWG/EMCAL/EMCALbase/AliEmcalTrackSelResultPtr.h
+++ b/PWG/EMCAL/EMCALbase/AliEmcalTrackSelResultPtr.h
@@ -419,7 +419,7 @@ std::ostream &operator<<(std::ostream &stream, const AliEmcalTrackSelResultPtr &
 /**
  * @class TestAliEmcalTrackSelResultPtr
  * @brief Unit test for class AliEmcalTrackSelResultPtr
- * @ingroup EMCALCOREFW
+ * @ingroup EMCALTESTS
  * @author Markus Fasel <markus.fasel@cern.ch>, Oak Ridge National Laboratory
  * @since Dec 18, 2017
  * 

--- a/PWG/EMCAL/EMCALbase/AliEmcalTrackSelectionAOD.h
+++ b/PWG/EMCAL/EMCALbase/AliEmcalTrackSelectionAOD.h
@@ -137,7 +137,7 @@ namespace EMCAL{
 /**
  * @class TestAliEmcalTrackSelectionAOD
  * @brief Unit test for the class AliEmcalTrackSelectionAOD
- * @ingroup EMCALCOREFW
+ * @ingroup EMCALTESTS
  * @author Markus Fasel <markus.fasel@cern.ch>, Oak Ridge National Laboratory
  * @since Dec 19, 2018 
  */

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalFastorMaskContainer.cxx
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalFastorMaskContainer.cxx
@@ -69,8 +69,8 @@ void AliEmcalFastorMaskContainer::Browse(TBrowser *b) {
   }
   std::unique_ptr<AliEMCALTriggerMapping> triggermapping;
   switch(fRunType) {
-    case RunType_t::kRun1: triggermapping = std::make_unique<AliEMCALTriggerMappingV1>(); break;
-    case RunType_t::kRun2: triggermapping = std::make_unique<AliEMCALTriggerMappingV2>(); break;
+    case RunType_t::kRun1: triggermapping = std::unique_ptr<AliEMCALTriggerMapping>(new AliEMCALTriggerMappingV1); break;
+    case RunType_t::kRun2: triggermapping = std::unique_ptr<AliEMCALTriggerMapping>(new AliEMCALTriggerMappingV2); break;
     case RunType_t::kRuntypeUndefined:
     default:
       Error("AliEmcalFastorMaskContainer::Browse", "Trigger mapping unknown");

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalFastorMaskContainer.cxx
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalFastorMaskContainer.cxx
@@ -1,0 +1,382 @@
+/************************************************************************************
+ * Copyright (C) 2021, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+#include <algorithm>
+#include <iostream>
+#include <iterator>
+#include <memory>
+#include <random>
+#include <string>
+
+#include <TBrowser.h>
+#include <TFile.h>
+#include <TH2.h>
+#include <TSystem.h>    // For I/O unit test
+
+#include "AliEMCALTriggerMappingV1.h"
+#include "AliEMCALTriggerMappingV2.h"
+#include "AliEmcalFastorMaskContainer.h"
+
+ClassImp(PWG::EMCAL::AliEmcalFastorMaskContainer)
+ClassImp(PWG::EMCAL::AliEmcalFastorMaskContainer::MaskedFastor)
+ClassImp(PWG::EMCAL::TestAliEmcalFastorMaskContainer)
+
+using namespace PWG::EMCAL;
+
+AliEmcalFastorMaskContainer::AliEmcalFastorMaskContainer():
+  TNamed(),
+  fMaskedFastors(),
+  fRunType(RunType_t::kRuntypeUndefined)
+{
+  fMaskedFastors.SetOwner(true);
+}
+
+AliEmcalFastorMaskContainer::AliEmcalFastorMaskContainer(const char *name):
+  TNamed(name, "Offline masked FastORs"),
+  fMaskedFastors(),
+  fRunType(RunType_t::kRuntypeUndefined)
+{
+  fMaskedFastors.SetOwner(true);
+}
+
+void AliEmcalFastorMaskContainer::Browse(TBrowser *b) {
+  if(fRunType == RunType_t::kRuntypeUndefined) {
+    Error("AliEmcalFastorMaskContainer::Browse", "Run type not defined, cannot draw bad channel mask");
+    return;
+  }
+  std::unique_ptr<AliEMCALTriggerMapping> triggermapping;
+  switch(fRunType) {
+    case RunType_t::kRun1: triggermapping = std::make_unique<AliEMCALTriggerMappingV1>(); break;
+    case RunType_t::kRun2: triggermapping = std::make_unique<AliEMCALTriggerMappingV2>(); break;
+    case RunType_t::kRuntypeUndefined:
+    default:
+      Error("AliEmcalFastorMaskContainer::Browse", "Trigger mapping unknown");
+  };
+  if(!triggermapping) {
+    Error("AliEmcalFastorMaskContainer::Browse", "Trigger mapping not set, cannot draw bad channel mask");
+    return;
+  }
+
+  int ncol = 48, nrow = fRunType == RunType_t::kRun1 ? 64 : 104;
+  auto plot = new TH2C("TriggerMask", "Offline trigger mask (bad and dead)", ncol, -0.5, ncol - 0.5, nrow, -0.5, nrow - 0.5);
+  plot->SetStats(false);
+  plot->SetXTitle("col (#eta)");
+  plot->SetYTitle("row (#phi)");
+  int col, row;
+  for(auto dead : GetMaskDead()) {
+    triggermapping->GetPositionInEMCALFromAbsFastORIndex(dead, col, row);
+    int binx = plot->GetXaxis()->FindBin(col),
+        biny = plot->GetYaxis()->FindBin(row);
+    plot->SetBinContent(binx, biny, 1);
+  }
+  for(auto bad : GetMaskBad()) {
+    triggermapping->GetPositionInEMCALFromAbsFastORIndex(bad, col, row);
+    int binx = plot->GetXaxis()->FindBin(col),
+        biny = plot->GetYaxis()->FindBin(row);
+    plot->SetBinContent(binx, biny, 2);
+  }
+  b->Add(plot);
+  plot->Draw("col");
+}
+
+std::vector<int> AliEmcalFastorMaskContainer::GetMaskAll() const {
+  std::vector<int> result;
+  for(auto fastor : fMaskedFastors) {
+    auto fastorInfo = dynamic_cast<MaskedFastor *>(fastor);
+    if(!fastorInfo) continue;
+    if(fastorInfo->IsDead() || fastorInfo->IsBad()) result.emplace_back(fastorInfo->GetAbsID());
+  }
+  std::sort(result.begin(), result.end(), std::less<int>());
+  return result;
+}
+
+std::vector<int> AliEmcalFastorMaskContainer::GetMaskDead() const {
+  std::vector<int> result;
+  for(auto fastor : fMaskedFastors) {
+    auto fastorInfo = dynamic_cast<MaskedFastor *>(fastor);
+    if(!fastorInfo) continue;
+    if(fastorInfo->IsDead()) result.emplace_back(fastorInfo->GetAbsID());
+  }
+  std::sort(result.begin(), result.end(), std::less<int>());
+  return result;
+}
+
+std::vector<int> AliEmcalFastorMaskContainer::GetMaskBad() const {
+  std::vector<int> result;
+  for(auto fastor : fMaskedFastors) {
+    auto fastorInfo = dynamic_cast<MaskedFastor *>(fastor);
+    if(!fastorInfo) continue;
+    if(fastorInfo->IsBad()) result.emplace_back(fastorInfo->GetAbsID());
+  }
+  std::sort(result.begin(), result.end(), std::less<int>());
+  return result;
+}
+
+AliEmcalFastorMaskContainer::MaskStatus_t AliEmcalFastorMaskContainer::GetFastorMaskStatus(int absID) const {
+  auto fastorInfo = FindInContainer(absID);
+  if(fastorInfo) return fastorInfo->GetMaskStatus();
+  return MaskStatus_t::kStatusUndefined;
+}
+
+void AliEmcalFastorMaskContainer::AddDeadFastors(std::vector<int> absIDs) {
+  for(auto absID : absIDs) AddDeadFastor(absID);
+}
+
+void AliEmcalFastorMaskContainer::AddBadFastors(std::vector<int> absIDs) {
+  for(auto absID : absIDs) AddBadFastor(absID);
+}
+
+void AliEmcalFastorMaskContainer::SetFastorStatus(int absID, MaskStatus_t status) {
+  auto fastorInfo = FindInContainer(absID);
+  if(fastorInfo) {
+    if(status == MaskStatus_t::kStatusUndefined) fMaskedFastors.Remove(fastorInfo);
+    else fastorInfo->SetMaskStatus(status);
+  } 
+  else {
+    if(status != MaskStatus_t::kStatusUndefined) fMaskedFastors.Add(new MaskedFastor(absID, status));
+  }
+}
+
+AliEmcalFastorMaskContainer::MaskedFastor *AliEmcalFastorMaskContainer::FindInContainer(int absID) const {
+  MaskedFastor test(absID, MaskStatus_t::kStatusUndefined);
+  auto found = fMaskedFastors.FindObject(&test);
+  if(found) {
+    return dynamic_cast<MaskedFastor *>(found);
+  }
+  return nullptr;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+/// Content of TestAliEmcalFastorMaskContainer
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+bool TestAliEmcalFastorMaskContainer::RunAllTests() const {
+  bool status = true;
+  std::cout << "Running test: In-memory" <<std::endl;
+  if(!TestInMemory()) {
+    std::cout << "Failed test: In-memory" << std::endl;
+    status = false;
+  }
+  std::cout << "Running test: I/O" <<std::endl;
+  if(!TestIO()) {
+    std::cout << "Failed test: I/O" << std::endl;
+    status = false;
+  } 
+  std::cout << "Running test: Change status" <<std::endl;
+  if(!TestChangeStatus()) {
+    std::cout << "Failed test: Change status" << std::endl;
+    status = false;
+  } 
+  std::cout << "Running test: Clean" <<std::endl;
+  if(!TestClean()) {
+    std::cout << "Failed test: Clean" << std::endl;
+    status = false;
+  }
+  return status;
+}
+
+bool TestAliEmcalFastorMaskContainer::TestInMemory() const {
+  std::vector<int> badchannels = GetTestBadChannels(),
+                   deadchannels = GetTestDeadChannels(),
+                   allchannels;
+  std::merge(deadchannels.begin(), deadchannels.end(), badchannels.begin(), badchannels.end(), std::back_inserter(allchannels));
+  AliEmcalFastorMaskContainer testcontainer("testcontainer");
+  testcontainer.AddBadFastors(badchannels);
+  testcontainer.AddDeadFastors(deadchannels);
+
+  auto readbadchannels = testcontainer.GetMaskBad(),
+       readdeadchannels = testcontainer.GetMaskDead(),
+       readallchannels = testcontainer.GetMaskAll();
+  bool status=true;
+  if(!CheckEqual(badchannels, readbadchannels)) {
+    std::cout << "Test In-memory: Fail equalness bad" << std::endl;
+    printVector(badchannels, "Bad channels, true");
+    printVector(readbadchannels, "Bad channels, test");
+    status = false;
+  }
+  if(!CheckEqual(deadchannels, readdeadchannels)) {
+    std::cout << "Test In-memory: Fail equalness dead" << std::endl;
+    printVector(deadchannels, "Dead channels, true");
+    printVector(readdeadchannels, "Dead channels, test");
+    status = false;
+  }
+  if(!CheckEqual(allchannels, readallchannels)){
+    std::cout << "Test In-memory: Fail equalness all" << std::endl;
+    printVector(allchannels, "All channels, true");
+    printVector(readallchannels, "All channels, test");
+    status = false;
+  }
+  return status;
+}
+
+bool TestAliEmcalFastorMaskContainer::TestIO() const {
+  std::vector<int> badchannels = GetTestBadChannels(),
+                   deadchannels = GetTestDeadChannels(),
+                   allchannels;
+  std::merge(deadchannels.begin(), deadchannels.end(), badchannels.begin(), badchannels.end(), std::back_inserter(allchannels));
+
+  std::string filename(Form("%s/TestFastorMaskContainer.root", gSystem->WorkingDirectory())), containername("testcontainer");
+  {
+    // First step: prepare file and write
+    AliEmcalFastorMaskContainer testcontainer(containername.data());
+    testcontainer.AddBadFastors(badchannels);
+    testcontainer.AddDeadFastors(deadchannels);
+    std::unique_ptr<TFile> testwriter(TFile::Open(filename.data(), "RECREATE"));
+    testwriter->cd();
+    testcontainer.Write(testcontainer.GetName(), TObject::kSingleKey);
+  }
+
+  std::vector<int> readbadchannels, readdeadchannels, readallchannels;
+  { 
+    std::unique_ptr<TFile> testreader(TFile::Open(filename.data(), "READ"));
+    if(!testreader || testreader->IsZombie()){
+      std::cout << "File entry not found" << std::endl;
+      return false;
+    } 
+    auto testcontainer = dynamic_cast<AliEmcalFastorMaskContainer *>(testreader->Get(containername.data()));
+    if(!testcontainer) {
+      std::cout << "No container " << testcontainer << " found in file" << std::endl;
+      return false;
+    }
+    readbadchannels = testcontainer->GetMaskBad();
+    readdeadchannels = testcontainer->GetMaskDead();
+    readallchannels = testcontainer->GetMaskAll();
+  }
+  // cleanup after test
+  if(!gSystem->AccessPathName(filename.data()), kFileExists) gSystem->Exec(Form("rm %s", filename.data()));
+  bool status=true;
+  if(!CheckEqual(badchannels, readbadchannels)) {
+    std::cout << "Test I/O: Fail equalness bad" << std::endl;
+    printVector(badchannels, "Bad channels, true");
+    printVector(readbadchannels, "Bad channels, test");
+    status = false;
+  }
+  if(!CheckEqual(deadchannels, readdeadchannels)) {
+    std::cout << "Test I/O: Fail equalness dead" << std::endl;
+    printVector(deadchannels, "Dead channels, true");
+    printVector(readdeadchannels, "Dead channels, test");
+    status = false;
+  }
+  if(!CheckEqual(allchannels, readallchannels)){
+    std::cout << "Test I/O: Fail equalness all" << std::endl;
+    printVector(allchannels, "All channels, true");
+    printVector(readallchannels, "All channels, test");
+    status = false;
+  }
+  return status;
+}
+
+bool TestAliEmcalFastorMaskContainer::TestChangeStatus() const {
+  std::vector<int> badchannels = GetTestBadChannels(),
+                   deadchannels = GetTestDeadChannels(),
+                   swapToDead = GetRandomSubsample(badchannels, 5),
+                   swapToBad = GetRandomSubsample(deadchannels, 5),
+                   expectDead,
+                   expectBad;
+  std::set_difference(badchannels.begin(), badchannels.end(), swapToDead.begin(), swapToDead.end(), std::back_inserter(expectBad));
+  for(auto en : swapToBad) expectBad.emplace_back(en);
+  std::set_difference(deadchannels.begin(), deadchannels.end(), swapToBad.begin(), swapToBad.end(), std::back_inserter(expectDead));
+  for(auto en : swapToDead) expectDead.emplace_back(en);
+
+  AliEmcalFastorMaskContainer testcontainer("testcontainer");
+  testcontainer.AddDeadFastors(deadchannels);
+  testcontainer.AddBadFastors(badchannels);
+  for(auto en : swapToDead) testcontainer.SetFastorStatus(en, AliEmcalFastorMaskContainer::MaskStatus_t::kDeadFastOR);
+  for(auto en : swapToBad) testcontainer.SetFastorStatus(en, AliEmcalFastorMaskContainer::MaskStatus_t::kBadFastOR);
+
+  auto readbadchannels = testcontainer.GetMaskBad(),
+       readdeadchannels = testcontainer.GetMaskDead();
+  bool status=true;
+  if(!CheckEqual(expectBad, readbadchannels)) {
+    std::cout << "Test I/O: Fail equalness bad" << std::endl;
+    printVector(expectBad, "Dead channels, true");
+    printVector(readbadchannels, "Dead channels, test");
+    status = false;
+  }
+  if(!CheckEqual(expectDead, readdeadchannels)) {
+    std::cout << "Test I/O: Fail equalness dead" << std::endl;
+    printVector(expectDead, "Dead channels, true");
+    printVector(readdeadchannels, "Dead channels, test");
+    status = false;
+  }       
+  return status;
+}
+
+bool TestAliEmcalFastorMaskContainer::TestClean() const {
+  std::vector<int> badchannels = GetTestBadChannels(),
+                   deadchannels = GetTestDeadChannels();
+  AliEmcalFastorMaskContainer testcontainer("testcontainer");
+  testcontainer.AddBadFastors(badchannels);
+  testcontainer.AddDeadFastors(deadchannels);
+  testcontainer.Clear();
+  auto allread = testcontainer.GetMaskAll();
+  if(allread.size() != 0) {
+    std::cout << "Test Clean: size all not 0 (" << allread.size() << ")" << std::endl;
+  }
+  return true;
+}
+
+std::vector<int> TestAliEmcalFastorMaskContainer::GetTestBadChannels() const {
+  return {87, 119, 165, 204, 215, 238, 276, 279, 303, 421, 516, 534, 615, 713, 769, 
+          776, 825, 910, 935, 971, 974, 975, 1124, 1156, 1159, 1215, 1234, 1267, 1329, 
+          1340, 1414, 1499, 1533, 1534, 1538, 1564, 1612, 1735, 1737, 1745, 1747, 1772, 
+          1803, 1812, 1828, 1858, 1876, 1937, 1969, 1999, 2053, 2200, 2235, 2239, 2374, 
+          2414, 2441, 2538, 2708, 2730, 2765, 2767, 2809, 2872, 2877, 2899, 2937, 2969, 
+          3022, 3079, 3081, 3247, 3249, 3282, 3326, 3411, 3691, 3709, 3795, 3853, 3873, 
+          3986, 4108, 4135, 4217, 4243, 4251, 4270, 4345, 4411, 4646, 4655, 4676, 4780, 
+          4880, 4888, 4898, 4928, 4935, 4969};
+}
+
+std::vector<int> TestAliEmcalFastorMaskContainer::GetTestDeadChannels() const {
+  return {35, 146, 211, 232, 535, 607, 626, 640, 660, 667, 704, 775, 788, 948, 1041, 1055, 
+          1109, 1313, 1331, 1570, 1723, 1878, 1907, 1942, 2044, 2265, 2308, 2328, 2369, 2381, 
+          2544, 2612, 2735, 2858, 3014, 3020, 3308, 3402, 3702, 3904, 3916, 4407, 4413, 4485, 
+          4626, 4719, 4745, 4851, 4884, 4979};
+}
+
+bool TestAliEmcalFastorMaskContainer::CheckEqual(const std::vector<int> &list1, const std::vector<int> &list2) const {
+  if(list1.size() != list2.size()) return false;
+  return std::is_permutation(list1.begin(), list1.end(), list2.begin());
+}
+
+std::vector<int> TestAliEmcalFastorMaskContainer::GetRandomSubsample(std::vector<int> inputlist, int length) const {
+  std::vector<int> result(length);
+  std::random_device randomhandler;
+  std::mt19937 reshuffler(randomhandler());
+  std::shuffle(inputlist.begin(), inputlist.end(), reshuffler);
+  std::copy(inputlist.begin(), inputlist.begin()+5, result.begin());
+  std::sort(result.begin(), result.end(), std::less<int>());
+  return result;
+}
+
+void TestAliEmcalFastorMaskContainer::printVector(std::vector<int> data, const char *header) const {
+  std::sort(data.begin(), data.end(), std::less<int>());
+  std::cout << header << " (size " << data.size() << "):" << std::endl;
+  std::cout << "__________________________________" << std::endl;
+  std::copy(data.begin(), data.end(), std::ostream_iterator<int>(std::cout, " "));
+  std::cout << "\n";
+  std::cout << "\n";
+}

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalFastorMaskContainer.h
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalFastorMaskContainer.h
@@ -1,0 +1,483 @@
+/************************************************************************************
+ * Copyright (C) 2021, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+#ifndef __PWG__EMCAL_ALIEMCALFASTORMASKCONTAINER_H__
+#define __PWG__EMCAL_ALIEMCALFASTORMASKCONTAINER_H__
+
+#include <vector>
+#include <TNamed.h>
+#include <TObjArray.h>
+
+class TBrowser;
+
+namespace PWG {
+
+namespace EMCAL {
+
+/**
+ * @class AliEmcalFastorMaskContainer
+ * @brief Container for offline masked FastORs
+ * @ingroup EMCALTRGFW
+ * @author Markus Fasel <markus.fasel@cern.ch>, Oak Ridge National Laboratory
+ * @since June 1st, 2021
+ * 
+ * # Container for masked FastORs
+ * 
+ * The container structure is designed as OADB object for FastORs which
+ * are tagged offline. FastORs can have two different tags:
+ * - Dead: FastOR should always be ignored
+ * - Bad: Warm FastORs with dedicated noise pattern, up to user analysis
+ * 
+ * The object has dedicated getters and setters for the channel status.
+ * In order to display the masked channels, the object is made browsable.
+ * As the Browse function internally relies on the trigger mapping in order
+ * to convert the FastOR absolute ID into a positon in EMCAL the run version
+ * (Run1 or Run2) needs to be specified when constructing the object.
+ */
+class AliEmcalFastorMaskContainer : public TNamed {
+public:
+
+  /**
+   * @enum MaskStatus_t
+   * @brief Type of FastOR masking
+   */
+  enum MaskStatus_t {
+    kDeadFastOR = 0,            ///< FastOR is set to dead
+    kBadFastOR = 1,             ///< FastOR is set to bad
+    kStatusUndefined = -1       ///< Mask status not defined
+  };
+
+  /**
+   * @enum RunType_t
+   * @brief Type of the run
+   */
+  enum RunType_t {
+    kRun1 = 0,                  ///< Run1 (2010-2013)
+    kRun2 = 1,                  ///< Run2 (2015-2018)
+    kRuntypeUndefined = -1      ///< Unknown
+  };
+
+  /**
+   * @brief Dummy constructor
+   */
+  AliEmcalFastorMaskContainer();
+
+  /**
+   * @brief Constructor, setting also the name
+   * @param name Name of the container
+   */
+  AliEmcalFastorMaskContainer(const char *name);
+
+  /**
+   * @brief Browse functionality: Draw map of masked FastORs
+   * @param b Browser where to draw the FastORs.
+   */
+  virtual void Browse(TBrowser *b);
+
+  /**
+   * @brief Mark type as not folder
+   * @return Always false
+   */
+  virtual Bool_t IsFolder() const { return false; }
+
+  /**
+   * @brief Destructor
+   */
+  virtual ~AliEmcalFastorMaskContainer() {}
+
+  /**
+   * @brief Clear list of masked FastORs (container empty afterwards)
+   */
+  virtual void Clear(Option_t * /*option*/ ="") { fMaskedFastors.Clear(); }
+
+  /**
+   * @brief Get list of all masked FastORs (bad and dead)
+   * @return List of all masked FastORs
+   */
+  std::vector<int> GetMaskAll() const;
+
+  /**
+   * @brief Get list of dead FastORs
+   * @return List of dead FastORs 
+   */
+  std::vector<int> GetMaskDead() const;
+
+  /**
+   * @brief Get list of bad FastORs
+   * @return List of bad FastORs
+   */
+  std::vector<int> GetMaskBad() const;
+
+  /**
+   * @brief Get the the mask status of a dedicated FastOR
+   * @param absID Absolute ID of the FastOR
+   * @return Mask status of the FastOR (kUndefined if not found)
+   */
+  MaskStatus_t GetFastorMaskStatus(int absID) const;
+
+  /**
+   * @brief Check whether a FastOR with a given absolute ID is dead
+   * @param absID Absolute ID of the FastOR
+   * @return True if the FastOR is dead, false otherwise 
+   */
+  bool IsDeadFastor(int absID) const { return GetFastorMaskStatus(absID) == MaskStatus_t::kDeadFastOR; }
+
+  /**
+   * @brief Check whether a FastOR with a given absolute ID is bad
+   * @param absID Absolute ID of the FastOR 
+   * @return True if the FastOR is bad, false otherwise 
+   */
+  bool IsBadFastor(int absID) const { return GetFastorMaskStatus(absID) == MaskStatus_t::kBadFastOR; }
+
+  /**
+   * @brief Check whether a FastOR with a given absolute ID is bad
+   * @param absID Absolute ID of the FastOR 
+   * @return True if the FastOR is bad, false otherwise 
+   */
+  bool IsGoodFastor(int absID) const { return GetFastorMaskStatus(absID) == MaskStatus_t::kStatusUndefined; }
+
+  /**
+   * @brief Add new dead FastOR to the mask container
+   * @param absID Absolute ID of the FastOR
+   */
+  void AddDeadFastor(int absID) { SetFastorStatus(absID, MaskStatus_t::kDeadFastOR); }
+
+  /**
+   * @brief Add new bad FastOR to the mask container
+   * @param absID Absolute ID of the FastOR
+   */
+  void AddBadFastor(int absID) { SetFastorStatus(absID, MaskStatus_t::kBadFastOR); }
+
+  /**
+   * @brief Mask FastOR as good (remove from container if present)
+   * @param absID Absolute ID of the FastOR
+   */
+  void SetGoodFastor(int absID) { SetFastorStatus(absID, MaskStatus_t::kStatusUndefined); }
+
+  /**
+   * @brief Add list of dead FastORs
+   * @param absIDs List of absolute FastOR IDs to be masked dead
+   * 
+   * In case the FastORs are already present in the container only
+   * the status is updated, otherwise they are added as new entry.
+   */
+  void AddDeadFastors(std::vector<int> absIDs);
+
+  /**
+   * @brief Add list of bad FastORs
+   * @param absIDs List of absolute FastOR IDs to be masked bad
+   * 
+   * In case the FastORs are already present in the container only
+   * the status is updated, otherwise they are added as new entry.
+   */
+  void AddBadFastors(std::vector<int> absIDs);
+
+  /**
+   * @brief Get the number of masked FastORs in the container
+   * @return Number of FastORs  
+   */
+  int Size() const { return fMaskedFastors.GetEntries(); }
+
+  /**
+   * @brief Set the mask status for a given FastOR status
+   * @param absID Absolute ID of the FastOR
+   * @param status Status (bad/dead/undefined)
+   * 
+   * In case the FastOR is not yet listed, add it in case it 
+   * is bad or dead, otherwise just update the status. In case
+   * the status in good (undefined), remove it from the list
+   */
+  void SetFastorStatus(int absID, MaskStatus_t status);
+
+  /**
+   * @brief Set the run type (run1 or run2) 
+   * @param runtype Run type
+   */
+  void SetRunType(RunType_t runtype) { fRunType = runtype; }
+
+  /**
+   * @brief Set the runtype by run number
+   * @param runnumber Run number of the current run
+   */
+  void SetRunTypeByRunNumber(int runnumber) { if(runnumber <= 197388) fRunType = RunType_t::kRun1; else fRunType = RunType_t::kRun2; }
+
+  /**
+   * @class MaskedFastor
+   * @brief Helper class storing FastOR information within the AliEmcalFastorMaskContainer 
+   * 
+   * The object is ROOT and C++ sortable, according to the FastOR absolute ID. As information
+   * it stores the FastOR absolute ID and the mask status.
+   */
+  class MaskedFastor : public TObject {
+  public:
+
+    /**
+     * @brief Dummy constructor
+     */
+    MaskedFastor() : TObject(), fFastORAbsID(-1), fMaskStatus(MaskStatus_t::kStatusUndefined) {}
+
+    /**
+     * @brief Constructor, also initializing the FastOR object
+     * @param absID  Absolute ID of the FastOR
+     * @param status Mask status (bad/dead)
+     */
+    MaskedFastor(int absID, MaskStatus_t status): TObject(), fFastORAbsID(absID), fMaskStatus(status) {}
+
+    /**
+     * @brief Destructor
+     */
+    virtual ~MaskedFastor() {}
+
+    /**
+     * @brief Comparison operator for equalness
+     * @param other FastOR to compare to
+     * @return True in case the FastORs have the same absolute ID, false otherwise 
+     */
+    bool operator==(const MaskedFastor &other) const { return fFastORAbsID == other.fFastORAbsID; }
+
+    /**
+     * @brief Comparison operator for smaller
+     * @param other FastOR to compare to
+     * @return True if the FastOR abs ID is smaller than the other, false otherwise 
+     */
+    bool operator<(const MaskedFastor &other) const { return fFastORAbsID < other.fFastORAbsID; }
+
+    /**
+     * @brief Mark object as ROOT-sortable
+     * @return Always true
+     */
+    virtual Bool_t IsSortable() const { return true; }
+
+    /**
+     * @brief ROOT check for equalness
+     * @param obj Object to compare to
+     * @return True if the other object is a MaskedFastor and the FastOR abs IDs are equal, false otherwise 
+     */
+    virtual Bool_t IsEqual(const TObject *obj) const {
+      const MaskedFastor *otherfastor = dynamic_cast<const MaskedFastor *>(obj);
+      if(!otherfastor) return false;
+      return *this == *otherfastor;
+    }
+
+    /**
+     * @brief ROOT comparison function
+     * @param obj Object to compare to
+     * @return -1 in case this object is smaller or other is not a MaskedFastor, 0 if the FastORs are equal, 1 if this FastOR is larger than the other
+     */
+    virtual Int_t Compare(const TObject *obj) const {
+      const MaskedFastor *otherfastor = dynamic_cast<const MaskedFastor *>(obj);
+      if(!otherfastor) return -1;
+      if(*this == *otherfastor) return 0;
+      else if (*this < *otherfastor) return -1;
+      else return 1;
+    }
+
+    /**
+     * @brief Get absolute ID of the FastOR
+     * @return Absolute ID of the FastOR 
+     */
+    int GetAbsID() const { return fFastORAbsID; }
+
+    /**
+     * @brief Get the mask status of the FastOR (dead/bad)
+     * @return Mask status of the FastOR
+     */
+    MaskStatus_t GetMaskStatus() const { return fMaskStatus; }
+
+    /**
+     * @brief Check whether the FastOR was masked as bad
+     * @return True if the FastOR is bad, false otherwise 
+     */
+    bool IsBad() const { return fMaskStatus == MaskStatus_t::kBadFastOR; }
+
+    /**
+     * @brief Check if the FastOR was masked as dead 
+     * @return True  if the FastOR is dead, false otherwise
+     */
+    bool IsDead() const { return fMaskStatus == MaskStatus_t::kDeadFastOR; }
+
+    /**
+     * @brief Set the absolute ID of the FastOR
+     * @param absID Absolute ID of the FastOR
+     */
+    void SetAbsID(int absID) { fFastORAbsID = absID; }
+
+    /**
+     * @brief Set the mask status (bad/dead) of the FastOR 
+     * @param status Mask status
+     */
+    void SetMaskStatus(MaskStatus_t status) { fMaskStatus = status; }
+
+    /**
+     * @brief Mask FastOR as bad
+     */
+    void SetBad() { SetMaskStatus(MaskStatus_t::kBadFastOR); }
+
+    /**
+     * @brief Mask FastOR as dead
+     */
+    void SetDead() { SetMaskStatus(MaskStatus_t::kDeadFastOR); }
+
+  private:
+    int             fFastORAbsID;     ///< Absolute ID of the FastOR
+    MaskStatus_t    fMaskStatus;      ///< Mask Status (dead / bad)
+
+    ClassDef(MaskedFastor, 1);
+  };
+
+private:
+
+  /**
+   * @brief Helper function finding masked FastOR object within the container
+   * @param absID 
+   * @return MaskedFastor* 
+   */
+  MaskedFastor *FindInContainer(int absID) const;
+
+  TObjArray fMaskedFastors;           ///< Container with masked FastORs
+  RunType_t fRunType;                 ///< Period in which run was taken, needed for Browse functionality
+
+  ClassDef(AliEmcalFastorMaskContainer, 1);
+};
+
+/**
+ * @class TestAliEmcalFastorMaskContainer
+ * @brief Unit test for the EMCAL Fastor mask container
+ * @ingroup EMCALTESTS
+ */
+class TestAliEmcalFastorMaskContainer : public TObject {
+public:
+
+  /**
+   * @brief Constructor
+   */
+  TestAliEmcalFastorMaskContainer() : TObject() {}
+
+  /**
+   * @brief Destructor
+   */
+  virtual ~TestAliEmcalFastorMaskContainer() {}
+
+  /**
+   * @brief Test runner for all tests
+   * @return true All tests passed
+   * @return false At least one test did not pass
+   */
+  bool RunAllTests() const;
+
+  /**
+   * @brief Run in-memory test
+   * @return true Test passed
+   * @return false Test failed
+   * 
+   * Preparing a container with example bad and dead channel list,
+   * and check whether the list of bad/dead channels matches the 
+   * list inserted. Container is not written to file.
+   */
+  bool TestInMemory() const;
+
+  /**
+   * @brief Test file IO
+   * @return true Test passed
+   * @return false Test failed
+   * 
+   * Preparing a container with example bad and dead channel list and
+   * write it to file. Then the container is read again from file and 
+   * compared to the input list to check wether the bad/dead channels 
+   * match.
+   */
+  bool TestIO() const;
+
+  /**
+   * @brief Test changing the status of certain FastORs
+   * @return true Test passed
+   * @return false Test failed
+   * 
+   * Preparing a container with bad and dead channel list. Randomly
+   * 5 channels are selected for which the status is changed from which
+   * the status is changed from dead to bad and vice versa. Lists of 
+   * dead and bad channels after the test must match with the input lists
+   * including the change of the channel status
+   */
+  bool TestChangeStatus() const;
+
+  /**
+   * @brief Test of the Clean method
+   * @return true Test passed
+   * @return false Test failed
+   * 
+   * Preparing a container with bad and dead channel list. The clean method
+   * is called then. After clean the list of bad and dead channels obtained
+   * from the container must be empty.
+   */
+  bool TestClean() const;
+
+private:
+
+  /**
+   * @brief Get example list with bad channels for unit tests
+   * @return Example lists with bad channels
+   */
+  std::vector<int> GetTestBadChannels() const;
+
+  /**
+   * @brief Get example list with dead channels for unit test
+   * @return Example list with dead channels 
+   */
+  std::vector<int> GetTestDeadChannels() const;
+
+  /**
+   * @brief Check where two vectors have the same content 
+   * @param list1 First list in teh check for equalness
+   * @param list2 Second list in the check for equalness
+   * @return true Vectors are equal
+   * @return false 
+   */
+  bool CheckEqual(const std::vector<int> &list1, const std::vector<int> &list2) const;
+
+  /**
+   * @brief Select randomly elements from a given inputlist
+   * @param inputlist Input list
+   * @param length Number of entries to select
+   * @return List with entries obtained from the inputlist 
+   */
+  std::vector<int> GetRandomSubsample(std::vector<int> inputlist, int length) const;
+
+  /**
+   * @brief Helper function printing the content of the vector
+   * @param data Vector to monitor
+   * @param header Header printed above the vector content
+   */
+  void printVector(std::vector<int> data, const char *header) const;
+
+  ClassDef(TestAliEmcalFastorMaskContainer, 1);
+};
+
+}
+
+}
+
+#endif // __PWG__EMCAL_ALIEMCALFASTORMASKCONTAINER_H__

--- a/PWG/EMCAL/EMCALtrigger/CMakeLists.txt
+++ b/PWG/EMCAL/EMCALtrigger/CMakeLists.txt
@@ -46,6 +46,7 @@ set(SRCS
   AliEMCALTriggerOfflineLightQAPP.cxx
   AliEMCALTriggerPatchADCInfoAP.cxx
   AliEmcalTriggerMaskHandlerOCDB.cxx
+  AliEmcalFastorMaskContainer.cxx
   AliEmcalTriggerStringDecoder.cxx
   )
 

--- a/PWG/EMCAL/EMCALtrigger/PWGEMCALtriggerLinkDef.h
+++ b/PWG/EMCAL/EMCALtrigger/PWGEMCALtriggerLinkDef.h
@@ -23,4 +23,7 @@
 #pragma link C++ class PWG::EMCAL::AliEmcalTriggerSelection+;
 #pragma link C++ class PWG::EMCAL::Triggerinfo+;
 #pragma link C++ class PWG::EMCAL::AliEmcalTriggerMaskHandlerOCDB+;
+#pragma link C++ class PWG::EMCAL::AliEmcalFastorMaskContainer+;
+#pragma link C++ class PWG::EMCAL::AliEmcalFastorMaskContainer::MaskedFastor+;
+#pragma link C++ class PWG::EMCAL::TestAliEmcalFastorMaskContainer+;
 #endif

--- a/PWG/EMCAL/macros/TestAliEmcalFastorMaskContainer.C
+++ b/PWG/EMCAL/macros/TestAliEmcalFastorMaskContainer.C
@@ -1,0 +1,5 @@
+int TestAliEmcalFastorMaskContainer() {
+  PWG::EMCAL::TestAliEmcalFastorMaskContainer testrunner;
+  if(testrunner.RunAllTests()) return 0;
+  return 1; 
+}


### PR DESCRIPTION
- Mask can have status dead or bad
- FastORs handled via FastOr abs ID
- Container browsable, in this case a
  2D col-row plot is created
- Corresponding unit tests added for
  - In-memory set/get
  - ROOT File-I/O
  - Modify
  - Clean