### PR TITLE
Add handling for offline trigger mask via trigger mask container

### DIFF
--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerKernel.h
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerKernel.h
@@ -259,7 +259,7 @@ public:
    * @brief Add a FastOR bad channel to the list
    * @param[in] absId Absolute ID of the bad channel
    */
-  void AddFastORBadChannel(Short_t absId) { fBadChannels.insert(absId); }
+  void AddFastORBadChannel(Short_t absId) { if(fBadChannels.find(absId) == fBadChannels.end()) fBadChannels.insert(absId); }
 
   /**
    * @brief Read the FastOR bad channel map from a standard stream
@@ -282,7 +282,7 @@ public:
    * @brief Add an offline bad channel to the set
    * @param[in] absId Absolute ID of the bad channel
    */
-  void AddOfflineBadChannel(Short_t absId) { fOfflineBadChannels.insert(absId); }
+  void AddOfflineBadChannel(Short_t absId) { if(fOfflineBadChannels.find(absId) == fOfflineBadChannels.end()) fOfflineBadChannels.insert(absId); }
 
   /**
    * @brief Read the offline bad channel map from a standard stream

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerTask.cxx
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerTask.cxx
@@ -37,6 +37,7 @@
 #include "AliCDBEntry.h"
 #include "AliCDBManager.h"
 #include "AliDataFile.h"
+#include "AliEmcalFastorMaskContainer.h"
 #include "AliEMCALGeometry.h"
 #include "AliEMCALTriggerBitConfig.h"
 #include "AliEMCALTriggerDCSConfig.h"
@@ -69,6 +70,8 @@ AliEmcalTriggerMakerTask::AliEmcalTriggerMakerTask():
   fMaskedFastorOADB(""),
   fUseL0Amplitudes(kFALSE),
   fLoadFastORMaskingFromOCDB(kTRUE),
+  fUseDeadFastORsOADB(kFALSE),
+  fUseBadFastORsOADB(kFALSE),
   fCaloTriggersOut(0),
   fRunSmearing(kTRUE),
   fSimulateNoise(kTRUE),
@@ -488,22 +491,50 @@ void AliEmcalTriggerMakerTask::InitializeSmearModel(){
 }
 
 void AliEmcalTriggerMakerTask::InitializeFastORMaskingFromOADB(){
+  std::cout << "EMCAL trigger maker: Loading masked fastors from OADB" << std::endl;
   TString containername;
   if(fMaskedFastorOADB == "oadb") {
     containername = AliDataFile::GetFileNameOADB("EMCAL/MaskedFastors.root").data();
   } else {
     containername = fMaskedFastorOADB;
   }
-  AliInfoStream() << "Initializing masked fastors from OADB container " << containername << std::endl;
+  std::cout << "EMCAL trigger maker: Initializing masked fastors from OADB container " << containername << std::endl;
   if(containername.Contains("alien://") && !gGrid) TGrid::Connect("alien");
   AliOADBContainer badchannelDB("AliEmcalMaskedFastors");
   badchannelDB.InitFromFile(containername, "AliEmcalMaskedFastors");
-  TObjArray *badchannelmap = static_cast<TObjArray *>(badchannelDB.GetObject(InputEvent()->GetRunNumber()));
-  if(!badchannelmap || !badchannelmap->GetEntries()) return;
-  for(TIter citer = TIter(badchannelmap).Begin(); citer != TIter::End(); ++citer){
-    TParameter<int> *channelID = static_cast<TParameter<int> *>(*citer);
-    AliDebugStream(1) << GetName() << ": Found masked fastor channel " << channelID->GetVal() << std::endl;
-    fTriggerMaker->AddFastORBadChannel(channelID->GetVal());
+  PWG::EMCAL::AliEmcalFastorMaskContainer *maskContainer = dynamic_cast<PWG::EMCAL::AliEmcalFastorMaskContainer *>(badchannelDB.GetObject(InputEvent()->GetRunNumber()));
+  if(maskContainer) {
+    std::string selectiontype;
+    std::vector<int> maskedfastors;
+    if(fUseDeadFastORsOADB) {
+      if(fUseBadFastORsOADB) {
+        maskedfastors = maskContainer->GetMaskAll();
+        selectiontype = "all";
+      } else{
+        maskedfastors = maskContainer->GetMaskDead();
+        selectiontype = "dead";
+      }
+    } else if(fUseBadFastORsOADB){
+      maskedfastors = maskContainer->GetMaskBad();
+      selectiontype = "bad";
+    } else selectiontype = "no";
+    std::cout << "EMCAL trigger maker: OADB Container is of new type AliEmcalTriggerMaskContainer - masking " << selectiontype << " FastORs" << std::endl;
+    for(auto fastor : maskedfastors) {
+      AliDebugStream(1) << GetName() << ": Found masked fastor channel " << fastor << std::endl;
+      fTriggerMaker->AddFastORBadChannel(fastor);
+    }
+  } else {
+    TObjArray *badchannelmap = dynamic_cast<TObjArray *>(badchannelDB.GetObject(InputEvent()->GetRunNumber()));
+    if(badchannelmap && badchannelmap->GetEntries()) {
+      std::cout << "EMCAL trigger maker: OADB Container is of old type (simple list) - no distinction between bad and dead channels possible" << std::endl;
+      for(TIter citer = TIter(badchannelmap).Begin(); citer != TIter::End(); ++citer){
+        TParameter<int> *channelID = static_cast<TParameter<int> *>(*citer);
+        AliDebugStream(1) << GetName() << ": Found masked fastor channel " << channelID->GetVal() << std::endl;
+        fTriggerMaker->AddFastORBadChannel(channelID->GetVal());
+      }
+    } else {
+      std::cerr << "EMCAL trigger maker: Unsupported OADB container type - no FastORs will be loaded" << std::endl;
+    }
   }
 }
 

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerTask.h
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerTask.h
@@ -244,6 +244,26 @@ public:
    */
   void SetSimulateNoise(Bool_t doSimulate) { fSimulateNoise = doSimulate; }
 
+  /**
+   * @brief Use bad FastORs from OADB (default: false)
+   * @param doUse If true bad fastors from the OADB are used 
+   * 
+   * Only has an impact in case the OADB container is specified and
+   * the OADB container is of the new format AliEmcalFastorMaskContainer
+   * which separates dead and bad FastORs
+   */
+  void SetUseBadFastorsOADB(Bool_t doUse) { fUseBadFastORsOADB = doUse; }
+
+  /**
+   * @brief Use dead FastORs from OADB (default: false)
+   * @param doUse If true bad fastors from the OADB are used 
+   * 
+   * Only has an impact in case the OADB container is specified and
+   * the OADB container is of the new format AliEmcalFastorMaskContainer
+   * which separates dead and bad FastORs
+   */
+  void SetUseDeadFastorsOADB(Bool_t doUse) { fUseDeadFastORsOADB = doUse; }
+
 protected:
 
 #if !(defined(__CINT__) || defined(__MAKECINT__))
@@ -342,6 +362,8 @@ protected:
   TString                                 fMaskedFastorOADB;          ///< name of the OADB container containing fastors to be masked inside the trigger maker
   Bool_t                                  fUseL0Amplitudes;           ///< Use L0 amplitudes instead of L1 time sum (useful for runs where STU was not read)
   Bool_t                                  fLoadFastORMaskingFromOCDB; ///< Load FastOR masking from the OCDB
+  Bool_t                                  fUseDeadFastORsOADB;        ///< Use dead FastORs from OADB (in case an OADB container of new format AliEmcalFastorMaskContainer is specified)
+  Bool_t                                  fUseBadFastORsOADB;         ///< Use bad FastORs from OADB (in case an OADB container of new format AliEmcalFastorMaskContainer is specified)
   TClonesArray                            *fCaloTriggersOut;          //!<! trigger array out
 
   Bool_t                                  fRunSmearing;               ///< Also calculate smeared patch energy based on FastOR energy resolution


### PR DESCRIPTION
Support for both types of trigger mask containers
(new trigger mask container and old TObjArray with
list of FastORs) implemented, however on in case of
the new trigger mask container it is possible to
distinguish bad from dead channels and therefore
allow to enable/disable them separately.