### PR TITLE
Dividing the Charge Particle level tracks by 3 

### DIFF
--- a/PWGJE/EMCALJetTasks/AliAnalysisTaskJetChargeFlavourTemplates.cxx
+++ b/PWGJE/EMCALJetTasks/AliAnalysisTaskJetChargeFlavourTemplates.cxx
@@ -903,7 +903,7 @@ Bool_t AliAnalysisTaskJetChargeFlavourTemplates::FillHistograms()
           for (UInt_t iTruthConst = 0; iTruthConst < nTruthConstituents; iTruthConst++ )
           {
             AliMCParticle* TruthParticle = (AliMCParticle*) TruthJet->Track(iTruthConst);
-            jetChargeParticle += TruthParticle->Charge()*pow(TruthParticle->Pt(),JetChargeK);
+            jetChargeParticle += TruthParticle->Charge()/3*pow(TruthParticle->Pt(),JetChargeK);
           }
 
 


### PR DESCRIPTION
since the charge on a particle level track are in units of 1/3 e instead of units of e. Thus correcting the mistake causing Particle level templates to be much broader.