### PR TITLE
Add getter for event weight (weighted production) in AliAnalysisTaskEmcal

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.cxx
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.cxx
@@ -2377,6 +2377,15 @@ void AliAnalysisTaskEmcal::GeneratePythiaInfoObject(AliMCEvent* mcEvent)
     fPythiaInfo->SetPythiaEventWeight(ptWeight);}
 }
 
+double AliAnalysisTaskEmcal::GetEventWeightFromHeader() const {
+  double eventweight = -1.;
+  if(fIsPythia || fIsHepMC) {
+    if(fIsPythia && fPythiaHeader) eventweight = fPythiaHeader->EventWeight();
+    if(fIsHepMC && fHepMCHeader) eventweight = fHepMCHeader->EventWeight();
+  }
+  return eventweight;
+}
+
 double AliAnalysisTaskEmcal::GetCrossSectionFromHeader() const {
   double crosssection = -1.;
   if(fIsPythia || fIsHepMC) {

--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.h
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.h
@@ -668,9 +668,15 @@ class AliAnalysisTaskEmcal : public AliAnalysisTaskSE {
 
   /**
    * @brief Get the event cross section from the generator event header
-   * @return Cross section (-1 in not a PYTHIA- or HepMC based production)
+   * @return Cross section (-1 if not a PYTHIA- or HepMC-based production)
    */
   double                      GetCrossSectionFromHeader()                     const;
+
+  /**
+   * @brief Get the event weight from the generator event header 
+   * @return Event weight (-1 if not a PPYTHIA- or HepMC-based production) 
+   */
+  double                      GetEventWeightFromHeader()                      const;
 
   /**
    * @brief Switch on pt-hard bin scaling

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetEnergySpectrum.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetEnergySpectrum.cxx
@@ -69,7 +69,7 @@ AliAnalysisTaskEmcalJetEnergySpectrum::AliAnalysisTaskEmcalJetEnergySpectrum():
   fNameJetContainer("datajets"),
   fRequestTriggerClusters(true),
   fRequestCentrality(false),
-  fFillHistosWeighted(false),
+  fFillHistosWeighted(kNoWeightType),
   fUseRun1Range(false),
   fUseSumw2(false),
   fUseMuonCalo(false),
@@ -100,7 +100,7 @@ AliAnalysisTaskEmcalJetEnergySpectrum::AliAnalysisTaskEmcalJetEnergySpectrum(EMC
   fNameJetContainer("datajets"),
   fRequestTriggerClusters(true),
   fRequestCentrality(false),
-  fFillHistosWeighted(false),
+  fFillHistosWeighted(kNoWeightType),
   fUseRun1Range(false),
   fUseSumw2(false),
   fUseMuonCalo(false),
@@ -277,11 +277,16 @@ bool AliAnalysisTaskEmcalJetEnergySpectrum::Run(){
   if(fUseDownscaleWeight) {
     weight = 1./PWG::EMCAL::AliEmcalDownscaleFactorsOCDB::Instance()->GetDownscaleFactorForTriggerClass(MatchTrigger(fInputEvent->GetFiredTriggerClasses().Data(), fTriggerSelectionString.Data(), fUseMuonCalo));
   }
-  if(fFillHistosWeighted && isMC) {
+  if(fFillHistosWeighted != EWeightType_t::kNoWeightType && isMC) {
     // Get cross section weight from supported generator event header
-    auto crossSectionWeight = GetCrossSectionFromHeader();
-    if(crossSectionWeight > 0) {
-      weight *= crossSectionWeight;
+    double mcweight = 1.;
+    switch(fFillHistosWeighted) {
+      case EWeightType_t::kCrossSectionWeightType: mcweight = GetCrossSectionFromHeader(); break;
+      case EWeightType_t::kEventWeightType: mcweight = GetEventWeightFromHeader(); break;
+      case EWeightType_t::kNoWeightType: break;
+    };
+    if(mcweight > 0) {
+      weight *= mcweight;
     }
   }
   AliDebugStream(2) << "Found downscale weight " << weight << " for trigger " << fTriggerSelectionString << std::endl;

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetEnergySpectrum.h
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetEnergySpectrum.h
@@ -46,6 +46,11 @@ public:
     kOutlierPartJet,
     kOutlierDetJet
   };
+  enum EWeightType_t {
+    kCrossSectionWeightType,
+    kEventWeightType,
+    kNoWeightType 
+  };
   AliAnalysisTaskEmcalJetEnergySpectrum();
   AliAnalysisTaskEmcalJetEnergySpectrum(EMCAL_STRINGVIEW name);
   virtual ~AliAnalysisTaskEmcalJetEnergySpectrum();
@@ -69,7 +74,7 @@ public:
   void SetRequestCentrality(bool doRequest) { fRequestCentrality = doRequest; }
   void SetRequestTriggerClusters(bool doRequest) { fRequestTriggerClusters = doRequest; }
   void SetCentralityEstimator(EMCAL_STRINGVIEW centest) { fCentralityEstimator = centest; }
-  void SetFillHistosWeighted(bool doFill)          { fFillHistosWeighted = doFill; }
+  void SetFillHistosWeighted(EWeightType_t weighttype) { fFillHistosWeighted = weighttype; }
   void SetFillHSparse(Bool_t doFill)               { fFillHSparse = doFill; }
   void SetUseMuonCalo(Bool_t doUse)                { fUseMuonCalo = doUse; }
   void SetEnergyScaleShfit(Double_t scaleshift)    { fScaleShift = scaleshift; } 
@@ -88,7 +93,7 @@ public:
     AliJetContainer::EJetType_t jettype, 
     AliJetContainer::ERecoScheme_t recoscheme, 
     AliVCluster::VCluUserDefEnergy_t energydef, 
-    double radius, 
+    double radius,
     EMCAL_STRINGVIEW namepartcont, 
     EMCAL_STRINGVIEW trigger, 
     EMCAL_STRINGVIEW suffix = ""
@@ -119,7 +124,7 @@ private:
   TString                       fNameJetContainer;              ///< Name of the jet container 
   Bool_t                        fRequestTriggerClusters;        ///< Request distinction of trigger clusters
   Bool_t                        fRequestCentrality;             ///< Request centrality
-  Bool_t                        fFillHistosWeighted;            ///< Fill histograms with cross section weight
+  EWeightType_t                 fFillHistosWeighted;            ///< Fill histograms with cross section or event weight
   Bool_t                        fUseRun1Range;                  ///< Use run1 run range for trending plots     
   Bool_t                        fUseSumw2;                      ///< Switch for sumw2 option in THnSparse (should not be used when a downscale weight is applied)
   Bool_t                        fUseMuonCalo;                   ///< Use events from the (muon)-calo-(fast) cluster

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetSpectrumSDPart.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetSpectrumSDPart.cxx
@@ -58,7 +58,7 @@ AliAnalysisTaskEmcalJetSpectrumSDPart::AliAnalysisTaskEmcalJetSpectrumSDPart():
     fUseNeutralConstituents(true),
     fUseStandardOutlierRejection(false),
     fCutHardPartonPt(false),
-    fFillHistosWeighted(false),
+    fFillHistosWeighted(EWeightType_t::kNoWeightType),
     fOutlierMode(kOutlierPtHard),
     fPtHardParton(0.),
     fPdgHardParton(INT_MIN),
@@ -80,7 +80,7 @@ AliAnalysisTaskEmcalJetSpectrumSDPart::AliAnalysisTaskEmcalJetSpectrumSDPart(con
     fUseNeutralConstituents(true),
     fUseStandardOutlierRejection(false),
     fCutHardPartonPt(false),
-    fFillHistosWeighted(false),
+    fFillHistosWeighted(EWeightType_t::kNoWeightType),
     fOutlierMode(kOutlierPtHard),
     fPtHardParton(0.),
     fPdgHardParton(INT_MIN),
@@ -302,11 +302,16 @@ bool AliAnalysisTaskEmcalJetSpectrumSDPart::Run()
     auto particles = jets->GetParticleContainer();
 
     double weight = 1.;
-    if(fFillHistosWeighted) {
+    if(fFillHistosWeighted != EWeightType_t::kNoWeightType) {
         // Get cross section weight from supported generator event header
-        auto crossSectionWeight = GetCrossSectionFromHeader();
-        if(crossSectionWeight > 0) {
-          weight *= crossSectionWeight;
+        double mcweight = 1.; 
+        switch(fFillHistosWeighted) {
+        case EWeightType_t::kCrossSectionWeightType: mcweight = GetCrossSectionFromHeader(); break;
+        case EWeightType_t::kEventWeightType: mcweight = GetEventWeightFromHeader(); break;
+        case EWeightType_t::kNoWeightType: break;
+        };
+        if(mcweight > 0) {
+          weight *= mcweight;
         }
     }
 

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetSpectrumSDPart.h
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetSpectrumSDPart.h
@@ -41,6 +41,11 @@ class AliAnalysisTaskEmcalJetSpectrumSDPart : public AliAnalysisTaskEmcalJet,
                                               public AliAnalysisEmcalSoftdropHelperImpl
 {
 public:
+    enum EWeightType_t {
+        kCrossSectionWeightType,
+        kEventWeightType,
+        kNoWeightType 
+    };
     AliAnalysisTaskEmcalJetSpectrumSDPart();
     AliAnalysisTaskEmcalJetSpectrumSDPart(const char *name);
     virtual ~AliAnalysisTaskEmcalJetSpectrumSDPart();
@@ -54,7 +59,7 @@ public:
     void SetCutHardestPartonPt(double ptmin, double ptmax) { fCutHardPartonPt = true; fMinPtHardParton = ptmin; fMaxPtHardParton = ptmax; }
     void SetUsePtHardPartonInOutlierCut(bool doUse) { fOutlierMode = kOutlierPtParton; }
     void SetUseOutlierPtMaxBin(double ptmaxBin) { fMaxPtHardValBin = ptmaxBin; fOutlierMode = kOutlierPtMax; }
-    void SetFillHistosWeighted(bool doFill) { fFillHistosWeighted = doFill; }
+    void SetFillHistosWeighted(EWeightType_t weighttype) { fFillHistosWeighted = weighttype; }
 
     static AliAnalysisTaskEmcalJetSpectrumSDPart *AddTaskEmcalJetSpectrumSDPart(AliJetContainer::EJetType_t jettype, double R, const char *nameparticles, const char *tag = "");
 
@@ -82,7 +87,7 @@ private:
     Bool_t                                  fUseNeutralConstituents;        ///< SoftDrop use neutral constituents
     Bool_t                                  fUseStandardOutlierRejection;   ///< Fall back to standard outlier rejection
     Bool_t                                  fCutHardPartonPt;               ///< Apply cut on the pt of the hardest parton
-    Bool_t                                  fFillHistosWeighted;            ///< Use event weight in order to fill the histograms
+    EWeightType_t                           fFillHistosWeighted;            ///< Use event weight in order to fill the histograms
     OutlierMode_t                           fOutlierMode;                   ///< Mode to determine the outlier (event pt-hard, hardest part, max of the pt-hard bin)
     Double_t                                fPtHardParton;                  ///< Pt of the hardest
     Int_t                                   fPdgHardParton;                 ///< Pdg of the hardest parton


### PR DESCRIPTION
Getter only implemented for pythia and HepMC-based
productions. Use getter also in the spectrum and
part. level task. In case of the jet analysis task the
user has to define whether apply cross section or
event weighting.