### PR TITLE
Fix handling of the 1/3rd supermodules in run2

### DIFF
--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMaskHandlerOCDB.h
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMaskHandlerOCDB.h
@@ -270,25 +270,27 @@ public:
    * @brief Conversion function between position in reg masks and channel ID for run1 setup
    * @param mask      Number of the mask
    * @param bitnumber Number of the bit in the mask
+   * @param onethirdsm Mark whether the supermodule is of type 1/3
    * @return          Channel ID beloging to bit number in reg mask
    * 
    * The reg mask consists of 6 separate masks each containing 16 bits,
    * resulting in 96 bits in total. In order to determin the channel ID
    * both mask number and bit number are needed
    */
-  static int GetChannelForMaskRun1(int mask, int bitnumber);
+  static int GetChannelForMaskRun1(int mask, int bitnumber, bool /*onethirdsm*/);
 
   /**
    * @brief Conversion function between position in reg masks and channel ID for run2 setup
    * @param mask      Number of the mask
    * @param bitnumber Number of the bit in the mask
+   * @param onethirdsm Mark whether the supermodule is of type 1/3
    * @return          Channel ID beloging to bit number in reg mask
    * 
    * The reg mask consists of 6 separate masks each containing 16 bits,
    * resulting in 96 bits in total. In order to determin the channel ID
    * both mask number and bit number are needed
    */
-  static int GetChannelForMaskRun2(int mask, int bitnumber);
+  static int GetChannelForMaskRun2(int mask, int bitnumber, bool onethirdsm);
 
   /**
    * @brief Draw L0 trigger mask from DCS config in cvmfs OCDB


### PR DESCRIPTION
The mask for the 1/3rd supermodules is the same as
in run1, while the masking handler tried to apply the
run2 mapping. Fixed in the way that the mapping
handlers need an argument for the SM type, and in
case it is the 1/3 type the old mapping is applied.