### PR TITLE
Use mask handler in trigger maker to read OCDB trigger mask

### DIFF
--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerTask.cxx
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerTask.cxx
@@ -294,7 +294,7 @@ Bool_t AliEmcalTriggerMakerTask::Run(){
     AliErrorStream() << "Trigger maker not configured" << std::endl;
     return false;    // only run trigger maker in case it is configured
   }
-  AliDebugStream(1) << "Looking for trigger patches ..." << std::endl;
+  AliDebugStream(2) << "Looking for trigger patches ..." << std::endl;
   fCaloTriggersOut->Delete(); // Needed to avoid memory leak
   // prepare trigger maker
   fTriggerMaker->Reset();

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerTask.cxx
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerTask.cxx
@@ -47,6 +47,7 @@
 #include "AliEmcalTriggerMakerKernel.h"
 #include "AliEmcalTriggerMakerTask.h"
 #include "AliEMCALTriggerMapping.h"
+#include "AliEmcalTriggerMaskHandlerOCDB.h"
 #include "AliLog.h"
 #include "AliOADBContainer.h"
 
@@ -372,7 +373,7 @@ void AliEmcalTriggerMakerTask::RunChanged(Int_t newrun){
   fTriggerMaker->ClearOfflineBadChannels();
   if(fBadFEEChannelOADB.Length()) InitializeBadFEEChannels();
   fTriggerMaker->ClearFastORBadChannels();
-  if(fLoadFastORMaskingFromOCDB) InitializeFastORMaskingFromOCDB();
+  if(fLoadFastORMaskingFromOCDB) InitializeFastORMaskingFromOCDB(newrun);
   if(fMaskedFastorOADB.Length()) InitializeFastORMaskingFromOADB();
   // QA: Monitor all channels which are masked in the current run
   if(fDoQA && fQAHistos){
@@ -398,85 +399,13 @@ void AliEmcalTriggerMakerTask::InitializeBadFEEChannels(){
   }
 }
 
-void AliEmcalTriggerMakerTask::InitializeFastORMaskingFromOCDB(){
+void AliEmcalTriggerMakerTask::InitializeFastORMaskingFromOCDB(int runnumber){
   std::cout << "EMCAL trigger maker: Loading masked fastors from OCDB" << std::endl;
-  AliCDBManager *cdb = AliCDBManager::Instance();
-
-  AliCDBEntry *en = cdb->Get("EMCAL/Calib/Trigger");
-  if(!en){
-    AliErrorStream() << GetName() << ": FastOR masking from CDB required, but OCDB entry is not available. No masking will be applied." << std::endl;
-    return;
-  }
-
-  AliEMCALTriggerDCSConfig *trgconf = dynamic_cast<AliEMCALTriggerDCSConfig *>(en->GetObject());
-  if(!trgconf){
-    AliErrorStream() << GetName() << ": Failed decoding OCDB entry: Object is not of type AliEMCALTriggerDCSConfig." << std::endl;
-    return;
-  }
-
-  // In run 1 the small supermodules were not contributing to triggers.
-  // Still the TRUs are counted. As access to the TRU config is not properly
-  // protected the loop over NTRU from the geometry will produce a segfault.
-  // As temporary workaround the loop limits are obtained from the DCS data itself.
-  Int_t fastOrAbsID(-1), ic(-1);
-  for(int itru = 0; itru < trgconf->GetTRUArr()->GetEntries(); itru++){
-    AliEMCALTriggerTRUDCSConfig *truconf = trgconf->GetTRUDCSConfig(itru);
-    // Test for each channel whether it is masked. The calculation is
-    // done reversely as the channel mapping is different between run1
-    // and run2: The loop is done over all masks and all bits inside the
-    // mask, and a handler matching to the correct mapping converts them
-    // into the channel ID. In case a masked channel is found, the absolute
-    // ID is calculated. For this the function GetAbsFastORIndexFromTRU
-    // is used - it is assumed that parameter 1 (iADC) corresponds to the
-    // channel ID.
-    for(unsigned int ifield = 0; ifield < 6; ifield++){
-      std::bitset<sizeof(unsigned int) * 4> regmask(truconf->GetMaskReg(ifield));
-      for(unsigned int ibit = 0; ibit < 16; ibit ++){
-        if(regmask.test(ibit)){
-          try{
-            fGeom->GetTriggerMapping()->GetAbsFastORIndexFromTRU(RemapTRUIndex(itru), (ic =  GetMaskHandler(itru)(ifield, ibit)), fastOrAbsID);
-            AliDebugStream(1) << GetName() << "Channel " << ic  << " in TRU " << itru << " ( abs fastor " << fastOrAbsID << ") masked." << std::endl;
-            fTriggerMaker->AddFastORBadChannel(fastOrAbsID);
-          } catch (int exept){
-            AliErrorStream() << GetName() << "Invalid mask: (" << ifield << "|" << ibit << "), exception " << exept << " thrown. Mask will not be recognized" << std::endl;
-          }
-        }
-      }
-    }
-  }
-
-  // Load STU regions
-  // In case of STU region whole TRUs are disabled in case their corresponding
-  // bit is set to 0 in the STU region bitset
-  auto emcalstu = trgconf->GetSTUDCSConfig(false),
-       dcalstu = trgconf->GetSTUDCSConfig(true);
-  if(emcalstu) {
-    std::bitset<sizeof(int) * 8> sturegion(emcalstu->GetRegion());
-    for(int itru = 0; itru < 32; itru++) {
-      if(!sturegion.test(itru)) {
-        // TRU disabled
-        std::cout << "Disable EMCAL TRU " << itru << "(" << itru << ")" << std::endl;
-        for(int ichannel = 0; ichannel < 96; ichannel++) {
-          fGeom->GetTriggerMapping()->GetAbsFastORIndexFromTRU(itru, ichannel, fastOrAbsID);
-          fTriggerMaker->AddFastORBadChannel(fastOrAbsID); 
-        }
-      }
-    }
-  }
-
-  if(dcalstu){
-    std::bitset<sizeof(int) * 8> sturegion(dcalstu->GetRegion());
-    for(int itru = 0; itru < 14; itru++) {
-      if(!sturegion.test(itru)) {
-        // TRU disabled
-        auto globTRUindex = fGeom->GetTriggerMapping()->GetTRUIndexFromSTUIndex(itru, 1);
-        std::cout << "Disable DCAL TRU " << itru << "(" << globTRUindex << ")" << std::endl;
-        for(int ichannel = 0; ichannel < 96; ichannel++) {
-          fGeom->GetTriggerMapping()->GetAbsFastORIndexFromTRU(globTRUindex, ichannel, fastOrAbsID);
-          fTriggerMaker->AddFastORBadChannel(fastOrAbsID); 
-        }
-      }
-    }
+  auto channels = PWG::EMCAL::AliEmcalTriggerMaskHandlerOCDB::Instance()->GetMaskedFastorIndicesL1(runnumber);
+  std::cout << "Found " << channels.size() << " masked FastORs at Level1" << std::endl;
+  for(auto fastORAbsId : channels) {
+    AliDebugStream(1) << "Adding masked FastOR " << fastORAbsId << " at L1" << std::endl;
+    fTriggerMaker->AddFastORBadChannel(fastORAbsId);
   }
 }
 
@@ -538,37 +467,6 @@ void AliEmcalTriggerMakerTask::InitializeFastORMaskingFromOADB(){
       std::cerr << "EMCAL trigger maker: Unsupported OADB container type - no FastORs will be loaded" << std::endl;
     }
   }
-}
-
-
-std::function<int (unsigned int, unsigned int)> AliEmcalTriggerMakerTask::GetMaskHandler(int itru) const {
-  bool isTRUsmallSM = ((itru >= 30 && itru < 31) || (itru >= 44 && itru < 45)) ;
-  if(fGeom->GetTriggerMappingVersion() == 2 && !isTRUsmallSM){
-    // Run 2 - complicated TRU layout in 6 subregions
-    return [] (unsigned int ifield, unsigned int ibit) -> int {
-      if(ifield >= 6 || ibit >= 16) throw kInvalidChannelException;
-      const int kChannelMap[6][16] = {{ 8, 9,10,11,20,21,22,23,32,33,34,35,44,45,46,47},   // Channels in mask0
-                                      {56,57,58,59,68,69,70,71,80,81,82,83,92,93,94,95},   // Channels in mask1
-                                      { 4, 5, 6, 7,16,17,18,19,28,29,30,31,40,41,42,43},   // Channels in mask2
-                                      {52,53,54,55,64,65,66,67,76,77,78,79,88,89,90,91},   // Channels in mask3
-                                      { 0, 1, 2, 3,12,13,14,15,24,25,26,27,36,37,38,39},   // Channels in mask4
-                                      {48,49,50,51,60,61,62,63,72,73,74,75,84,85,86,87}};  // Channels in mask5
-      return kChannelMap[ifield][ibit];
-    };
-  } else {
-    // Run 1 - linear mapping was used
-    return [] (int ifield, int ibit) -> int {
-      if(ifield >= 6 || ibit >= 16) throw kInvalidChannelException;
-      return ifield * 16 + ibit;
-    };
-  }
-}
-
-int AliEmcalTriggerMakerTask::RemapTRUIndex(int itru) const {
-  if(fGeom->GetTriggerMappingVersion() == 2){
-    const int trumapping[46] = {0,1,2,5,4,3,6,7,8,11,10,9,12,13,14,17,16,15,18,19,20,23,22,21,24,25,26,29,28,27,30,31,32,33,37,36,38,39,43,42,44,45,49,48,50,51};
-    return trumapping[itru];
-  } else return itru;
 }
 
 void AliEmcalTriggerMakerTask::FillQAHistos(const TString &patchtype, const AliEMCALTriggerPatchInfo &recpatch){

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerTask.h
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerTask.h
@@ -266,42 +266,6 @@ public:
 
 protected:
 
-#if !(defined(__CINT__) || defined(__MAKECINT__))
-  /**
-   * @brief Create functor handling the conversion between reg mask and channel
-   * 
-   * Closure producing a handler converting a set of mask / bit number into a channel
-   * ID. In case the mask / bit number is invalid the function will return -1
-   * @return function that converts a set of mask / bit number into a channel ID
-   * 
-   * The handling is different for LHC run1 and LHC run2 due to different TRU geometry:
-   * - In run1 a linear indexing was applied
-   * - In run2 the indexing is not linear for the TRUs in the full and DCAL supermodules,
-   *   while it follows the linear indexing for the 1/3rd supermodules
-   * Due to run2 definitions the handlers are created based on the index of the TRU
-   * using L0 convention.
-   * 
-   * @param[in] itru Index of the TRU (L0 convention, without remapping)
-   */
-  std::function<int (unsigned int, unsigned int)> GetMaskHandler(int itru) const;
-#endif
-
- /**
-  * @brief Fix mapping in TRU index
-  * 
-  * In run 2 the index of the TRU is different between
-  * TRU indexing and STU indexing:
-  * - STU indexing: Linear, including PHOS region
-  * - TRU indexing: Out to in in eta (C-side mirrored), no PHOS region
-  * Obviously the mapping uses the STU indexing. This function
-  * remaps the TRU indexing (used in the DCS configuration) to the
-  * STU indexing
-  * 
-  * @param itru TRU index in TRU convention 
-  * @return int TRU index in STU convention
-  */
-  int RemapTRUIndex(int itru) const;
-
   /**
    * @brief Internal QA handler for trigger pathches of given type
    *
@@ -332,8 +296,9 @@ protected:
 
   /**
    * @brief Initialize the FastOR masking from the OCDB
+   * @brief Run number for which to load the FastOR mask
    */
-  void InitializeFastORMaskingFromOCDB();
+  void InitializeFastORMaskingFromOCDB(int runnumber);
 
   /**
    * @brief Initialize the FastOR masking from the OADB

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMaskHandlerOCDB.cxx
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMaskHandlerOCDB.cxx
@@ -142,7 +142,7 @@ std::vector<int> AliEmcalTriggerMaskHandlerOCDB::GetGlobalMaskedTRUIndices(int r
   auto geo = GetGeometry(runnumber);
 
   auto emcalstu = fCurrentConfig->GetSTUDCSConfig(false),
-       dcalstu = fCurrentConfig->GetSTUDCSConfig(false);
+       dcalstu = fCurrentConfig->GetSTUDCSConfig(true);
 
   if(emcalstu) {
     std::bitset<32> mask(emcalstu->GetRegion());

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMaskHandlerOCDB.cxx
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMaskHandlerOCDB.cxx
@@ -28,6 +28,7 @@
 #include <bitset>
 #include <functional>
 #include <iostream>
+#include <iterator>
 #include <map>
 
 #include <TCanvas.h>
@@ -103,13 +104,13 @@ std::vector<int> AliEmcalTriggerMaskHandlerOCDB::GetMaskedFastorIndicesL1(int ru
   std::vector<int> maskedfastors;
   // Find masked FastORs at L0
   auto maskedL0 = GetMaskedFastorIndicesL0(runnumber);
-  std::copy(maskedL0.begin(), maskedL0.end(), maskedfastors.begin());
+  std::copy(maskedL0.begin(), maskedL0.end(), std::back_inserter(maskedfastors));
 
   // Look for TRUs which are masked in the L1 region
   // For each STU which is masked at L1 mask also the FastORs 
   // if not yet masked at L0
   AliEMCALGeometry *geo = nullptr;
-  for(auto truID : GetGlobalMaskedTRUIndices()) {
+  for(auto truID : GetGlobalMaskedTRUIndices(runnumber)) {
     if(!geo) geo = GetGeometry(runnumber);
     for(int ichannel = 0; ichannel < 96; ichannel++) {
       int absfastor;

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMaskHandlerOCDB.cxx
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMaskHandlerOCDB.cxx
@@ -43,6 +43,7 @@
 #include "AliEMCALTriggerTRUDCSConfig.h"
 #include "AliEMCALTriggerSTUDCSConfig.h"
 #include "AliEmcalTriggerMaskHandlerOCDB.h"
+#include "AliLog.h"
 
 ClassImp(PWG::EMCAL::AliEmcalTriggerMaskHandlerOCDB)
 
@@ -75,6 +76,7 @@ std::vector<int> AliEmcalTriggerMaskHandlerOCDB::GetMaskedFastorIndicesL0(int ru
           auto channel = ChannelMaskHandler(ipos, ibit, onethirdsm);
           int absfastor;
           geo->GetTriggerMapping()->GetAbsFastORIndexFromTRU(globaltru, channel, absfastor);
+          AliDebugStream(1) << GetName() << "Channel " << channel  << " in TRU " << globaltru << " ( abs fastor " << absfastor << ") masked." << std::endl;
           maskedfastors.push_back(absfastor);
         }
       }
@@ -146,6 +148,7 @@ std::vector<int> AliEmcalTriggerMaskHandlerOCDB::GetGlobalMaskedTRUIndices(int r
     for(int itru = 0; itru < 32; itru++) {
       if(!mask.test(itru)) {
         // TRU excluded from region, add to masked TRUs
+        AliDebugStream(1) << "EMCAL TRU " << itru << " masked in STU region" << std::endl;
         truindices.push_back(geo->GetTRUIndexFromSTUIndex(itru, 0));
       } 
     }
@@ -156,6 +159,7 @@ std::vector<int> AliEmcalTriggerMaskHandlerOCDB::GetGlobalMaskedTRUIndices(int r
     for(int itru = 0; itru < 14; itru++) {
       if(!mask.test(itru)) {
         // TRU excluded from region, add to masked TRUs
+        AliDebugStream(1) << "DCAL TRU " << itru << " masked in STU region" << std::endl;
         truindices.push_back(geo->GetTRUIndexFromSTUIndex(itru, 1));
       } 
     }
@@ -215,6 +219,7 @@ void AliEmcalTriggerMaskHandlerOCDB::ClearCache() {
 
 void AliEmcalTriggerMaskHandlerOCDB::UpdateCache(int runnumber) {
   if((runnumber == fCurrentRunnumber) && fCurrentConfig) return;
+  AliInfoStream() << "Update trigger DCS config for run " << runnumber << std::endl;
   ClearCache();
   auto cdb = InitCDB(runnumber);
   auto trgobject = cdb->Get("EMCAL/Calib/Trigger")->GetObject();
@@ -234,6 +239,7 @@ AliCDBManager *AliEmcalTriggerMaskHandlerOCDB::InitCDB(int runnumber) {
     auto currentrun = cdb->GetRun();
     if(currentrun != runnumber) {
       // Changing run numbre
+      AliInfoStream() << "Run number in CDB (" << currentrun << ") different from requested (" << runnumber << "), updating ..." << std::endl;
       cdb->SetRun(runnumber);
     }
   } else {


### PR DESCRIPTION
Use mask handler for trigger mask reading from the
OCDB and remove builting trigger mask reading. With
this the same code can be used for visualization of the
trigger mask and utilization in the trigger maker, so
the trigger maker can make use of a well tested and
unit-testable code.