### PR TITLE
Adjust scaling histograms for AliAnalysisTaskEmcalLight

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliEmcalList.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEmcalList.cxx
@@ -118,7 +118,7 @@ void AliEmcalList::ScaleAllHistograms(TCollection *hlist, Double_t scalingFactor
     // Don't scale profiles and histograms used for scaling
     TString histogram_class (listObject->ClassName());
     TString histogram_name (listObject->GetName());
-    if (histogram_name.Contains("fHistXsection") || histogram_name.Contains("fHistTrials") || histogram_name.Contains("fHistEvents"))
+    if ((histogram_name.Contains("fHistXsection") || histogram_name.Contains("fHistTrials") || histogram_name.Contains("fHistEvents")) && (!histogram_name.Contains("PtHard")))
     {
       AliInfoStream() << "Histogram " << listObject->GetName() << " will not be scaled, because a scaling histogram" << std::endl;
       continue;

--- a/PWG/EMCAL/EMCALbase/AliEmcalList.h
+++ b/PWG/EMCAL/EMCALbase/AliEmcalList.h
@@ -97,6 +97,18 @@ public:
    */
   void                        SetNameTrials(const char *name) { fNameNTrials = name; }
 
+  /**
+   * @brief Get name of the cross section histogram for weighting
+   * @return Name of the cross section histogram
+   */
+  const TString &             GetNameXsec() const { return fNameXsec; }
+
+  /**
+   * @brief Get name of the histogram with the number of trials for weighting
+   * @return Name of the histogram with the number of trials 
+   */
+  const TString &             GetNameTrials() const { return fNameNTrials; }
+
 private:
   // ####### Helper functions
 


### PR DESCRIPTION
Exclude historgrams with tag "PtHard" from list of
scaling histograms (affects only tasks based on
AliAnalysisTaskEmcalLight. Also add getters for
the scaling histogram names for user access.