### PR TITLE
Draw L1 mask and fix double delete

### DIFF
--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMaskHandlerOCDB.cxx
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMaskHandlerOCDB.cxx
@@ -115,7 +115,7 @@ std::vector<int> AliEmcalTriggerMaskHandlerOCDB::GetMaskedFastorIndicesL1(int ru
     for(int ichannel = 0; ichannel < 96; ichannel++) {
       int absfastor;
       geo->GetTriggerMapping()->GetAbsFastORIndexFromTRU(truID, ichannel, absfastor);
-      if(std::find(maskedfastors.begin(), maskedfastors.end(), absfastor)  != maskedfastors.end()) maskedfastors.push_back(absfastor);
+      if(std::find(maskedfastors.begin(), maskedfastors.end(), absfastor) == maskedfastors.end()) maskedfastors.push_back(absfastor);
     }
   }
 

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMaskHandlerOCDB.cxx
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMaskHandlerOCDB.cxx
@@ -213,7 +213,9 @@ AliEMCALGeometry *AliEmcalTriggerMaskHandlerOCDB::GetGeometry(int runnumber) {
 }
 
 void AliEmcalTriggerMaskHandlerOCDB::ClearCache() {
-  if(fCurrentConfig) delete fCurrentConfig;
+  // In general the handler is non-owning, therefore
+  // we do not delete the object but rahther just set
+  // the pointer to nullptr.
   fCurrentConfig = nullptr;
   fCurrentRunnumber = -1;
 }
@@ -381,7 +383,7 @@ void AliEmcalTriggerMaskHandlerOCDB::drawRun2Frame(){
   }
 }
 
-void AliEmcalTriggerMaskHandlerOCDB::drawL0MaskFromCVMFS(int runnumber) {
+void AliEmcalTriggerMaskHandlerOCDB::drawMaskFromCVMFS(int runnumber, bool isLevel1) {
   if(gSystem->AccessPathName("/cvmfs/alice-ocdb.cern.ch/calibration/data", kReadPermission )) {
     Error("PWG::EMCAL::drawMappingFromCVMFS", "cvmfs repository alice-ocdb.cern.ch needs to be mounted on the system");
     return;
@@ -413,7 +415,7 @@ void AliEmcalTriggerMaskHandlerOCDB::drawL0MaskFromCVMFS(int runnumber) {
 
   AliCDBManager *cdb = AliCDBManager::Instance();
   cdb->SetDefaultStorage(Form("local:///cvmfs/alice-ocdb.cern.ch/calibration/data/%d/OCDB", year));
-  auto maskhist = MonitorMaskedFastORsL0(runnumber);
+  auto maskhist = isLevel1 ? MonitorMaskedFastORsL1(runnumber) : MonitorMaskedFastORsL0(runnumber);
   maskhist->SetDirectory(nullptr);
   maskhist->SetStats(false);
   maskhist->SetXTitle("col (#eta)");

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMaskHandlerOCDB.h
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMaskHandlerOCDB.h
@@ -305,7 +305,22 @@ public:
    * number must be a valid physics run. Stand-alone runs or 
    * technical runs are not guaranteed.
    */
-  void drawL0MaskFromCVMFS(int runnumber);
+  void drawL0MaskFromCVMFS(int runnumber) { drawMaskFromCVMFS(runnumber, false); }
+
+  /**
+   * @brief Draw L1 trigger mask from DCS config in cvmfs OCDB
+   * @param runnumber Run number for which to draw trigger mapping
+   * 
+   * Creating plot with the mask channels at L1 in eta-phi space.
+   * For easier reading, a frame is highlighting supermodules,
+   * TRUs and FastORs. In case a canvas exists, this canvas is used
+   * for plotting, otherwise a new canvas is created. 
+   * 
+   * Attention: Access to the OCDB on cvmfs is requested. The run
+   * number must be a valid physics run. Stand-alone runs or 
+   * technical runs are not guaranteed.
+   */
+  void drawL1MaskFromCVMFS(int runnumber) { drawMaskFromCVMFS(runnumber, true); }
 
 private:
   /**
@@ -399,6 +414,16 @@ private:
    * intermediate size lines mark TRUs within supermodules and big lines supermodules.
    */
   void drawRun2Frame();
+
+  /**
+   * @brief Draw trigger mask at L0 or L1 for a given run number using the OCDB on cvmfs
+   * @param runnumber Run number 
+   * @param isLevel1 If true the mask is shown at L0, otherwise at L1
+   * 
+   * Helper function creating the monitoring plots of the trigger mask at L0 or at L1, 
+   * used in drawL0MaskFromCVMFS and drawL1MaskFromCVMFS
+   */
+  void drawMaskFromCVMFS(int runnumber, bool isLevel1);
 
 
   Int_t fCurrentRunnumber;                  //!<! Current run number of cache


### PR DESCRIPTION
- Add draw funtion for mask at L1 similar to the draw
  function for the mask at L0
- Don't delete the cache object, just set the pointer to
  nullptr, because the handler does not have
  ownership of the OCDB entry of the DCS config