### PR TITLE
Add vertex recalculation to AliRDHFCutsKFP

### DIFF
--- a/PWGHF/vertexingHF/AliRDHFCutsKFP.cxx
+++ b/PWGHF/vertexingHF/AliRDHFCutsKFP.cxx
@@ -422,7 +422,7 @@ void AliRDHFCutsKFP::GetCutVarsForOpt(AliAODRecoDecayHF *d, Float_t *vars, Int_t
   return;
 }
 //---------------------------------------------------------------------------
-Int_t AliRDHFCutsKFP::IsSelected(TObject* obj,Int_t selectionLevel) 
+Int_t AliRDHFCutsKFP::IsSelected(TObject* obj,Int_t selectionLevel, AliAODEvent *aod) 
 {
   //
   // Apply selection
@@ -463,7 +463,7 @@ Int_t AliRDHFCutsKFP::IsSelected(TObject* obj,Int_t selectionLevel)
     Bool_t cleanvtx = kFALSE;
     AliAODVertex *origownvtx = 0x0;
     if(fRemoveDaughtersFromPrimary && aod) {
-       if(d->GetOwnPrimaryVtx()) origownvtx = new ALiAODVertex(*d->GetOwnPrimaryVtx());
+       if(d->GetOwnPrimaryVtx()) origownvtx = new AliAODVertex(*d->GetOwnPrimaryVtx());
        cleanvtx = kTRUE;
        if(!RecalcOwnPrimaryVtx(d,aod)) {
           CleanOwnPrimaryVtx(d,aod,origownvtx);
@@ -535,6 +535,7 @@ Int_t AliRDHFCutsKFP::IsSelected(TObject* obj,Int_t selectionLevel)
       return 0;
     }
     returnvalueCuts = 1;
+    if(cleanvtx) CleanOwnPrimaryVtx(d,aod,origownvtx);
   }
 
   Int_t returnvaluePID=1;
@@ -555,7 +556,6 @@ Int_t AliRDHFCutsKFP::IsSelected(TObject* obj,Int_t selectionLevel)
   Int_t returnvalue = 0;
   if(returnvalueCuts==1 && returnvaluePID==1) returnvalue=1;
 
-  if(cleanvtx) CleanOwnPrimaryVtx(d,aod,origownvtx);
   return returnvalue;
 }
 

--- a/PWGHF/vertexingHF/AliRDHFCutsKFP.cxx
+++ b/PWGHF/vertexingHF/AliRDHFCutsKFP.cxx
@@ -325,7 +325,7 @@ AliRDHFCutsKFP::~AliRDHFCutsKFP() {
 }
 
 //---------------------------------------------------------------------------
-void AliRDHFCutsKFP::GetCutVarsForOpt(AliAODRecoDecayHF *d, Float_t *vars, Int_t nvars, Int_t *pdgdaughters) {
+void AliRDHFCutsKFP::GetCutVarsForOpt(AliAODRecoDecayHF *d, Float_t *vars, Int_t nvars, Int_t *pdgdaughters, AliAODEvent *aod) {
   //
   // Fills in vars the values of the variables
   //
@@ -342,6 +342,20 @@ void AliRDHFCutsKFP::GetCutVarsForOpt(AliAODRecoDecayHF *d, Float_t *vars, Int_t
     AliError("AliRDHFCutsKFP wrong number of variables\n");
     return;
   }
+
+  Bool_t cleanvtx = kFALSE;
+  AliAODVertex *origownvtx = 0x0;
+  if(fRemoveDaughtersFromPrimary && aod) {
+     if (dd->GetOwnPrimaryVtx()) origownvtx = new AliAODVertex(*dd->GetOwnPrimaryVtx());
+     cleanvtx = kTRUE;
+     if(!RecalcOwnPrimaryVtx(dd,aod)) {
+         CleanOwnPrimaryVtx(dd,aod,origownvtx);
+         cleanvtx = kFALSE;
+     }
+  }
+
+  
+
 
   //Double_t ptD=d->Pt();
   //Int_t ptbin=PtBin(ptD);
@@ -404,7 +418,7 @@ void AliRDHFCutsKFP::GetCutVarsForOpt(AliAODRecoDecayHF *d, Float_t *vars, Int_t
     iter++;
     vars[iter]= dd->PtProng(0);
   }
-
+  if(cleanvtx) CleanOwnPrimaryVtx(dd,aod,origownvtx);
   return;
 }
 //---------------------------------------------------------------------------
@@ -445,6 +459,18 @@ Int_t AliRDHFCutsKFP::IsSelected(TObject* obj,Int_t selectionLevel)
       return 0;
     }
     Bool_t okcand=kTRUE;
+
+    Bool_t cleanvtx = kFALSE;
+    AliAODVertex *origownvtx = 0x0;
+    if(fRemoveDaughtersFromPrimary && aod) {
+       if(d->GetOwnPrimaryVtx()) origownvtx = new ALiAODVertex(*d->GetOwnPrimaryVtx());
+       cleanvtx = kTRUE;
+       if(!RecalcOwnPrimaryVtx(d,aod)) {
+          CleanOwnPrimaryVtx(d,aod,origownvtx);
+          cleanvtx = kFALSE;
+          return 0;
+       }
+    }
 
     Double_t mLPDG =  TDatabasePDG::Instance()->GetParticle(3122)->Mass();
     Double_t mxiPDG =  TDatabasePDG::Instance()->GetParticle(3312)->Mass();
@@ -504,7 +530,10 @@ Int_t AliRDHFCutsKFP::IsSelected(TObject* obj,Int_t selectionLevel)
 	okcand = kFALSE;
       }
 
-    if(!okcand)  return 0;
+    if(!okcand) { 
+      if(cleanvtx) CleanOwnPrimaryVtx(d,aod,origownvtx);
+      return 0;
+    }
     returnvalueCuts = 1;
   }
 
@@ -526,6 +555,7 @@ Int_t AliRDHFCutsKFP::IsSelected(TObject* obj,Int_t selectionLevel)
   Int_t returnvalue = 0;
   if(returnvalueCuts==1 && returnvaluePID==1) returnvalue=1;
 
+  if(cleanvtx) CleanOwnPrimaryVtx(d,aod,origownvtx);
   return returnvalue;
 }
 

--- a/PWGHF/vertexingHF/AliRDHFCutsKFP.h
+++ b/PWGHF/vertexingHF/AliRDHFCutsKFP.h
@@ -30,10 +30,10 @@ class AliRDHFCutsKFP : public AliRDHFCuts
   AliRDHFCutsKFP& operator=(const AliRDHFCutsKFP& source);
 
   using AliRDHFCuts::GetCutVarsForOpt;
-  virtual void GetCutVarsForOpt(AliAODRecoDecayHF *d,Float_t *vars,Int_t nvars,Int_t *pdgdaughters);
+  virtual void GetCutVarsForOpt(AliAODRecoDecayHF *d,Float_t *vars,Int_t nvars,Int_t *pdgdaughters, AliAODEvent *aod);
 
   using AliRDHFCuts::IsSelected;
-  virtual Int_t IsSelected(TObject* obj,Int_t selectionLevel);
+  virtual Int_t IsSelected(TObject* obj,Int_t selectionLevel, AliAODEvent* aod);
   using AliRDHFCuts::IsSelectedPID;
   virtual Int_t IsSelectedPID(AliAODRecoDecayHF* obj);
   Int_t IsSelectedCombinedPID(AliAODRecoDecayHF* obj);

--- a/PWGHF/vertexingHF/AliRDHFCutsKFP.h
+++ b/PWGHF/vertexingHF/AliRDHFCutsKFP.h
@@ -30,9 +30,13 @@ class AliRDHFCutsKFP : public AliRDHFCuts
   AliRDHFCutsKFP& operator=(const AliRDHFCutsKFP& source);
 
   using AliRDHFCuts::GetCutVarsForOpt;
+  virtual void GetCutVarsForOpt(AliAODRecoDecayHF *d,Float_t *vars,Int_t nvars,Int_t *pdgdaughters) {
+                           return GetCutVarsForOpt(d,vars,nvars,pdgdaughters,0x0); }
   virtual void GetCutVarsForOpt(AliAODRecoDecayHF *d,Float_t *vars,Int_t nvars,Int_t *pdgdaughters, AliAODEvent *aod);
 
   using AliRDHFCuts::IsSelected;
+  virtual Int_t IsSelected(TObject* obj,Int_t selectionLevel)
+                        {return IsSelected(obj,selectionLevel,0);}
   virtual Int_t IsSelected(TObject* obj,Int_t selectionLevel, AliAODEvent* aod);
   using AliRDHFCuts::IsSelectedPID;
   virtual Int_t IsSelectedPID(AliAODRecoDecayHF* obj);
@@ -228,39 +232,39 @@ class AliRDHFCutsKFP : public AliRDHFCuts
 
   EPIDStrategy fPIDStrategy;        /// PID Strategy
   Double_t fCombinedPIDThreshold;   /// PID threshold used in IsSelectedCombinedPID
+  Bool_t fUseLcPID;                   /// Use PID or not for Lc
   Bool_t fUseXic0PID;                 /// Use PID or not for Xic0
   Bool_t fUseXicPlusPID;              /// Use PID or not for XicPlus
-  Bool_t fUseLcPID;                   /// Use PID or not for Lc
   AliAODPidHF *fPidObjDau;              /// PID object for all daughter tracks
-  AliAODPidHF *fPidObjPiFromXic0;       /// PID object for Xic0-pion
   AliAODPidHF *fPidObjPiFromXicPlus;    /// PID object for XicPlus-pion
+  AliAODPidHF *fPidObjPiFromXic0;       /// PID object for Xic0-pion
   AliAODPidHF *fPidObjPiFromXi;         /// PID object for cascade-pion
   AliAODPidHF *fPidObjPrFromV0;         /// PID object for V0-proton
   AliAODPidHF *fPidObjPiFromV0;         /// PID object for V0-pion
 
   Double_t fPtMinLc;                 /// Minimum pT of Lc
   Double_t fPtMinPrFromLc;           /// Minimum pT of proton from Lc decay
-  Double_t fPtMinPiFromLc;           /// Minimum pT of pion from Lc decay
   Double_t fPtMinXic0;               /// Minimum pT of Xic0
-  Double_t fPtMinXicPlus;            /// Minimum pT of XicPlus
   Double_t fPtMinPiFromXic0;         /// Minimum Bachelor pT of pion from Xic0 decay
-  Double_t fPtMinPiFromXicPlus;      /// Minimum Bachelor pT of pion from XicPlus decay
   Double_t fPtMinPiFromXi;         /// Minimum Bachelor pT of pion from Xi decay
+  Double_t fPtMinPiFromLc;           /// Minimum pT of pion from Lc decay
+  Double_t fPtMinXicPlus;            /// Minimum pT of XicPlus
+  Double_t fPtMinPiFromXicPlus;      /// Minimum Bachelor pT of pion from XicPlus decay
   Double_t fProdTrackEtaRange;      /// Bachelor Eta range
   Bool_t   fProdUseAODFilterBit;    /// Use AODfilterBit or not
   Double_t fProdMassTolLc;          /// Tolerance of Lc mass from PDG value
-  Double_t fProdMassTolLambda;      /// Tolerance of Lambda mass from PDG value
-  Double_t fProdMassRejLambda;      /// Rejection of Lambda mass from PDG value
   Double_t fProdMassTolKs0;         /// Tolerance of Ks0 mass from PDG value
-  Double_t fProdMassRejKs0;         /// Rejection of Ks0 mass from PDG value
+  Double_t fProdMassTolLambda;      /// Tolerance of Lambda mass from PDG value
   Double_t fProdMassTolXi;          /// Tolerance of Xi mass from PDG value
   Double_t fProdMassTolXic0;        /// Tolerance of Xic0 mass from PDG value
-  Double_t fProdMassTolXicPlus;     /// Tolerance of XicPlus mass from PDG value
   Double_t fProdRfidMinV0;          /// Minimum Decay vertex of V0
   Double_t fProdRfidMaxV0;          /// Max Decay vertex of V0
   Double_t fProdRfidMinXi;          /// Minimum Decay vertex of Xi
   Double_t fProdRfidMaxXi;          /// Max Decay vertex of Xi
   Double_t fProdCascProperDecayLengthMax;        /// mL/p of cascade
+  Double_t fProdMassRejLambda;      /// Rejection of Lambda mass from PDG value
+  Double_t fProdMassRejKs0;         /// Rejection of Ks0 mass from PDG value
+  Double_t fProdMassTolXicPlus;     /// Tolerance of XicPlus mass from PDG value
   Double_t fProdDcaXiDaughtersMax;  /// Max Dca between Xi daughters
   Double_t fProdDcaV0DaughtersMax;  /// Max Dca between V0 daughters
   Double_t fProdDcaBachToPrimVertexMin;  /// Min Dca between Bachelor and PV


### PR DESCRIPTION
add functionality to AliRDHFCutsKFP to exclude daughter tracks from primary vertex