### PR TITLE
PWGGA/GammaConv: Fixed output for JJ MC-Events in my Analysis

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskGammaCaloMergedML.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaCaloMergedML.cxx
@@ -1645,21 +1645,21 @@ void AliAnalysisTaskGammaCaloMergedML::UserCreateOutputObjects(){
 
   Int_t nContainerOutput = 2;
   for(Int_t iCut=0; iCut<fnCuts; iCut++){
-    if(fIsMC==1){
+    if(fIsMC>0){
       OpenFile(nContainerOutput);
       PostData(nContainerOutput, tTrueMergedCaloClusterPi0[iCut]);
     }
     nContainerOutput++;
   }
   for(Int_t iCut=0; iCut<fnCuts; iCut++){
-    if(fIsMC==1){
+    if(fIsMC>0){
       OpenFile(nContainerOutput);
       PostData(nContainerOutput, tTrueMergedCaloClusterEta[iCut]);
     }
     nContainerOutput++;
   }
   for(Int_t iCut=0; iCut<fnCuts; iCut++){
-    if(fIsMC==1){
+    if(fIsMC>0){
       OpenFile(nContainerOutput);
       PostData(nContainerOutput, tTrueMergedCaloClusterBck[iCut]);
     }


### PR DESCRIPTION
The trees of my analysis will now also be connected to the output for JJ MC-events, which was previously not the case.