### PR TITLE
Add option to treat Pi0s as stable particles

### DIFF
--- a/PWG/EMCAL/EMCALtasks/AliEmcalMCTrackSelector.h
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalMCTrackSelector.h
@@ -99,6 +99,18 @@ class AliEmcalMCTrackSelector : public AliAnalysisTaskSE {
    */
   void SetRejectPhotonMother(bool doReject)             { fRejectPhotonMothers = doReject; }
 
+  /**
+   * @brief Make Pi0 stable
+   * 
+   * Select Pi0 as stable (physical primary) particle, and reject particles where 
+   * an ancestor in the decay chain is a pi0. Ancestor is usually the mother, however
+   * in order to drop conversions of photons from pi0 to electrons any particle in the 
+   * decay chain is checked.
+   * 
+   * @param doSelect If true Pi0s are selected as primary particles and their daughters are rejected
+   */
+  void SelectStablePi0(bool doSelect)                   { fSelectStablePi0 = doSelect; }
+
   void SetOnlyHIJING(Bool_t s)                          { fOnlyHIJING       = s    ; }
 
   /**
@@ -175,6 +187,14 @@ class AliEmcalMCTrackSelector : public AliAnalysisTaskSE {
    * @param partMap Index map between particles in input and output container
    */
   void                      CopyMCParticles(TClonesArray* partIn, TClonesArray* partOut, AliNamedArrayI* partMap=0);
+
+  /**
+   * @brief Recursive check if the mother or another ancestor is a Pi0
+   * 
+   * @param part Particle to be checked
+   * @return True if any ancestor is a pi0, false otherwise
+   */
+  bool                      IsFromPi0Mother(const AliVParticle &part) const;
   
   
   TString                   fParticlesOutName;     ///< name of output particle array
@@ -183,6 +203,7 @@ class AliEmcalMCTrackSelector : public AliAnalysisTaskSE {
   Bool_t                    fChargedMC;            ///< true = only charged particles
   Bool_t                    fOnlyHIJING;           ///< true = only HIJING particles
   Bool_t                    fRejectPhotonMothers;  ///< Reject photons that are mothers of other photons
+  Bool_t                    fSelectStablePi0;      ///< Select Pi0 as stable particle, and reject daughters of Pi0 in case they are physical primary
   Double_t                  fEtaMax;               ///< maximum eta to accept particles
   TString                   fParticlesMapName;     //!<! name of the particle map
   Bool_t                    fInit;                 //!<! true = task initialized
@@ -198,6 +219,6 @@ class AliEmcalMCTrackSelector : public AliAnalysisTaskSE {
   AliEmcalMCTrackSelector(const AliEmcalMCTrackSelector&);            // not implemented
   AliEmcalMCTrackSelector &operator=(const AliEmcalMCTrackSelector&); // not implemented
 
-  ClassDef(AliEmcalMCTrackSelector, 5); 
+  ClassDef(AliEmcalMCTrackSelector, 6); 
 };
 #endif

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetEnergyScale.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetEnergyScale.cxx
@@ -33,6 +33,7 @@
 #include <TCustomBinning.h>
 #include <TLinearBinning.h>
 #include <TCustomBinning.h>
+#include <TPDGCode.h>
 #include <TRandom.h>
 
 #include "AliAODInputHandler.h"
@@ -212,6 +213,9 @@ void AliAnalysisTaskEmcalJetEnergyScale::UserCreateOutputObjects(){
   fHistos->CreateTH2("hQAClusterM02VsE", "Cluster M02 vs energy; M02; E (GeV)", 150, 0., 1.5, 200, 0., 200.);
   fHistos->CreateTH2("hQAClusterFracLeadingVsE", "Cluster frac leading cell vs energy; E (GeV); Frac. leading cell", 200, 0., 200., 110, 0., 1.1);
   fHistos->CreateTH2("hQAClusterFracLeadingVsNcell", "Cluster frac leading cell vs number of cells; Number of cells; Frac. leading cell", 201, -0.5, 200.5, 110, 0., 1.1);
+  fHistos->CreateTH1("hPartConstPi0", "Particle-level consitutent spectrum of pi0 constituents", 200, 0., 200.);
+  fHistos->CreateTH1("hPartConstK0s", "Particle-level consitutent spectrum of K0 constituents", 200, 0., 200.);
+  fHistos->CreateTH1("hPartConstPhoton", "Particle-level consitutent spectrum of photon constituents", 200, 0., 200.);
   fHistos->CreateTH1("hFracPtHardPart", "Part. level jet Pt relative to the Pt-hard of the event", 100, 0., 10.);
   fHistos->CreateTH1("hFracPtHardDet", "Det. level jet Pt relative to the Pt-hard of the event", 100, 0., 10.);
   if(fDebugMaxJetOutliers) {
@@ -491,6 +495,15 @@ Bool_t AliAnalysisTaskEmcalJetEnergyScale::Run(){
   // efficiency x acceptance: Add histos for all accepted and reconstucted accepted jets
   for(auto partjet : partjets->accepted()){
     fHistos->FillTH1("hJetSpectrumPartAll", partjet->Pt());
+    for(auto itrk = 0; itrk < partjet->GetNumberOfTracks(); itrk++) {
+      auto constituent = partjet->Track(itrk);
+      switch(TMath::Abs(constituent->PdgCode())) {
+      case kPi0: fHistos->FillTH1("hPartConstPi0", constituent->Pt()); break;
+      case kK0Short: fHistos->FillTH1("hPartConstK0s", constituent->Pt()); break;
+      case kGamma: fHistos->FillTH1("hPartConstPhoton", constituent->Pt()); break;
+      default: break;
+      };
+    }
     auto detjet = partjet->ClosestJet();
     int tagstatus = 0;
     if(detjet) {

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalSoftDropResponse.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalSoftDropResponse.cxx
@@ -1428,7 +1428,7 @@ void AliAnalysisTaskEmcalSoftDropResponse::FillJetQA(const AliEmcalJet &jet, boo
       auto cluster = jet.Cluster(icl);
       TLorentzVector clustervec;
       cluster->GetMomentum(clustervec, fVertex, energydef);
-      TVector3 clustervec3(clustervec.Pt(), clustervec.Eta(), clustervec.Phi());
+      TVector3 clustervec3(clustervec.Px(), clustervec.Py(), clustervec.Pz());
       fHistManager.FillTH2("hSDUsedNeutralPtjvPtcDet", jet.Pt(), clustervec.Pt());
       fHistManager.FillTH2("hSDUsedNeutralEtaPhiDet", clustervec.Eta(), TVector2::Phi_0_2pi(clustervec.Phi()));
       fHistManager.FillTH2("hSDUsedNeutralDRDet", jet.Pt(), jetvec.DeltaR(clustervec3));
@@ -1460,9 +1460,9 @@ void AliAnalysisTaskEmcalSoftDropResponse::FillJetQA(const AliEmcalJet &jet, boo
   }
 
   if(hasMaxNeutral) {
-    fHistManager.FillTH2("hSDUsedNeutralPtjvPcMaxPart", jet.Pt(), maxneutral.Pt());
-    fHistManager.FillTH2("hSDUsedNeutralEtaPhiMaxPart", maxneutral.Eta(), TVector2::Phi_0_2pi(maxneutral.Phi()));
-    fHistManager.FillTH2("hSDUsedNeutralDRMaxPart", jet.Pt(), jetvec.DeltaR(maxneutral));
+    fHistManager.FillTH2(Form("hSDUsedNeutralPtjvPcMax%s", tag.data()), jet.Pt(), maxneutral.Pt());
+    fHistManager.FillTH2(Form("hSDUsedNeutralEtaPhiMax%s", tag.data()), maxneutral.Eta(), TVector2::Phi_0_2pi(maxneutral.Phi()));
+    fHistManager.FillTH2(Form("hSDUsedNeutralDRMax%s", tag.data()), jet.Pt(), jetvec.DeltaR(maxneutral));
   }
 }
 

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalSoftDropResponse.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalSoftDropResponse.cxx
@@ -36,6 +36,7 @@
 #include <TH2.h>
 #include <TLinearBinning.h>
 #include <TLorentzVector.h>
+#include <TPDGCode.h>
 #include <TRandom.h>
 
 
@@ -617,6 +618,9 @@ void AliAnalysisTaskEmcalSoftDropResponse::UserCreateOutputObjects()
     fHistManager.CreateTH2("hSDUsedChargedDRMaxDet", "#DeltaR vs. p_{t,jet} for tracks used in SD (det. level); p_{t,jet}; #DeltaR", 350, 0., 350., 100, 0., 1.);
     fHistManager.CreateTH2("hSDUsedNeutralDRMaxPart", "#DeltaR vs. p_{t,jet} for clusters used in SD (part. level); p_{t,jet}; #DeltaR", 350, 0., 350., 100, 0., 1.);
     fHistManager.CreateTH2("hSDUsedNeutralDRMaxDet", "#DeltaR vs. p_{t,jet} for clusters used in SD (det. level); p_{t,jet}; #DeltaR", 350, 0., 350., 100, 0., 1.);
+    fHistManager.CreateTH1("hPartConstPi0", "Particle-level consitutent spectrum of pi0 constituents", 200, 0., 200.);
+    fHistManager.CreateTH1("hPartConstK0s", "Particle-level consitutent spectrum of K0 constituents", 200, 0., 200.);
+    fHistManager.CreateTH1("hPartConstPhoton", "Particle-level consitutent spectrum of photon constituents", 200, 0., 200.);
     // Cluster constituent QA
     fHistManager.CreateTH2("hSDUsedClusterTimeVsE", "Cluster time vs. energy; time (ns); E (GeV)", 1200, -600, 600, 200, 0., 200);
     fHistManager.CreateTH2("hSDUsedClusterTimeVsEFine", "Cluster time vs. energy (main region); time (ns); E (GeV)", 1000, -100, 100, 200, 0., 200);
@@ -1279,6 +1283,15 @@ bool AliAnalysisTaskEmcalSoftDropResponse::Run()
   // this is of relevance for the jet finding efficiency
   if(fForceBeamType == kpp){
     for(auto partjet : partLevelJets->accepted()){
+      for(auto itrk = 0; itrk < partjet->GetNumberOfTracks(); itrk++) {
+        auto constituent = partjet->Track(itrk);
+        switch(TMath::Abs(constituent->PdgCode())) {
+        case kPi0: fHistManager.FillTH1("hPartConstPi0", constituent->Pt()); break;
+        case kK0Short: fHistManager.FillTH1("hPartConstK0s", constituent->Pt()); break;
+        case kGamma: fHistManager.FillTH1("hPartConstPhoton", constituent->Pt()); break;
+        default: break;
+        };
+      }
       SoftdropResults softdropPart, softdropDet;
       std::vector<SoftdropResults> splittingsPart, splittingsDet;
       try{


### PR DESCRIPTION
- Add phys. primary flag for pi0 and remove phys.
  primary flag of daughter particles in MC track
  selector
- Add monitoring histograms for Pi0, K0s and gamma
   in response matrix tasks (pp-only)