### PR TITLE
PWGGA/GammaConv: OmegaToPiZeroGamma - Added Cluster Cut Variations

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskOmegaToPiZeroGamma.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskOmegaToPiZeroGamma.cxx
@@ -846,7 +846,7 @@ void AliAnalysisTaskOmegaToPiZeroGamma::UserCreateOutputObjects(){
       }
     }
 
-    fHistoPhotonPairInvMassPt[iCut]             = new TH2F("ESD_PhotonPair_InvMass_Pt","ESD_PhotonPair_InvMass_Pt",300,0,0.3,200,0.,20.);
+    fHistoPhotonPairInvMassPt[iCut]             = new TH2F("ESD_PhotonPair_InvMass_Pt","ESD_PhotonPair_InvMass_Pt",300,0,0.3,300,0.,30.);
     fHistoPhotonPairInvMassPt[iCut]->SetXTitle("M_{inv, #pi^{0} cand}(GeV/c^{2})");
     fHistoPhotonPairInvMassPt[iCut]->SetYTitle("p_{T, #pi^{0} cand}(GeV/c)");
     fESDList[iCut]->Add(fHistoPhotonPairInvMassPt[iCut]);
@@ -875,7 +875,7 @@ void AliAnalysisTaskOmegaToPiZeroGamma::UserCreateOutputObjects(){
     }
 
     if(fReconMethod<2){
-      fHistoPhotonPairMatchedInvMassPt[iCut]      = new TH2F("ESD_PhotonPair_Matched_InvMass_Pt","ESD_PhotonPair_Matched_InvMass_Pt",300,0,0.3,200,0.,20.);
+      fHistoPhotonPairMatchedInvMassPt[iCut]      = new TH2F("ESD_PhotonPair_Matched_InvMass_Pt","ESD_PhotonPair_Matched_InvMass_Pt",300,0,0.3,300,0.,30.);
       fHistoPhotonPairMatchedInvMassPt[iCut]->SetXTitle("M_{inv}(GeV/c^{2}) matched conv e^{+/-}to cluster");
       fHistoPhotonPairMatchedInvMassPt[iCut]->SetYTitle("p_{T}(GeV/c)");
       fESDList[iCut]->Add(fHistoPhotonPairMatchedInvMassPt[iCut]);
@@ -889,7 +889,7 @@ void AliAnalysisTaskOmegaToPiZeroGamma::UserCreateOutputObjects(){
 
       if( ( ( (AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->DoGammaSwappForBg() ) == 2 )
       {
-        fHistoPi0SwappingBackInvMassPt[iCut]     = new TH2F("ESD_Pi0_SwappingBack_InvMass_Pt","ESD_Pi0_SwappingBack_InvMass_Pt", 300, 0.0, 0.3, 200, 0., 20.);
+        fHistoPi0SwappingBackInvMassPt[iCut]     = new TH2F("ESD_Pi0_SwappingBack_InvMass_Pt","ESD_Pi0_SwappingBack_InvMass_Pt", 300, 0.0, 0.3, 300,0.,30.);
         fHistoPi0SwappingBackInvMassPt[iCut]->SetXTitle("M_{inv}(GeV/c^{2})");
         fHistoPi0SwappingBackInvMassPt[iCut]->SetYTitle("p_{T}(GeV/c)");
         fESDList[iCut]->Add(fHistoPi0SwappingBackInvMassPt[iCut]);
@@ -931,7 +931,7 @@ void AliAnalysisTaskOmegaToPiZeroGamma::UserCreateOutputObjects(){
 
     if(!fDoLightOutput){
       if(fDoMesonQA & 0b00000001) {
-        fHistoPhotonPairYPt[iCut]              = new TH2F("ESD_PhotonPair_Y_Pt","ESD_PhotonPair_Y_Pt",200,0.03,20.,150,-1.5,1.5);
+        fHistoPhotonPairYPt[iCut]              = new TH2F("ESD_PhotonPair_Y_Pt","ESD_PhotonPair_Y_Pt",300,0.03,30.,150,-1.5,1.5);
         fHistoPhotonPairYPt[iCut]->SetXTitle("p_{T, #pi^{0}cand}(GeV/c)");
         fHistoPhotonPairYPt[iCut]->SetYTitle("y_{#pi^{0}cand}");
         SetLogBinningXTH2(fHistoPhotonPairYPt[iCut]);
@@ -943,7 +943,7 @@ void AliAnalysisTaskOmegaToPiZeroGamma::UserCreateOutputObjects(){
         fESDList[iCut]->Add(fHistoMotherYPt[iCut]);
       }
       if(fDoMesonQA & 0b00000010) {
-        fHistoPhotonPairAlphaPt[iCut]          = new TH2F("ESD_PhotonPair_Alpha_Pt","ESD_PhotonPair_Alpha_Pt",200,0.03,20.,200,-1,1);
+        fHistoPhotonPairAlphaPt[iCut]          = new TH2F("ESD_PhotonPair_Alpha_Pt","ESD_PhotonPair_Alpha_Pt",300,0.03,30.,200,-1,1);
         fHistoPhotonPairAlphaPt[iCut]->SetXTitle("p_{T, #pi^{0}cand}(GeV/c)");
         fHistoPhotonPairAlphaPt[iCut]->SetYTitle("#alpha_{#pi^{0}cand}");
         SetLogBinningXTH2(fHistoPhotonPairAlphaPt[iCut]);
@@ -955,7 +955,7 @@ void AliAnalysisTaskOmegaToPiZeroGamma::UserCreateOutputObjects(){
         fESDList[iCut]->Add(fHistoMotherAlphaPt[iCut]);
       }
       if(fDoMesonQA & 0b00000100) {
-        fHistoPhotonPairOpenAnglePt[iCut]      = new TH2F("ESD_PhotonPair_OpenAngle_Pt","ESD_PhotonPair_OpenAngle_Pt",200,0.03,20.,100,0,1);
+        fHistoPhotonPairOpenAnglePt[iCut]      = new TH2F("ESD_PhotonPair_OpenAngle_Pt","ESD_PhotonPair_OpenAngle_Pt",300,0.03,30.,100,0,1);
         fHistoPhotonPairOpenAnglePt[iCut]->SetXTitle("p_{T, #pi^{0}cand}(GeV/c)");
         fHistoPhotonPairOpenAnglePt[iCut]->SetYTitle("#theta_{#pi^{0}cand}");
         SetLogBinningXTH2(fHistoPhotonPairOpenAnglePt[iCut]);
@@ -1295,12 +1295,12 @@ void AliAnalysisTaskOmegaToPiZeroGamma::UserCreateOutputObjects(){
           fHistoMCOmegaInAccYPt[iCut]->SetYTitle("Y_{#omega}");
           fMCList[iCut]->Add(fHistoMCOmegaInAccYPt[iCut]);
 
-          fHistoMCPi0FromAllOmegaYPt[iCut] = new TH2F("MC_Pi0FromAllOmega_Y_Pt","MC_Pi0FromAllOmega_Y_Pt",200,0,20,150,-1.5,1.5);
+          fHistoMCPi0FromAllOmegaYPt[iCut] = new TH2F("MC_Pi0FromAllOmega_Y_Pt","MC_Pi0FromAllOmega_Y_Pt",300,0,30,150,-1.5,1.5);
           fHistoMCPi0FromAllOmegaYPt[iCut]->SetXTitle("p_{T,#pi^{0}}(GeV/c)");
           fHistoMCPi0FromAllOmegaYPt[iCut]->SetYTitle("Y_{#pi^{0}}");
           fMCList[iCut]->Add(fHistoMCPi0FromAllOmegaYPt[iCut]);
 
-          fHistoMCPi0FromOmegaInAccYPt[iCut] = new TH2F("MC_Pi0FromOmegaInAcc_Y_Pt","MC_Pi0FromOmegaInAcc_Y_Pt",200,0,20,150,-1.5,1.5);
+          fHistoMCPi0FromOmegaInAccYPt[iCut] = new TH2F("MC_Pi0FromOmegaInAcc_Y_Pt","MC_Pi0FromOmegaInAcc_Y_Pt",300,0,30,150,-1.5,1.5);
           fHistoMCPi0FromOmegaInAccYPt[iCut]->SetXTitle("p_{T,#pi^{0}}(GeV/c)");
           fHistoMCPi0FromOmegaInAccYPt[iCut]->SetYTitle("Y_{#pi^{0}}");
           fMCList[iCut]->Add(fHistoMCPi0FromOmegaInAccYPt[iCut]);
@@ -1322,12 +1322,12 @@ void AliAnalysisTaskOmegaToPiZeroGamma::UserCreateOutputObjects(){
           fHistoMCOmegaInAccAlphaPt[iCut]->SetYTitle("#alpha_{#omega}");
           fMCList[iCut]->Add(fHistoMCOmegaInAccAlphaPt[iCut]);
 
-          fHistoMCPi0FromAllOmegaAlphaPt[iCut] = new TH2F("MC_Pi0FromAllOmega_Alpha_Pt","MC_Pi0FromAllOmega_Alpha_Pt",200,0,20,200,-1,1);
+          fHistoMCPi0FromAllOmegaAlphaPt[iCut] = new TH2F("MC_Pi0FromAllOmega_Alpha_Pt","MC_Pi0FromAllOmega_Alpha_Pt",300,0,30,200,-1,1);
           fHistoMCPi0FromAllOmegaAlphaPt[iCut]->SetXTitle("p_{T,#pi^{0}}(GeV/c)");
           fHistoMCPi0FromAllOmegaAlphaPt[iCut]->SetYTitle("#alpha_{#pi^{0}}");
           fMCList[iCut]->Add(fHistoMCPi0FromAllOmegaAlphaPt[iCut]);
 
-          fHistoMCPi0FromOmegaInAccAlphaPt[iCut] = new TH2F("MC_Pi0FromOmegaInAcc_Alpha_Pt","MC_Pi0FromOmegaInAcc_Alpha_Pt",200,0,20,200,-1,1);
+          fHistoMCPi0FromOmegaInAccAlphaPt[iCut] = new TH2F("MC_Pi0FromOmegaInAcc_Alpha_Pt","MC_Pi0FromOmegaInAcc_Alpha_Pt",300,0,30,200,-1,1);
           fHistoMCPi0FromOmegaInAccAlphaPt[iCut]->SetXTitle("p_{T,#pi^{0}}(GeV/c)");
           fHistoMCPi0FromOmegaInAccAlphaPt[iCut]->SetYTitle("#alpha_{#pi^{0}}");
           fMCList[iCut]->Add(fHistoMCPi0FromOmegaInAccAlphaPt[iCut]);
@@ -1389,22 +1389,22 @@ void AliAnalysisTaskOmegaToPiZeroGamma::UserCreateOutputObjects(){
           fMCList[iCut]->Add(fHistoMCInAccOmegaGammaAnglePt[iCut]);
         }
         if(fDoMesonQA & 0b100000000) {
-          fHistoMCAllOmegaPtPi0Pt[iCut] = new TH2F("MC_All_OmegaPt_Pi0Pt","MC_All_OmegaPt_Pi0Pt",nBinsPt, arrPtBinning,200,0,20);
+          fHistoMCAllOmegaPtPi0Pt[iCut] = new TH2F("MC_All_OmegaPt_Pi0Pt","MC_All_OmegaPt_Pi0Pt",nBinsPt, arrPtBinning,300,0,30);
           fHistoMCAllOmegaPtPi0Pt[iCut]->SetXTitle("#omega p_{T}(GeV/c)");
           fHistoMCAllOmegaPtPi0Pt[iCut]->SetYTitle("#pi^{0} p_{T}(GeV/c)");
           fMCList[iCut]->Add(fHistoMCAllOmegaPtPi0Pt[iCut]);
 
-          fHistoMCInAccOmegaPtPi0Pt[iCut] = new TH2F("MC_InAcc_OmegaPt_Pi0Pt","MC_InAcc_OmegaPt_Pi0Pt",nBinsPt, arrPtBinning,200,0,20);
+          fHistoMCInAccOmegaPtPi0Pt[iCut] = new TH2F("MC_InAcc_OmegaPt_Pi0Pt","MC_InAcc_OmegaPt_Pi0Pt",nBinsPt, arrPtBinning,300,0,30);
           fHistoMCInAccOmegaPtPi0Pt[iCut]->SetXTitle("#omega p_{T}(GeV/c)");
           fHistoMCInAccOmegaPtPi0Pt[iCut]->SetYTitle("#pi^{0} p_{T}(GeV/c)");
           fMCList[iCut]->Add(fHistoMCInAccOmegaPtPi0Pt[iCut]);
 
-          fHistoMCAllOmegaPtGammaPt[iCut] = new TH2F("MC_All_OmegaPt_GammaPt","MC_All_OmegaPt_GammaPt",nBinsPt, arrPtBinning,200,0,20);
+          fHistoMCAllOmegaPtGammaPt[iCut] = new TH2F("MC_All_OmegaPt_GammaPt","MC_All_OmegaPt_GammaPt",nBinsPt, arrPtBinning,300,0,30);
           fHistoMCAllOmegaPtGammaPt[iCut]->SetXTitle("#omega p_{T}(GeV/c)");
           fHistoMCAllOmegaPtGammaPt[iCut]->SetYTitle("#gamma p_{T}(GeV/c)");
           fMCList[iCut]->Add(fHistoMCAllOmegaPtGammaPt[iCut]);
 
-          fHistoMCInAccOmegaPtGammaPt[iCut] = new TH2F("MC_InAcc_OmegaPt_GammaPt","MC_InAcc_OmegaPt_GammaPt",nBinsPt, arrPtBinning,200,0,20);
+          fHistoMCInAccOmegaPtGammaPt[iCut] = new TH2F("MC_InAcc_OmegaPt_GammaPt","MC_InAcc_OmegaPt_GammaPt",nBinsPt, arrPtBinning,300,0,30);
           fHistoMCInAccOmegaPtGammaPt[iCut]->SetXTitle("#omega p_{T}(GeV/c)");
           fHistoMCInAccOmegaPtGammaPt[iCut]->SetYTitle("#gamma p_{T}(GeV/c)");
           fMCList[iCut]->Add(fHistoMCInAccOmegaPtGammaPt[iCut]);
@@ -1482,7 +1482,7 @@ void AliAnalysisTaskOmegaToPiZeroGamma::UserCreateOutputObjects(){
       fHistoTrueOmegaInvMassPt[iCut]->SetYTitle("#omega p_{T}(GeV/c)");
       fTrueList[iCut]->Add(fHistoTrueOmegaInvMassPt[iCut]);
 
-      fHistoTruePi0FromOmegaInvMassPt[iCut]          = new TH2F("True_Pi0FromOmega_InvMass_Pt","True_Pi0FromOmega_InvMass_Pt",300,0,0.3,200,0.,20.);
+      fHistoTruePi0FromOmegaInvMassPt[iCut]          = new TH2F("True_Pi0FromOmega_InvMass_Pt","True_Pi0FromOmega_InvMass_Pt",300,0,0.3,300,0.,30.);
       fHistoTruePi0FromOmegaInvMassPt[iCut]->SetXTitle("M_{inv,#pi^{0}}(GeV/c^{2})");
       fHistoTruePi0FromOmegaInvMassPt[iCut]->SetYTitle("p_{T, #pi^{0}}(GeV/c)");
       fTrueList[iCut]->Add(fHistoTruePi0FromOmegaInvMassPt[iCut]);
@@ -1498,7 +1498,7 @@ void AliAnalysisTaskOmegaToPiZeroGamma::UserCreateOutputObjects(){
           fHistoTrueOmegaYPt[iCut]->SetYTitle("Y_{#omega}");
           fTrueList[iCut]->Add(fHistoTrueOmegaYPt[iCut]);
 
-          fHistoTruePi0FromOmegaYPt[iCut] = new TH2F("True_Pi0FromOmega_Y_Pt","True_Pi0FromOmega_Y_Pt",200,0.,20.,150,-1.5,1.5);
+          fHistoTruePi0FromOmegaYPt[iCut] = new TH2F("True_Pi0FromOmega_Y_Pt","True_Pi0FromOmega_Y_Pt",300,0.,30.,150,-1.5,1.5);
           fHistoTruePi0FromOmegaYPt[iCut]->SetXTitle("p_{T,pi^{0}}(GeV/c)");
           fHistoTruePi0FromOmegaYPt[iCut]->SetYTitle("Y_{#pi^{0}}");
           fTrueList[iCut]->Add(fHistoTruePi0FromOmegaYPt[iCut]);
@@ -1509,7 +1509,7 @@ void AliAnalysisTaskOmegaToPiZeroGamma::UserCreateOutputObjects(){
           fHistoTrueOmegaAlphaPt[iCut]->SetYTitle("#alpha_{#omega}");
           fTrueList[iCut]->Add(fHistoTrueOmegaAlphaPt[iCut]);
 
-          fHistoTruePi0FromOmegaAlphaPt[iCut] = new TH2F("True_Pi0FromOmega_Alpha_Pt","MC_Pi0FromOmega_Alpha_Pt",200,0.,20.,200,-1,1);
+          fHistoTruePi0FromOmegaAlphaPt[iCut] = new TH2F("True_Pi0FromOmega_Alpha_Pt","MC_Pi0FromOmega_Alpha_Pt",300,0.,30.,200,-1,1);
           fHistoTruePi0FromOmegaAlphaPt[iCut]->SetXTitle("p_{T,pi^{0}}(GeV/c)");
           fHistoTruePi0FromOmegaAlphaPt[iCut]->SetYTitle("#alpha_{#pi^{0}}");
           fTrueList[iCut]->Add(fHistoTruePi0FromOmegaAlphaPt[iCut]);

--- a/PWGGA/GammaConv/macros/AddTask_OmegaToPiZeroGamma_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_OmegaToPiZeroGamma_pp.C
@@ -406,132 +406,125 @@ void AddTask_OmegaToPiZeroGamma_pp(
     /////////////////////////////////
     // 13 TeV
     /////////////////////////////////
-
-    // EMCal + DCal
   } else if( trainConfig == 2060) {
-    // MB 13TeV EMcal + DCal
-    cuts.AddCut("00010113","00200009327000008250400000","411791106f032230000","01631031000000d0","01631030000000d0");
-    cuts.AddCut("00052113","00200009327000008250400000","411791106f032230000","01631031000000d0","01631030000000d0");
-    cuts.AddCut("00085113","00200009327000008250400000","411791106f032230000","01631031000000d0","01631030000000d0");
-    cuts.AddCut("00083113","00200009327000008250400000","411791106f032230000","01631031000000d0","01631030000000d0");
-  } else if( trainConfig == 2061) {
     // MB 13TeV only EMCal
-    cuts.AddCut("00010113","00200009327000008250400000","1111100067032230000","01631031000000d0","01631031000000d0");
+    cuts.AddCut("00010113","00200009327000008250400000","1111100067032230000","01631031000000d0","0v631031000000d0");
+  } else if( trainConfig == 2061) {
+    // MB std EMCal + DCal
+    cuts.AddCut("00010113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0v631031000000d0");
   } else if( trainConfig == 2062) {
-    // MB std NL 12 EMCal + DCal
-    cuts.AddCut("00010113","00200009327000008250400000","411792109fe32220000","01631031000000d0","01631031000000d0");
+    // EG2 13TeV EMcal + Dcal, Pi0 selection plus Gamma dropout
+    cuts.AddCut("00010113","00200009327000008250400000","411792109fe32220000","0163103u000000d0","0v631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout
+    cuts.AddCut("00010113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0v631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout
+    cuts.AddCut("00010113","00200009327000008250400000","411792109fe32220000","0163103v000000d0","0v631031000000d0"); // 3 sigma Pi0 selection plus Gamma dropout
+    cuts.AddCut("00010113","00200009327000008250400000","411792109fe32220000","0163103w000000d0","0v631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout
   } else if( trainConfig == 2063) {
-    // MB 13TeV EMCal + DCal, Pi0 selection plus Gamma dropout
-    cuts.AddCut("00010113","00200009327000008250400000","411792109fe32220000","0163103u000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout
-    cuts.AddCut("00010113","00200009327000008250400000","411792109fe32220000","01631031000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout
-    cuts.AddCut("00010113","00200009327000008250400000","411792109fe32220000","0163103v000000d0","01631031000000d0"); // 3 sigma Pi0 selection plus Gamma dropout
-    cuts.AddCut("00010113","00200009327000008250400000","411792109fe32220000","0163103w000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout
+    // EG2 13TeV EMcal + Dcal, Background Variation (Swapping Method by Joshua)
+    cuts.AddCut("00010113","00200009327000008250400000","411792109fe32220000","01631031000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme mixed event
+    cuts.AddCut("00010113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0r631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation
+    cuts.AddCut("00010113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0x631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
+    cuts.AddCut("00010113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0z631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS (Pi0)
   } else if( trainConfig == 2064) {
-    // MB 13TeV EMCal + DCal Background Variation (Swapping Method by Joshua)
-    cuts.AddCut("00010113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0r631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation (omega)
-    cuts.AddCut("00010113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0v631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS without constraints (omega)
-    cuts.AddCut("00010113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0x631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints (omega)
-  } else if( trainConfig == 2065) {
-    // MB 13TeV EMCal + DCal, Pi0 selection plus Gamma dropout, alpha cut pi0
+    // EG2 13TeV EMCal + DCal, Pi0 selection plus Gamma dropout, alpha cut pi0
     cuts.AddCut("00010113","00200009327000008250400000","411792109fe32220000","01631071000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for pi0
     cuts.AddCut("00010113","00200009327000008250400000","411792109fe32220000","01631051000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for pi0
     cuts.AddCut("00010113","00200009327000008250400000","411792109fe32220000","01631041000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for pi0
     cuts.AddCut("00010113","00200009327000008250400000","411792109fe32220000","01631081000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for pi0
-  } else if( trainConfig == 2066) {
-    // MB 13TeV EMCal + DCal, Pi0 selection plus Gamma dropout, alpha cut omega
+  } else if( trainConfig == 2065) {
+    // EG2 13TeV EMCal + DCal, Pi0 selection plus Gamma dropout, alpha cut omega
     cuts.AddCut("00010113","00200009327000008250400000","411792109fe32220000","01631031000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, OAC Pi0 and Omega
     cuts.AddCut("00010113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0163103100000000"); // 2 sigma Pi0 selection plus Gamma dropout, OAC Pi0
     cuts.AddCut("00010113","00200009327000008250400000","411792109fe32220000","0163103100000000","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, OAC Omega
     cuts.AddCut("00010113","00200009327000008250400000","411792109fe32220000","0163103100000000","0163103100000000"); // 2 sigma Pi0 selection plus Gamma dropout, no OAC
+  } else if( trainConfig == 2066) {
+    // EG2 13TeV EMCal + DCal Background Variation (Swapping Method by Joshua), AP-like cut
+    cuts.AddCut("00010113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0v631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints, no AP like cut
+    cuts.AddCut("00010113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0v631031010000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints, AP like cut 1 sigma
+    cuts.AddCut("00010113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0v631031020000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints, AP like cut 2 sigma
+    cuts.AddCut("00010113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0v631031030000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints, AP like cut 3 sigma
   } else if( trainConfig == 2067) {
-    // MB 13TeV EMCal + DCal Background Variation (Swapping Method by Joshua), AP-like cut
-    cuts.AddCut("00010113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0x631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints, no AP like cut
-    cuts.AddCut("00010113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0x631031010000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints, AP like cut 1 sigma
-    cuts.AddCut("00010113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0x631031020000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints, AP like cut 2 sigma
-    cuts.AddCut("00010113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0x631031030000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints, AP like cut 3 sigma
-  } else if( trainConfig == 2068) {
-    // MB 13TeV EMCal + DCal Background Variation (Swapping around Pi0, Method by Joshua)
+    // EG2 13TeV EMcal + Dcal, Background Variation (Swapping around Pi0, Method by Joshua)
     cuts.AddCut("00010113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0x631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints (omega)
     cuts.AddCut("00010113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0y631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation (Pi0)
-    cuts.AddCut("00010113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0z631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints (Pi0)
-  } else if( trainConfig == 2071) {
+    cuts.AddCut("00010113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0z631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS (Pi0)
+  } else if( trainConfig == 2070) {
     // EG2 13TeV EMcal
     cuts.AddCut("0008e113","00200009327000008250400000","1111100067032230000","01631031000000d0","0v631031000000d0");
-  } else if( trainConfig == 2072) {
+  } else if( trainConfig == 2071) {
     // EG2 13TeV EMcal + Dcal
     cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0v631031000000d0"); // standad is with Omega TGPS
-  } else if( trainConfig == 2073) {
+  } else if( trainConfig == 2072) {
     // EG2 13TeV EMcal + Dcal, Pi0 selection plus Gamma dropout
     cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","0163103u000000d0","0v631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout
     cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0v631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout
     cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","0163103v000000d0","0v631031000000d0"); // 3 sigma Pi0 selection plus Gamma dropout
     cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","0163103w000000d0","0v631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout
-  } else if( trainConfig == 2074) {
+  } else if( trainConfig == 2073) {
     // EG2 13TeV EMcal + Dcal, Background Variation (Swapping Method by Joshua)
     cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","01631031000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme mixed event
     cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0r631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation
     cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0x631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
     cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0z631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS (Pi0)
-  } else if( trainConfig == 2075) {
+  } else if( trainConfig == 2074) {
     // EG2 13TeV EMCal + DCal, Pi0 selection plus Gamma dropout, alpha cut pi0
     cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","01631071000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for pi0
     cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","01631051000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for pi0
     cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","01631041000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for pi0
     cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","01631081000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for pi0
-  } else if( trainConfig == 2076) {
+  } else if( trainConfig == 2075) {
     // EG2 13TeV EMCal + DCal, Pi0 selection plus Gamma dropout, alpha cut omega
     cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","01631031000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, OAC Pi0 and Omega
     cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0163103100000000"); // 2 sigma Pi0 selection plus Gamma dropout, OAC Pi0
     cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","0163103100000000","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, OAC Omega
     cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","0163103100000000","0163103100000000"); // 2 sigma Pi0 selection plus Gamma dropout, no OAC
-  } else if( trainConfig == 2077) {
+  } else if( trainConfig == 2076) {
     // EG2 13TeV EMCal + DCal Background Variation (Swapping Method by Joshua), AP-like cut
     cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0v631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints, no AP like cut
     cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0v631031010000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints, AP like cut 1 sigma
     cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0v631031020000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints, AP like cut 2 sigma
     cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0v631031030000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints, AP like cut 3 sigma
-  } else if( trainConfig == 2078) {
+  } else if( trainConfig == 2077) {
     // EG2 13TeV EMcal + Dcal, Background Variation (Swapping around Pi0, Method by Joshua)
     cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0x631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints (omega)
     cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0y631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation (Pi0)
     cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0z631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS (Pi0)
-  } else if( trainConfig == 2081) {
+  } else if( trainConfig == 2080) {
     // EG1 13TeV EMcal
     cuts.AddCut("0008d113","00200009327000008250400000","1111100067032230000","01631031000000d0","0v631031000000d0");
-  } else if( trainConfig == 2082) {
+  } else if( trainConfig == 2081) {
     // EG1 13TeV EMcal + Dcal
-    cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0v631031000000d0"); // standad is with Omega TGPS
-  } else if( trainConfig == 2083) {
+    cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0v631031000000d0"); // standad with Omega TGPS
+  } else if( trainConfig == 2082) {
     // EG1 13TeV EMcal + Dcal, Pi0 selection plus Gamma dropout
     cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","0163103u000000d0","0v631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout
     cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0v631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout
     cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","0163103v000000d0","0v631031000000d0"); // 3 sigma Pi0 selection plus Gamma dropout
     cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","0163103w000000d0","0v631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout
-  } else if( trainConfig == 2084) {
+  } else if( trainConfig == 2083) {
     // EG1 13TeV EMcal + Dcal, Background Variation (Swapping Method by Joshua)
     cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","01631031000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme mixed event
     cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0r631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation
     cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0x631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
     cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0z631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS (Pi0)
-  } else if( trainConfig == 2085) {
+  } else if( trainConfig == 2084) {
     // EG1 13TeV EMCal + DCal, Pi0 selection plus Gamma dropout, alpha cut pi0
     cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","01631071000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for pi0
     cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","01631051000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.75 alpha cut for pi0
     cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","01631041000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.65 alpha cut for pi0
     cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","01631081000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.60 alpha cut for pi0
-  } else if( trainConfig == 2086) {
+  } else if( trainConfig == 2085) {
     // EG1 13TeV EMCal + DCal, Pi0 selection plus Gamma dropout, alpha cut omega
     cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","01631031000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, OAC Pi0 and Omega
     cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0163103100000000"); // 2 sigma Pi0 selection plus Gamma dropout, OAC Pi0
     cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","0163103100000000","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, OAC Omega
     cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","0163103100000000","0163103100000000"); // 2 sigma Pi0 selection plus Gamma dropout, no OAC
-  } else if( trainConfig == 2087) {
+  } else if( trainConfig == 2086) {
     // EG1 13TeV EMCal + DCal Background Variation (Swapping Method by Joshua), AP-like cut
-    cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0v631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints, no AP like cut
-    cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0v631031010000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints, AP like cut 1 sigma
-    cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0v631031020000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints, AP like cut 2 sigma
-    cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0v631031030000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints, AP like cut 3 sigma
-  } else if( trainConfig == 2088) {
+    cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0v631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS, no AP like cut
+    cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0v631031010000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS, AP like cut 1 sigma
+    cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0v631031020000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS, AP like cut 2 sigma
+    cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0v631031030000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS, AP like cut 3 sigma
+  } else if( trainConfig == 2087) {
     // EG2 13TeV EMcal + Dcal, Background Variation (Swapping around Pi0, Method by Joshua)
     cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0x631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints (omega)
     cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0y631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation (Pi0)
@@ -1264,17 +1257,14 @@ void AddTask_OmegaToPiZeroGamma_pp(
     cuts.AddCut("0008d113","00200009327000008250400000","411792109fe30220000","01631031000000d0","0x631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
     // EMCal + DCal
   } else if( trainConfig == 6060) {
-    // MB 13TeV EMcal + DCal
-    cuts.AddCut("00010113","00200009327000008250400000","411791106f032230000","01631031000000d0","01631030000000d0");
-    cuts.AddCut("00052113","00200009327000008250400000","411791106f032230000","01631031000000d0","01631030000000d0");
-    cuts.AddCut("00085113","00200009327000008250400000","411791106f032230000","01631031000000d0","01631030000000d0");
-    cuts.AddCut("00083113","00200009327000008250400000","411791106f032230000","01631031000000d0","01631030000000d0");
+    // MB 13TeV EMcal
+    cuts.AddCut("00010113","00200009327000008250400000","111792109fe32220000","01631031000000d0","0v631031000000d0"); // standad with Omega TGPS
   } else if( trainConfig == 6061) {
-    // MB 13TeV only EMCal
-    cuts.AddCut("00010113","00200009327000008250400000","1111100067032230000","01631031000000d0","01631031000000d0");
+    // MB 13TeV EMcal + Dcal
+    cuts.AddCut("00010113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0v631031000000d0"); // standad with Omega TGPS
   } else if( trainConfig == 6062) {
-    // MB std NL 12 EMCal + DCal
-    cuts.AddCut("00010113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0x631031000000d0"); // background scheme swapping method trough TGPS with constraints (omega)
+    // MB  EMCal + DCal
+    cuts.AddCut("00010113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0v631031000000d0"); // standad with Omega TGPS
   } else if( trainConfig == 6063) {
     // MB 13TeV EMCal + DCal, Pi0 selection plus Gamma dropout
     cuts.AddCut("00010113","00200009327000008250400000","411792109fe32220000","0163103u000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout
@@ -1309,12 +1299,15 @@ void AddTask_OmegaToPiZeroGamma_pp(
     cuts.AddCut("00010113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0x631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints (omega)
     cuts.AddCut("00010113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0y631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation (Pi0)
     cuts.AddCut("00010113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0z631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints (Pi0)
-  } else if( trainConfig == 6071) {
+  } else if( trainConfig == 6070) {
     // EG2 13TeV EMcal
-    cuts.AddCut("0008e113","00200009327000008250400000","1111100067032230000","01631031000000d0","01631031000000d0");
+    cuts.AddCut("0008e113","00200009327000008250400000","111792109fe32220000","01631031000000d0","0v631031000000d0"); // standad with Omega TGPS
+  } else if( trainConfig == 6071) {
+    // EG2 13TeV EMcal + Dcal
+    cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0v631031000000d0"); // standad with Omega TGPS
   } else if( trainConfig == 6072) {
-    // EG2 std NL 12 EMCal + DCal
-    cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0x631031000000d0"); // background scheme swapping method trough TGPS with constraints
+    // EG2  EMCal + DCal
+    cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0v631031000000d0"); // standad with Omega TGPS
   } else if( trainConfig == 6073) {
     // EG2 13TeV EMcal + Dcal, Pi0 selection plus Gamma dropout
     cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","0163103u000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout
@@ -1353,12 +1346,16 @@ void AddTask_OmegaToPiZeroGamma_pp(
     // EG2 13TeV EMcal + Dcal, Background Variation (Swapping Method by Joshua)
     cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0r631031000000d0"); // background scheme swapping method trough roation
     cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0s631031000000d0"); // background scheme swapping method trough roation with weighting
-  } else if( trainConfig == 6081) {
+
+  } else if( trainConfig == 6080) {
     // EG1 13TeV EMcal
     cuts.AddCut("0008d113","00200009327000008250400000","1111100067032230000","01631031000000d0","01631031000000d0");
+  } else if( trainConfig == 6081) {
+    /// EG1 13TeV EMcal + Dcal
+    cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0v631031000000d0"); // standad with Omega TGPS
   } else if( trainConfig == 6082) {
-    // EG1 13TeV EMcal + Dcal
-    cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0x631031000000d0"); // background scheme swapping method trough TGPS with constraints
+    /// EG1 13TeV EMcal + Dcal
+    cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0v631031000000d0"); // standad with Omega TGPS
   } else if( trainConfig == 6083) {
     // EG1 13TeV EMcal + Dcal, Pi0 selection plus Gamma dropout
     cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","0163103u000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout

--- a/PWGGA/GammaConv/macros/AddTask_OmegaToPiZeroGamma_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_OmegaToPiZeroGamma_pp.C
@@ -456,21 +456,22 @@ void AddTask_OmegaToPiZeroGamma_pp(
     cuts.AddCut("00010113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0z631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints (Pi0)
   } else if( trainConfig == 2071) {
     // EG2 13TeV EMcal
-    cuts.AddCut("0008e113","00200009327000008250400000","1111100067032230000","01631031000000d0","01631031000000d0");
+    cuts.AddCut("0008e113","00200009327000008250400000","1111100067032230000","01631031000000d0","0v631031000000d0");
   } else if( trainConfig == 2072) {
-    // EG2 std NL 12 EMCal + DCal
-    cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","01631031000000d0","01631031000000d0");
+    // EG2 13TeV EMcal + Dcal
+    cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0v631031000000d0"); // standad is with Omega TGPS
   } else if( trainConfig == 2073) {
     // EG2 13TeV EMcal + Dcal, Pi0 selection plus Gamma dropout
-    cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","0163103u000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout
-    cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","01631031000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout
-    cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","0163103v000000d0","01631031000000d0"); // 3 sigma Pi0 selection plus Gamma dropout
-    cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","0163103w000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout
+    cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","0163103u000000d0","0v631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout
+    cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0v631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout
+    cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","0163103v000000d0","0v631031000000d0"); // 3 sigma Pi0 selection plus Gamma dropout
+    cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","0163103w000000d0","0v631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout
   } else if( trainConfig == 2074) {
     // EG2 13TeV EMcal + Dcal, Background Variation (Swapping Method by Joshua)
+    cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","01631031000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme mixed event
     cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0r631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation
-    cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0v631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS without constraints
     cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0x631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
+    cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0z631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS (Pi0)
   } else if( trainConfig == 2075) {
     // EG2 13TeV EMCal + DCal, Pi0 selection plus Gamma dropout, alpha cut pi0
     cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","01631071000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for pi0
@@ -484,33 +485,34 @@ void AddTask_OmegaToPiZeroGamma_pp(
     cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","0163103100000000","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, OAC Omega
     cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","0163103100000000","0163103100000000"); // 2 sigma Pi0 selection plus Gamma dropout, no OAC
   } else if( trainConfig == 2077) {
-    // MB 13TeV EMCal + DCal Background Variation (Swapping Method by Joshua), AP-like cut
-    cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0x631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints, no AP like cut
-    cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0x631031010000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints, AP like cut 1 sigma
-    cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0x631031020000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints, AP like cut 2 sigma
-    cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0x631031030000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints, AP like cut 3 sigma
+    // EG2 13TeV EMCal + DCal Background Variation (Swapping Method by Joshua), AP-like cut
+    cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0v631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints, no AP like cut
+    cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0v631031010000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints, AP like cut 1 sigma
+    cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0v631031020000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints, AP like cut 2 sigma
+    cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0v631031030000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints, AP like cut 3 sigma
   } else if( trainConfig == 2078) {
     // EG2 13TeV EMcal + Dcal, Background Variation (Swapping around Pi0, Method by Joshua)
     cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0x631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints (omega)
     cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0y631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation (Pi0)
-    cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0z631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints (Pi0)
+    cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0z631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS (Pi0)
   } else if( trainConfig == 2081) {
     // EG1 13TeV EMcal
-    cuts.AddCut("0008d113","00200009327000008250400000","1111100067032230000","01631031000000d0","01631031000000d0");
+    cuts.AddCut("0008d113","00200009327000008250400000","1111100067032230000","01631031000000d0","0v631031000000d0");
   } else if( trainConfig == 2082) {
     // EG1 13TeV EMcal + Dcal
-    cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","01631031000000d0","01631031000000d0");
+    cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0v631031000000d0"); // standad is with Omega TGPS
   } else if( trainConfig == 2083) {
     // EG1 13TeV EMcal + Dcal, Pi0 selection plus Gamma dropout
-    cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","0163103u000000d0","01631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout
-    cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","01631031000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout
-    cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","0163103v000000d0","01631031000000d0"); // 3 sigma Pi0 selection plus Gamma dropout
-    cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","0163103w000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout
+    cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","0163103u000000d0","0v631031000000d0"); // 1 sigma Pi0 selection plus Gamma dropout
+    cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0v631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout
+    cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","0163103v000000d0","0v631031000000d0"); // 3 sigma Pi0 selection plus Gamma dropout
+    cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","0163103w000000d0","0v631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout
   } else if( trainConfig == 2084) {
     // EG1 13TeV EMcal + Dcal, Background Variation (Swapping Method by Joshua)
+    cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","01631031000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme mixed event
     cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0r631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation
-    cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0v631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS without constraints
     cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0x631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
+    cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0z631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS (Pi0)
   } else if( trainConfig == 2085) {
     // EG1 13TeV EMCal + DCal, Pi0 selection plus Gamma dropout, alpha cut pi0
     cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","01631071000000d0","01631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, 0.0-0.85 alpha cut for pi0
@@ -525,15 +527,15 @@ void AddTask_OmegaToPiZeroGamma_pp(
     cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","0163103100000000","0163103100000000"); // 2 sigma Pi0 selection plus Gamma dropout, no OAC
   } else if( trainConfig == 2087) {
     // EG1 13TeV EMCal + DCal Background Variation (Swapping Method by Joshua), AP-like cut
-    cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0x631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints, no AP like cut
-    cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0x631031010000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints, AP like cut 1 sigma
-    cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0x631031020000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints, AP like cut 2 sigma
-    cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0x631031030000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints, AP like cut 3 sigma
+    cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0v631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints, no AP like cut
+    cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0v631031010000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints, AP like cut 1 sigma
+    cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0v631031020000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints, AP like cut 2 sigma
+    cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0v631031030000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints, AP like cut 3 sigma
   } else if( trainConfig == 2088) {
     // EG2 13TeV EMcal + Dcal, Background Variation (Swapping around Pi0, Method by Joshua)
     cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0x631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints (omega)
     cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0y631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation (Pi0)
-    cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0z631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints (Pi0)
+    cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0z631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS (Pi0)
 
   } else if( trainConfig == 2160) {
     // MB 13TeV PHOS
@@ -809,7 +811,102 @@ void AddTask_OmegaToPiZeroGamma_pp(
     cuts.AddCut("00010113","00200009327000008250400000","411792109fe32220000","0163103v000000d0","01631031000000d0"); // 3 sigma Pi0 selection plus Gamma dropout
     cuts.AddCut("00010113","00200009327000008250400000","411792109fe32220000","0163103w000000d0","01631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout
 
-
+  //----------------------------------------------------------------------------
+  // EMCal + DCal Cluster Cut Variations
+  } else if( trainConfig == 2960) {
+    // MB 13TeV EMcal + Dcal
+    cuts.AddCut("00010113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0v631031000000d0"); // standad is with Omega TGPS
+  } else if( trainConfig == 2961) {
+    // MB 13TeV EMCal + DCal, NonLin variation
+    cuts.AddCut("00010113","00200009327000008250400000","411792209fe32220000","01631031000000d0","0v631031000000d0"); // NL 22
+    cuts.AddCut("00010113","00200009327000008250400000","411790109fe32220000","01631031000000d0","0v631031000000d0"); // NL 01
+    cuts.AddCut("00010113","00200009327000008250400000","411793309fe32220000","01631031000000d0","0v631031000000d0"); // NL 33
+    cuts.AddCut("00010113","00200009327000008250400000","411793409fe32220000","01631031000000d0","0v631031000000d0"); // NL 34
+  } else if( trainConfig == 2962) {
+    // MB 13TeV EMcal + Dcal, timing cut variation
+    cuts.AddCut("00010113","00200009327000008250400000","411792105fe32220000","01631031000000d0","0v631031000000d0"); // +-50
+    cuts.AddCut("00010113","00200009327000008250400000","41179210afe32220000","01631031000000d0","0v631031000000d0"); // -12.5 to +13
+  } else if( trainConfig == 2963) {
+    // MB 13TeV EMcal + Dcal, track matching variation
+    cuts.AddCut("00010113","00200009327000008250400000","4117921090e32220000","01631031000000d0","0v631031000000d0"); // no TM
+    cuts.AddCut("00010113","00200009327000008250400000","4117921091e32220000","01631031000000d0","0v631031000000d0"); // np pT depending matching, no E/p
+    cuts.AddCut("00010113","00200009327000008250400000","411792109de32220000","01631031000000d0","0v631031000000d0"); // loose E/p
+    cuts.AddCut("00010113","00200009327000008250400000","411792109he32220000","01631031000000d0","0v631031000000d0"); // strict E/p
+  } else if( trainConfig == 2964) {
+    // MB 13TeV EMcal + Dcal, exotic cluster cut variation
+    cuts.AddCut("00010113","00200009327000008250400000","411792109fb32220000","01631031000000d0","0v631031000000d0"); // different F+ value (0.95 instead of 0.97)
+    cuts.AddCut("00010113","00200009327000008250400000","411792109fg32220000","01631031000000d0","0v631031000000d0"); // from corr. framework
+  } else if( trainConfig == 2965) {
+    // MB 13TeV EMcal + Dcal, NCell cut variation
+    cuts.AddCut("00010113","00200009327000008250400000","411792109fe3v220000","01631031000000d0","0v631031000000d0"); // NCell efficiency applied on photon clusters, function from PCM-EMC tagged pi0 clusters
+    cuts.AddCut("00010113","00200009327000008250400000","411792109fe30220000","01631031000000d0","0v631031000000d0"); // No NCell cut
+  } else if( trainConfig == 2966) {
+    // MB 13TeV EMcal + Dcal, M02 max cut variation
+    cuts.AddCut("00010113","00200009327000008250400000","411792109fe32210000","01631031000000d0","0v631031000000d0"); // 1.0
+    cuts.AddCut("00010113","00200009327000008250400000","411792109fe32230000","01631031000000d0","0v631031000000d0"); // 0.5
+  } else if( trainConfig == 2970) {
+    // EG2 13TeV EMcal + Dcal
+    cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0v631031000000d0"); // standad is with Omega TGPS
+  } else if( trainConfig == 2971) {
+    // EG2 13TeV EMCal + DCal, NonLin variation
+    cuts.AddCut("0008e113","00200009327000008250400000","411792209fe32220000","01631031000000d0","0v631031000000d0"); // NL 22
+    cuts.AddCut("0008e113","00200009327000008250400000","411790109fe32220000","01631031000000d0","0v631031000000d0"); // NL 01
+    cuts.AddCut("0008e113","00200009327000008250400000","411793309fe32220000","01631031000000d0","0v631031000000d0"); // NL 33
+    cuts.AddCut("0008e113","00200009327000008250400000","411793409fe32220000","01631031000000d0","0v631031000000d0"); // NL 34
+  } else if( trainConfig == 2972) {
+    // EG2 13TeV EMcal + Dcal, timing cut variation
+    cuts.AddCut("0008e113","00200009327000008250400000","411792105fe32220000","01631031000000d0","0v631031000000d0"); // +-50
+    cuts.AddCut("0008e113","00200009327000008250400000","41179210afe32220000","01631031000000d0","0v631031000000d0"); // -12.5 to +13
+  } else if( trainConfig == 2973) {
+    // EG2 13TeV EMcal + Dcal, track matching variation
+    cuts.AddCut("0008e113","00200009327000008250400000","4117921090e32220000","01631031000000d0","0v631031000000d0"); // no TM
+    cuts.AddCut("0008e113","00200009327000008250400000","4117921091e32220000","01631031000000d0","0v631031000000d0"); // np pT depending matching, no E/p
+    cuts.AddCut("0008e113","00200009327000008250400000","411792109de32220000","01631031000000d0","0v631031000000d0"); // loose E/p
+    cuts.AddCut("0008e113","00200009327000008250400000","411792109he32220000","01631031000000d0","0v631031000000d0"); // strict E/p
+  } else if( trainConfig == 2974) {
+    // EG2 13TeV EMcal + Dcal, exotic cluster cut variation
+    cuts.AddCut("0008e113","00200009327000008250400000","411792109fb32220000","01631031000000d0","0v631031000000d0"); // different F+ value (0.95 instead of 0.97)
+    cuts.AddCut("0008e113","00200009327000008250400000","411792109fg32220000","01631031000000d0","0v631031000000d0"); // from corr. framework
+  } else if( trainConfig == 2975) {
+    // EG2 13TeV EMcal + Dcal, NCell cut variation
+    cuts.AddCut("0008e113","00200009327000008250400000","411792109fe3v220000","01631031000000d0","0v631031000000d0"); // NCell efficiency applied on photon clusters, function from PCM-EMC tagged pi0 clusters
+    cuts.AddCut("0008e113","00200009327000008250400000","411792109fe30220000","01631031000000d0","0v631031000000d0"); // No NCell cut
+  } else if( trainConfig == 2976) {
+    // EG2 13TeV EMcal + Dcal, M02 max cut variation
+    cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32210000","01631031000000d0","0v631031000000d0"); // 1.0
+    cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32230000","01631031000000d0","0v631031000000d0"); // 0.5
+  } else if( trainConfig == 2980) {
+    // EG1 13TeV EMcal + Dcal
+    cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0v631031000000d0"); // standad is with Omega TGPS
+  } else if( trainConfig == 2981) {
+    // EG1 13TeV EMCal + DCal, NonLin variation
+    cuts.AddCut("0008d113","00200009327000008250400000","411792209fe32220000","01631031000000d0","0v631031000000d0"); // NL 22
+    cuts.AddCut("0008d113","00200009327000008250400000","411790109fe32220000","01631031000000d0","0v631031000000d0"); // NL 01
+    cuts.AddCut("0008d113","00200009327000008250400000","411793309fe32220000","01631031000000d0","0v631031000000d0"); // NL 33
+    cuts.AddCut("0008d113","00200009327000008250400000","411793409fe32220000","01631031000000d0","0v631031000000d0"); // NL 34
+  } else if( trainConfig == 2982) {
+    // EG1 13TeV EMcal + Dcal, timing cut variation
+    cuts.AddCut("0008d113","00200009327000008250400000","411792105fe32220000","01631031000000d0","0v631031000000d0"); // +-50
+    cuts.AddCut("0008d113","00200009327000008250400000","41179210afe32220000","01631031000000d0","0v631031000000d0"); // -12.5 to +13
+  } else if( trainConfig == 2983) {
+    // EG1 13TeV EMcal + Dcal, track matching variation
+    cuts.AddCut("0008d113","00200009327000008250400000","4117921090e32220000","01631031000000d0","0v631031000000d0"); // no TM
+    cuts.AddCut("0008d113","00200009327000008250400000","4117921091e32220000","01631031000000d0","0v631031000000d0"); // np pT depending matching, no E/p
+    cuts.AddCut("0008d113","00200009327000008250400000","411792109de32220000","01631031000000d0","0v631031000000d0"); // loose E/p
+    cuts.AddCut("0008d113","00200009327000008250400000","411792109he32220000","01631031000000d0","0v631031000000d0"); // strict E/p
+  } else if( trainConfig == 2984) {
+    // EG1 13TeV EMcal + Dcal, exotic cluster cut variation
+    cuts.AddCut("0008d113","00200009327000008250400000","411792109fb32220000","01631031000000d0","0v631031000000d0"); // different F+ value (0.95 instead of 0.97)
+    cuts.AddCut("0008d113","00200009327000008250400000","411792109fg32220000","01631031000000d0","0v631031000000d0"); // from corr. framework
+  } else if( trainConfig == 2985) {
+    // EG1 13TeV EMcal + Dcal, NCell cut variation
+    cuts.AddCut("0008d113","00200009327000008250400000","411792109fe3v220000","01631031000000d0","0v631031000000d0"); // NCell efficiency applied on photon clusters, function from PCM-EMC tagged pi0 clusters
+    cuts.AddCut("0008d113","00200009327000008250400000","411792109fe30220000","01631031000000d0","0v631031000000d0"); // No NCell cut
+  } else if( trainConfig == 2986) {
+    // EG1 13TeV EMcal + Dcal, M02 max cut variation
+    cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32210000","01631031000000d0","0v631031000000d0"); // 1.0
+    cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32230000","01631031000000d0","0v631031000000d0"); // 0.5
+  //----------------------------------------------------------------------------
   // cuts for ReconMethod==3 Cal-Cal-PCM
   } else if(trainConfig == 3001){ // EMCAL clusters pp 7 TeV
     cuts.AddCut("00000113","00200009327000008250400000","1111111017032230000","0163103a00000010","0163103000000010"); // pion mass (0.08,0.145)


### PR DESCRIPTION
- Added cluster cut variations (train configs X9X1 till X9X6) for:
1. NonLin
2. timing
3. track matching
4. exotic cluster
5. Ncell
6. M02 max

- changed the ordering of some train configs, so they are grouped together in a more logical sense
- Increased Pi0 pT binning from 20 to 30 GeV/c as the max value