### PR TITLE
Add option to remove pile-up particles in MC Gen

### DIFF
--- a/PWGHF/hfe/AliAnalysisTaskEHCorrel.cxx
+++ b/PWGHF/hfe/AliAnalysisTaskEHCorrel.cxx
@@ -163,6 +163,7 @@ AliAnalysisTaskEHCorrel::AliAnalysisTaskEHCorrel(const char *name)
   fWeight(1.0),
   fCalcHadronTrackEffi(kFALSE),
   fFillEHCorrel(kTRUE),
+  fRemovePileUpinMCGen(kFALSE),
   //Non-HFE
   fCalculateNonHFEEffi(kFALSE),
   fCalPi0EtaWeight(kFALSE),
@@ -357,6 +358,7 @@ AliAnalysisTaskEHCorrel::AliAnalysisTaskEHCorrel()
   fWeight(1.0),
   fCalcHadronTrackEffi(kFALSE),
   fFillEHCorrel(kTRUE),
+  fRemovePileUpinMCGen(kFALSE),
   //Non-HFE
   fCalculateNonHFEEffi(kFALSE),
   fCalPi0EtaWeight(kFALSE),
@@ -1907,6 +1909,11 @@ void AliAnalysisTaskEHCorrel::GetHadronTrackingEfficiency()
 
   //All hadrons
   for(Int_t imcArrayL=0; imcArrayL< fMCarray->GetEntries(); imcArrayL++){
+      
+    if(fRemovePileUpinMCGen){
+      if(AliAnalysisUtils::IsParticleFromOutOfBunchPileupCollision(imcArrayL, fMCHeader, fMCarray)) continue;
+    }
+      
     AliAODMCParticle *AODMCtrack = (AliAODMCParticle*)fMCarray->At(imcArrayL);
     Int_t PDGcode = TMath::Abs(AODMCtrack->GetPdgCode());
 

--- a/PWGHF/hfe/AliAnalysisTaskEHCorrel.h
+++ b/PWGHF/hfe/AliAnalysisTaskEHCorrel.h
@@ -131,6 +131,8 @@ class AliAnalysisTaskEHCorrel : public AliAnalysisTaskSE {
     Bool_t  GetNonHFEEffiRecoTag(AliVTrack *track);
     Bool_t  IsNonHFE(AliAODMCParticle *MCPart, Bool_t &fFromMB, Int_t &type, Int_t &iMom, Int_t &MomPDG, Double_t &MomPt);
     Int_t   GetPi0EtaType(AliAODMCParticle *part);
+    
+    void    RemovePileUpInMCGen(Bool_t fSwitch) {fRemovePileUpinMCGen = fSwitch;};
 
   private:
     Bool_t GetNMCPartProduced();
@@ -204,6 +206,7 @@ class AliAnalysisTaskEHCorrel : public AliAnalysisTaskSE {
     Double_t            fWeight;//!
     Bool_t              fCalcHadronTrackEffi;//
     Bool_t              fFillEHCorrel;//
+    Bool_t              fRemovePileUpinMCGen;//
 
     //Non-HFE
     Bool_t              fCalculateNonHFEEffi;//

--- a/PWGHF/hfe/macros/AddTaskEHCorrel.C
+++ b/PWGHF/hfe/macros/AddTaskEHCorrel.C
@@ -13,7 +13,7 @@ AliAnalysisTask *AddTaskEHCorrel(TString ContNameExt = "", Bool_t isPbPb=kFALSE,
     Bool_t ClsTypeEMC=kTRUE, Bool_t ClsTypeDCAL=kTRUE,
     Int_t AddPileUpCut=kFALSE, Int_t hadCutCase=2,  Bool_t FillEHCorrel=kTRUE,
     Bool_t  CalcHadronTrackEffi=kFALSE, Bool_t CalculateNonHFEEffi=kFALSE, Bool_t CalPi0EtaWeight=kFALSE,
-    Bool_t applyEleEffi=kFALSE, Int_t nBins=32, Bool_t isMC=kFALSE)
+    Bool_t applyEleEffi=kFALSE, Int_t nBins=32, Bool_t isMC=kFALSE, Bool_t removePileUpMCGen=kFALSE)
 {
   //get the current analysis manager
   AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
@@ -85,6 +85,7 @@ AliAnalysisTask *AddTaskEHCorrel(TString ContNameExt = "", Bool_t isPbPb=kFALSE,
     taskHFEeh->SetNonHFEEffi(CalculateNonHFEEffi);
     taskHFEeh->SetNDeltaPhiBins(nBins);
     taskHFEeh->IsMC(isMC);
+    taskHFEeh->RemovePileUpInMCGen(removePileUpMCGen);
 
     TString containerName = mgr->GetCommonFileName();
     TString SubcontainerName = ContNameExt;


### PR DESCRIPTION
Adding an option to remove out-of-bunch pileup particles in the MC generated particle stack