### PR TITLE
fix narrowing conversion error

### DIFF
--- a/PWGLF/STRANGENESS/Ratios/AliAnalysisTaskStrangenessRatios.cxx
+++ b/PWGLF/STRANGENESS/Ratios/AliAnalysisTaskStrangenessRatios.cxx
@@ -146,7 +146,7 @@ void AliAnalysisTaskStrangenessRatios::UserExec(Option_t *)
   fRecCascade->centrality = fEventCut.GetCentrality();
   fRecLambda->centrality = fEventCut.GetCentrality();
 
-  float rdmState{gRandom->Uniform()};
+  float rdmState{static_cast<float>(gRandom->Uniform())};
 
   std::vector<int> checkedLabel, checkedLambdaLabel;
   fGenCascade.isReconstructed = true;


### PR DESCRIPTION
FYI @mpuccio I had to change this line because my compiler seems not to like narrowing conversions in initializer lists