### PR TITLE
Option for pT cut on generated MC

### DIFF
--- a/PWGLF/RESONANCES/AliRsnCutMiniPair.cxx
+++ b/PWGLF/RESONANCES/AliRsnCutMiniPair.cxx
@@ -82,6 +82,9 @@ Bool_t AliRsnCutMiniPair::IsSelected(TObject *obj)
          return OkRangeD();
       case kPassesOOBPileupCut:
          return pair->PassesOOBPileupCut();
+      case kPtMC:
+         fCutValueD = pair->Pt(1);
+         return OkRangeD();
 
    default:
          AliWarning("Undefined enum value");

--- a/PWGLF/RESONANCES/AliRsnCutMiniPair.h
+++ b/PWGLF/RESONANCES/AliRsnCutMiniPair.h
@@ -31,6 +31,7 @@ public:
       kPseudorapidityRange,
       kPseudorapidityRangeMC,
       kPassesOOBPileupCut,
+      kPtMC,
       kTypes
    };
 

--- a/PWGLF/RESONANCES/macros/mini/AddTaskF0.C
+++ b/PWGLF/RESONANCES/macros/mini/AddTaskF0.C
@@ -44,6 +44,8 @@ AliRsnMiniAnalysisTask * AddTaskF0
  Float_t     ptlow         = 0.0,   //pT axis low edge 
  Float_t     ptup          = 20.0,   //pT axis upper edge 
  Int_t       nbinspt       = 200,   //pT axis n bins
+ Float_t     ptMClowCut    = 0.001, // lower pT cut on MC
+ Float_t     ptMCupCut     = 20.0,  // upper pT cut on MC
  Bool_t      enableTrackQA = kTRUE, //enable single track QA
  Bool_t      enableAdvEvtQA = kFALSE) //enable advanced QA for multiplicity and event properties
 {  
@@ -227,10 +229,13 @@ AliRsnMiniAnalysisTask * AddTaskF0
   //-----------------------------------------------------------------------------------------------
   AliRsnCutMiniPair *cutY = new AliRsnCutMiniPair("cutRapidity", AliRsnCutMiniPair::kRapidityRange);
   cutY->SetRangeD(minYlab, maxYlab);
+  AliRsnCutMiniPair *cutPtMC = new AliRsnCutMiniPair("cutPtMC", AliRsnCutMiniPair::kPtMC);
+  cutPtMC->SetRangeD(ptMClowCut,ptMCupCut);
   
   AliRsnCutSet *cutsPair = new AliRsnCutSet("pairCuts", AliRsnTarget::kMother);
   cutsPair->AddCut(cutY);
-  cutsPair->SetCutScheme(cutY->GetName());
+  if (isMC) cutsPair->AddCut(cutPtMC);
+  cutsPair->SetCutScheme(Form("%s&%s",cutY->GetName(),cutPtMC->GetName()));
 
   //-----------------------------------------------------------------------------------------------
   // -- CONFIG ANALYSIS --------------------------------------------------------------------------


### PR DESCRIPTION
The commit includes option for pT cut on generated MC. This is necessary for f0 analysis in pp collisions at 5.02 TeV.