### PR TITLE
Increasing statistics: More open cuts for systematics + timing condition relaxed

### DIFF
--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliAnalysisTaskGeorgiosNTuple.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliAnalysisTaskGeorgiosNTuple.cxx
@@ -330,11 +330,11 @@ fGeorgiosTree->Branch("Trackv0Ncl",&fTTrackv0Ncl,"fTTrackv0Ncl[fTnv0][2]/I");
  * reduce disk space for background
 fGeorgiosTree->Branch("Trackv0CrR",&fTTrackv0CrR,"fTTrackv0CrR[fTnv0][2]/F");
 fGeorgiosTree->Branch("Trackv0CrF",&fTTrackv0CrF,"fTTrackv0CrF[fTnv0][2]/F");
+fGeorgiosTree->Branch("Trackv0FilterBit",&fTTrackv0FilterBit,"fTTrackv0FilterBit[fTnv0][2]/O");
+fGeorgiosTree->Branch("Trackv0Phi",&fTTrackv0Phi,"fTTrackv0Phi[fTnv0][2]/F");
 fGeorgiosTree->Branch("Trackv0ITStime",&fTTrackv0ITStime,"fTTrackv0ITStime[fTnv0][2]/O");
 fGeorgiosTree->Branch("Trackv0TOFtime",&fTTrackv0TOFtime,"fTTrackv0TOFtime[fTnv0][2]/O");
-fGeorgiosTree->Branch("Trackv0FilterBit",&fTTrackv0FilterBit,"fTTrackv0FilterBit[fTnv0][2]/O");
 */
-//fGeorgiosTree->Branch("Trackv0Phi",&fTTrackv0Phi,"fTTrackv0Phi[fTnv0][2]/F");
 fGeorgiosTree->Branch("Trackv0ID",&fTTrackv0ID,"fTTrackv0ID[fTnv0][2]/I");
 	
 #ifdef MONTECARLO
@@ -382,11 +382,11 @@ fGeorgiosTree->Branch("Trackv0ID",&fTTrackv0ID,"fTTrackv0ID[fTnv0][2]/I");
  * reducing disk space for background
  fGeorgiosTree->Branch("TrackCrR",&fTTrackCrR,"fTTrackCrR[fTnCascade][3]/F");
  fGeorgiosTree->Branch("TrackCrF",&fTTrackCrF,"fTTrackCrF[fTnCascade][3]/F");
- fGeorgiosTree->Branch("TrackITStime",&fTTrackITStime,"fTTrackITStime[fTnCascade][3]/O");
- fGeorgiosTree->Branch("TrackTOFtime",&fTTrackTOFtime,"fTTrackTOFtime[fTnCascade][3]/O");
  fGeorgiosTree->Branch("TrackFilterBit",&fTTrackFilterBit,"fTTrackFilterBit[fTnCascade][3]/O");
 */
 // fGeorgiosTree->Branch("TrackPhi",&fTTrackPhi,"fTTrackPhi[fTnCascade][3]/F");
+ fGeorgiosTree->Branch("TrackITStime",&fTTrackITStime,"fTTrackITStime[fTnCascade][3]/O");
+ fGeorgiosTree->Branch("TrackTOFtime",&fTTrackTOFtime,"fTTrackTOFtime[fTnCascade][3]/O");
  fGeorgiosTree->Branch("TrackID",&fTTrackID,"fTTrackID[fTnCascade][3]/I");
 
 #ifdef MONTECARLO
@@ -538,15 +538,15 @@ void AliAnalysisTaskGeorgiosNTuple::UserExec(Option_t *option) {
     fTTrackv0CrF[ii][jj]=-100000.;
     fTTrackv0Shared[ii][jj]=-100000;
     fTTrackv0TPCchi2[ii][jj]=-100000.;
-    fTTrackv0ITStime[ii][jj]=kFALSE;
-    fTTrackv0TOFtime[ii][jj]=kFALSE;
     fTTrackv0TPConly[ii][jj]=kFALSE;
     fTTrackv0ITScomplementary[ii][jj]=kFALSE;
     fTTrackv0ITSpure[ii][jj]=kFALSE;
     fTTrackv0GLOBAL[ii][jj]=kFALSE;
     fTTrackv0FilterBit[ii][jj]=0;
+    fTTrackv0Phi[ii][jj]=-100000.;
+    fTTrackv0ITStime[ii][jj]=kFALSE;
+    fTTrackv0TOFtime[ii][jj]=kFALSE;
 */
-//    fTTrackv0Phi[ii][jj]=-100000.;
     fTTrackv0ID[ii][jj]=-100000;
 
 #ifdef MONTECARLO
@@ -666,8 +666,6 @@ void AliAnalysisTaskGeorgiosNTuple::UserExec(Option_t *option) {
     fTTrackCrF[ii][jj]=-100000.;
     fTTrackShared[ii][jj]=-100000;
     fTTrackTPCchi2[ii][jj]=-100000.;
-    fTTrackITStime[ii][jj]=kFALSE;
-    fTTrackTOFtime[ii][jj]=kFALSE;
     fTTrackTPConly[ii][jj]=kFALSE;
     fTTrackITScomplementary[ii][jj]=kFALSE;
     fTTrackITSpure[ii][jj]=kFALSE;
@@ -675,6 +673,8 @@ void AliAnalysisTaskGeorgiosNTuple::UserExec(Option_t *option) {
     fTTrackFilterBit[ii][jj]=0;
 */
 //    fTTrackPhi[ii][jj]=-100000.;
+    fTTrackITStime[ii][jj]=kFALSE;
+    fTTrackTOFtime[ii][jj]=kFALSE;
     fTTrackID[ii][jj]=-100000;
    
 #ifdef MONTECARLO
@@ -911,11 +911,11 @@ Bool_t AliAnalysisTaskGeorgiosNTuple::Fillv0(AliFemtoDreamv0 *Thev0, int Thev0Ch
    fTTrackv0Ncl[fTnv0][jj] = TheTrackv0->GetNClsTPC();
    //fTTrackv0CrF[fTnv0][jj] = TheTrackv0->GetRatioCr();
    //fTTrackv0CrR[fTnv0][jj] = TheTrackv0->GetTPCCrossedRows();
-   //fTTrackv0ITStime[fTnv0][jj] = TheTrackv0->GetHasITSHit();
-   //fTTrackv0TOFtime[fTnv0][jj] = TheTrackv0->GetTOFTimingReuqirement();
    //fTTrackv0FilterBit[fTnv0][jj] = TheTrackv0->GetFilterMap();
 
 //   fTTrackv0Phi[fTnv0][jj] = (TheTrackv0->GetPhiAtRaidius().at(0)).at(0);//phi for r=85.cm ???
+//   fTTrackv0ITStime[fTnv0][jj] = TheTrackv0->GetHasITSHit();
+//   fTTrackv0TOFtime[fTnv0][jj] = TheTrackv0->GetTOFTimingReuqirement();
    fTTrackv0ID[fTnv0][jj] = TheTrackv0->GetIDTracks().at(0);
   }
 
@@ -1004,11 +1004,11 @@ Bool_t AliAnalysisTaskGeorgiosNTuple::FillCascade(AliFemtoDreamCascade *TheCasc)
  *
   fTTrackCrF[fTnCascade][jj] = TheTrack->GetRatioCr();
   fTTrackCrR[fTnCascade][jj] = TheTrack->GetTPCCrossedRows();
-  fTTrackITStime[fTnCascade][jj] = TheTrack->GetHasITSHit();
-  fTTrackTOFtime[fTnCascade][jj] = TheTrack->GetTOFTimingReuqirement();
   fTTrackFilterBit[fTnCascade][jj] = TheTrack->GetFilterMap();
 */  
 //  fTTrackPhi[fTnCascade][jj] = (TheTrack->GetPhiAtRaidius().at(0)).at(0);//phi for r=85.cm ???
+  fTTrackITStime[fTnCascade][jj] = TheTrack->GetHasITSHit();
+  fTTrackTOFtime[fTnCascade][jj] = TheTrack->GetTOFTimingReuqirement();
   fTTrackID[fTnCascade][jj] = TheTrack->GetIDTracks().at(0);
  }
 

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliAnalysisTaskGeorgiosNTuple.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliAnalysisTaskGeorgiosNTuple.h
@@ -159,15 +159,15 @@ class AliAnalysisTaskGeorgiosNTuple : public AliAnalysisTaskSE {
   Float_t fTTrackv0CrF[300][2];
   Int_t fTTrackv0Shared[300][2];
   Float_t fTTrackv0TPCchi2[300][2];
-  Bool_t fTTrackv0ITStime[300][2];
-  Bool_t fTTrackv0TOFtime[300][2];
   Bool_t fTTrackv0TPConly[300][2];
   Bool_t fTTrackv0ITScomplementary[300][2];
   Bool_t fTTrackv0ITSpure[300][2];
   Bool_t fTTrackv0GLOBAL[300][2];
   UInt_t fTTrackv0FilterBit[300][2];
+  Float_t fTTrackv0Phi[300][2];
+  Bool_t fTTrackv0ITStime[300][2];
+  Bool_t fTTrackv0TOFtime[300][2];
 */
-//  Float_t fTTrackv0Phi[300][2];
   Int_t fTTrackv0ID[300][2];
 
 #ifdef MONTECARLO 
@@ -235,8 +235,6 @@ class AliAnalysisTaskGeorgiosNTuple : public AliAnalysisTaskSE {
   Float_t fTTrackCrF[300][3];
   Int_t fTTrackShared[300][3];
   Float_t fTTrackTPCchi2[300][3];
-  Bool_t fTTrackITStime[300][3];
-  Bool_t fTTrackTOFtime[300][3];
   Bool_t fTTrackTPConly[300][3];
   Bool_t fTTrackITScomplementary[300][3];
   Bool_t fTTrackITSpure[300][3];
@@ -244,6 +242,8 @@ class AliAnalysisTaskGeorgiosNTuple : public AliAnalysisTaskSE {
   UInt_t fTTrackFilterBit[300][3];
 */
 //  Float_t fTTrackPhi[300][3];
+  Bool_t fTTrackITStime[300][3];
+  Bool_t fTTrackTOFtime[300][3];
   Int_t fTTrackID[300][3];
 
 #ifdef MONTECARLO 

--- a/PWGCF/FEMTOSCOPY/macros/AddTaskGeorgiosNTuple.C
+++ b/PWGCF/FEMTOSCOPY/macros/AddTaskGeorgiosNTuple.C
@@ -35,6 +35,8 @@ AliAnalysisTaskSE *AddTaskGeorgiosNTuple(bool fullBlastQA = true,
   AliFemtoDreamv0Cuts *v0Cuts = AliFemtoDreamv0Cuts::LambdaCuts(isMC, true, false);
   AliFemtoDreamTrackCuts *Posv0Daug = AliFemtoDreamTrackCuts::DecayProtonCuts(isMC, true, false);//PileUpRej, false
   AliFemtoDreamTrackCuts *Negv0Daug = AliFemtoDreamTrackCuts::DecayPionCuts(isMC, true, false);
+  Posv0Daug->SetNClsTPC(60); //openen for systematic variation
+  Negv0Daug->SetNClsTPC(60); //opened for systematic variation
   v0Cuts->SetPosDaugterTrackCuts(Posv0Daug);
   v0Cuts->SetNegDaugterTrackCuts(Negv0Daug);
   v0Cuts->SetPDGCodePosDaug(2212);  //Proton
@@ -48,6 +50,8 @@ AliAnalysisTaskSE *AddTaskGeorgiosNTuple(bool fullBlastQA = true,
   PosAntiv0Daug->SetCutCharge(1);
   AliFemtoDreamTrackCuts *NegAntiv0Daug = AliFemtoDreamTrackCuts::DecayProtonCuts(isMC, true, false);
   NegAntiv0Daug->SetCutCharge(-1);
+  PosAntiv0Daug->SetNClsTPC(60); //openen for systematic variation
+  NegAntiv0Daug->SetNClsTPC(60); //opened for systematic variation
   Antiv0Cuts->SetPosDaugterTrackCuts(PosAntiv0Daug);
   Antiv0Cuts->SetNegDaugterTrackCuts(NegAntiv0Daug);
   Antiv0Cuts->SetPDGCodePosDaug(211);  //Pion
@@ -57,10 +61,10 @@ AliAnalysisTaskSE *AddTaskGeorgiosNTuple(bool fullBlastQA = true,
   Antiv0Cuts->SetCutCPA(0.9); //include this for the CPA template fits
 
   //Systematic variations for v0
-  //v0Cuts->SetCutDCADaugTov0Vtx(1.9);
-  //Antiv0Cuts->SetCutDCADaugTov0Vtx(1.9);
-  v0Cuts->SetCutDCADaugToPrimVtx(0.05);
-  Antiv0Cuts->SetCutDCADaugToPrimVtx(0.05);
+  v0Cuts->SetCutDCADaugTov0Vtx(1.65);
+  Antiv0Cuts->SetCutDCADaugTov0Vtx(1.65);
+  v0Cuts->SetCutDCADaugToPrimVtx(0.027); //0.05
+  Antiv0Cuts->SetCutDCADaugToPrimVtx(0.027);
   v0Cuts->SetPtRange(0.22,999.);
   Antiv0Cuts->SetPtRange(0.22,999.);
 
@@ -69,10 +73,16 @@ AliAnalysisTaskSE *AddTaskGeorgiosNTuple(bool fullBlastQA = true,
   CascadeXiBGRCuts->SetXiCharge(-1);
   AliFemtoDreamTrackCuts *XiBGRNegCuts = AliFemtoDreamTrackCuts::Xiv0PionCuts(isMC, true, false);
   XiBGRNegCuts->SetCheckTPCRefit(false);//for nanos this is already done while prefiltering
+  XiBGRNegCuts->SetCheckPileUp(false);  //release timing information 
   AliFemtoDreamTrackCuts *XiBGRPosCuts = AliFemtoDreamTrackCuts::Xiv0ProtonCuts(isMC, true, false);
   XiBGRPosCuts->SetCheckTPCRefit(false);
   AliFemtoDreamTrackCuts *XiBGRBachCuts = AliFemtoDreamTrackCuts::XiBachPionCuts(isMC, true, false);
   XiBGRBachCuts->SetCheckTPCRefit(false);
+  //systematics of the Xi's tracks 
+  XiBGRNegCuts->SetEtaRange(-0.91, 0.91);
+  XiBGRPosCuts->SetEtaRange(-0.91, 0.91);
+  XiBGRBachCuts->SetEtaRange(-0.91, 0.91);
+  
   CascadeXiBGRCuts->Setv0Negcuts(XiBGRNegCuts);
   CascadeXiBGRCuts->Setv0PosCuts(XiBGRPosCuts);
   CascadeXiBGRCuts->SetBachCuts(XiBGRBachCuts);
@@ -81,6 +91,7 @@ AliAnalysisTaskSE *AddTaskGeorgiosNTuple(bool fullBlastQA = true,
   CascadeXiBGRCuts->SetPDGCodePosDaug(2212);
   CascadeXiBGRCuts->SetPDGCodeNegDaug(-211);
   CascadeXiBGRCuts->SetPDGCodeBach(-211);
+ 
   //AntiCascade cuts (Background)
   AliFemtoDreamCascadeCuts* AntiCascadeXiBGRCuts = AliFemtoDreamCascadeCuts::XiCuts(isMC, false);
   AntiCascadeXiBGRCuts->SetXiCharge(1);
@@ -90,9 +101,15 @@ AliAnalysisTaskSE *AddTaskGeorgiosNTuple(bool fullBlastQA = true,
   AliFemtoDreamTrackCuts *AntiXiBGRPosCuts = AliFemtoDreamTrackCuts::Xiv0PionCuts(isMC, true, false);
   AntiXiBGRPosCuts->SetCutCharge(1);
   AntiXiBGRPosCuts->SetCheckTPCRefit(false);
+  AntiXiBGRPosCuts->SetCheckPileUp(false);  //release timing information 
   AliFemtoDreamTrackCuts *AntiXiBGRBachCuts =AliFemtoDreamTrackCuts::XiBachPionCuts(isMC, true, false);
   AntiXiBGRBachCuts->SetCutCharge(1);
   AntiXiBGRBachCuts->SetCheckTPCRefit(false);
+  //systematics of the Xi's tracks 
+  AntiXiBGRNegCuts->SetEtaRange(-0.91, 0.91);
+  AntiXiBGRPosCuts->SetEtaRange(-0.91, 0.91);
+  AntiXiBGRBachCuts->SetEtaRange(-0.91, 0.91);
+  
   AntiCascadeXiBGRCuts->Setv0Negcuts(AntiXiBGRNegCuts);
   AntiCascadeXiBGRCuts->Setv0PosCuts(AntiXiBGRPosCuts);
   AntiCascadeXiBGRCuts->SetBachCuts(AntiXiBGRBachCuts);
@@ -107,10 +124,16 @@ AliAnalysisTaskSE *AddTaskGeorgiosNTuple(bool fullBlastQA = true,
   CascadeXiCuts->SetXiCharge(-1);
   AliFemtoDreamTrackCuts *XiNegCuts = AliFemtoDreamTrackCuts::Xiv0PionCuts(isMC, true, false);
   XiNegCuts->SetCheckTPCRefit(false);
+  XiNegCuts->SetCheckPileUp(false);  //release timing information 
   AliFemtoDreamTrackCuts *XiPosCuts = AliFemtoDreamTrackCuts::Xiv0ProtonCuts(isMC, true, false);
   XiPosCuts->SetCheckTPCRefit(false);
   AliFemtoDreamTrackCuts *XiBachCuts = AliFemtoDreamTrackCuts::XiBachPionCuts(isMC, true, false);
   XiBachCuts->SetCheckTPCRefit(false);
+  //systematics of the Xi's tracks 
+  XiNegCuts->SetEtaRange(-0.91, 0.91);
+  XiPosCuts->SetEtaRange(-0.91, 0.91);
+  XiBachCuts->SetEtaRange(-0.91, 0.91);
+  
   CascadeXiCuts->Setv0Negcuts(XiNegCuts);
   CascadeXiCuts->Setv0PosCuts(XiPosCuts);
   CascadeXiCuts->SetBachCuts(XiBachCuts);
@@ -131,9 +154,15 @@ AliAnalysisTaskSE *AddTaskGeorgiosNTuple(bool fullBlastQA = true,
   AliFemtoDreamTrackCuts *AntiXiPosCuts = AliFemtoDreamTrackCuts::Xiv0PionCuts(isMC, true, false);
   AntiXiPosCuts->SetCutCharge(1);
   AntiXiPosCuts->SetCheckTPCRefit(false);
+  AntiXiPosCuts->SetCheckPileUp(false);  //release timing information 
   AliFemtoDreamTrackCuts *AntiXiBachCuts =AliFemtoDreamTrackCuts::XiBachPionCuts(isMC, true, false);
   AntiXiBachCuts->SetCutCharge(1);
   AntiXiBachCuts->SetCheckTPCRefit(false);
+  //systematics of the Xi's tracks 
+  AntiXiNegCuts->SetEtaRange(-0.91, 0.91);
+  AntiXiPosCuts->SetEtaRange(-0.91, 0.91);
+  AntiXiBachCuts->SetEtaRange(-0.91, 0.91);
+  
   AntiCascadeXiCuts->Setv0Negcuts(AntiXiNegCuts);
   AntiCascadeXiCuts->Setv0PosCuts(AntiXiPosCuts);
   AntiCascadeXiCuts->SetBachCuts(AntiXiBachCuts);
@@ -145,44 +174,36 @@ AliAnalysisTaskSE *AddTaskGeorgiosNTuple(bool fullBlastQA = true,
   AntiCascadeXiCuts->SetXiMassRange(1.322, 0.06); //include Background
 
   //systematics for Xis
-  CascadeXiCuts->SetCutXiDaughterDCA(1.9);
-  AntiCascadeXiCuts->SetCutXiDaughterDCA(1.9);
-  CascadeXiCuts->SetCutXiMinDistBachToPrimVtx(0.04);
-  AntiCascadeXiCuts->SetCutXiMinDistBachToPrimVtx(0.04);
+  CascadeXiCuts->SetCutXiDaughterDCA(1.6);
+  AntiCascadeXiCuts->SetCutXiDaughterDCA(1.6);
+  CascadeXiCuts->SetCutXiMinDistBachToPrimVtx(0.03);
+  AntiCascadeXiCuts->SetCutXiMinDistBachToPrimVtx(0.03);
   CascadeXiCuts->SetCutv0MinDistToPrimVtx(0.06);
   AntiCascadeXiCuts->SetCutv0MinDistToPrimVtx(0.06);
-  CascadeXiCuts->SetCutv0MinDaugDistToPrimVtx(0.04);
-  AntiCascadeXiCuts->SetCutv0MinDaugDistToPrimVtx(0.04);
+  CascadeXiCuts->SetCutv0MinDaugDistToPrimVtx(0.03);
+  AntiCascadeXiCuts->SetCutv0MinDaugDistToPrimVtx(0.03);
+  CascadeXiCuts->SetCutXiCPA(0.97);
+  AntiCascadeXiCuts->SetCutXiCPA(0.97);
   CascadeXiCuts->SetCutXiTransverseRadius(0.6, 200);
   AntiCascadeXiCuts->SetCutXiTransverseRadius(0.6, 200);
-  CascadeXiCuts->SetCutv0TransverseRadius(1.1, 200);
-  AntiCascadeXiCuts->SetCutv0TransverseRadius(1.1, 200);
-  XiNegCuts->SetEtaRange(-0.91, 0.91);
-  XiPosCuts->SetEtaRange(-0.91, 0.91);
-  XiBachCuts->SetEtaRange(-0.91, 0.91);
-  AntiXiNegCuts->SetEtaRange(-0.91, 0.91);
-  AntiXiPosCuts->SetEtaRange(-0.91, 0.91);
-  AntiXiBachCuts->SetEtaRange(-0.91, 0.91);
+  CascadeXiCuts->SetCutv0TransverseRadius(1.0, 200);
+  AntiCascadeXiCuts->SetCutv0TransverseRadius(1.0, 200);
 
   //BGR 
-  CascadeXiBGRCuts->SetCutXiDaughterDCA(1.9);
-  AntiCascadeXiBGRCuts->SetCutXiDaughterDCA(1.9);
-  CascadeXiBGRCuts->SetCutXiMinDistBachToPrimVtx(0.04);
-  AntiCascadeXiBGRCuts->SetCutXiMinDistBachToPrimVtx(0.04);
+  CascadeXiBGRCuts->SetCutXiDaughterDCA(1.6);
+  AntiCascadeXiBGRCuts->SetCutXiDaughterDCA(1.6);
+  CascadeXiBGRCuts->SetCutXiMinDistBachToPrimVtx(0.03);
+  AntiCascadeXiBGRCuts->SetCutXiMinDistBachToPrimVtx(0.03);
   CascadeXiBGRCuts->SetCutv0MinDistToPrimVtx(0.06);
   AntiCascadeXiBGRCuts->SetCutv0MinDistToPrimVtx(0.06);   
-  CascadeXiBGRCuts->SetCutv0MinDaugDistToPrimVtx(0.04);
-  AntiCascadeXiBGRCuts->SetCutv0MinDaugDistToPrimVtx(0.04);
+  CascadeXiBGRCuts->SetCutv0MinDaugDistToPrimVtx(0.03);
+  AntiCascadeXiBGRCuts->SetCutv0MinDaugDistToPrimVtx(0.03);
+  CascadeXiBGRCuts->SetCutXiCPA(0.97);
+  AntiCascadeXiBGRCuts->SetCutXiCPA(0.97);
   CascadeXiBGRCuts->SetCutXiTransverseRadius(0.6, 200);
   AntiCascadeXiBGRCuts->SetCutXiTransverseRadius(0.6, 200);
-  CascadeXiBGRCuts->SetCutv0TransverseRadius(1.1, 200);
-  AntiCascadeXiBGRCuts->SetCutv0TransverseRadius(1.1, 200);
-  XiBGRNegCuts->SetEtaRange(-0.91, 0.91);
-  XiBGRPosCuts->SetEtaRange(-0.91, 0.91);
-  XiBGRBachCuts->SetEtaRange(-0.91, 0.91);
-  AntiXiBGRNegCuts->SetEtaRange(-0.91, 0.91);
-  AntiXiBGRPosCuts->SetEtaRange(-0.91, 0.91);
-  AntiXiBGRBachCuts->SetEtaRange(-0.91, 0.91);
+  CascadeXiBGRCuts->SetCutv0TransverseRadius(1.0, 200);
+  AntiCascadeXiBGRCuts->SetCutv0TransverseRadius(1.0, 200);
 
 
   if (suffix != "0" && suffix != "999") {


### PR DESCRIPTION
Setting new open Cuts for systematic variations and releasing timing information for the Pion Track of the Xi candidates