### PR TITLE
Add correlation histograms for trigger classes

### DIFF
--- a/PWG/EMCAL/EMCALtasks/AliAnalysisTaskEmcalTriggerNormalization.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliAnalysisTaskEmcalTriggerNormalization.cxx
@@ -103,6 +103,16 @@ void AliAnalysisTaskEmcalTriggerNormalization::UserCreateOutputObjects(){
     }
   }
 
+  // Histograms for trigger correlation
+  for(auto clust : fgkTriggerClusterLabels) {
+    fHistos->CreateTH2(Form("hTriggerCorrelation%s", clust.data()), Form("Correlation selected trigger classes for cluster %s", clust.data()), triggers.size(), -0.5, triggers.size() - 0.5, triggers.size(), -0.5, triggers.size() - 0.5);
+    TH1 *correlationHist = static_cast<TH1 *>(fHistos->FindObject(Form("hTriggerCorrelation%s", clust.data())));
+    for(decltype(triggers.size()) ib = 0; ib < triggers.size(); ib++){
+      correlationHist->GetXaxis()->SetBinLabel(ib+1, triggers[ib].data());
+      correlationHist->GetYaxis()->SetBinLabel(ib+1, triggers[ib].data());
+    }
+  }
+
   for(auto h : *fHistos->GetListOfHistograms()) fOutput->Add(h);
   PostData(1, fOutput);
 }
@@ -166,8 +176,11 @@ Bool_t AliAnalysisTaskEmcalTriggerNormalization::Run(){
   
   std::array<std::string, 5> mixedtriggers = {"EDMC7", "EDG1", "EDG2", "EDJ1", "EDJ2"};
 
+  std::vector<std::string> selectedTriggerClasses;
+
   // Min. bias trigger (reference trigger)
   if(fInputHandler->IsEventSelected() & AliVEvent::kINT7) {
+    selectedTriggerClasses.push_back("INT7");
     auto match_triggerclass = MatchTrigger(triggerstring, fMBTriggerClasses);
     AliDebugStream(2) << "Matched trigger: " << match_triggerclass << std::endl;
     if(match_triggerclass.length()){
@@ -231,14 +244,14 @@ Bool_t AliAnalysisTaskEmcalTriggerNormalization::Run(){
   if(hasEMCALtrigger) {
     AliDebugStream(2) << "Found EMCAL trigger: "  << triggerstring << std::endl;
   }
-  for(Int_t i = 0; i < NEMCAL_TRIGGERS; i++) {      
-    auto &triggerclass = EMCAL_TRIGGERS[i];
+  for(Int_t trgID = 0; trgID < NEMCAL_TRIGGERS; trgID++) {      
+    auto &triggerclass = EMCAL_TRIGGERS[trgID];
     auto emctriggerfound = fCacheTriggerClasses.find(triggerclass);
     if(emctriggerfound == fCacheTriggerClasses.end()) {
       AliDebugStream(2) << "Trigger " << triggerclass << " not found in the list of supported triggers" << std::endl;
       continue;     // trigger class was not enabled in the run
     } 
-    if(!(fInputHandler->IsEventSelected() & EMCAL_TRIGGERBITS[i])) continue;
+    if(!(fInputHandler->IsEventSelected() & EMCAL_TRIGGERBITS[trgID])) continue;
     // check if it is a mixed trigger
     if(triggerclass.find("ED") != std::string::npos){
       // mixed trigger class, check if either the EMCAL or the DCAL trigger is selectged
@@ -246,6 +259,7 @@ Bool_t AliAnalysisTaskEmcalTriggerNormalization::Run(){
                   dcaltriggerclass = "D" + triggerclass.substr(2);
       if(fInputEvent->GetFiredTriggerClasses().Contains(emcaltriggerclass.data()) ||
          fInputEvent->GetFiredTriggerClasses().Contains(dcaltriggerclass.data())) {
+        selectedTriggerClasses.push_back(EMCAL_TRIGGERS[trgID]);
         // Mixed trigger, downscaled in sync, use trigger weight for the EMCAL trigger
         double triggerweight = 1./fCacheDownscaleFactors[emcaltriggerclass];
         auto triggerbin = normhist->GetXaxis()->FindBin(triggerclass.data());
@@ -260,6 +274,7 @@ Bool_t AliAnalysisTaskEmcalTriggerNormalization::Run(){
     } else {
       // Single detector trigger, either EMCAL or DCAL
       if(fInputEvent->GetFiredTriggerClasses().Contains(triggerclass.data())) {
+        selectedTriggerClasses.push_back(EMCAL_TRIGGERS[trgID]);
         double triggerweight = 1./fCacheDownscaleFactors[triggerclass];
         auto triggerbin = normhist->GetXaxis()->FindBin(triggerclass.data());
         normhist->Fill(normhist->GetXaxis()->GetBinCenter(triggerbin), centralitypercentile, triggerweight);
@@ -270,6 +285,24 @@ Bool_t AliAnalysisTaskEmcalTriggerNormalization::Run(){
           triggerclusterhist->Fill(triggercluster);
         }
       } 
+    }
+  }
+
+  // trigger correlation histograms, mainly used to cross check the downscaling
+  // self-correlations include
+  // distinguish between trigger classes
+  for(auto clust : triggerclusters) {
+    auto *corrhist = static_cast<TH2 *>(fHistos->GetListOfHistograms()->FindObject(Form("hTriggerCorrelation%s", fgkTriggerClusterLabels[clust].data())));
+    for(int itrg = 0; itrg < corrhist->GetXaxis()->GetNbins(); itrg++){
+      const char *xlabel = corrhist->GetXaxis()->GetBinLabel(itrg+1);
+      bool hasTriggerA = (std::find(selectedTriggerClasses.begin(), selectedTriggerClasses.end(), xlabel) != selectedTriggerClasses.end());
+      if(hasTriggerA) {
+        for(int jtrg = 0; jtrg < corrhist->GetYaxis()->GetNbins(); jtrg++){
+          const char *ylabel = corrhist->GetYaxis()->GetBinLabel(jtrg+1);
+          bool hasTriggerB = (std::find(selectedTriggerClasses.begin(), selectedTriggerClasses.end(), ylabel) != selectedTriggerClasses.end());
+          if(hasTriggerB) corrhist->Fill(xlabel, ylabel, 1.);
+        }
+      }
     }
   }
   return true;

--- a/PWG/EMCAL/EMCALtasks/AliAnalysisTaskEmcalTriggerNormalization.h
+++ b/PWG/EMCAL/EMCALtasks/AliAnalysisTaskEmcalTriggerNormalization.h
@@ -84,6 +84,18 @@ namespace EMCAL {
  * | p-Pb 8.16 TeV | CENT->CENTNOPMD            | EMC7, DMC7         |
  * | p-Pb 8.16 TeV | CENTNOPMD->CENTNOTRD       | EJ1, EG1, DJ1, DG1 |
  * 
+ * # Trigger correlation 
+ * 
+ * Further histograms are filled for each trigger cluster monitoring the correlation between
+ * different trigger classes. The diagonal elements are self-correlations and can therefore
+ * be used to as absolute event counter. The off-diagonal elements of the matrix monitor
+ * which triggers fire together with the trigger class and show the correlation of a trigger
+ * with other triggers, where the other trigger is always a subset.
+ * 
+ * Downscale factors can be checked comparing the event count of the off-diagonal element for
+ * the trigger to the diagonal eleemnt for a reference trigger. In this case the reference 
+ * process must not be downscaled.
+ * 
  * # Basic task configuration
  * 
  * A static Add function performs the basic task configuration. The tasks configures itself


### PR DESCRIPTION
Correlation histograms are implemented for each
trigger cluster separately. Diagonal elements are
absolute event counters, off-diagonal elements
show the correlation with the trigger.

Mainly used to cross check downscale factors.