### PR TITLE
PWG/EMCal: Added new functions for NCell efficiency & Added new MC energy fine tuning

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.cxx
@@ -1679,10 +1679,25 @@ void AliEMCALRecoUtils::InitNCellEfficiencyParam()
     fNCellEfficiencyParams[1] = 1.28118;
     fNCellEfficiencyParams[2] = 0.583403;
   }
-  else if (fNCellEfficiencyFunction == kNCePi0TaggedPCMEMC) {
-    fNCellEfficiencyParams[0] = -0.0377925;
-    fNCellEfficiencyParams[1] = 0.160758;
-    fNCellEfficiencyParams[2] = -0.00357992;
+  else if (fNCellEfficiencyFunction == kNCePCMEMCGaussian) {
+    fNCellEfficiencyParams[0] = 0.130462;
+    fNCellEfficiencyParams[1] = 1.62858;
+    fNCellEfficiencyParams[2] = 0.572064;
+  }
+  else if (fNCellEfficiencyFunction == kNCePCMEMCPol2) {
+    fNCellEfficiencyParams[0] = -0.0794055;
+    fNCellEfficiencyParams[1] = 0.290664;
+    fNCellEfficiencyParams[2] = -0.136717;
+  }
+  else if (fNCellEfficiencyFunction == kNCeEMCGaussian) {
+    fNCellEfficiencyParams[0] = 0.0864766;
+    fNCellEfficiencyParams[1] = 1.50279;
+    fNCellEfficiencyParams[2] = 0.61173;
+  }
+  else if (fNCellEfficiencyFunction == kNCeEMCPol2) {
+    fNCellEfficiencyParams[0] = -0.0638141;
+    fNCellEfficiencyParams[1] = 0.203806;
+    fNCellEfficiencyParams[2] = -0.0774961;
   }
 
 }
@@ -1768,14 +1783,66 @@ Bool_t AliEMCALRecoUtils::GetIsNCellCorrected(AliVCluster* cluster, AliVCaloCell
       break;
     }
 
-    case kNCePi0TaggedPCMEMC:
+    case kNCePCMEMCGaussian:
     {
       // based on clusters which are part of a (PCM-EMC) cluster pair with a mass of: [M(Pi0) - 0.05;M(Pi0) + 0.02]
       // mostly photon clusters and electron(conversion) clusters (purity about 95%)
       // exotics should be nearly cancled by that
-      // fNCellEfficiencyParams[0] = -0.0377925;
-      // fNCellEfficiencyParams[1] = 0.160758;
-      // fNCellEfficiencyParams[2] = -0.00357992;
+      // Gaussian par.
+      // fNCellEfficiencyParams[0] = 0.130462;
+      // fNCellEfficiencyParams[1] = 1.62858;
+      // fNCellEfficiencyParams[2] = 0.572064;
+      Float_t val = fNCellEfficiencyParams[0]*exp(
+                    -0.5*((energy-fNCellEfficiencyParams[1])/fNCellEfficiencyParams[2])*
+                    ((energy-fNCellEfficiencyParams[1])/fNCellEfficiencyParams[2]));
+      if(randNr < val) return kTRUE;
+      else return kFALSE;
+      break;
+    }
+
+    case kNCePCMEMCPol2:
+    {
+      // based on clusters which are part of a (PCM-EMC) cluster pair with a mass of: [M(Pi0) - 0.05;M(Pi0) + 0.02]
+      // mostly photon clusters and electron(conversion) clusters (purity about 95%)
+      // exotics should be nearly cancled by that
+      // Pol2 par.
+      // fNCellEfficiencyParams[0] = -0.0794055;
+      // fNCellEfficiencyParams[1] = 0.290664;
+      // fNCellEfficiencyParams[2] = -0.136717;
+      Float_t val = fNCellEfficiencyParams[0]*energy*energy +
+                    fNCellEfficiencyParams[1]*energy +
+                    fNCellEfficiencyParams[2];
+      if(randNr < val) return kTRUE;
+      else return kFALSE;
+      break;
+    }
+
+    case kNCeEMCGaussian:
+    {
+      // based on clusters which are part of a (EMC-EMC) cluster pair with a mass of: [M(Pi0) - 0.05;M(Pi0) + 0.02]
+      // mostly photon clusters and electron(conversion) clusters (purity about 95%)
+      // exotics should be nearly cancled by that
+      // Gaussian par.
+      // fNCellEfficiencyParams[0] = 0.0864766;
+      // fNCellEfficiencyParams[1] = 1.50279;
+      // fNCellEfficiencyParams[2] = 0.61173;
+      Float_t val = fNCellEfficiencyParams[0]*exp(
+                    -0.5*((energy-fNCellEfficiencyParams[1])/fNCellEfficiencyParams[2])*
+                    ((energy-fNCellEfficiencyParams[1])/fNCellEfficiencyParams[2]));
+      if(randNr < val) return kTRUE;
+      else return kFALSE;
+      break;
+    }
+
+    case kNCeEMCPol2:
+    {
+      // based on clusters which are part of a (EMC-EMC) cluster pair with a mass of: [M(Pi0) - 0.05;M(Pi0) + 0.02]
+      // mostly photon clusters and electron(conversion) clusters (purity about 95%)
+      // exotics should be nearly cancled by that
+      // Pol2 par.
+      // fNCellEfficiencyParams[0] = -0.0638141;
+      // fNCellEfficiencyParams[1] = 0.203806;
+      // fNCellEfficiencyParams[2] = -0.0774961;
       Float_t val = fNCellEfficiencyParams[0]*energy*energy +
                     fNCellEfficiencyParams[1]*energy +
                     fNCellEfficiencyParams[2];

--- a/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.h
+++ b/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.h
@@ -104,7 +104,10 @@ public:
     kNCeAllClusters     = 1,
     kNCeTestBeam        = 2,
     kNCeGammaAndElec    = 3,
-    kNCePi0TaggedPCMEMC = 4
+    kNCePCMEMCGaussian  = 4,
+    kNCePCMEMCPol2      = 5,
+    kNCeEMCGaussian     = 6,
+    kNCeEMCPol2         = 7
   };
 
   /// Cluster position enum list of possible algoritms
@@ -738,7 +741,7 @@ private:
   Bool_t     fMCGenerToAcceptForTrack;   ///<  Activate the removal of tracks entering the track matching that come from a particular generator
 
   /// \cond CLASSIMP
-  ClassDef(AliEMCALRecoUtils, 40) ;
+  ClassDef(AliEMCALRecoUtils, 41) ;
   /// \endcond
 
 };

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterLowEnergyEfficiency.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterLowEnergyEfficiency.cxx
@@ -21,7 +21,10 @@ const std::map <std::string, AliEMCALRecoUtils::NCellEfficiencyFunctions> AliEmc
     { "kAllClusters", AliEMCALRecoUtils::kNCeAllClusters },
     { "kTestBeam", AliEMCALRecoUtils::kNCeTestBeam },
     { "kGammaAndElec", AliEMCALRecoUtils::kNCeGammaAndElec },
-    { "kPi0TaggedPCMEMC", AliEMCALRecoUtils::kNCePi0TaggedPCMEMC }
+    { "kPCMEMCGaussian", AliEMCALRecoUtils::kNCePCMEMCGaussian },
+    { "kPCMEMCPol2", AliEMCALRecoUtils::kNCePCMEMCPol2 },
+    { "kEMCGaussian", AliEMCALRecoUtils::kNCeEMCGaussian },
+    { "kEMCPol2", AliEMCALRecoUtils::kNCeEMCPol2 }
 };
 
 /**

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterNonLinearityMCAfterburner.h
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterNonLinearityMCAfterburner.h
@@ -11,7 +11,7 @@
  * Non-linearity correction to the MC cluster energy is necessary because the current non linearity is done for
  * 50MeV cell threshold and all analyses use a 100MeV cell threshold for the clusterization.
  * Thus, the MC need to be corrected in a second step
- 
+
  The energy of the cluster **after** the MC non-linearity correction can be retrieved using the method `cluster->GetNonLinCorrEnergy()`.
  *
  * Based on code in AliCaloPhotonCuts.cxx.
@@ -56,7 +56,7 @@ protected:
   TH2F                  *fEnergyTimeHistBefore;      		//!<!energy/time distribution before
   TH1F                  *fEnergyDistAfter;          	 		//!<!energy distribution after
   TH2F                  *fEnergyTimeHistAfter;      			//!<!energy/time distribution after
-  Float_t                fNLAfterburnerPara[9];     			///< Parameters for the non linearity function
+  Float_t                fNLAfterburnerPara[11];     			///< Parameters for the non linearity function
   Int_t                  fNonLinearityAfterburnerFunction; ///< Type of function used for the non linearity afterburner correction
 
   EMCAfterburnerMethod_t fAfterburnerMethod;        			 ///< The version of the non-linearity afterburner correction (0-3, see enum NonlinearityMCAfterburnerMethod), 4=no correction
@@ -71,7 +71,7 @@ protected:
   static RegisterCorrectionComponent<AliEmcalCorrectionClusterNonLinearityMCAfterburner> reg;
 
   /// \cond CLASSIMP
-  ClassDef(AliEmcalCorrectionClusterNonLinearityMCAfterburner, 1); // EMCal cluster non-linearity MC correction afterburner component
+  ClassDef(AliEmcalCorrectionClusterNonLinearityMCAfterburner, 2); // EMCal cluster non-linearity MC correction afterburner component
   /// \endcond
 };
 


### PR DESCRIPTION
- Settings have to be used together with the new cell scale in data
- New fine tuning needed as cell scales in data changed (fine tuning is based on interpolation between PCM-EMC and EMC-EMC)
- Separate fine tuning for pp13TeV lowB periods
- New NCell efficiencies obtained with PCM-EMC tagged clusters and EMC-EMC tagged clusters. Pol2 and Gaussian param available for both cases. PCM-EMC with Gaussian should be default!