### PR TITLE
Add PID function kTPCpidTOFveto in AliRsnCutSetDaughterParticle

### DIFF
--- a/PWGLF/RESONANCES/AliRsnCutSetDaughterParticle.cxx
+++ b/PWGLF/RESONANCES/AliRsnCutSetDaughterParticle.cxx
@@ -542,6 +542,20 @@ void AliRsnCutSetDaughterParticle::Init()
       SetCutScheme( Form("%s&((%s&(!%s))|(%s&%s))",fCutQuality->GetName(), iCutTPCNSigma->GetName(), iCutTOFMatch->GetName(),iCutTOFNSigma->GetName(), iCutTPCNSigma->GetName()) ) ;
        break;     
 
+    case AliRsnCutSetDaughterParticle::kTPCpidTOFveto:
+      iCutTPCNSigma->SinglePIDRange(fNsigmaTPC);
+      AddCut(fCutQuality);
+      iCutTOFNSigma->SinglePIDRange(fNsigmaTOF);
+
+      AddCut(iCutTPCNSigma);
+      AddCut(iCutTOFMatch);
+      AddCut(iCutTOFNSigma);
+      
+      // scheme:
+      // quality & [ (TPCsigma & !TOFmatch) | (TPCsigma & TOFsigma) ]
+      SetCutScheme( Form("%s&((%s&(!%s))|(%s&%s))",fCutQuality->GetName(), iCutTPCNSigma->GetName(), iCutTOFMatch->GetName(),iCutTOFNSigma->GetName(), iCutTPCNSigma->GetName()) ) ;
+       break;     
+
     case AliRsnCutSetDaughterParticle::kCombinedPidBestPtDep:
       /* Set TPC  PID (if no TOF)*/
       // all   below  500 MeV: 3sigma

--- a/PWGLF/RESONANCES/AliRsnCutSetDaughterParticle.h
+++ b/PWGLF/RESONANCES/AliRsnCutSetDaughterParticle.h
@@ -48,6 +48,7 @@ public:
     kTPCpidMatchPPB2011, //Match with nsigma = fNsigmaTPC
     kTPCpidTOFveto4s, //TPC n sigma + 4.0 sigma TOF veto
     kTPCpidTOFveto3s, //TPC n sigma + 3.0 sigma TOF veto
+    kTPCpidTOFveto, //TPC n sigma +  n sigma TOF veto
     kCombinedPidBestPtDep, //combined TPC-TOF cut
     kTPCPidPtDep,     //basic PID cuts with pt dependence
     kTOFPidPtDep,


### PR DESCRIPTION
Add the new PID scheme function, kTPCpidTOFveto into AliRsnCutSetDaughterParticle class.
The PID function requires acceptable TPC sigma and veto TOF sigma.