### PR TITLE
MeanPtV2 efficiency calculation: outsourced primary selection (DCAxy …

### DIFF
--- a/PWGCF/FLOW/GF/AliAnalysisTaskMeanPtV2Corr.h
+++ b/PWGCF/FLOW/GF/AliAnalysisTaskMeanPtV2Corr.h
@@ -183,9 +183,9 @@ class AliAnalysisTaskMeanPtV2Corr : public AliAnalysisTaskSE {
   Bool_t Fillv2dPtFCs(const AliGFW::CorrConfig &corconf, const Double_t &dpt, const Double_t &rndmn, const Int_t index);
   Bool_t FillCovariance(AliProfileBS* target, const AliGFW::CorrConfig &corconf, const Double_t &cent, const Double_t &d_mpt, const Double_t &dw_mpt, const Double_t &l_rndm);
   Bool_t AcceptAODTrack(AliAODTrack *lTr, Double_t*, const Double_t &ptMin=0.5, const Double_t &ptMax=2, Double_t *vtxp=0);
-  Bool_t AcceptESDTrack(AliESDtrack *lTr, Double_t*, const Double_t &ptMin=0.5, const Double_t &ptMax=2, Double_t *vtxp=0);
   Bool_t AcceptAODTrack(AliAODTrack *lTr, Double_t*, const Double_t &ptMin, const Double_t &ptMax, Double_t *vtxp, Int_t &nTot);
-  Bool_t AcceptESDTrack(AliESDtrack *lTr, Double_t*, const Double_t &ptMin, const Double_t &ptMax, Double_t *vtxp, Int_t &nTot);
+  Bool_t AcceptESDTrack(AliESDtrack *lTr, UInt_t&, Double_t*, const Double_t &ptMin=0.5, const Double_t &ptMax=2, Double_t *vtxp=0);
+  Bool_t AcceptESDTrack(AliESDtrack *lTr, UInt_t&, Double_t*, const Double_t &ptMin, const Double_t &ptMax, Double_t *vtxp, Int_t &nTot);
   Bool_t AcceptCustomEvent(AliAODEvent*);
   Bool_t fDisablePID;
   UInt_t fConsistencyFlag;

--- a/PWGCF/FLOW/GF/AliGFW.cxx
+++ b/PWGCF/FLOW/GF/AliGFW.cxx
@@ -280,7 +280,7 @@ TComplex AliGFW::Calculate(Int_t poi, Int_t ref, vector<Int_t> hars, Int_t ptbin
 };
 TComplex AliGFW::Calculate(CorrConfig corconf, Int_t ptbin, Bool_t SetHarmsToZero, Bool_t DisableOverlap) {
   if(corconf.Regs.size()==0) return TComplex(0,0); //Check if we have any regions at all
-  TComplex retval(1,1);
+  TComplex retval(1,0);
   for(Int_t i=0;i<(Int_t)corconf.Regs.size();i++) { //looping over all regions
     if(corconf.Regs.at(i).size()==0)  return TComplex(0,0); //again, if no regions in the current subevent, then quit immediatelly
     //picking up the indecies of regions...

--- a/PWGCF/FLOW/GF/AliGFWCuts.h
+++ b/PWGCF/FLOW/GF/AliGFWCuts.h
@@ -15,6 +15,7 @@ If used, modified, or distributed, please aknowledge the original author of this
 #include "AliESDtrackCuts.h"
 #include "AliESDtrack.h"
 #include "AliESDEvent.h"
+#include "TF1.h"
 
 class AliGFWCuts {
  public:
@@ -24,7 +25,8 @@ class AliGFWCuts {
   Int_t AcceptVertex(AliAODEvent*, Int_t BitShift=0);
   Int_t AcceptVertex(AliESDEvent*, Int_t BitShift=0);
   Int_t AcceptTrack(AliAODTrack*, Double_t*, const Int_t &BitShift=0, const Bool_t &lDisableDCAxyCheck=kTRUE);
-  Int_t AcceptTrack(AliESDtrack*, Double_t*, const Int_t &BitShift=0, const Bool_t &lDisableDCAxyCheck=kTRUE);
+  Int_t AcceptTrack(AliESDtrack*, Double_t*, const Int_t &BitShift, UInt_t &PrimFlags);
+  void SetPtDepDCAXY(TString newval) { if(fPtDepXYCut) delete fPtDepXYCut; fPtDepXYCut = new TF1("ptDepDCAxy",newval.Data(),0.001,100); };
   void ResetCuts();
   void PrintSetup();
   void SetupCuts(Int_t);
@@ -32,6 +34,7 @@ class AliGFWCuts {
   TString *GetFlagDescription(Int_t flag);
   const char *GetSystPF() { return Form("%s",fSystFlag?Form("_SystFlag%i_",fSystFlag):""); };
   Int_t GetSystFlagIndex() { return fSystFlag; };
+  Double_t GetChi2TPCConstrained(const AliESDtrack *);
   Int_t fSystFlag;
   Int_t fFilterBit;//=96;
   Double_t fDCAxyCut;//=-1;
@@ -47,6 +50,7 @@ class AliGFWCuts {
   static AliESDtrackCuts *fTCFB512;
   Bool_t NeedsExtraWeight() { return fRequiresExtraWeight; };
  private:
+  TF1 *fPtDepXYCut;
   Bool_t fRequiresExtraWeight;
   void SetupTrackCuts(Int_t);
   void SetupEventCuts(Int_t);


### PR DESCRIPTION
…and Chi2TPCConstrainedVsGlobal) to AliGFWCuts, to allow for DCAxy template measurement. Changed the initial retval in AliGFW::Calculate