### PR TITLE
PWGGA/GammaConv+EMCal: EDC cuts for iso analysis & experimental track propagation

### DIFF
--- a/OADB/EMCAL/READMEoadb.txt
+++ b/OADB/EMCAL/READMEoadb.txt
@@ -98,5 +98,10 @@ In addition, a short history of changes to the files in EOS will be listed here:
 - 20200414: Update of EMCALTimeL1PhaseCalib.root with additional 2016 and 2018 PAR calibrations
 - 20210608: Update of EMCALTimeL1PhaseCalib.root with missing runs from LHC16j, LHC16h and LHC18k
 - 20210615: Update of EMCALTimeL1PhaseCalib.root with PAR for run 256227 in LHC16j
+- 20210813: Fix and update of EMCALTimeCalibMergedBCs.root: It is suspected that since June 4th, multiple periods were missing merged BC low gain timecalib information 
+            for the majority of cells. The following periods were updated: LHC15ij,LHC15n,LHC15o,LHC16fgh,LHC16ijk,LHC16op,LHC16qrst,LHC17g,LHC17h,LHC17ik,LHC17lm,
+            LHC17o,LHC17pq,LHC18b,LHC18c,LHC18def,LHC18ghijklm,LHC18nop,LHC18qr
+            Energy dependent merged BC time calib was added for: LHC16l, LHC17r
+
 
 */

--- a/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.cxx
@@ -5380,18 +5380,18 @@ const Double_t kEpsilon = 0.00001;
       Double_t meanZ = param[3];
       Double_t meanA = param[2];
       Double_t meanZoverA = meanZ/meanA;
-     AliDebug(2,Form(" --> The following information has been extracted\n")); 
-     AliDebug(2,Form(" Propagation lenghth (cm): %f\n" ,length)); 
-     AliDebug(2,Form(" meanDensiy (g/cc): %f\n" ,meanDensiy)); 
-     AliDebug(2,Form(" meanZoverA: %f\n" ,meanZoverA)); 
-     AliDebug(2,Form(" meanX0 (cm): %f\n" ,meanX0)); 
-     AliDebug(2,Form(" meanZ: %f\n" ,meanZ)); 
+    //  printf(" --> The following information has been extracted\n"); 
+    //  printf(" Propagation lenghth (cm): %f\n" ,length); 
+    //  printf(" meanDensiy (g/cc): %f\n" ,meanDensiy); 
+    //  printf(" meanZoverA: %f\n" ,meanZoverA); 
+    //  printf(" meanX0 (cm): %f\n" ,meanX0); 
+    //  printf(" meanZ: %f\n" ,meanZ); 
       // determine excitation energy from mean Z (GeV)
       Double_t excitationE;
       if (meanZ < 13) excitationE = (12. * meanZ + 7.) * 1.e-9;
       else excitationE = (9.76 * meanZ + 58.8 * TMath::Power(meanZ,-0.19)) * 1.e-9;
 
-      AliDebug(2,Form("Optaining excitation energy in (eV): %f\n",excitationE*1e9));
+      // printf("Optaining excitation energy in (eV): %f\n",excitationE*1e9);
 
       // determine density effect for ionization losses of charged particles
       // values given in table
@@ -5423,9 +5423,9 @@ const Double_t kEpsilon = 0.00001;
           }
       }
 
-      AliDebug(2,"According to paper density correction parameters were set to:\n");
-      AliDebug(2,Form("x0= %f\n" ,x0));
-      AliDebug(2,Form("x1= %f\n" ,x1));
+      // printf("According to paper density correction parameters were set to:\n");
+      // printf("x0= %f\n" ,x0);
+      // printf("x1= %f\n" ,x1);
       
       // Calculate dEdx
       Double_t bg=track->P()/mass;
@@ -5476,17 +5476,16 @@ const Double_t kEpsilon = 0.00001;
     // }
     // TGeoMaterial *material = startnode->GetVolume()->GetMedium()->GetMaterial();
     // TGeoMaterial *
-    AliDebug(2,Form("Critical energy (MeV): %f\n", ECritSolid));
-    AliDebug(2,Form("Mass: %f\n", mass));
+    // printf("Critical energy (MeV): %f\n", ECritSolid);
+    // printf("Mass: %f\n", mass);
      
     Double_t p = track->GetP();
     Double_t trackE = TMath::Sqrt((p*p) + (mass*mass));
-    AliDebug(2,Form("Track Energy %f\n", trackE*1000));
-    
+    // printf("Track Energy %f\n", trackE*1000);
     if((mass>=0.000510)&&(mass<=0.000512)){ // if electron
-            AliDebug(2,"IsElectron\n");
+            // printf("IsElectron\n");
       if((trackE*1000)>ECritSolid){ // compare energies in MeV
-            AliDebug(2,Form("Energy %f was higher than crit\n",track->E()*1000));
+            // printf("Energy %f was higher than crit\n",track->E()*1000);
             dEdxRadiationLoss = trackE/meanX0; // energy loss dedx due to bremsstrahlung in GeV
             
       }

--- a/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.cxx
@@ -5274,6 +5274,261 @@ void AliEMCALRecoUtils::SetEMCALL1PhaseInTimeRecalibrationForAllSM(const TH1C* h
   fEMCALL1PhaseInTimeRecalibration->AddAt(clone,parNumber);
 }
 
+/**
+ * @brief function that allows propagation of a track to EMCal surface. In this case, full BetheBloch inspired by GEANT
+ *  is used instead of an approximation of BetheBloch for solids (Silicon) that is normally used.
+ * 
+ * For electrons the enrrgy loss due to Bremsstrahlung is accounted for above critial Energy E_Crit
+ * of the respective (mean) material passed in the step
+ * 
+ * @param trkParam track parameters
+ * @param emcalR radius of emcal surface used for propagation (cm)
+ * @param mass mass hypothesis used for track extrpolation (GeV/c2)
+ * @param step step length for propagation
+ * @param eta return. Track eta on emcal surface
+ * @param phi return. Track phi on emcal surface
+ * @param pt return. Track pt on emcal surface
+ */
+ Bool_t AliEMCALRecoUtils::ExtrapolateTrackToEMCalSurfaceExperimental(AliExternalTrackParam *trkParam, 
+                                                             Double_t emcalR,
+                                                             Double_t mass, 
+                                                             Double_t step, 
+                                                             Float_t &eta, 
+                                                             Float_t &phi,
+                                                             Float_t &pt){
+
+  eta = -999, phi = -999, pt = -999;
+  
+  if (!trkParam) return kFALSE;
+  
+  if (!PropagateTrackToBxByBzExperimental(trkParam, emcalR, mass, step, kTRUE, 0.8, -1)) return kFALSE;
+  
+  Double_t trkPos[3] = {0.,0.,0.};
+  
+  if (!trkParam->GetXYZ(trkPos)) return kFALSE;
+  
+  TVector3 trkPosVec(trkPos[0],trkPos[1],trkPos[2]);
+  
+  eta = trkPosVec.Eta();
+  phi = trkPosVec.Phi();
+  pt  = trkParam->Pt();
+  
+  if ( phi < 0 )
+    phi += TMath::TwoPi();
+  
+  return kTRUE;
+}
+
+/**
+ * @brief Function that 
+ * 
+ * @param track external track parameters of tracks
+ * @param xToGo x of where to propagate to in cm
+ * @param mass mass assumption use for propagation
+ * @param maxStep size of each step done for propagation in cm
+ * @param rotateTo 
+ * @param maxSnp 
+ * @param sign  
+ * @param addTimeStep 
+ * @param correctMaterialBudget if true, track momentum will be corrected for passed material
+ * @return Bool_t 
+ */
+Bool_t AliEMCALRecoUtils::PropagateTrackToBxByBzExperimental(AliExternalTrackParam *track,
+				       Double_t xToGo,Double_t mass, Double_t maxStep, Bool_t rotateTo, Double_t maxSnp,Int_t sign, Bool_t addTimeStep,
+				       Bool_t correctMaterialBudget){
+const Double_t kEpsilon = 0.00001;
+  Double_t xpos     = track->GetX();
+  Int_t dir         = (xpos<xToGo) ? 1:-1;
+
+  while ( (xToGo-xpos)*dir > kEpsilon){
+    Double_t step = dir*TMath::Min(TMath::Abs(xToGo-xpos), maxStep);
+    Double_t x    = xpos+step;
+    Double_t xyz0[3],xyz1[3],param[7];
+    track->GetXYZ(xyz0);   //starting global position
+
+    Double_t b[3]; AliTrackerBase::GetBxByBz(xyz0,b); // getting the local Bx, By and Bz
+
+    if (!track->GetXYZAt(x,b[2],xyz1)) return kFALSE;   // no prolongation
+    xyz1[2]+=kEpsilon; // waiting for bug correction in geo
+
+    //    if (maxSnp>0 && TMath::Abs(track->GetSnpAt(x,b[2])) >= maxSnp) return kFALSE;
+    if (!track->PropagateToBxByBz(x,b))  return kFALSE;
+    if (maxSnp>0 && TMath::Abs(track->GetSnp())>=maxSnp) return kFALSE;
+
+
+    // New part to correct properly for material traversed
+    if (correctMaterialBudget) {
+      AliTrackerBase::MeanMaterialBudget(xyz0,xyz1,param);    
+      Double_t xrho=param[0]*param[4], xx0=param[1]; // thickness in unit of radiation length so x/x0 
+      if (sign) {
+        if (sign<0) xrho = -xrho;
+      } else { // determine automatically the sign from direction
+	       if (dir>0) xrho = -xrho; // outward should be negative
+      }    
+      // DIFFERENCE TO NORMAL PROPAGATION STARTING HERE
+      // if (!track->CorrectForMeanMaterial(xx0,xrho,mass)) return kFALSE;
+     // calculate traversed length
+      Double_t length = TMath::Sqrt((xyz1[0]-xyz0[0])*(xyz1[0]-xyz0[0])+
+                       (xyz1[1]-xyz0[1])*(xyz1[1]-xyz0[1])+
+                       (xyz1[2]-xyz0[2])*(xyz1[2]-xyz0[2]));
+ 
+
+      Double_t meanDensiy = param[0]; // [g/cm3]
+      // Double_t meanZoverA = param[5];
+     
+      Double_t meanX0 = length/xx0;
+      Double_t meanZ = param[3];
+      Double_t meanA = param[2];
+      Double_t meanZoverA = meanZ/meanA;
+     AliDebug(2,Form(" --> The following information has been extracted\n")); 
+     AliDebug(2,Form(" Propagation lenghth (cm): %f\n" ,length)); 
+     AliDebug(2,Form(" meanDensiy (g/cc): %f\n" ,meanDensiy)); 
+     AliDebug(2,Form(" meanZoverA: %f\n" ,meanZoverA)); 
+     AliDebug(2,Form(" meanX0 (cm): %f\n" ,meanX0)); 
+     AliDebug(2,Form(" meanZ: %f\n" ,meanZ)); 
+      // determine excitation energy from mean Z (GeV)
+      Double_t excitationE;
+      if (meanZ < 13) excitationE = (12. * meanZ + 7.) * 1.e-9;
+      else excitationE = (9.76 * meanZ + 58.8 * TMath::Power(meanZ,-0.19)) * 1.e-9;
+
+      AliDebug(2,Form("Optaining excitation energy in (eV): %f\n",excitationE*1e9));
+
+      // determine density effect for ionization losses of charged particles
+      // values given in table
+      // https://journals.aps.org/prb/abstract/10.1103/PhysRevB.3.3681
+
+      // default values for silicon used in normal propagation, so always the same values for x0 and x1
+      // however one can obtain x0 and x1 for solids and liquid given by formula in paper depending on Cbar
+      // which is related to plasma energy
+      Double_t x0 = 0.2; // first junction density correction
+      Double_t x1 = 3;   // second junction density correction
+
+      // calculate CBAR = - C
+      Double_t cbar=2*TMath::Log(excitationE*1e9/28.816*TMath::Sqrt(meanDensiy*meanZoverA))-1; // todo
+      
+      // selection for solids and liquids, for a gas different formular would need to be used to obtain x0 and x1
+      if(excitationE*1.e9<100){ // <100eV
+           x1 = 2.0;
+           if(cbar < 3.681){
+               x0 = 0.2;
+           } else{
+               x0 = 0.326*cbar-1.0;
+           }
+      } else{
+          x1 = 3.0;
+          if(cbar < 5.215){
+            x0 = 0.2;
+          } else{
+            x0 = 0.326*cbar - 1.5;
+          }
+      }
+
+      AliDebug(2,"According to paper density correction parameters were set to:\n");
+      AliDebug(2,Form("x0= %f\n" ,x0));
+      AliDebug(2,Form("x1= %f\n" ,x1));
+      
+      // Calculate dEdx
+      Double_t bg=track->P()/mass;
+      if (mass<0) {
+        if (mass<-990) {
+          return kFALSE;
+          }
+          bg = -2*bg;
+      }
+      // dEdx from Bethe-Bloch inspired by GEANT. Normally material properties are
+      // assumed to be from silicon, we now apply proper corrections
+      // assuming that we have a solid or liquid and NOT A GAS
+      // bg  - beta*gamma
+      // kp0 - density [g/cm^3]
+      // kp1 - density effect first junction point
+      // kp2 - density effect second junction point
+      // kp3 - mean excitation energy [GeV]
+      // kp4 - mean Z/A
+      //
+      Double_t dEdx=AliExternalTrackParam::BetheBlochGeant(bg,meanDensiy,x0,x1,excitationE,meanZoverA);
+
+
+     // If one finds mass hypothesis to be electron mass
+     // calculate corrections for Bremsstrahlung
+     // one can safely assume dE/dx aprox E/X0 for electrons
+     // above a critical energy Ecrit above which this is the dominant
+     // source of energy loss. 
+     //
+     // we obtain ECrit with emperical formulas relating ECrit to Z
+     // formula only correct for solids and electrons
+     // 
+     // below Ecrit no additional corrections are applied
+     // we also neglect moller and bhabha cross section for collision energy losses 
+     // we also also neglect any corrections needed at ultra high energies (LPM effect)
+     Double_t dEdxRadiationLoss = 0;
+     // check first if radiative loss is dominant by determining the critival energy following Rossi definition
+     Double_t ECritSolid = 610 /(meanZ+1.24);//MeV, only valid for solids, obtained for PDG Fig 33.14
+     //  Double_t ECritGas = 710 /(meanZ+0.92); //MeV, only valid for solids, obtained for PDG Fig 33.14
+     // cant really figure out if I am in a Gas or solid, sinse we might traverse Gas and solid
+     // might be able to use 
+     //
+    //    TGeoNode *currentnode = 0;
+    // TGeoNode *startnode = gGeoManager->InitTrack(start, dir);
+    // if (!startnode) {
+    //   AliDebugClass(1,Form("start point out of geometry: x %f, y %f, z %f",
+    // 		 start[0],start[1],start[2]));
+    //   return 0.0;
+    // }
+    // TGeoMaterial *material = startnode->GetVolume()->GetMedium()->GetMaterial();
+    // TGeoMaterial *
+    AliDebug(2,Form("Critical energy (MeV): %f\n", ECritSolid));
+    AliDebug(2,Form("Mass: %f\n", mass));
+     
+    Double_t p = track->GetP();
+    Double_t trackE = TMath::Sqrt((p*p) + (mass*mass));
+    AliDebug(2,Form("Track Energy %f\n", trackE*1000));
+    
+    if((mass>=0.000510)&&(mass<=0.000512)){ // if electron
+            AliDebug(2,"IsElectron\n");
+      if((trackE*1000)>ECritSolid){ // compare energies in MeV
+            AliDebug(2,Form("Energy %f was higher than crit\n",track->E()*1000));
+            dEdxRadiationLoss = trackE/meanX0; // energy loss dedx due to bremsstrahlung in GeV
+            
+      }
+
+      dEdx = dEdxRadiationLoss; // use radiation energy losses in case of electron
+    }
+
+    // correct with dEdx
+    if(! track->CorrectForMeanMaterialdEdx(xx0,xrho,mass,dEdx,kTRUE)); // with angle correction
+    
+    }
+    if (rotateTo){
+      track->GetXYZ(xyz1);   // global position
+      Double_t alphan = TMath::ATan2(xyz1[1], xyz1[0]); 
+      /*
+	if (maxSnp>0) {
+	if (TMath::Abs(track->GetSnp()) >= maxSnp) return kFALSE;
+	Double_t ca=TMath::Cos(alphan-track->GetAlpha()), sa=TMath::Sin(alphan-track->GetAlpha());
+	Double_t sf=track->GetSnp(), cf=TMath::Sqrt((1.-sf)*(1.+sf));
+	Double_t sinNew =  sf*ca - cf*sa;
+	if (TMath::Abs(sinNew) >= maxSnp) return kFALSE;
+	}
+      */
+      if (!track->AliExternalTrackParam::Rotate(alphan)) return kFALSE;
+      if (maxSnp>0 && TMath::Abs(track->GetSnp())>=maxSnp) return kFALSE;
+    }
+    xpos = track->GetX();    
+    if (addTimeStep && track->IsStartedTimeIntegral()) {
+      if (!rotateTo) track->GetXYZ(xyz1); // if rotateTo==kTRUE, then xyz1 is already extracted
+      Double_t dX=xyz0[0]-xyz1[0],dY=xyz0[1]-xyz1[1],dZ=xyz0[2]-xyz1[2]; 
+      Double_t d=TMath::Sqrt(dX*dX + dY*dY + dZ*dZ);
+      if (sign) {if (sign>0) d = -d;}  // step sign is imposed, positive means inward direction
+      else { // determine automatically the sign from direction
+	if (dir<0) d = -d;
+      }
+      track->AddTimeStep(d);
+    }
+  }
+  return kTRUE;
+  
+}
+
 ///
 /// Print Parameters.
 ///

--- a/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.h
+++ b/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.h
@@ -331,6 +331,15 @@ public:
   TH1C *   GetEMCALL1PhaseInTimeRecalibrationForAllSM(Short_t par=0) const      { return (TH1C*)fEMCALL1PhaseInTimeRecalibration->At(par) ; }
   void     SetEMCALL1PhaseInTimeRecalibrationForAllSM(const TObjArray *map);
   void     SetEMCALL1PhaseInTimeRecalibrationForAllSM(const TH1C* h, Short_t par=0);
+  Bool_t ExtrapolateTrackToEMCalSurfaceExperimental(AliExternalTrackParam *trkParam, 
+                                                             Double_t emcalR,
+                                                             Double_t mass, 
+                                                             Double_t step, 
+                                                             Float_t &eta, 
+                                                             Float_t &phi,
+                                                             Float_t &pt);
+  static Bool_t PropagateTrackToBxByBzExperimental(AliExternalTrackParam *track, Double_t x, Double_t m,Double_t maxStep, Bool_t rotateTo=kTRUE, 
+				       Double_t maxSnp=0.8,Int_t sign=0, Bool_t addTimeStep=kFALSE,Bool_t correctMaterialBudget=kTRUE);  
 
   void SwitchOnParRun()  { fIsParRun = kTRUE ; }
   void SwitchOffParRun() { fIsParRun = kFALSE ; }
@@ -741,7 +750,7 @@ private:
   Bool_t     fMCGenerToAcceptForTrack;   ///<  Activate the removal of tracks entering the track matching that come from a particular generator
 
   /// \cond CLASSIMP
-  ClassDef(AliEMCALRecoUtils, 41) ;
+  ClassDef(AliEMCALRecoUtils, 42) ;
   /// \endcond
 
 };

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterizer.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterizer.cxx
@@ -599,7 +599,11 @@ void AliEmcalCorrectionClusterizer::RecPoints2Clusters(TClonesArray *clus)
     Float_t *parentListDE = recpoint->GetParentsDE();  // deposited energy
     
     c->SetLabel(parentList, parentMult);
-    c->SetClusterMCEdepFractionFromEdepArray(parentListDE);
+    if(parentListDE[0]) {
+      c->SetClusterMCEdepFractionFromEdepArray(parentListDE);
+    } else{
+      AliWarning("Could not get deposited energy of parents. Particle might not have parents?");
+    }
     
     //
     // Set the cell energy deposition fraction map:

--- a/PWGGA/GammaConv/AliAnalysisTaskElectronStudies.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskElectronStudies.cxx
@@ -31,6 +31,7 @@
 #include "AliAODTrack.h"
 #include "AliVTrack.h"
 #include "AliEMCALRecoUtilsBase.h"
+#include "AliEMCALRecoUtils.h"
 #include "AliAODConversionMother.h"
 #include "TObjectTable.h"
 
@@ -50,6 +51,7 @@ AliAnalysisTaskElectronStudies::AliAnalysisTaskElectronStudies() : AliAnalysisTa
   fReaderGammas(NULL),
   fAODMCTrackArray(NULL),
   fGeomEMCAL(NULL),
+  fEMCalRecoUtils(NULL),
   fCorrTaskSetting(""),
   fEventCuts(NULL),
   fClusterCutsEMC(NULL),
@@ -83,6 +85,12 @@ AliAnalysisTaskElectronStudies::AliAnalysisTaskElectronStudies() : AliAnalysisTa
   fTruePtElectronTrackInEmcalAcc(NULL),
   fGenPtElectrons(NULL),
   fGenPtElectronsInEmcalAcc(NULL),
+  fTrackPvsPOnSurface(NULL),
+  fTrackPvsPOnSurfaceOwn(NULL),
+  fTrackRefPvsR(NULL),
+  fTrackPOnSurface(NULL),
+  fTrackPOnSurfaceOwn(NULL),
+  fTrackPOnSurfaceTrue(NULL),
   fTreeBuffSize(60*1024*1024),
   fMemCountAOD(0),
   fTrackMatcherRunningMode(0),
@@ -139,6 +147,7 @@ AliAnalysisTaskElectronStudies::AliAnalysisTaskElectronStudies(const char *name)
   fReaderGammas(NULL),
   fAODMCTrackArray(NULL),
   fGeomEMCAL(NULL),
+  fEMCalRecoUtils(NULL),
   fCorrTaskSetting(""),
   fEventCuts(NULL),
   fClusterCutsEMC(NULL),
@@ -171,6 +180,12 @@ AliAnalysisTaskElectronStudies::AliAnalysisTaskElectronStudies(const char *name)
   fTruePtElectronTrackInEmcalAcc(NULL),
   fGenPtElectrons(NULL),
   fGenPtElectronsInEmcalAcc(NULL),
+  fTrackPvsPOnSurface(NULL),
+  fTrackPvsPOnSurfaceOwn(NULL),
+  fTrackRefPvsR(NULL),
+   fTrackPOnSurface(NULL),
+  fTrackPOnSurfaceOwn(NULL),
+  fTrackPOnSurfaceTrue(NULL),
   fTreeBuffSize(60*1024*1024),
   fMemCountAOD(0),
   fTrackMatcherRunningMode(0),
@@ -224,6 +239,7 @@ AliAnalysisTaskElectronStudies::~AliAnalysisTaskElectronStudies()
 //________________________________________________________________________
 void AliAnalysisTaskElectronStudies::UserCreateOutputObjects()
 {
+  fEMCalRecoUtils  = new AliEMCALRecoUtils;
   // Create User Output Objects
   fOutputList                         = new TList();
   fOutputList->SetOwner(kTRUE);
@@ -328,7 +344,21 @@ void AliAnalysisTaskElectronStudies::UserCreateOutputObjects()
     fOutputList->Add(fGenPtElectronsInEmcalAcc);
   }
 
+  fTrackPvsPOnSurface =  new TH2F("fTrackPvsPOnSurface","fTrackPvsPOnSurface;P at vertex (GeV/c); P on EMCal surface",100,0.,10.,100,0,10);
+  fOutputList->Add(fTrackPvsPOnSurface);
+
+  fTrackPvsPOnSurfaceOwn =  new TH2F("fTrackPvsPOnSurfaceOwn","fTrackPvsPOnSurfaceOwn;P at vertex (GeV/c); P on EMCal surface (with Bremsstrahlung)",100,0.,10.,100,0,10);
+  fOutputList->Add(fTrackPvsPOnSurfaceOwn);
+
+  fTrackRefPvsR =  new TH2F("fTrackRefPvsR","fTrackRefPvsR;R (cm); P (GeV/c)",48,0.,480,100,0,10);
+  fOutputList->Add(fTrackRefPvsR);
   
+  fTrackPOnSurface =  new TH1F("fTrackPOnSurface","fTrackPOnSurface;P on EMCal surface ",100,0,10);
+  fTrackPOnSurfaceOwn =  new TH1F("fTrackPOnSurfaceOwn","fTrackPOnSurfaceOwn;P on EMCal surface ",100,0,10);
+  fTrackPOnSurfaceTrue =  new TH1F("fTrackPOnSurfaceTrue","fTrackPOnSurfaceTrue;P on EMCal surface ",100,0,10);
+  fOutputList->Add(fTrackPOnSurface);
+  fOutputList->Add(fTrackPOnSurfaceOwn);
+  fOutputList->Add(fTrackPOnSurfaceTrue);
   
   PostData(1, fOutputList);
   TString eventCutString = fEventCuts->GetCutNumber();
@@ -470,6 +500,12 @@ void AliAnalysisTaskElectronStudies::UserExec(Option_t *){
   // ─── MAIN PROCESSING ────────────────────────────────────────────────────────────
   //
   if (triggered==kFALSE) return;
+
+  if(fInputEvent->IsA()==AliESDEvent::Class()){
+     // do only tracking studies and quit
+     ProcessTracksESD();
+     return;
+  }
 
   ProcessCaloPhotons(); // track matching is done here as well
   ProcessTracks();
@@ -794,6 +830,102 @@ void AliAnalysisTaskElectronStudies::ProcessTracks(){
 
    }
    fBuffer_NPrimaryTracks = ntracks;
+}
+
+//________________________________________________________________________
+void AliAnalysisTaskElectronStudies::ProcessTracksESD(){
+  AliESDEvent *fESDEvent=dynamic_cast<AliESDEvent*>(fInputEvent);
+	if(fESDEvent){
+		for(Int_t i=0;i<fESDEvent->GetNumberOfTracks();i++){
+            AliESDtrack *track = dynamic_cast<AliESDtrack*> (fESDEvent->GetTrack(i));
+            cout << "P" << track->P() << endl;
+
+            // Calculate P on emcal surface
+
+          // If the esdFriend is available, use the TPCOuter point as the starting point of extrapolation
+          // Otherwise use the TPCInner point. Ignored special case for ITS standalone
+
+          Float_t fStep =  20;
+          Float_t fEMCalSurfaceDistance = 440; //cm
+           AliExternalTrackParam *trkParam = 0;
+
+           const AliESDfriendTrack*  friendTrack = track->GetFriendTrack();
+     
+          if (friendTrack && friendTrack->GetTPCOut())
+               trkParam = const_cast<AliExternalTrackParam*>(friendTrack->GetTPCOut());
+          else if (track->GetInnerParam())
+               trkParam = const_cast<AliExternalTrackParam*>(track->GetInnerParam());
+          if(!trkParam) {
+            AliWarning("Could not find track params ... Ignoring track ...");
+            continue;
+          }
+          AliExternalTrackParam trkParamTmp(*trkParam);
+          Float_t eta, phi, pt;
+          if (AliEMCALRecoUtilsBase::ExtrapolateTrackToEMCalSurface(&trkParamTmp, fEMCalSurfaceDistance, track->GetMass(kTRUE), fStep, eta, phi, pt))
+          {
+             track->SetTrackPhiEtaPtOnEMCal(phi,eta,pt);
+          } else{
+            AliWarning("Could not propagate!");
+            continue;
+          }
+          fTrackPvsPOnSurface->Fill(track->P(),track->GetTrackPOnEMCal());
+
+          if(track->P()>=4.5 && track->P()<=5.5) fTrackPOnSurface->Fill(track->GetTrackPOnEMCal());
+
+        
+          cout << "POnEMCal Step 20 (MeV) " << track->GetTrackPOnEMCal()*1000 << endl;
+
+
+           // Do own propagation now
+          if (fEMCalRecoUtils->ExtrapolateTrackToEMCalSurfaceExperimental(&trkParamTmp, fEMCalSurfaceDistance, track->GetMass(kTRUE), fStep, eta, phi, pt))
+          {
+            cout << "Success" << endl;
+             track->SetTrackPhiEtaPtOnEMCal(phi,eta,pt);
+          } else{
+            AliWarning("Could not propagate!");
+            continue;
+          }
+          cout << "POnEMCal Own (MeV) " << track->GetTrackPOnEMCal()*1000 << endl;
+           fTrackPvsPOnSurfaceOwn->Fill(track->P(),track->GetTrackPOnEMCal());
+           if(track->P()>=4.5 && track->P()<=5.5) fTrackPOnSurfaceOwn->Fill(track->GetTrackPOnEMCal());
+
+          
+    }
+  }
+
+
+  // do a loop over MC particles
+  AliMCEventHandler* mcinfo = (AliMCEventHandler*) (AliAnalysisManager::GetAnalysisManager()->GetMCtruthEventHandler());  	     
+  AliMCEvent* mcevent = mcinfo->MCEvent();
+ 
+ Double_t truePOnSurface = 0;
+ Double_t truePOnSurfaceBefore = 0; // last value before EMCal surface was passed
+ for (Int_t ipart=0; ipart < mcevent->GetNumberOfTracks(); ipart++) {
+    AliMCParticle *mcPart = (AliMCParticle*)mcevent->GetTrack(ipart);
+    if (TMath::Abs(mcPart->PdgCode()) != 11) continue;
+    if(mcPart->E()>5.5 || mcPart->E()<4.5) continue;
+    Int_t nTrackRefs = mcPart->GetNumberOfTrackReferences();
+    cout << "nTrackRefs " << nTrackRefs << endl;
+    for (Int_t iTrackRef1 = 0; iTrackRef1 < nTrackRefs; iTrackRef1++){
+	      AliTrackReference * trackRef1 = mcPart->GetTrackReference(iTrackRef1);
+        if((iTrackRef1==0) && (trackRef1->R()>10)) break; // only consider tracks that start close to the center
+
+            cout << trackRef1->R() << "\t" << trackRef1->P() << endl;
+
+            fTrackRefPvsR->Fill(trackRef1->R(),trackRef1->P());
+        if(trackRef1->R()>=430){
+           truePOnSurface = truePOnSurfaceBefore;
+            cout << "R() "<< trackRef1->R() << endl;
+            cout << "P() "<< trackRef1->P() << endl;
+
+           break;
+        }
+        truePOnSurfaceBefore = trackRef1->P();
+    }
+    if(truePOnSurface ==0) truePOnSurface =truePOnSurfaceBefore;
+    cout << "------" << endl;
+ }
+ fTrackPOnSurfaceTrue->Fill(truePOnSurface);
 }
 
 ///________________________________________________________________________
@@ -1525,6 +1657,7 @@ void AliAnalysisTaskElectronStudies::PushToVectors(treeWriteContainer input){
     fBuffer_MC_ClusterTrack_Same_Electron.push_back(input.MC_ClusterTrack_Same_Electron);
     fBuffer_MC_True_Track_MotherPDG.push_back(input.MC_True_Track_MotherPDG);
  }
+
 
 
 

--- a/PWGGA/GammaConv/AliAnalysisTaskElectronStudies.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskElectronStudies.h
@@ -142,7 +142,7 @@ class AliAnalysisTaskElectronStudies : public AliAnalysisTaskSE{
     TClonesArray*               fAODMCTrackArray;    // storage of track array
    
     AliEMCALGeometry*           fGeomEMCAL;    // pointer to EMCAL geometry
-    
+    AliEMCALRecoUtils*          fEMCalRecoUtils;
     // cuts and setting
     TString                     fCorrTaskSetting;           //
     AliConvEventCuts*           fEventCuts;                 // event cuts
@@ -187,6 +187,14 @@ class AliAnalysisTaskElectronStudies : public AliAnalysisTaskSE{
 
     TH1F*                       fGenPtElectrons;
     TH1F*                       fGenPtElectronsInEmcalAcc;
+    
+    
+    TH2F*                       fTrackPvsPOnSurface;
+    TH2F*                       fTrackPvsPOnSurfaceOwn;
+    TH2F*                       fTrackRefPvsR;
+    TH1F*                       fTrackPOnSurface;
+    TH1F*                       fTrackPOnSurfaceOwn;
+    TH1F*                       fTrackPOnSurfaceTrue;
 
     Long64_t                    fTreeBuffSize;           ///< allowed uncompressed buffer size per tree
     Long64_t                    fMemCountAOD;            //!<! accumulated tree size before AutoSave
@@ -236,6 +244,7 @@ class AliAnalysisTaskElectronStudies : public AliAnalysisTaskSE{
     void ProcessMCCaloPhoton(AliAODCaloCluster* clus,vector<Double32_t> isoCharged,vector<Double32_t> isoNeutral,vector<Double32_t> isoCell,Int_t tmptag);
     void ProcessCaloPhotons();
     void ProcessTracks(); // only needed for track effi
+    void ProcessTracksESD(); // only needed for track effi
     Bool_t TrackIsSelectedAOD(AliAODTrack* lTrack);
     void ProcessMatchedTrack(AliAODTrack* track, AliAODCaloCluster* clus, Bool_t isV0, Float_t dEtaV0 = 99, Float_t dPhiV0 = 99);
     void ProcessMCParticles();
@@ -256,7 +265,7 @@ class AliAnalysisTaskElectronStudies : public AliAnalysisTaskSE{
     std::pair<Double_t,Double_t> ProcessChargedIsolation(AliAODTrack* track);
     AliAnalysisTaskElectronStudies(const AliAnalysisTaskElectronStudies&); // Prevent copy-construction
     AliAnalysisTaskElectronStudies& operator=(const AliAnalysisTaskElectronStudies&); // Prevent assignment  
-    ClassDef(AliAnalysisTaskElectronStudies, 13);
+    ClassDef(AliAnalysisTaskElectronStudies, 14);
 
 };
 

--- a/PWGGA/GammaConv/macros/AddTask_ElectronStudies.C
+++ b/PWGGA/GammaConv/macros/AddTask_ElectronStudies.C
@@ -134,6 +134,12 @@ void AddTask_ElectronStudies(
       TaskClusterCutnumberEMC           = "4117921060e32000000";
       TaskConvCutnumber                 = "0dm00009f9730000dge0404000";
       TaskTMCut                         = "4117921062e32000000";
+  } else if(trainConfig == 100){  // no event cuts (to be used for particle gun)
+      TaskEventCutnumber                = "00000000";
+      TaskClusterCutnumberEMC           = "4117900060l30000000";
+                                         //411792106fe32220000 latest and greates
+      TaskConvCutnumber                 = "0dm00009f9730000dge0404000";
+      TaskTMCut                         = "4117900062l30000000";
 
   //
   // ─── OLD NL ─────────────────────────────────────────────────────────────────────

--- a/PWGGA/GammaConv/macros/AddTask_GammaIsoTree.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaIsoTree.C
@@ -580,6 +580,66 @@ void AddTask_GammaIsoTree(
       doChargedIso = kTRUE;
       doTagging = kFALSE;
       doCellIso = kFALSE;
+
+  // EMCAL + DCAL
+       // stricter track eta cut
+  } else if(trainConfig == 70){  // pPb INT7
+      TaskEventCutnumber                = "80010103";
+      TaskClusterCutnumberEMC           = "4117932060032000000";
+      TaskTMCut = TaskClusterCutnumberEMC.Data();
+      TaskTMCut.Replace(9,1,"5");
+      TaskClusterCutnumberIsolationEMC  = "411793206f022000000";
+      TaskClusterCutnumberTaggingEMC    = "411793206f000000000";
+      TaskClusterCutnumberPHOS          = "2444411044013300000";
+      TaskConvCutnumber                 = "0dm00009f9730000dge0404000";
+
+      minSignalM02 = 0.1;
+      maxSignalM02 = 0.5;
+      fEtaCut = 0.8;
+
+      backgroundTrackMatching = kFALSE; // obsolete
+      doNeutralIso = kFALSE;
+      doChargedIso = kTRUE;
+      doTagging = kFALSE;
+      doCellIso = kFALSE;
+  } else if(trainConfig == 71){  // EG2 DG2
+      TaskEventCutnumber                = "8008e103";
+      TaskClusterCutnumberEMC           = "4117932060032000000";
+      TaskTMCut = TaskClusterCutnumberEMC.Data();
+      TaskTMCut.Replace(9,1,"5");
+      TaskClusterCutnumberIsolationEMC  = "411793206f022000000";
+      TaskClusterCutnumberTaggingEMC    = "411793206f000000000";
+      TaskClusterCutnumberPHOS          = "2444411044013300000";
+      TaskConvCutnumber                 = "0dm00009f9730000dge0404000";
+
+      minSignalM02 = 0.1;
+      maxSignalM02 = 0.5;
+      fEtaCut = 0.8;
+
+      backgroundTrackMatching = kFALSE; // obsolete
+      doNeutralIso = kFALSE;
+      doChargedIso = kTRUE;
+      doTagging = kFALSE;
+      doCellIso = kFALSE;
+  } else if(trainConfig == 72){  // EG1 DG1
+      TaskEventCutnumber                = "8008d103";
+      TaskClusterCutnumberEMC           = "4117932060032000000";
+      TaskTMCut = TaskClusterCutnumberEMC.Data();
+      TaskTMCut.Replace(9,1,"5");
+      TaskClusterCutnumberIsolationEMC  = "411793206f022000000";
+      TaskClusterCutnumberTaggingEMC    = "411793206f000000000";
+      TaskClusterCutnumberPHOS          = "2444411044013300000";
+      TaskConvCutnumber                 = "0dm00009f9730000dge0404000";
+
+      minSignalM02 = 0.1;
+      maxSignalM02 = 0.5;
+      fEtaCut = 0.8;
+
+      backgroundTrackMatching = kFALSE; // obsolete
+      doNeutralIso = kFALSE;
+      doChargedIso = kTRUE;
+      doTagging = kFALSE;
+      doCellIso = kFALSE;
   }
   
 


### PR DESCRIPTION
- implemented AliEMCALRecoUtils::ExtrapolateTrackToEMCalSurfaceExperimental which is an experimental function to propagate tracks to the EMCal surface and not used anywhere so far. The function is not validated, however, I think the name of the function containing "Experimental" should make clear enough that this can not be used without validation. The function uses PropagateTrackToBxByBzExperimental for track propagation, which properly takes into account different materials and does not assume Silicon as default for the material passed. Furthermore, the critical energy for electrons is calculated, after which Bremsstrahlung is the dominant source of energy loss. Furthermore, the calculation of density fluctuation corrections has been imroved
- added new configs for iso analysis to include EDC
- fixed crash in clusterizer when using single particle gun ESDs