### PR TITLE
cmake:: fix doxygen finding on f34

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,7 @@ endif()
 unset(isSystemDir)
 
 # Optional: Doxygen for reference doc generation
+set(DOXYGEN_EXECUTABLE "")
 find_package(Doxygen)
 if(DOXYGEN_FOUND AND DOXYGEN_DOT_FOUND)
   message(STATUS "Doxygen ${DOXYGEN_VERSION} and Graphviz found: ${DOXYGEN_EXECUTABLE}, ${DOXYGEN_DOT_EXECUTABLE}")


### PR DESCRIPTION
on cmake 3.20.5 there are problems if doxygen is already found. Just invalidate the already detected doxygen executable.
solution from https://gitlab.kitware.com/cmake/cmake/-/issues/18708