### PR TITLE
Fixing the filling of a histogram

### DIFF
--- a/PWGHF/jetsHF/AliAnalysisTaskBJetTC.cxx
+++ b/PWGHF/jetsHF/AliAnalysisTaskBJetTC.cxx
@@ -2614,7 +2614,7 @@ Bool_t AliAnalysisTaskBJetTC::Run()
                     {
                         firstJetFound = true;
                         Double_t EmbeddingPt = GetDeltaPtPerpEmbedding(jetrec->Eta(), jetrec->Phi());
-                        fh2DeltaPtEmbeddCorrelationPerpendicular->Fill(fJetContainerData->GetRhoVal(), EmbeddingPt);
+                        fh2DeltaPtEmbeddCorrelationPerpendicular->Fill(EmbeddingPt, fJetContainerData->GetRhoVal());
                     }
                 }
 


### PR DESCRIPTION
The X and Y of the embedding histogram was filled in a wrong way. It has been fixed with this commit.