### PR TITLE
[WIP] Adapt EMCAL trigger table to STU format in run3

### DIFF
--- a/RUN3/AliAnalysisTaskAO2Dconverter.cxx
+++ b/RUN3/AliAnalysisTaskAO2Dconverter.cxx
@@ -18,6 +18,7 @@
  * Convert Run 2 ESDs to Run 3 AODs (AO2D.root).
  */
 
+#include <algorithm>
 #include <TFile.h>
 #include <TDirectory.h>
 #include <TChain.h>
@@ -26,6 +27,7 @@
 #include <Math/SMatrix.h>
 #include <TTimeStamp.h>
 #include <TClonesArray.h>
+#include <TRandom.h>
 #include <TSystem.h>
 #include "AliAnalysisTask.h"
 #include "AliAnalysisManager.h"
@@ -38,6 +40,8 @@
 #include "AliCentrality.h"
 #include "AliVMultiplicity.h"
 #include "AliEMCALGeometry.h"
+#include "AliEMCALTriggerDataGrid.h"
+#include "AliEMCALTriggerPatchInfo.h"
 #include "AliAnalysisTaskAO2Dconverter.h"
 #include "AliVHeader.h"
 #include "COMMON/MULTIPLICITY/AliMultSelection.h"
@@ -95,6 +99,7 @@ const TString AliAnalysisTaskAO2Dconverter::TreeName[kTrees] = {
   "O2fwdtrackcov",
   "O2calo",
   "O2calotrigger",
+  "O2emcaltrigger",
   "O2muoncluster",
   "O2zdc",
   "O2fv0a",
@@ -124,6 +129,7 @@ const TString AliAnalysisTaskAO2Dconverter::TreeTitle[kTrees] = {
   "Forward tracks Covariances",
   "Calorimeter cells",
   "Calorimeter triggers",
+  "EMCAL triggers",
   "MUON clusters",
   "ZDC",
   "FV0A",
@@ -224,6 +230,7 @@ AliAnalysisTaskAO2Dconverter::AliAnalysisTaskAO2Dconverter(const char* name)
 #endif
     calo(),
     calotrigger(),
+    emcaltrigger(),
     fwdtracks(),
     mucls(),
     zdc(),
@@ -812,6 +819,14 @@ void AliAnalysisTaskAO2Dconverter::InitTF(ULong64_t tfId)
     tCaloTrigger->Branch("fTriggerBits", &calotrigger.fTriggerBits, "fTriggerBits/I");
     tCaloTrigger->Branch("fCaloType", &calotrigger.fCaloType, "fCaloType/B");
     tCaloTrigger->SetBasketSize("*", fBasketSizeEvents);
+  }
+
+
+  TTree *tEmcalTrigger = CreateTree(kEmcalTrigger);
+  if (fTreeStatus[kEmcalTrigger]) {
+    tEmcalTrigger->Branch("fIndexBCs", &emcaltrigger.fIndexDCs, "fIndexBCs/I");
+    tEmcalTrigger->Branch("fFastOrAbsID", &emcaltrigger.fAbsID, "fFastOrAbsID/S");
+    tEmcalTrigger->Branch("fL1TimeSum", &emcaltrigger.fADC, "fL1TimeSum/S");
   }
 
   // Associate FwdTrack branches for MUON tracks
@@ -1921,41 +1936,95 @@ void AliAnalysisTaskAO2Dconverter::FillEventInTF()
   } // end loop on calo cells
   eventextra.fNentries[kCalo] = ncalocells_filled;
 
+  // Trigger data for EMCAL:
+  // - For full payload (monitoring) events store all non-0 L1 ADCs
+  // - For regular events store non-0 L1 ADCs of the 3 leading Gamma patches
   AliEMCALGeometry *geo = AliEMCALGeometry::GetInstanceFromRunNumber(fVEvent->GetRunNumber()); // Needed for EMCAL trigger mapping
   AliVCaloTrigger *calotriggers = fVEvent->GetCaloTrigger("EMCAL");
+  Bool_t fullPayload = gRandom->Uniform() < fFractionL1MonitorEventsEMCAL;
+  emcaltrigger.fIndexDCs = fBCCount;
+  emcaltrigger.fAbsID = 10001;
+  emcaltrigger.fADC = fullPayload ? 1 : 0;
+  FillTree(kEmcalTrigger);
+  // Median for EMCAL
+  emcaltrigger.fAbsID = 10002;
+  emcaltrigger.fADC = calotriggers->GetMedian(0);
+  FillTree(kEmcalTrigger);
+  // Median for DCAL
+  emcaltrigger.fAbsID = 10003;
+  emcaltrigger.fADC = calotriggers->GetMedian(1);
+  FillTree(kEmcalTrigger);
+
   calotriggers->Reset();
-  Int_t ncalotriggers_filled = 0; // total number of EMCAL triggers filled per event
-  while (calotriggers->Next())
-  {
-    calotrigger.fIndexBCs = fBCCount;
-    int col, row, fastorID;
-    calotriggers->GetPosition(col, row);
-    // filter null entries: they usually have negative entries and no trigger bits
-    // in case of trigger bits the energy can be 0 or negative but the trigger position is marked
-    int l1timesum, triggerbits;
-    calotriggers->GetTriggerBits(triggerbits);
-    calotriggers->GetL1TimeSum(l1timesum);
-    if (!triggerbits && l1timesum <= 0)
-      continue;
-    // store trigger
-    geo->GetTriggerMapping()->GetAbsFastORIndexFromPositionInEMCAL(col, row, fastorID);
-    calotrigger.fFastOrAbsID = fastorID;
-    calotriggers->GetAmplitude(calotrigger.fL0Amplitude);
-    calotrigger.fL0Amplitude = AliMathBase::TruncateFloatFraction(calotrigger.fL0Amplitude, mCaloAmp);
-    calotrigger.fL1TimeSum = AliMathBase::TruncateFloatFraction(l1timesum, mCaloAmp);
-    calotriggers->GetTime(calotrigger.fL0Time);
-    calotrigger.fL0Time = AliMathBase::TruncateFloatFraction(calotrigger.fL0Time, mCaloTime);
-    calotriggers->GetTriggerBits(calotrigger.fTriggerBits);
-    Int_t nL0times;
-    calotriggers->GetNL0Times(nL0times);
-    calotrigger.fNL0Times = nL0times;
-    calotrigger.fTriggerBits = triggerbits;
-    calotrigger.fCaloType = 1;
-    FillTree(kCaloTrigger);
-    if (fTreeStatus[kCaloTrigger])
-      ncalotriggers_filled++;
+  Int_t nemcaltriggers_filled = 3; // total number of EMCAL triggers filled per event
+  int col, row, fastorID, l1timesums;
+  if(fullPayload) {
+    // Full payload - store all ADCs
+    while (calotriggers->Next())
+    {
+      calotriggers->GetPosition(col, row);
+      calotriggers->GetL1TimeSum(l1timesums);
+      if(l1timesums <=0) 
+        continue;
+      geo->GetTriggerMapping()->GetAbsFastORIndexFromPositionInEMCAL(col, row, fastorID);
+      emcaltrigger.fAbsID = fastorID;
+      emcaltrigger.fADC = l1timesums;
+      FillTree(kEmcalTrigger);
+      if (fTreeStatus[kEmcalTrigger])
+        nemcaltriggers_filled++;
+    }
+  } else {
+    TClonesArray *emcalpatches = dynamic_cast<TClonesArray *>(fInputEvent->FindListObject("EmcalTriggers"));
+    if(emcalpatches) {
+      AliEMCALTriggerDataGrid<int> l1adcs;
+      l1adcs.Allocate(48, 104);
+      // Pre-sort the ADCs in the data grid in order to find the ADCs belonging to the 3 leading patches later
+      while (calotriggers->Next())
+      {
+        calotriggers->GetPosition(col, row);
+        calotriggers->GetL1TimeSum(l1timesums);
+        if(l1timesums <=0) 
+          continue;
+        l1adcs(col, row) = l1timesums;
+      }
+      std::vector<AliEMCALTriggerPatchInfo *> allpatches;
+      for(int ipatch = 0; ipatch < emcalpatches->GetEntries(); ipatch++) {
+        AliEMCALTriggerPatchInfo *nextpatch = static_cast<AliEMCALTriggerPatchInfo *>(emcalpatches->At(ipatch));
+        if(nextpatch->IsGammaLowRecalc()) allpatches.emplace_back(nextpatch);
+      }
+      // sort patches in descending order according to the patch ADC
+      std::sort(allpatches.begin(), allpatches.end(), [](const AliEMCALTriggerPatchInfo *lhs, const AliEMCALTriggerPatchInfo *rhs) { return lhs->GetADCAmp() > rhs->GetADCAmp(); } );
+      std::vector<int> fastOrIDsInTree;  // in order to avoid double counting
+      int npatches = 0;
+      for(auto patch : allpatches) {
+        for(int icol = patch->GetColStart(); icol < patch->GetColStart() + patch->GetPatchSize(); icol++) {
+          for(int irow = patch->GetRowStart(); irow < patch->GetRowStart() + patch->GetPatchSize(); irow++) {
+            int adc = l1adcs(icol, irow);
+            if(adc > 0) {
+              geo->GetTriggerMapping()->GetAbsFastORIndexFromPositionInEMCAL(icol, irow, fastorID);
+              if(std::find(fastOrIDsInTree.begin(), fastOrIDsInTree.end(), fastorID) == fastOrIDsInTree.end()) {
+                // FastOr not present in other (selected) trigger patch - add to tree
+                emcaltrigger.fAbsID = fastorID;
+                emcaltrigger.fADC = adc;
+                FillTree(kEmcalTrigger);
+                if (fTreeStatus[kEmcalTrigger])
+                  nemcaltriggers_filled++;
+                fastOrIDsInTree.emplace_back(fastorID);
+              }
+            }
+          }
+        }
+        npatches++;
+        if(npatches == 3) {
+          // select at maximum the 3 leading trigger patches
+          break;
+        }
+      }
+    } else {
+      AliErrorStream() << "Needs EMCAL patches (from EMCAL trigger maker) for the selection of the FastORs belonging to the 3 leading gamma patches" << std::endl;
+    }
   }
-  eventextra.fNentries[kCaloTrigger] = ncalotriggers_filled;
+  eventextra.fNentries[kEmcalTrigger] = nemcaltriggers_filled; //DP: Should we fill separate branches for PHOS and EMCAL?
 
   //------PHOS trigger -----------
   const double mPHOSCalib = 0.005; // Mean PHOS calibration 5 MeV/ADC

--- a/RUN3/AliAnalysisTaskAO2Dconverter.h
+++ b/RUN3/AliAnalysisTaskAO2Dconverter.h
@@ -50,6 +50,7 @@ public:
   virtual void SetCompression(UInt_t compress=101) {fCompress = compress; }
   virtual void SetMaxBytes(ULong_t nbytes = 100000000) {fMaxBytes = nbytes;}
   void SetEMCALAmplitudeThreshold(Double_t threshold) { fEMCALAmplitudeThreshold = threshold; }
+  void SetEMCALFractionL1MonitoringEvents(Double_t fraction) { fFractionL1MonitorEventsEMCAL = fraction; }
 
   static AliAnalysisTaskAO2Dconverter* AddTask(TString suffix = "");
   enum TreeIndex { // Index of the output trees
@@ -62,6 +63,7 @@ public:
     kFwdTrackCov,
     kCalo,
     kCaloTrigger,
+    kEmcalTrigger,
     kMuonCls,
     kZdc,
     kFV0A,
@@ -434,7 +436,7 @@ private:
   } calo;                         //! structure to keep EMCAL info
 
   struct {
-    // Calorimeter trigger data (EMCAL & PHOS)
+    // Calorimeter trigger data (PHOS)
     Int_t fIndexBCs = 0u;        /// Index to BC table
     Short_t fFastOrAbsID = - 1;   /// FastOR absolute ID
     Float_t fL0Amplitude = -1.f;  /// L0 amplitude (ADC) := Peak Amplitude
@@ -444,6 +446,13 @@ private:
     Int_t fTriggerBits = 0;       /// Online trigger bits
     Char_t fCaloType = -1;            /// Calorimeter type (-1 is undefined, 0 is PHOS, 1 is EMCAL)
   } calotrigger;                  //! structure to keep calo trigger info
+
+  struct {
+    // EMCAL trigger data
+    Int_t fIndexDCs = 0u;         /// Index to BC table
+    Short_t fAbsID = -1;          /// FastOR Abs ID (Event properties; Payload type: 10001, Median for EMCAL: 10002, Median for DCAL: 10003)
+    Short_t fADC = -1;            /// FastOR ADC and event properties
+  } emcaltrigger;                 //! structure to 
 
   struct FwdTrackPars {   /// Forward track parameters
     Int_t   fIndexCollisions = -1;    /// The index of the collision vertex in the TF, to which the track is attached
@@ -587,6 +596,7 @@ private:
   TH1F *fCentralityINT7 = nullptr; ///! Centrality histogram for the INT7 triggers
   TH1I *fHistPileupEvents = nullptr; ///! Counter histogram for pileup events
   Double_t fEMCALAmplitudeThreshold = 0.1; ///< EMCAL amplitude threshold (for compression - default: 100 MeV := cluster cell threshold)
+  Double_t fFractionL1MonitorEventsEMCAL = 0.001; ///< Fraction of monitoring events (full payload) for EMCAL L1 trigger
 
   /// Byte counter
   ULong_t fBytes = 0; ///! Number of bytes stored in all trees


### PR DESCRIPTION
- Only 2 columns (FastOR ID and ADC)
- All FastOR ADCs only for fraction of events (settable)
- FastOR ADCs from the 3 leading patches for the other events