### PR TITLE
Some methods to work without top. selections added

### DIFF
--- a/PWGHF/vertexingHF/AliAnalysisTaskSEXicTopKpi.cxx
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSEXicTopKpi.cxx
@@ -1179,8 +1179,8 @@ void AliAnalysisTaskSEXicTopKpi::UserExec(Option_t */*option*/)
 
   // if required, reject events without a recognised p, K or pi track
   if(fRejEvWoutpKpi){
-    // the event must have at least 1 proton, 1 kaon and 1 pion
-    if(fnProt==0 && fnKaon==0 && fnPion==0){
+    // the event must have at least 1 proton, or 1 kaon, or 1 pion
+    if(fnProt==0 || fnKaon==0 || fnPion==0){
       fnProt=999;
       fnKaon=999;
       fnPion=999;

--- a/PWGHF/vertexingHF/AliAnalysisTaskSEXicTopKpi.cxx
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSEXicTopKpi.cxx
@@ -209,6 +209,12 @@ AliAnalysisTaskSEXicTopKpi::AliAnalysisTaskSEXicTopKpi():
   ,fPtSoftPionCand_insideScLoop(0)
   ,fKeepGenPtMC(kTRUE)
   ,fAbsValueScCharge(-1)
+  ,fSwitchOffTopCuts(kFALSE)
+  ,fSwitchOffPIDafterFilt(kFALSE)
+  ,fnProt(999)
+  ,fnKaon(999)
+  ,fnPion(999)
+  ,fRejEvWoutpKpi(kFALSE)
 {
   /// Default constructor
 
@@ -336,6 +342,12 @@ AliAnalysisTaskSEXicTopKpi::AliAnalysisTaskSEXicTopKpi(const char *name,AliRDHFC
   ,fPtSoftPionCand_insideScLoop(0)
   ,fKeepGenPtMC(kTRUE)
   ,fAbsValueScCharge(-1)
+  ,fSwitchOffTopCuts(kFALSE)
+  ,fSwitchOffPIDafterFilt(kFALSE)
+  ,fnProt(999)
+  ,fnKaon(999)
+  ,fnPion(999)
+  ,fRejEvWoutpKpi(kFALSE)
 {
   /// Default constructor
 
@@ -562,6 +574,13 @@ void AliAnalysisTaskSEXicTopKpi::Init()
     printf("===== !!! INPUT VALUE NOT VALID !!! Putting it to -1 (keep both Sc0 and Sc++)\n\n");
     fAbsValueScCharge = -1;
   }
+
+  printf("\n\n##### fRejEvWoutpKpi: %d\n",fRejEvWoutpKpi);
+  if(fRejEvWoutpKpi)  printf("\t===> Events without recognised p, K, pi rejected!\n");
+  printf("\n\n##### fSwitchOffTopCuts: %d\n",fSwitchOffTopCuts);
+  if(fSwitchOffTopCuts) printf("\t===> Topological selections not applied!\n");
+  printf("\n\n##### fSwitchOffPIDafterFilt: %d\n",fSwitchOffPIDafterFilt);
+  if(fSwitchOffTopCuts && fSwitchOffPIDafterFilt) printf("===> PID selections after filtering not applied!\n");
 
   return;
 }
@@ -1158,6 +1177,22 @@ void AliAnalysisTaskSEXicTopKpi::UserExec(Option_t */*option*/)
     return;
   }
 
+  // if required, reject events without a recognised p, K or pi track
+  if(fRejEvWoutpKpi){
+    // the event must have at least 1 proton, 1 kaon and 1 pion
+    if(fnProt==0 && fnKaon==0 && fnPion==0){
+      fnProt=999;
+      fnKaon=999;
+      fnPion=999;
+      delete fvHF;
+      PostData(1,fNentries);
+      PostData(2,fCounter);
+      PostData(3,fOutput);
+      PostData(4,fTreeVar);
+      return;
+    }
+  }
+
   
   //  Int_t pdgDg[3]={211,321,2212};
   
@@ -1343,7 +1378,7 @@ void AliAnalysisTaskSEXicTopKpi::UserExec(Option_t */*option*/)
 	}
   fCandCounter_onTheFly->Fill(4); // in fiducial acceptance
 
-	if(io3Prong->GetReducedChi2()>fMaxVtxChi2Cut){
+	if(io3Prong->GetReducedChi2()>fMaxVtxChi2Cut && !fSwitchOffTopCuts){
 	  AliAODVertex *vtx3 = (AliAODVertex*)io3Prong->GetSecondaryVtx();
 	  if(vtx3){delete vtx3;vtx3=0;}
 	  if(unsetvtx)io3Prong->UnsetOwnPrimaryVtx();
@@ -1652,8 +1687,18 @@ void AliAnalysisTaskSEXicTopKpi::UserExec(Option_t */*option*/)
 	  // POSTPONED HERE !!!
 	  //
 	  //massHypothesis=isSeleCuts&massHypothesis;
-	  if(fExplore_PIDstdCuts)   massHypothesis=resp_onlyCuts&massHypothesis;  // we do not want the candidates to be filtered by Bayes PID
-	  else                      massHypothesis=isSeleCuts&massHypothesis;
+
+    if(fSwitchOffTopCuts) { // here we switch the topological selections on candidates off
+      //
+      // if wee keep the selection on PID, modify the massHypothesis
+      // otherwise, do not touch it
+      if(!fSwitchOffPIDafterFilt) massHypothesis=resp_onlyPID&massHypothesis;
+    }
+    else {  // this is the default
+      if(fExplore_PIDstdCuts)   massHypothesis=resp_onlyCuts&massHypothesis;  // we do not want the candidates to be filtered by Bayes PID
+	    else                      massHypothesis=isSeleCuts&massHypothesis;
+    }
+
 	  //
 	  //
 
@@ -2687,6 +2732,13 @@ void AliAnalysisTaskSEXicTopKpi::IsSelectedPID(AliAODTrack *track,Int_t &iSelPio
     }
   }
 
+  if(fRejEvWoutpKpi) {
+    // update the number of recognised p, K, pi
+    if(iSelProton>0)  fnProt++;
+    if(iSelKaon>0)    fnKaon++;
+    if(iSelPion>0)    fnPion++;
+  }
+
 }
 
 
@@ -3185,6 +3237,11 @@ void AliAnalysisTaskSEXicTopKpi::PrepareTracks(AliAODEvent *aod,TClonesArray *mc
     ftrackArraySel->AddAt(itrack,fnSel);
   
     // PID SELECTION
+    if(fRejEvWoutpKpi) {
+      fnProt = 0; // number of PID selected protons
+      fnKaon = 0; // number of PID selected kaons
+      fnPion = 0; // number of PID selected pions
+    }
     IsSelectedPID(track,iSelPion,iSelKaon,iSelProton,iSelPionCuts,iSelKaonCuts,iSelProtonCuts,kTRUE);
     //    if(itrack%50==0)Printf("Track %d, pt: %f",itrack,track->Pt());
     ftrackSelStatusProton->AddAt(iSelProton,fnSel);

--- a/PWGHF/vertexingHF/AliAnalysisTaskSEXicTopKpi.h
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSEXicTopKpi.h
@@ -164,6 +164,14 @@ class AliAnalysisTaskSEXicTopKpi : public AliAnalysisTaskSE
   // switch on/off the ev. sel ev. selection (useful to run on ITS2-ITS3 upgrade MC)
   void SetApplyEvSel(Bool_t flag){fApplyEvSel=flag;}
 
+  // switch off the topological selections
+  void SetSwitchOffTopCuts(){fSwitchOffTopCuts=kTRUE;}
+  // switch off the PID after filtering
+  void SetSwitchOffPIDafterFilt(){fSwitchOffPIDafterFilt=kTRUE;}
+
+  // reject events without a recognised p, K, pi
+  void SetRejEvWoutpKpi(){fRejEvWoutpKpi=kTRUE;}
+
 /*   void SetDoMCAcceptanceHistos(Bool_t doMCAcc=kTRUE){fStepMCAcc=doMCAcc;} */
 /*   void SetCutOnDistr(Bool_t cutondistr=kFALSE){fCutOnDistr=cutondistr;} */
 /*   void SetUsePid4Distr(Bool_t usepid=kTRUE){fUsePid4Distr=usepid;} */
@@ -424,8 +432,21 @@ class AliAnalysisTaskSEXicTopKpi : public AliAnalysisTaskSE
   // integer to keep only SigmaC candidate with 0 or ++ charge
   Int_t fAbsValueScCharge;  // -1: keep both Sc0, Sc++;   0: keep only Sc0;   2: keep only Sc++
 
+  // bool to switch the topological selections off
+  Bool_t fSwitchOffTopCuts; //
+  // bool to switch the PID selection after filtering off
+  Bool_t fSwitchOffPIDafterFilt; //
+
+  // number of protons, kaons and pions in a single event
+  Int_t fnProt; //
+  Int_t fnKaon; //
+  Int_t fnPion; //
+
+  // bool to avoid processing events without recognised p, K, pi
+  Bool_t fRejEvWoutpKpi; //
+
   /// \cond CLASSIMP
-  ClassDef(AliAnalysisTaskSEXicTopKpi,20); /// AliAnalysisTaskSE for Xic->pKpi
+  ClassDef(AliAnalysisTaskSEXicTopKpi,21); /// AliAnalysisTaskSE for Xic->pKpi
   /// \endcond
 };
 


### PR DESCRIPTION
 - method to switch off the topological selections added
 - method to switch off als othe PID selection after filtering added
 - method to reject events without at least one identified proton, one identified kaon and one identified pion added, to spare CPU time