### PR TITLE
PWGGA/GammaConv: Updated Analysistask to be more memory efficient

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskGammaCaloMergedML.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaCaloMergedML.cxx
@@ -933,8 +933,8 @@ void AliAnalysisTaskGammaCaloMergedML::UserCreateOutputObjects(){
     UChar_t MaxClusterCellN = 100;
     fMergedClusterTreeCluster                 = new Float_t[MaxClusterCellN];
     fMergedClusterTreeClusterModNum           = new UChar_t[MaxClusterCellN];
-    fMergedClusterTreeClusterCol             = new UChar_t[MaxClusterCellN];
-    fMergedClusterTreeClusterRow             = new UChar_t[MaxClusterCellN];
+    fMergedClusterTreeClusterCol              = new UChar_t[MaxClusterCellN];
+    fMergedClusterTreeClusterRow              = new UChar_t[MaxClusterCellN];
 
 
     fHistoMCHeaders                               = new TH1I*[fnCuts];
@@ -1541,13 +1541,13 @@ void AliAnalysisTaskGammaCaloMergedML::UserCreateOutputObjects(){
 
       tTrueMergedCaloClusterPi0[iCut] = new TTree(Form("%s_%s_%s_%s_Pio", cutstringEvent.Data(), cutstringCalo.Data(), cutstringCaloMerged.Data(), cutstringMeson.Data()), Form("%s_%s_%s_%s_Pi0", cutstringEvent.Data(), cutstringCalo.Data(), cutstringCaloMerged.Data(), cutstringMeson.Data()));
       tTrueMergedCaloClusterPi0[iCut]->Branch("ClusterCellN", &fMergedClusterCellN, "ClusterCellN/b");
-      tTrueMergedCaloClusterPi0[iCut]->Branch("Cluster",             fMergedClusterTreeCluster, "Cluster[fMergedClusterCellN]/F");
+      tTrueMergedCaloClusterPi0[iCut]->Branch("Cluster",             fMergedClusterTreeCluster, "Cluster[ClusterCellN]/F");
       tTrueMergedCaloClusterPi0[iCut]->Branch("ClusterType",         &fMergedClusterTreeClusterType,"ClusterType/b");
       tTrueMergedCaloClusterPi0[iCut]->Branch("ClusterE",            &fMergedClusterTreeClusterEnergy, "ClusterE/F");
       tTrueMergedCaloClusterPi0[iCut]->Branch("ClusterPt",           &fMergedClusterTreeClusterPt, "ClusterPt/F");
-      tTrueMergedCaloClusterPi0[iCut]->Branch("ClusterModuleNumber", fMergedClusterTreeClusterModNum, "ClusterModuleNumber[fMergedClusterCellN]/b");
-      tTrueMergedCaloClusterPi0[iCut]->Branch("ClusterCol",            fMergedClusterTreeClusterCol, "ClusterCol[fMergedClusterCellN]/b");
-      tTrueMergedCaloClusterPi0[iCut]->Branch("ClusterRow",            fMergedClusterTreeClusterRow, "ClusterRow[fMergedClusterCellN]/b");
+      tTrueMergedCaloClusterPi0[iCut]->Branch("ClusterModuleNumber", fMergedClusterTreeClusterModNum, "ClusterModuleNumber[ClusterCellN]/b");
+      tTrueMergedCaloClusterPi0[iCut]->Branch("ClusterCol",            fMergedClusterTreeClusterCol, "ClusterCol[ClusterCellN]/b");
+      tTrueMergedCaloClusterPi0[iCut]->Branch("ClusterRow",            fMergedClusterTreeClusterRow, "ClusterRow[ClusterCellN]/b");
       tTrueMergedCaloClusterPi0[iCut]->Branch("PartIsPrimary",       &fMergedClusterTreePartIsPrimary, "PartIsPrimary/O");
       tTrueMergedCaloClusterPi0[iCut]->Branch("PartPID",             &fMergedClusterTreePartPID, "PartPID/S");
       tTrueMergedCaloClusterPi0[iCut]->Branch("PartPt",              &fMergedClusterTreePartPt, "PartPt/F");
@@ -1560,13 +1560,13 @@ void AliAnalysisTaskGammaCaloMergedML::UserCreateOutputObjects(){
 
       tTrueMergedCaloClusterEta[iCut] = new TTree(Form("%s_%s_%s_%s_Eta", cutstringEvent.Data(), cutstringCalo.Data(), cutstringCaloMerged.Data(), cutstringMeson.Data()), Form("%s_%s_%s_%s_Eta", cutstringEvent.Data(), cutstringCalo.Data(), cutstringCaloMerged.Data(), cutstringMeson.Data()));
       tTrueMergedCaloClusterEta[iCut]->Branch("ClusterCellN", &fMergedClusterCellN, "ClusterCellN/b");
-      tTrueMergedCaloClusterEta[iCut]->Branch("Cluster",             fMergedClusterTreeCluster, "Cluster[fMergedClusterCellN]/F");
+      tTrueMergedCaloClusterEta[iCut]->Branch("Cluster",             fMergedClusterTreeCluster, "Cluster[ClusterCellN]/F");
       tTrueMergedCaloClusterEta[iCut]->Branch("ClusterType",         &fMergedClusterTreeClusterType,"ClusterType/b");
       tTrueMergedCaloClusterEta[iCut]->Branch("ClusterE",            &fMergedClusterTreeClusterEnergy, "ClusterE/F");
       tTrueMergedCaloClusterEta[iCut]->Branch("ClusterPt",           &fMergedClusterTreeClusterPt, "ClusterPt/F");
-      tTrueMergedCaloClusterEta[iCut]->Branch("ClusterModuleNumber", fMergedClusterTreeClusterModNum, "ClusterModuleNumber[fMergedClusterCellN]/b");
-      tTrueMergedCaloClusterEta[iCut]->Branch("ClusterCol",            fMergedClusterTreeClusterCol, "ClusterCol[fMergedClusterCellN]/b");
-      tTrueMergedCaloClusterEta[iCut]->Branch("ClusterRow",            fMergedClusterTreeClusterRow, "ClusterRow[fMergedClusterCellN]/b");
+      tTrueMergedCaloClusterEta[iCut]->Branch("ClusterModuleNumber", fMergedClusterTreeClusterModNum, "ClusterModuleNumber[ClusterCellN]/b");
+      tTrueMergedCaloClusterEta[iCut]->Branch("ClusterCol",            fMergedClusterTreeClusterCol, "ClusterCol[ClusterCellN]/b");
+      tTrueMergedCaloClusterEta[iCut]->Branch("ClusterRow",            fMergedClusterTreeClusterRow, "ClusterRow[ClusterCellN]/b");
       tTrueMergedCaloClusterEta[iCut]->Branch("PartIsPrimary",           &fMergedClusterTreePartIsPrimary, "PartIsPrimary/O");
       tTrueMergedCaloClusterEta[iCut]->Branch("PartPID",             &fMergedClusterTreePartPID, "PartPID/S");
       tTrueMergedCaloClusterEta[iCut]->Branch("PartPt",              &fMergedClusterTreePartPt, "PartPt/F");
@@ -1581,13 +1581,13 @@ void AliAnalysisTaskGammaCaloMergedML::UserCreateOutputObjects(){
 
       tTrueMergedCaloClusterBck[iCut] = new TTree(Form("%s_%s_%s_%s_Bck", cutstringEvent.Data(), cutstringCalo.Data(), cutstringCaloMerged.Data(), cutstringMeson.Data()), Form("%s_%s_%s_%s_Bck", cutstringEvent.Data(), cutstringCalo.Data(), cutstringCaloMerged.Data(), cutstringMeson.Data()));
       tTrueMergedCaloClusterBck[iCut]->Branch("ClusterCellN", &fMergedClusterCellN, "ClusterCellN/b");
-      tTrueMergedCaloClusterBck[iCut]->Branch("Cluster",             fMergedClusterTreeCluster, "Cluster[fMergedClusterCellN]/F");
+      tTrueMergedCaloClusterBck[iCut]->Branch("Cluster",             fMergedClusterTreeCluster, "Cluster[ClusterCellN]/F");
       tTrueMergedCaloClusterBck[iCut]->Branch("ClusterType",         &fMergedClusterTreeClusterType,"ClusterType/b");
       tTrueMergedCaloClusterBck[iCut]->Branch("ClusterE",            &fMergedClusterTreeClusterEnergy, "ClusterE/F");
       tTrueMergedCaloClusterBck[iCut]->Branch("ClusterPt",           &fMergedClusterTreeClusterPt, "ClusterPt/F");
-      tTrueMergedCaloClusterBck[iCut]->Branch("ClusterModuleNumber", fMergedClusterTreeClusterModNum, "ClusterModuleNumber[fMergedClusterCellN]/b");
-      tTrueMergedCaloClusterBck[iCut]->Branch("ClusterCol",            fMergedClusterTreeClusterCol, "ClusterCol[fMergedClusterCellN]/b");
-      tTrueMergedCaloClusterBck[iCut]->Branch("ClusterRow",            fMergedClusterTreeClusterRow, "ClusterRow[fMergedClusterCellN]/b");
+      tTrueMergedCaloClusterBck[iCut]->Branch("ClusterModuleNumber", fMergedClusterTreeClusterModNum, "ClusterModuleNumber[ClusterCellN]/b");
+      tTrueMergedCaloClusterBck[iCut]->Branch("ClusterCol",            fMergedClusterTreeClusterCol, "ClusterCol[ClusterCellN]/b");
+      tTrueMergedCaloClusterBck[iCut]->Branch("ClusterRow",            fMergedClusterTreeClusterRow, "ClusterRow[ClusterCellN]/b");
       tTrueMergedCaloClusterBck[iCut]->Branch("PartPID",             &fMergedClusterTreePartPID, "PartPID/S");
       tTrueMergedCaloClusterBck[iCut]->Branch("PartPt",              &fMergedClusterTreePartPt, "PartPt/F");
       tTrueMergedCaloClusterBck[iCut]->Branch("PartE",               &fMergedClusterTreePartE, "PartE/F");

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaCaloMergedML.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaCaloMergedML.cxx
@@ -267,12 +267,14 @@ AliAnalysisTaskGammaCaloMergedML::AliAnalysisTaskGammaCaloMergedML(): AliAnalysi
   fHistoPi0EvsGammaOverlapE(NULL),
   fMergedClusterCellN(0),
   fMergedClusterTreeCluster(NULL),
+  fMergedClusterTreeClusterTiming(NULL),
   fMergedClusterTreeClusterType(0),
   fMergedClusterTreeClusterEnergy(0),
   fMergedClusterTreeClusterPt(0),
   fMergedClusterTreeClusterModNum(NULL),
   fMergedClusterTreeClusterCol(NULL),
   fMergedClusterTreeClusterRow(NULL),
+  fMergedClusterTreeDistFromVert(0),
   fMergedClusterTreePartIsPrimary(0),
   fMergedClusterTreePartPID(0),
   fMergedClusterTreePartPt(0),
@@ -487,12 +489,14 @@ AliAnalysisTaskGammaCaloMergedML::AliAnalysisTaskGammaCaloMergedML(const char *n
   fHistoPi0EvsGammaOverlapE(NULL),
   fMergedClusterCellN(0),
   fMergedClusterTreeCluster(NULL),
+  fMergedClusterTreeClusterTiming(NULL),
   fMergedClusterTreeClusterType(0),
   fMergedClusterTreeClusterEnergy(0),
   fMergedClusterTreeClusterPt(0),
   fMergedClusterTreeClusterModNum(NULL),
   fMergedClusterTreeClusterCol(NULL),
   fMergedClusterTreeClusterRow(NULL),
+  fMergedClusterTreeDistFromVert(0),
   fMergedClusterTreePartIsPrimary(0),
   fMergedClusterTreePartPID(0),
   fMergedClusterTreePartPt(0),
@@ -502,12 +506,6 @@ AliAnalysisTaskGammaCaloMergedML::AliAnalysisTaskGammaCaloMergedML(const char *n
   fMergedClusterTreeClusterM02(0),
   fMergedClusterTreeClusterM20(0)
 {
-
-  //for(Int_t i=0; i<50; i++){
-  //  for(Int_t j=0; j<50; j++){
-  //    fMergedClusterTreeCluster[i][j] = 0.;
-  //  }
-  //}
 
   // Define output slots here
   DefineOutput(1, TList::Class());
@@ -930,8 +928,10 @@ void AliAnalysisTaskGammaCaloMergedML::UserCreateOutputObjects(){
     tTrueMergedCaloClusterEta                 = new TTree*[fnCuts];
     tTrueMergedCaloClusterBck                 = new TTree*[fnCuts];
 
+
     UChar_t MaxClusterCellN = 100;
     fMergedClusterTreeCluster                 = new Float_t[MaxClusterCellN];
+    fMergedClusterTreeClusterTiming           = new Float_t[MaxClusterCellN];
     fMergedClusterTreeClusterModNum           = new UChar_t[MaxClusterCellN];
     fMergedClusterTreeClusterCol              = new UChar_t[MaxClusterCellN];
     fMergedClusterTreeClusterRow              = new UChar_t[MaxClusterCellN];
@@ -1542,12 +1542,14 @@ void AliAnalysisTaskGammaCaloMergedML::UserCreateOutputObjects(){
       tTrueMergedCaloClusterPi0[iCut] = new TTree(Form("%s_%s_%s_%s_Pio", cutstringEvent.Data(), cutstringCalo.Data(), cutstringCaloMerged.Data(), cutstringMeson.Data()), Form("%s_%s_%s_%s_Pi0", cutstringEvent.Data(), cutstringCalo.Data(), cutstringCaloMerged.Data(), cutstringMeson.Data()));
       tTrueMergedCaloClusterPi0[iCut]->Branch("ClusterCellN", &fMergedClusterCellN, "ClusterCellN/b");
       tTrueMergedCaloClusterPi0[iCut]->Branch("Cluster",             fMergedClusterTreeCluster, "Cluster[ClusterCellN]/F");
+      tTrueMergedCaloClusterPi0[iCut]->Branch("ClusterTiming",             fMergedClusterTreeClusterTiming, "ClusterTiming[ClusterCellN]/F");
       tTrueMergedCaloClusterPi0[iCut]->Branch("ClusterType",         &fMergedClusterTreeClusterType,"ClusterType/b");
       tTrueMergedCaloClusterPi0[iCut]->Branch("ClusterE",            &fMergedClusterTreeClusterEnergy, "ClusterE/F");
       tTrueMergedCaloClusterPi0[iCut]->Branch("ClusterPt",           &fMergedClusterTreeClusterPt, "ClusterPt/F");
       tTrueMergedCaloClusterPi0[iCut]->Branch("ClusterModuleNumber", fMergedClusterTreeClusterModNum, "ClusterModuleNumber[ClusterCellN]/b");
       tTrueMergedCaloClusterPi0[iCut]->Branch("ClusterCol",            fMergedClusterTreeClusterCol, "ClusterCol[ClusterCellN]/b");
       tTrueMergedCaloClusterPi0[iCut]->Branch("ClusterRow",            fMergedClusterTreeClusterRow, "ClusterRow[ClusterCellN]/b");
+      tTrueMergedCaloClusterPi0[iCut]->Branch("ClusterDistFromVert",             &fMergedClusterTreeDistFromVert, "ClusterDistFromVert/F");
       tTrueMergedCaloClusterPi0[iCut]->Branch("PartIsPrimary",       &fMergedClusterTreePartIsPrimary, "PartIsPrimary/O");
       tTrueMergedCaloClusterPi0[iCut]->Branch("PartPID",             &fMergedClusterTreePartPID, "PartPID/S");
       tTrueMergedCaloClusterPi0[iCut]->Branch("PartPt",              &fMergedClusterTreePartPt, "PartPt/F");
@@ -1561,12 +1563,14 @@ void AliAnalysisTaskGammaCaloMergedML::UserCreateOutputObjects(){
       tTrueMergedCaloClusterEta[iCut] = new TTree(Form("%s_%s_%s_%s_Eta", cutstringEvent.Data(), cutstringCalo.Data(), cutstringCaloMerged.Data(), cutstringMeson.Data()), Form("%s_%s_%s_%s_Eta", cutstringEvent.Data(), cutstringCalo.Data(), cutstringCaloMerged.Data(), cutstringMeson.Data()));
       tTrueMergedCaloClusterEta[iCut]->Branch("ClusterCellN", &fMergedClusterCellN, "ClusterCellN/b");
       tTrueMergedCaloClusterEta[iCut]->Branch("Cluster",             fMergedClusterTreeCluster, "Cluster[ClusterCellN]/F");
+      tTrueMergedCaloClusterEta[iCut]->Branch("ClusterTiming",             fMergedClusterTreeClusterTiming, "ClusterTiming[ClusterCellN]/F");
       tTrueMergedCaloClusterEta[iCut]->Branch("ClusterType",         &fMergedClusterTreeClusterType,"ClusterType/b");
       tTrueMergedCaloClusterEta[iCut]->Branch("ClusterE",            &fMergedClusterTreeClusterEnergy, "ClusterE/F");
       tTrueMergedCaloClusterEta[iCut]->Branch("ClusterPt",           &fMergedClusterTreeClusterPt, "ClusterPt/F");
       tTrueMergedCaloClusterEta[iCut]->Branch("ClusterModuleNumber", fMergedClusterTreeClusterModNum, "ClusterModuleNumber[ClusterCellN]/b");
       tTrueMergedCaloClusterEta[iCut]->Branch("ClusterCol",            fMergedClusterTreeClusterCol, "ClusterCol[ClusterCellN]/b");
       tTrueMergedCaloClusterEta[iCut]->Branch("ClusterRow",            fMergedClusterTreeClusterRow, "ClusterRow[ClusterCellN]/b");
+      tTrueMergedCaloClusterEta[iCut]->Branch("ClusterDistFromVert",             &fMergedClusterTreeDistFromVert, "ClusterDistFromVert/F");
       tTrueMergedCaloClusterEta[iCut]->Branch("PartIsPrimary",           &fMergedClusterTreePartIsPrimary, "PartIsPrimary/O");
       tTrueMergedCaloClusterEta[iCut]->Branch("PartPID",             &fMergedClusterTreePartPID, "PartPID/S");
       tTrueMergedCaloClusterEta[iCut]->Branch("PartPt",              &fMergedClusterTreePartPt, "PartPt/F");
@@ -1582,12 +1586,14 @@ void AliAnalysisTaskGammaCaloMergedML::UserCreateOutputObjects(){
       tTrueMergedCaloClusterBck[iCut] = new TTree(Form("%s_%s_%s_%s_Bck", cutstringEvent.Data(), cutstringCalo.Data(), cutstringCaloMerged.Data(), cutstringMeson.Data()), Form("%s_%s_%s_%s_Bck", cutstringEvent.Data(), cutstringCalo.Data(), cutstringCaloMerged.Data(), cutstringMeson.Data()));
       tTrueMergedCaloClusterBck[iCut]->Branch("ClusterCellN", &fMergedClusterCellN, "ClusterCellN/b");
       tTrueMergedCaloClusterBck[iCut]->Branch("Cluster",             fMergedClusterTreeCluster, "Cluster[ClusterCellN]/F");
+      tTrueMergedCaloClusterBck[iCut]->Branch("ClusterTiming",             fMergedClusterTreeClusterTiming, "ClusterTiming[ClusterCellN]/F");
       tTrueMergedCaloClusterBck[iCut]->Branch("ClusterType",         &fMergedClusterTreeClusterType,"ClusterType/b");
       tTrueMergedCaloClusterBck[iCut]->Branch("ClusterE",            &fMergedClusterTreeClusterEnergy, "ClusterE/F");
       tTrueMergedCaloClusterBck[iCut]->Branch("ClusterPt",           &fMergedClusterTreeClusterPt, "ClusterPt/F");
       tTrueMergedCaloClusterBck[iCut]->Branch("ClusterModuleNumber", fMergedClusterTreeClusterModNum, "ClusterModuleNumber[ClusterCellN]/b");
       tTrueMergedCaloClusterBck[iCut]->Branch("ClusterCol",            fMergedClusterTreeClusterCol, "ClusterCol[ClusterCellN]/b");
       tTrueMergedCaloClusterBck[iCut]->Branch("ClusterRow",            fMergedClusterTreeClusterRow, "ClusterRow[ClusterCellN]/b");
+      tTrueMergedCaloClusterBck[iCut]->Branch("ClusterDistFromVert",             &fMergedClusterTreeDistFromVert, "ClusterDistFromVert/F");
       tTrueMergedCaloClusterBck[iCut]->Branch("PartPID",             &fMergedClusterTreePartPID, "PartPID/S");
       tTrueMergedCaloClusterBck[iCut]->Branch("PartPt",              &fMergedClusterTreePartPt, "PartPt/F");
       tTrueMergedCaloClusterBck[iCut]->Branch("PartE",               &fMergedClusterTreePartE, "PartE/F");
@@ -2617,15 +2623,21 @@ void AliAnalysisTaskGammaCaloMergedML::ProcessTrueClusterCandidatesAOD(AliAODCon
 
   // Fill tree variables
   const AliVVertex* primVtxMC   = fMCEvent->GetPrimaryVertex();
-  Double_t mcProdVtxX   = primVtxMC->GetX();
-  Double_t mcProdVtxY   = primVtxMC->GetY();
-  Double_t mcProdVtxZ   = primVtxMC->GetZ();
+  const Double_t mcProdVtxX   = primVtxMC->GetX();
+  const Double_t mcProdVtxY   = primVtxMC->GetY();
+  const Double_t mcProdVtxZ   = primVtxMC->GetZ();
 
   TLorentzVector clusVec;
-  Double_t vert[3] = {mcProdVtxX,mcProdVtxY,mcProdVtxZ};
+  const Double_t vert[3] = {mcProdVtxX,mcProdVtxY,mcProdVtxZ};
   cluster->GetMomentum(clusVec, vert);
 
+  Float_t pos[3];
+  cluster->GetPosition(pos);
+  pos[0] -= vert[0];
+  pos[1] -= vert[1];
+  pos[2] -= vert[2];
 
+  fMergedClusterTreeDistFromVert = TMath::Sqrt(pos[0]*pos[0] + pos[1]*pos[1] + pos[2]*pos[2]);
   fMergedClusterTreeClusterPt = clusVec.Pt();
   fMergedClusterTreeClusterEnergy = cluster->E();
   fMergedClusterTreeClusterM02 = m02;
@@ -2653,20 +2665,11 @@ void AliAnalysisTaskGammaCaloMergedML::ProcessTrueClusterCandidatesAOD(AliAODCon
         fMergedClusterTreeClusterModNum[iCell] = tempsup;
 
         fMergedClusterTreeCluster[iCell] = cells->GetCellAmplitude(cellAbsID);
+        fMergedClusterTreeClusterTiming[iCell] = cells->GetCellTime(cellAbsID);
       }
 
 
-  //GetClusterReadout(cluster, fInputEvent, fMergedClusterTreeCluster);
 
-  //Int_t tempXPos=0;
-  //Int_t tempYPos=0;
-  //Int_t tempModNum=0;
-  //Int_t Cellid = ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->FindLargestCellInCluster(cluster, fInputEvent);
-
-  //tempModNum = ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetModuleNumberAndCellPosition(Cellid, tempXPos, tempYPos);
-  //fMergedClusterTreeClusterModNum = tempModNum;
-  //fMergedClusterTreeClusterCol = tempXPos;
-  //fMergedClusterTreeClusterRow = tempYPos;
 
   Double_t tempClusterWeight       = fWeightJetJetMC;
   AliAODMCParticle *Photon = NULL;

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaCaloMergedML.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaCaloMergedML.h
@@ -122,9 +122,8 @@ class AliAnalysisTaskGammaCaloMergedML : public AliAnalysisTaskSE {
 
     //Own functions for data extraction
     void GetClusterReadout(AliVCluster* cluster, AliVEvent* event, Float_t cellarray[50][50]);
-    void GetClusterTime(AliVCluster* cluster, AliVEvent* event);
 
-    void ResetBuffer();
+
 
 
   protected:
@@ -329,13 +328,14 @@ class AliAnalysisTaskGammaCaloMergedML : public AliAnalysisTaskSE {
     TTree**                 tTrueMergedCaloClusterEta;			   //! array of trees with MC information of merged clusters from eta
     TTree**                 tTrueMergedCaloClusterBck;                          //! array of tress with MC information of merged clusters from background
 
-    Float_t                 fMergedClusterTreeCluster[50][50];		   //! energy of cluster
+    UChar_t                 fMergedClusterCellN; //! number of cells in cluster
+    Float_t*                fMergedClusterTreeCluster;		   //! energy of cluster
     UChar_t                 fMergedClusterTreeClusterType;			   //! cluster classification
     Float_t                 fMergedClusterTreeClusterEnergy;			   //! cluster energy
     Float_t                 fMergedClusterTreeClusterPt; 				   //! cluster pt
-    UChar_t                 fMergedClusterTreeClusterModNum;			   //! cluster supermodule number
-    UChar_t                 fMergedClusterTreeClusterXPos;				   //! coloumn of leading cell
-    UChar_t                 fMergedClusterTreeClusterYPos;				   //! row of leading cell
+    UChar_t*                fMergedClusterTreeClusterModNum;			   //! cells supermodule numbers
+    UChar_t*                fMergedClusterTreeClusterCol;				   //! coloumn numbers of cells
+    UChar_t*                fMergedClusterTreeClusterRow;				   //! row numbers of cells
     Bool_t                  fMergedClusterTreePartIsPrimary;			   //! is mother particle primary
     Short_t                 fMergedClusterTreePartPID;	 			   //! mother particle PID
     Float_t                 fMergedClusterTreePartPt;                                //! mother particle pT
@@ -347,14 +347,7 @@ class AliAnalysisTaskGammaCaloMergedML : public AliAnalysisTaskSE {
 
 
 
-    TTree**                 tClusterTiming;
-    UChar_t                 fClusterN;
-    UChar_t*                fRow;
-    UChar_t*                fCol;
-    UChar_t*                fSupMod;
-    Float_t*                fTiming;
-    Float_t*                fEnergy;
-    UChar_t                 isTiming;
+
 
     // additional variables
     TRandom3                fRandom;                                            // random
@@ -383,7 +376,7 @@ class AliAnalysisTaskGammaCaloMergedML : public AliAnalysisTaskSE {
     AliAnalysisTaskGammaCaloMergedML(const AliAnalysisTaskGammaCaloMergedML&); // Prevent copy-construction
     AliAnalysisTaskGammaCaloMergedML &operator=(const AliAnalysisTaskGammaCaloMergedML&); // Prevent assignment
 
-    ClassDef(AliAnalysisTaskGammaCaloMergedML, 45);
+    ClassDef(AliAnalysisTaskGammaCaloMergedML, 46);
 };
 
 #endif

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaCaloMergedML.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaCaloMergedML.h
@@ -348,12 +348,13 @@ class AliAnalysisTaskGammaCaloMergedML : public AliAnalysisTaskSE {
 
 
     TTree**                 tClusterTiming;
-    UChar_t                 MaxClusterN;
+    UChar_t                 fClusterN;
     UChar_t*                fRow;
     UChar_t*                fCol;
+    UChar_t*                fSupMod;
     Float_t*                fTiming;
     Float_t*                fEnergy;
-
+    UChar_t                 isTiming;
 
     // additional variables
     TRandom3                fRandom;                                            // random
@@ -382,7 +383,7 @@ class AliAnalysisTaskGammaCaloMergedML : public AliAnalysisTaskSE {
     AliAnalysisTaskGammaCaloMergedML(const AliAnalysisTaskGammaCaloMergedML&); // Prevent copy-construction
     AliAnalysisTaskGammaCaloMergedML &operator=(const AliAnalysisTaskGammaCaloMergedML&); // Prevent assignment
 
-    ClassDef(AliAnalysisTaskGammaCaloMergedML, 42);
+    ClassDef(AliAnalysisTaskGammaCaloMergedML, 45);
 };
 
 #endif

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaCaloMergedML.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaCaloMergedML.h
@@ -328,22 +328,24 @@ class AliAnalysisTaskGammaCaloMergedML : public AliAnalysisTaskSE {
     TTree**                 tTrueMergedCaloClusterEta;			   //! array of trees with MC information of merged clusters from eta
     TTree**                 tTrueMergedCaloClusterBck;                          //! array of tress with MC information of merged clusters from background
 
-    UChar_t                 fMergedClusterCellN; //! number of cells in cluster
-    Float_t*                fMergedClusterTreeCluster;		   //! energy of cluster
-    UChar_t                 fMergedClusterTreeClusterType;			   //! cluster classification
-    Float_t                 fMergedClusterTreeClusterEnergy;			   //! cluster energy
-    Float_t                 fMergedClusterTreeClusterPt; 				   //! cluster pt
-    UChar_t*                fMergedClusterTreeClusterModNum;			   //! cells supermodule numbers
-    UChar_t*                fMergedClusterTreeClusterCol;				   //! coloumn numbers of cells
-    UChar_t*                fMergedClusterTreeClusterRow;				   //! row numbers of cells
-    Bool_t                  fMergedClusterTreePartIsPrimary;			   //! is mother particle primary
-    Short_t                 fMergedClusterTreePartPID;	 			   //! mother particle PID
-    Float_t                 fMergedClusterTreePartPt;                                //! mother particle pT
-    Float_t                 fMergedClusterTreePartE;                               //! mother particle E
-    Float_t                 fMergedClusterTreePartEta;				   //! mother particle eta
-    Float_t                 fMergedClusterTreePartPhi;  				   //! mother particle phi
-    Float_t                 fMergedClusterTreeClusterM02;                                 //! cluster m02
-    Float_t                 fMergedClusterTreeClusterM20;                                 //! cluster m20
+    UChar_t                 fMergedClusterCellN;                  //! number of cells in cluster
+    Float_t*                fMergedClusterTreeCluster;		        //! energy of cluster cells
+    Float_t*                fMergedClusterTreeClusterTiming;      //! timing of cluster cells
+    UChar_t                 fMergedClusterTreeClusterType;			  //! cluster classification
+    Float_t                 fMergedClusterTreeClusterEnergy;			//! cluster energy
+    Float_t                 fMergedClusterTreeClusterPt; 				  //! cluster pt
+    UChar_t*                fMergedClusterTreeClusterModNum;			//! cells supermodule numbers
+    UChar_t*                fMergedClusterTreeClusterCol;				  //! coloumn numbers of cells
+    UChar_t*                fMergedClusterTreeClusterRow;				  //! row numbers of cells
+    Float_t                 fMergedClusterTreeDistFromVert;       //! distance from vertex
+    Bool_t                  fMergedClusterTreePartIsPrimary;			//! is mother particle primary
+    Short_t                 fMergedClusterTreePartPID;	 			    //! mother particle PID
+    Float_t                 fMergedClusterTreePartPt;             //! mother particle pT
+    Float_t                 fMergedClusterTreePartE;              //! mother particle E
+    Float_t                 fMergedClusterTreePartEta;				    //! mother particle eta
+    Float_t                 fMergedClusterTreePartPhi;  				  //! mother particle phi
+    Float_t                 fMergedClusterTreeClusterM02;         //! cluster m02
+    Float_t                 fMergedClusterTreeClusterM20;         //! cluster m20
 
 
 

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaCaloMergedML.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaCaloMergedML.h
@@ -122,9 +122,11 @@ class AliAnalysisTaskGammaCaloMergedML : public AliAnalysisTaskSE {
 
     //Own functions for data extraction
     void GetClusterReadout(AliVCluster* cluster, AliVEvent* event, Float_t cellarray[50][50]);
+    void GetClusterTime(AliVCluster* cluster, AliVEvent* event);
+
     void ResetBuffer();
 
-    
+
   protected:
     AliV0ReaderV1*          fV0Reader;                                          // basic photon Selection Task
     TString                 fV0ReaderName;
@@ -337,7 +339,7 @@ class AliAnalysisTaskGammaCaloMergedML : public AliAnalysisTaskSE {
     Bool_t                  fMergedClusterTreePartIsPrimary;			   //! is mother particle primary
     Short_t                 fMergedClusterTreePartPID;	 			   //! mother particle PID
     Float_t                 fMergedClusterTreePartPt;                                //! mother particle pT
-    Float_t                 fMergedClusterTreePartE;                               //! mother particle E 
+    Float_t                 fMergedClusterTreePartE;                               //! mother particle E
     Float_t                 fMergedClusterTreePartEta;				   //! mother particle eta
     Float_t                 fMergedClusterTreePartPhi;  				   //! mother particle phi
     Float_t                 fMergedClusterTreeClusterM02;                                 //! cluster m02
@@ -345,8 +347,14 @@ class AliAnalysisTaskGammaCaloMergedML : public AliAnalysisTaskSE {
 
 
 
+    TTree**                 tClusterTiming;
+    UChar_t                 MaxClusterN;
+    UChar_t*                fRow;
+    UChar_t*                fCol;
+    Float_t*                fTiming;
+    Float_t*                fEnergy;
 
-    
+
     // additional variables
     TRandom3                fRandom;                                            // random
     Int_t                   fnCuts;                                             // number of cuts to be analysed in parallel
@@ -374,7 +382,7 @@ class AliAnalysisTaskGammaCaloMergedML : public AliAnalysisTaskSE {
     AliAnalysisTaskGammaCaloMergedML(const AliAnalysisTaskGammaCaloMergedML&); // Prevent copy-construction
     AliAnalysisTaskGammaCaloMergedML &operator=(const AliAnalysisTaskGammaCaloMergedML&); // Prevent assignment
 
-    ClassDef(AliAnalysisTaskGammaCaloMergedML, 40);
+    ClassDef(AliAnalysisTaskGammaCaloMergedML, 42);
 };
 
 #endif

--- a/PWGGA/GammaConv/macros/AddTask_GammaCaloMergedML_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaCaloMergedML_pp.C
@@ -1525,7 +1525,7 @@ void AddTask_GammaCaloMergedML_pp(
   } else if (trainConfig == 1541){
     cuts.AddCutMergedCalo("0008e113","411790106fe92000000","411790106fe92200001","0163300000000000"); // EG2+DG2
     cuts.AddCutMergedCalo("0008d113","411790106fe92200000","411790106fe92200001","0163300000000000"); // EG1+DG1
-    
+
     // systematics pp 8 TeV no TM
     // MB configs
   } else if (trainConfig == 3900){ // std
@@ -2051,7 +2051,13 @@ void AddTask_GammaCaloMergedML_pp(
       nContainer++;
     }
   }
-  
-  
+
+  for(Int_t i = 0; i<numberOfCuts; i++){
+    if(isMC>0){
+      mgr->ConnectOutput(task,nContainer,mgr->CreateContainer(Form("%s_%s_%s_%s_Cluster",(cuts.GetEventCut(i)).Data(),(cuts.GetClusterCut(i)).Data(),(cuts.GetClusterMergedCut(i)).Data(),(cuts.GetMesonCut(i)).Data()), TTree::Class(), AliAnalysisManager::kOutputContainer, Form("GammaCaloMergedML_%i.root",trainConfig)) );
+      nContainer++;
+    }
+  }
+
   return;
 }

--- a/PWGGA/GammaConv/macros/AddTask_GammaCaloMergedML_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaCaloMergedML_pp.C
@@ -2052,12 +2052,7 @@ void AddTask_GammaCaloMergedML_pp(
     }
   }
 
-  for(Int_t i = 0; i<numberOfCuts; i++){
-    if(isMC>0){
-      mgr->ConnectOutput(task,nContainer,mgr->CreateContainer(Form("%s_%s_%s_%s_Cluster",(cuts.GetEventCut(i)).Data(),(cuts.GetClusterCut(i)).Data(),(cuts.GetClusterMergedCut(i)).Data(),(cuts.GetMesonCut(i)).Data()), TTree::Class(), AliAnalysisManager::kOutputContainer, Form("GammaCaloMergedML_%i.root",trainConfig)) );
-      nContainer++;
-    }
-  }
+
 
   return;
 }


### PR DESCRIPTION
I changed branches in the trees to be more efficient with regard to memory by using variable length arrays. The clusters can be reconstructed from the information in the trees later, instead of writing a 2d-array containing the cluster into a tree. Also added additional branches to extract more information about clusters.  