### PR TITLE
Dong-Fang Wang(dowang) the first pull request.

### DIFF
--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoEventReaderNanoAOD.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoEventReaderNanoAOD.cxx
@@ -563,6 +563,17 @@ AliFemtoEvent *AliFemtoEventReaderNanoAOD::CopyAODtoFemtoEvent()
 	trackCopy->SetNSigmaTPCE(nsigmaTPCE);
 	trackCopy->SetNSigmaTPCD(nsigmaTPCD);
 
+    // dowang 2021.8.30 for t/He3 identification
+    static const Int_t kcstNSigmaTPCT = AliNanoAODTrack::GetPIDIndex(AliNanoAODTrack::kSigmaTPC, AliPID::kTriton);
+    static const Int_t kcstNSigmaTPCHe3 = AliNanoAODTrack::GetPIDIndex(AliNanoAODTrack::kSigmaTPC, AliPID::kHe3);
+    if(kcstNSigmaTPCT!=-1){
+        const float nsigmaTPCT = aodtrack->GetVar(kcstNSigmaTPCT);
+        trackCopy->SetNSigmaTPCT(nsigmaTPCT);
+    }
+    if(kcstNSigmaTPCHe3!=-1){
+        const float nsigmaTPCHe3 = aodtrack->GetVar(kcstNSigmaTPCHe3);
+        trackCopy->SetNSigmaTPCH(nsigmaTPCHe3);
+    }
 //	trackCopy->SetTPCsignal(aodtrack->GetTPCsignal());
 //	trackCopy->SetTPCsignalS(1);
 //	trackCopy->SetTPCsignalN(aodtrack->GetTPCsignalN());
@@ -594,6 +605,17 @@ AliFemtoEvent *AliFemtoEventReaderNanoAOD::CopyAODtoFemtoEvent()
 	trackCopy->SetNSigmaTOFE(nsigmaTOFE);
 	trackCopy->SetNSigmaTOFD(nsigmaTOFD);
 
+    // dowang 2021.8.30 for t/He3 identification
+    static const Int_t kcstNSigmaTOFT = AliNanoAODTrack::GetPIDIndex(AliNanoAODTrack::kSigmaTOF, AliPID::kTriton);
+    static const Int_t kcstNSigmaTOFHe3 = AliNanoAODTrack::GetPIDIndex(AliNanoAODTrack::kSigmaTOF, AliPID::kHe3);
+    if(kcstNSigmaTOFT!=-1){
+      const float nsigmaTOFT = aodtrack->GetVar(kcstNSigmaTOFT);
+      trackCopy->SetNSigmaTOFT(nsigmaTOFT);
+    }
+    if(kcstNSigmaTOFHe3!=-1){
+      const float nsigmaTOFHe3 = aodtrack->GetVar(kcstNSigmaTOFHe3);
+      trackCopy->SetNSigmaTOFH(nsigmaTOFHe3);
+    }
 //	trackCopy->SetTOFsignal(aodtrack->GetTOFsignal());
 
       }

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoSimpleAnalysisOnlyMixP1.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoSimpleAnalysisOnlyMixP1.cxx
@@ -1,0 +1,291 @@
+#include "AliFemtoSimpleAnalysisOnlyMixP1.h"
+#include "AliFemtoTrackCut.h"
+#include "AliFemtoV0Cut.h"
+#include "AliFemtoKinkCut.h"
+#include "AliFemtoXiCut.h"
+#include "AliFemtoXiTrackCut.h"
+#include "AliFemtoPicoEvent.h"
+
+#include <string>
+#include <iostream>
+#include <iterator>
+
+
+#ifdef __ROOT__
+  /// \cond CLASSIMP
+  ClassImp(AliFemtoSimpleAnalysisOnlyMixP1);
+  /// \endcond
+#endif
+
+//////////////////////////////////////////////////////////////////////////////////
+// dongfang.wang@cern.ch                                                        //
+// AliFemtoSimpleAnalysisOnlyMixP1: Only keep update/save first particle        //
+// The key is in line 200(if current event has first particle, but not have     //
+// second particle, then save it)                                               //
+// and line 260(Only allow first particle in mixing pool making pair            //
+// with second particle in current event                                        //
+//                                                                              //
+//////////////////////////////////////////////////////////////////////////////////
+
+
+template <class TrackCollectionType, class TrackCutType>
+void DoFillParticleCollection(TrackCutType *cut,
+                              TrackCollectionType *track_collection,
+                              AliFemtoParticleCollection *output)
+{
+  for (const auto &track : *track_collection) {
+    const Bool_t track_passes = cut->Pass(track);
+    cut->FillCutMonitor(track, track_passes);
+    if (track_passes) {
+      output->push_back(new AliFemtoParticle(track, cut->Mass()));
+    }
+  }
+}
+
+
+// This little function is used to apply ParticleCuts (TrackCuts or V0Cuts) and
+// fill ParticleCollections from tacks in picoEvent. It is called from
+// AliFemtoSimpleAnalysis::ProcessEvent().
+//
+// The actual loop implementation has been moved to the collection-generic
+// DoFillParticleCollection() function
+void FillHbtParticleCollection(AliFemtoParticleCut *partCut,
+                               const AliFemtoEvent *hbtEvent,
+                               AliFemtoParticleCollection *partCollection,
+                               bool performSharedDaughterCut=kFALSE)
+{
+  /// Fill particle collection with all particles in the event which pass
+  /// the provided cut
+
+  // determine which track collection to use based on the particle type.
+  switch (partCut->Type()) {
+
+  // cut is cutting on Tracks
+  case hbtTrack:
+    {
+      DoFillParticleCollection(
+			       (AliFemtoTrackCut*)partCut,
+			       hbtEvent->TrackCollection(),
+			       partCollection
+			       );
+    }
+    break;
+
+  // cut is cutting on V0s
+  case hbtV0:
+  {
+    AliFemtoV0Cut *v0_cut = (AliFemtoV0Cut*)partCut;
+
+    // shared daughter cut returns all passed v0s - add to particle collection
+    if (performSharedDaughterCut) {
+      AliFemtoV0SharedDaughterCut shared_daughter_cut;
+      AliFemtoV0Collection v0_coll = shared_daughter_cut.AliFemtoV0SharedDaughterCutCollection(hbtEvent->V0Collection(), v0_cut);
+      // for (AliFemtoV0Iterator pIter = v0_coll.begin(); pIter != v0_coll.end(); ++pIter) {
+      for (auto v0 : v0_coll) {
+        partCollection->push_back(new AliFemtoParticle(v0, v0_cut->Mass()));
+      }
+    } else {
+
+      DoFillParticleCollection(
+        v0_cut,
+        hbtEvent->V0Collection(),
+        partCollection
+      );
+
+    }
+
+    break;
+  }
+
+  // cut is cutting on Xis
+  case hbtXi:
+  {
+    AliFemtoXiTrackCut *xi_cut = (AliFemtoXiTrackCut*)partCut;
+
+    // shared daughter cut returns all passed xis - add to particle collection
+    if (performSharedDaughterCut)
+    {
+      AliFemtoXiSharedDaughterCut shared_daughter_cut;
+      AliFemtoXiCollection xi_coll = shared_daughter_cut.AliFemtoXiSharedDaughterCutCollection(hbtEvent->XiCollection(), xi_cut);
+      for (AliFemtoXiIterator pIter = xi_coll.begin(); pIter != xi_coll.end(); ++pIter) {
+        partCollection->push_back(new AliFemtoParticle(*pIter, xi_cut->Mass()));
+      }
+    }
+    else
+    {
+      DoFillParticleCollection(
+        (AliFemtoXiTrackCut*)partCut,
+        hbtEvent->XiCollection(),
+        partCollection
+      );
+    }
+    break;
+  }
+
+  // cut is cutting on Kinks
+  case hbtKink:
+
+    DoFillParticleCollection(
+      (AliFemtoKinkCut*)partCut,
+      hbtEvent->KinkCollection(),
+      partCollection
+    );
+
+    break;
+
+  default:
+    cout << "E-FillHbtParticleCollection function (in AliFemtoSimpleAnalysis.cxx): "
+            "Undefined Particle Cut type!!! (" << partCut->Type() << ")\n";
+  }
+
+  partCut->FillCutMonitor(hbtEvent, partCollection);
+}
+
+// Leave this here to appease any legacy code that expected a non-const AliFemtoEvent
+void FillHbtParticleCollection(AliFemtoParticleCut *partCut,
+                               AliFemtoEvent *hbtEvent,
+                               AliFemtoParticleCollection *partCollection,
+                               bool performSharedDaughterCut)
+{
+  FillHbtParticleCollection(partCut, const_cast<const AliFemtoEvent*>(hbtEvent), partCollection, performSharedDaughterCut);
+}
+
+
+AliFemtoSimpleAnalysisOnlyMixP1::AliFemtoSimpleAnalysisOnlyMixP1():
+    AliFemtoSimpleAnalysis()
+{
+    //ccc;
+  number = 10;
+}
+AliFemtoSimpleAnalysisOnlyMixP1::AliFemtoSimpleAnalysisOnlyMixP1(const AliFemtoSimpleAnalysisOnlyMixP1 &OriAnalysis):
+    AliFemtoSimpleAnalysis(OriAnalysis)
+{
+    //copy constructor 
+}
+AliFemtoSimpleAnalysisOnlyMixP1::~AliFemtoSimpleAnalysisOnlyMixP1()
+{
+  // Destructor
+}
+
+AliFemtoSimpleAnalysisOnlyMixP1& AliFemtoSimpleAnalysisOnlyMixP1::operator=(const AliFemtoSimpleAnalysisOnlyMixP1& OriAnalysis)
+{
+    // assignment operator
+    if (this == &OriAnalysis)
+        return *this;
+
+    AliFemtoSimpleAnalysisOnlyMixP1::operator=(OriAnalysis);
+
+    number = OriAnalysis.number;
+    return *this;
+}
+
+void AliFemtoSimpleAnalysisOnlyMixP1::ProcessEvent(const AliFemtoEvent* hbtEvent){
+
+    cout<<"AliFemtoSimpleAnalysisOnlyMixP1 ProcessEvent"<<endl;
+
+    fPicoEvent = nullptr;
+    AddEventProcessed();
+    EventBegin(hbtEvent);
+    bool tmpPassEvent = fEventCut->Pass(hbtEvent);
+    if (!tmpPassEvent) {
+        cout<<"no pass"<<endl;
+        fEventCut->FillCutMonitor(hbtEvent, tmpPassEvent);
+        EventEnd(hbtEvent);  // cleanup for EbyE
+        return;
+    }
+    fPicoEvent = new AliFemtoPicoEvent;
+
+    
+     
+    AliFemtoParticleCollection *collection1 = fPicoEvent->FirstParticleCollection(),
+                               *collection2 = fPicoEvent->SecondParticleCollection();
+    // wdf 2020.8.17
+    // only collection1 == nullptr, we delete this event!
+    if (collection1 == nullptr){
+        cout << "E-AliFemtoSimpleAnalysisOnlyMixP1::ProcessEvent: new PicoEvent is missing particle collections!\n";
+        EventEnd(hbtEvent);  // cleanup for EbyE
+        delete fPicoEvent;
+        return;
+    }
+    // if collection2 == nullptr, we also update this event, but not do make pair!
+    if (collection2 == nullptr ){
+        if ( MixingBufferFull() ) {
+            delete MixingBuffer()->back();
+            MixingBuffer()->pop_back();
+        }
+        MixingBuffer()->push_front(fPicoEvent);
+        EventEnd(hbtEvent);
+        return;  
+    }
+
+    FillHbtParticleCollection(fFirstParticleCut,
+                            hbtEvent,
+                            fPicoEvent->FirstParticleCollection(),
+                            fPerformSharedDaughterCut);
+
+    // fill second particle cut if not analyzing identical particles
+    if ( !AnalyzeIdenticalParticles() ) {
+        FillHbtParticleCollection(fSecondParticleCut,
+                                hbtEvent,
+                                fPicoEvent->SecondParticleCollection(),
+                                fPerformSharedDaughterCut);
+    }
+
+    const UInt_t coll_1_size = collection1->size(),
+                 coll_2_size = collection2->size();
+    
+    fEventCut->FillCutMonitor(collection1, collection2); //MJ!
+    
+    const bool coll_1_size_passes = (coll_1_size >= fMinSizePartCollection),
+               coll_2_size_passes = (AnalyzeIdenticalParticles() || (coll_2_size >= fMinSizePartCollection));
+
+    tmpPassEvent = tmpPassEvent && coll_1_size_passes && coll_2_size_passes;
+
+    // fill the event cut monitor
+    fEventCut->FillCutMonitor(hbtEvent, tmpPassEvent);
+    if (!tmpPassEvent) {
+        EventEnd(hbtEvent);
+        delete fPicoEvent;
+        return;
+    }
+    if (AnalyzeIdenticalParticles()) {
+        collection2 = nullptr;
+    }
+
+    MakePairs("real", collection1, collection2, EnablePairMonitors());
+    for (auto storedEvent : *fMixingBuffer) {
+        if (AnalyzeIdenticalParticles()) {
+            MakePairs("mixed", collection1, storedEvent->FirstParticleCollection());
+            // If non-identical - mix both combinations of first and second particles
+        }else {
+            // MakePairs("mixed", collection1,
+            //                storedEvent->SecondParticleCollection());
+            // only make first particle in pool with second particle in current event
+            MakePairs("mixed", storedEvent->FirstParticleCollection(),collection2);
+        }
+
+    }
+    if ( MixingBufferFull() ) {
+        delete MixingBuffer()->back();
+        MixingBuffer()->pop_back();
+    }
+    MixingBuffer()->push_front(fPicoEvent);
+    EventEnd(hbtEvent);
+
+
+
+}
+
+
+
+bool AliFemtoSimpleAnalysisOnlyMixP1::Pass(float inputcut)
+{
+
+    cout<<"AliFemtoSimpleAnalysisOnlyMixP1 Pass"<<inputcut<<endl;
+
+}
+
+void AliFemtoSimpleAnalysisOnlyMixP1::Test(float InputNumber){
+    cout<<"AliFemtoSimpleAnalysisOnlyMixP1 Test "<<InputNumber<<endl;
+    number = InputNumber;
+}

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoSimpleAnalysisOnlyMixP1.h
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoSimpleAnalysisOnlyMixP1.h
@@ -2,15 +2,14 @@
 #define AliFemtoSimpleAnalysisOnlyMixP1_hh
 
 
-//////////////////////////////////////////////////////////////////////////////////
+//==============================================================================//
 // dongfang.wang@cern.ch                                                        //
 // AliFemtoSimpleAnalysisOnlyMixP1: Only keep update/save first particle        //
 // The key is in line 200(if current event has first particle, but not have     //
 // second particle, then save it)                                               //
 // and line 260(Only allow first particle in mixing pool making pair            //
 // with second particle in current event                                        //
-//                                                                              //
-//////////////////////////////////////////////////////////////////////////////////
+//==============================================================================//
 
 #include "AliFemtoSimpleAnalysis.h"
 class AliFemtoSimpleAnalysisOnlyMixP1 : public AliFemtoSimpleAnalysis{
@@ -24,11 +23,6 @@ class AliFemtoSimpleAnalysisOnlyMixP1 : public AliFemtoSimpleAnalysis{
         
         virtual void ProcessEvent(const AliFemtoEvent* hbtEvent);
 
-        // wdf for test
-        virtual bool Pass(float inputcut);
-        void Test(float InputNumber);
-    private:
-        float  number;
 
 };
 

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoSimpleAnalysisOnlyMixP1.h
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoSimpleAnalysisOnlyMixP1.h
@@ -1,0 +1,36 @@
+#ifndef AliFemtoSimpleAnalysisOnlyMixP1_hh
+#define AliFemtoSimpleAnalysisOnlyMixP1_hh
+
+
+//////////////////////////////////////////////////////////////////////////////////
+// dongfang.wang@cern.ch                                                        //
+// AliFemtoSimpleAnalysisOnlyMixP1: Only keep update/save first particle        //
+// The key is in line 200(if current event has first particle, but not have     //
+// second particle, then save it)                                               //
+// and line 260(Only allow first particle in mixing pool making pair            //
+// with second particle in current event                                        //
+//                                                                              //
+//////////////////////////////////////////////////////////////////////////////////
+
+#include "AliFemtoSimpleAnalysis.h"
+class AliFemtoSimpleAnalysisOnlyMixP1 : public AliFemtoSimpleAnalysis{
+
+    public:
+        AliFemtoSimpleAnalysisOnlyMixP1();
+        AliFemtoSimpleAnalysisOnlyMixP1(const AliFemtoSimpleAnalysisOnlyMixP1 &OriAnalysis);
+        virtual ~AliFemtoSimpleAnalysisOnlyMixP1();
+        AliFemtoSimpleAnalysisOnlyMixP1& operator =(const AliFemtoSimpleAnalysisOnlyMixP1 &OriAnalysis);
+
+        
+        virtual void ProcessEvent(const AliFemtoEvent* hbtEvent);
+
+        // wdf for test
+        virtual bool Pass(float inputcut);
+        void Test(float InputNumber);
+    private:
+        float  number;
+
+};
+
+
+#endif

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoVertexMultAnalysisOnlyMixP1.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoVertexMultAnalysisOnlyMixP1.cxx
@@ -1,8 +1,11 @@
-
-// wdf Fudan
+//===============================================================================//
+// dongfang.wang@cern.ch
+// AliFemtoVertexMultAnalysisOnlyMixP1: Making pool which keep update/save
+// as long as the first particle has been found in this event!
+// Only difference with AliFemtoVertexMultAnalysis.cxx in line 217.
+//===============================================================================//
 
 #include "AliFemtoVertexMultAnalysisOnlyMixP1.h"
-
 #include "AliFemtoParticleCollection.h"
 #include "AliFemtoTrackCut.h"
 #include "AliFemtoV0Cut.h"
@@ -17,13 +20,6 @@
   ClassImp(AliFemtoVertexMultAnalysisOnlyMixP1);
   /// \endcond
 #endif
-
-//////////////////////////////////////////////////////////////////////////////////
-// dongfang.wang@cern.ch                                                        //
-// AliFemtoVertexMultAnalysisOnlyMixP1: Making pool which keep update/save      //
-// only this event has first particle                                           //
-//////////////////////////////////////////////////////////////////////////////////
-
 
 AliFemtoVertexMultAnalysisOnlyMixP1::AliFemtoVertexMultAnalysisOnlyMixP1(   UInt_t binsVertex,
                                                                             Double_t minVertex,
@@ -85,8 +81,6 @@ AliFemtoVertexMultAnalysisOnlyMixP1::AliFemtoVertexMultAnalysisOnlyMixP1(   UInt
         fMult[0],
         fMult[1]
     );
-    //test;
-    number = 10;
 }
 AliFemtoVertexMultAnalysisOnlyMixP1::AliFemtoVertexMultAnalysisOnlyMixP1(const AliFemtoVertexMultAnalysisOnlyMixP1 &OriAnalysis):
     AliFemtoSimpleAnalysisOnlyMixP1(OriAnalysis),
@@ -163,8 +157,7 @@ AliFemtoVertexMultAnalysisOnlyMixP1& AliFemtoVertexMultAnalysisOnlyMixP1::operat
         fMult[0],
         fMult[1]
     );
-
-    number = OriAnalysis.number;
+    
     return *this;
 }
 
@@ -196,14 +189,13 @@ TList* AliFemtoVertexMultAnalysisOnlyMixP1::ListSettings()
 }
 
 void AliFemtoVertexMultAnalysisOnlyMixP1::ProcessEvent(const AliFemtoEvent* HbtEventToProcess){
-    cout<<"AliFemtoVertexMultAnalysisOnlyMixP1 ProcessEvent"<<endl;
     const Double_t  vertexZ = HbtEventToProcess->PrimVertPos().z(),
                     mult = HbtEventToProcess->UncorrectedNumberOfPrimaries();
 
     fMixingBuffer = fPicoEventCollectionVectorHideAway->PicoEventCollection(vertexZ, mult);
 
     if (!fMixingBuffer) {
-        cout<<"no fMixingBuffer"<<endl;
+        
         if (vertexZ < fVertexZ[0]) {
         fUnderFlowVertexZ++;
         }
@@ -227,19 +219,4 @@ void AliFemtoVertexMultAnalysisOnlyMixP1::ProcessEvent(const AliFemtoEvent* HbtE
     // NULL out the mixing buffer after event processed
     fMixingBuffer = NULL;
 
-}
-
-
-bool AliFemtoVertexMultAnalysisOnlyMixP1::Pass(float inputcut)
-{
-    cout<<"AliFemtoVertexMultAnalysisOnlyMixP1 Pass"<<inputcut<<endl;
-
-
-}
-
-void AliFemtoVertexMultAnalysisOnlyMixP1::Test(float InputNumber){ 
-    cout<<"AliFemtoVertexMultAnalysisOnlyMixP1 Test "<<InputNumber<<endl;
-    number = InputNumber;
-
-    AliFemtoSimpleAnalysisOnlyMixP1::Test(number);
 }

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoVertexMultAnalysisOnlyMixP1.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoVertexMultAnalysisOnlyMixP1.cxx
@@ -1,0 +1,245 @@
+
+// wdf Fudan
+
+#include "AliFemtoVertexMultAnalysisOnlyMixP1.h"
+
+#include "AliFemtoParticleCollection.h"
+#include "AliFemtoTrackCut.h"
+#include "AliFemtoV0Cut.h"
+#include "AliFemtoXiCut.h"
+#include "AliFemtoKinkCut.h"
+#include "AliFemtoPicoEventCollectionVector.h"
+#include "AliFemtoPicoEventCollectionVectorHideAway.h"
+
+
+#ifdef __ROOT__
+  /// \cond CLASSIMP
+  ClassImp(AliFemtoVertexMultAnalysisOnlyMixP1);
+  /// \endcond
+#endif
+
+//////////////////////////////////////////////////////////////////////////////////
+// dongfang.wang@cern.ch                                                        //
+// AliFemtoVertexMultAnalysisOnlyMixP1: Making pool which keep update/save      //
+// only this event has first particle                                           //
+//////////////////////////////////////////////////////////////////////////////////
+
+
+AliFemtoVertexMultAnalysisOnlyMixP1::AliFemtoVertexMultAnalysisOnlyMixP1(   UInt_t binsVertex,
+                                                                            Double_t minVertex,
+                                                                            Double_t maxVertex,
+                                                                            UInt_t binsMult,
+                                                                            Double_t minMult,
+                                                                            Double_t maxMult):
+    AliFemtoSimpleAnalysisOnlyMixP1(),
+    fVertexZBins(binsVertex),
+    fOverFlowVertexZ(0),
+    fUnderFlowVertexZ(0),
+    fMultBins(binsMult),
+    fOverFlowMult(0),
+    fUnderFlowMult(0)
+{
+
+    fVertexZ[0] = minVertex;
+    fVertexZ[1] = maxVertex;
+    fMult[0] = minMult;
+    fMult[1] = maxMult;
+
+    // We COULD swap these automatically, but we will just print out a warning
+    // so users may potentially fix bugs of a larger scale.
+    if (minVertex >= maxVertex) {
+        cout << "W-AliFemtoVertexMultAnalysis: Provided minVertex >= maxVertex "
+                "(" << minVertex << " >= " << maxVertex << "). "
+                "No events are expected to pass.";
+    }
+
+    if (minMult >= maxMult) {
+        cout << "W-AliFemtoVertexMultAnalysis: Provided minMult >= maxMult "
+                "(" << minMult << " >= " << maxMult << "). "
+                "No events are expected to pass.";
+    }
+
+    // create if the correlation function collection was not set in previous
+    // constructor (though it SHOULD be)
+    if (fCorrFctnCollection == NULL) {
+        fCorrFctnCollection = new AliFemtoCorrFctnCollection;
+    }
+
+    // always keep fMixingBuffer NULL unless in ProcessEvent()
+    if (fMixingBuffer) {
+        delete fMixingBuffer;
+        fMixingBuffer = NULL;
+    }
+
+    // if the event collection was already create (it should NOT be) delete
+    // before we allocate a new one
+    if (fPicoEventCollectionVectorHideAway) {
+        delete fPicoEventCollectionVectorHideAway;
+    }
+
+    fPicoEventCollectionVectorHideAway = new AliFemtoPicoEventCollectionVectorHideAway(
+        fVertexZBins,
+        fVertexZ[0],
+        fVertexZ[1],
+        fMultBins,
+        fMult[0],
+        fMult[1]
+    );
+    //test;
+    number = 10;
+}
+AliFemtoVertexMultAnalysisOnlyMixP1::AliFemtoVertexMultAnalysisOnlyMixP1(const AliFemtoVertexMultAnalysisOnlyMixP1 &OriAnalysis):
+    AliFemtoSimpleAnalysisOnlyMixP1(OriAnalysis),
+    fVertexZBins(OriAnalysis.fVertexZBins),
+    fOverFlowVertexZ(0),
+    fUnderFlowVertexZ(0),
+    fMultBins(OriAnalysis.fMultBins),
+    fOverFlowMult(0),
+    fUnderFlowMult(0)
+{
+    //copy constructor 
+    fVertexZ[0] = OriAnalysis.fVertexZ[0];
+    fVertexZ[1] = OriAnalysis.fVertexZ[1];
+    fMult[0] = OriAnalysis.fMult[0];
+    fMult[1] = OriAnalysis.fMult[1];
+
+    if (fMixingBuffer) {
+        delete fMixingBuffer;
+        fMixingBuffer = NULL;
+    }
+
+    // This *should* be NULL from AliFemtoVertexMultAnalysisOnlyMixP1 constructor - but delete just in case
+    delete fPicoEventCollectionVectorHideAway;
+
+    fPicoEventCollectionVectorHideAway = new AliFemtoPicoEventCollectionVectorHideAway(
+        fVertexZBins,
+        fVertexZ[0],
+        fVertexZ[1],
+        fMultBins,
+        fMult[0],
+        fMult[1]
+    );
+
+    // if (fVerbose) {
+    //     cout << " AliFemtoVertexMultAnalysisOnlyMixP1::AliFemtoVertexMultAnalysisOnlyMixP1(const AliFemtoVertexMultAnalysisOnlyMixP1&) - analysis copied " << endl;
+    // }
+}
+
+
+AliFemtoVertexMultAnalysisOnlyMixP1& AliFemtoVertexMultAnalysisOnlyMixP1::operator=(const AliFemtoVertexMultAnalysisOnlyMixP1& OriAnalysis)
+{
+    // assignment operator
+    if (this == &OriAnalysis) {
+        return *this;
+    }
+
+    // Allow parent class to copy the cuts and correlation functions
+    AliFemtoVertexMultAnalysisOnlyMixP1::operator=(OriAnalysis);
+
+    fVertexZBins = OriAnalysis.fVertexZBins;
+    fMultBins = OriAnalysis.fMultBins;
+
+    fVertexZ[0] = OriAnalysis.fVertexZ[0];
+    fVertexZ[1] = OriAnalysis.fVertexZ[1];
+    fUnderFlowVertexZ = 0;
+    fOverFlowVertexZ = 0;
+
+    fMult[0] = OriAnalysis.fMult[0];
+    fMult[1] = OriAnalysis.fMult[1];
+    fUnderFlowMult = 0;
+    fOverFlowMult = 0;
+
+    if (fMixingBuffer) {
+        delete fMixingBuffer;
+        fMixingBuffer = NULL;
+    }
+
+    delete fPicoEventCollectionVectorHideAway;
+    fPicoEventCollectionVectorHideAway = new AliFemtoPicoEventCollectionVectorHideAway(
+        fVertexZBins,
+        fVertexZ[0],
+        fVertexZ[1],
+        fMultBins,
+        fMult[0],
+        fMult[1]
+    );
+
+    number = OriAnalysis.number;
+    return *this;
+}
+
+AliFemtoVertexMultAnalysisOnlyMixP1::~AliFemtoVertexMultAnalysisOnlyMixP1()
+{
+    // Destructor
+    delete fPicoEventCollectionVectorHideAway;
+}
+AliFemtoString AliFemtoVertexMultAnalysisOnlyMixP1::Report()
+{
+    TString report("-----------\nHbt AliFemtoVertexMultAnalysisOnlyMixP1 Report:\n");
+
+    report += TString::Format("Events are mixed in %d VertexZ bins in the range %E cm to %E cm.\n", fVertexZBins, fVertexZ[0], fVertexZ[1])
+            + TString::Format("Events underflowing: %d\n", fUnderFlowVertexZ)
+            + TString::Format("Events overflowing: %d\n", fOverFlowVertexZ)
+            + TString::Format("Events are mixed in %d Mult bins in the range %E cm to %E cm.\n", fMultBins, fMult[0], fMult[1])
+            + TString::Format("Events underflowing: %d\n", fUnderFlowMult)
+            + TString::Format("Events overflowing: %d\n", fOverFlowMult)
+            + TString::Format("Now adding AliFemtoVertexMultAnalysisOnlyMixP1 Report\n");
+            //+ AliFemtoSimpleAnalysis::Report();
+
+    return AliFemtoString((const char *)report);
+
+}
+TList* AliFemtoVertexMultAnalysisOnlyMixP1::ListSettings()
+{
+    TList *settings = new TList;
+    return settings;
+}
+
+void AliFemtoVertexMultAnalysisOnlyMixP1::ProcessEvent(const AliFemtoEvent* HbtEventToProcess){
+    cout<<"AliFemtoVertexMultAnalysisOnlyMixP1 ProcessEvent"<<endl;
+    const Double_t  vertexZ = HbtEventToProcess->PrimVertPos().z(),
+                    mult = HbtEventToProcess->UncorrectedNumberOfPrimaries();
+
+    fMixingBuffer = fPicoEventCollectionVectorHideAway->PicoEventCollection(vertexZ, mult);
+
+    if (!fMixingBuffer) {
+        cout<<"no fMixingBuffer"<<endl;
+        if (vertexZ < fVertexZ[0]) {
+        fUnderFlowVertexZ++;
+        }
+        else if (vertexZ > fVertexZ[1]) {
+        fOverFlowVertexZ++;
+        }
+
+        if (mult < fMult[0]) {
+        fUnderFlowMult++;
+        }
+        else if (mult > fMult[1]) {
+        fOverFlowMult++;
+        }
+
+        return;
+    }
+
+    // now that fMixingBuffer has been set - call superclass ProcessEvent()
+    AliFemtoSimpleAnalysisOnlyMixP1::ProcessEvent(HbtEventToProcess);
+
+    // NULL out the mixing buffer after event processed
+    fMixingBuffer = NULL;
+
+}
+
+
+bool AliFemtoVertexMultAnalysisOnlyMixP1::Pass(float inputcut)
+{
+    cout<<"AliFemtoVertexMultAnalysisOnlyMixP1 Pass"<<inputcut<<endl;
+
+
+}
+
+void AliFemtoVertexMultAnalysisOnlyMixP1::Test(float InputNumber){ 
+    cout<<"AliFemtoVertexMultAnalysisOnlyMixP1 Test "<<InputNumber<<endl;
+    number = InputNumber;
+
+    AliFemtoSimpleAnalysisOnlyMixP1::Test(number);
+}

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoVertexMultAnalysisOnlyMixP1.h
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoVertexMultAnalysisOnlyMixP1.h
@@ -1,0 +1,88 @@
+#ifndef AliFemtoVertexMultAnalysisOnlyMixP1_hh
+#define AliFemtoVertexMultAnalysisOnlyMixP1_hh
+
+
+#include "AliFemtoSimpleAnalysisOnlyMixP1.h"
+
+//////////////////////////////////////////////////////////////////////////////////
+// dongfang.wang@cern.ch                                                        //
+// AliFemtoVertexMultAnalysisOnlyMixP1: Making pool which keep update/save      //
+// only this event has first particle                                           //
+//////////////////////////////////////////////////////////////////////////////////
+
+// class wdf 2021.8.17 
+class AliFemtoVertexMultAnalysisOnlyMixP1 : public AliFemtoSimpleAnalysisOnlyMixP1{
+
+    public:
+        AliFemtoVertexMultAnalysisOnlyMixP1(UInt_t binsVertex=10,
+                                            Double_t minVertex=-100.0,
+                                            Double_t maxVertex=+100.0,
+                                            UInt_t binsMult=10,
+                                            Double_t minMult=-1.0e9,
+                                            Double_t maxMult=+1.0e9);
+        AliFemtoVertexMultAnalysisOnlyMixP1(const AliFemtoVertexMultAnalysisOnlyMixP1 &OriAnalysis);
+        AliFemtoVertexMultAnalysisOnlyMixP1& operator =(const AliFemtoVertexMultAnalysisOnlyMixP1 &OriAnalysis);
+        virtual ~AliFemtoVertexMultAnalysisOnlyMixP1();
+
+
+        
+        virtual void ProcessEvent(const AliFemtoEvent* HbtEventToProcess);
+        virtual AliFemtoString Report(); 
+
+        virtual TList* ListSettings();
+
+        virtual UInt_t OverflowVertexZ() const;   ///< Number of events above vertex-z range
+        virtual UInt_t UnderflowVertexZ() const;  ///< Number of events below vertex-z range
+        virtual UInt_t OverflowMult() const;      ///< Number of events above multiplicity range
+        virtual UInt_t UnderflowMult() const;     ///< Number of events below multiplicity range
+
+    protected:
+
+        Double_t fVertexZ[2];     ///< min/max z-vertex position allowed to be processed
+        UInt_t fVertexZBins;      ///< number of VERTEX mixing bins in z-vertex in EventMixing Buffer
+        UInt_t fOverFlowVertexZ;  ///< number of events encountered which had too large z-vertex
+        UInt_t fUnderFlowVertexZ; ///< number of events encountered which had too small z-vertex
+
+        Double_t fMult[2];        ///< min/max multiplicity allowed for event to be processed
+        UInt_t fMultBins;         ///< number of MULTIPLICITY mixing bins in z-vertex in EventMixing Buffer
+        UInt_t fOverFlowMult;     ///< number of events encountered which had too large multiplicity
+        UInt_t fUnderFlowMult;    ///< number of events encountered which had too small multiplicity
+
+    public:
+        // wdf for test
+        virtual bool Pass(float inputcut);
+        void Test(float InputNumber);
+    private:
+        float  number;
+    //----------------------------------------------------------------------------------------------------------------
+    //----------------------------------------------------------------------------------------------------------------
+    //----------------------------------------------------------------------------------------------------------------
+    #ifdef __ROOT__
+    /// \cond CLASSIMP
+    ClassDef(AliFemtoVertexMultAnalysisOnlyMixP1, 1);
+    /// \endcond
+    #endif
+
+};
+
+inline UInt_t AliFemtoVertexMultAnalysisOnlyMixP1::OverflowVertexZ() const
+{
+  return fOverFlowVertexZ;
+}
+
+inline UInt_t AliFemtoVertexMultAnalysisOnlyMixP1::UnderflowVertexZ() const
+{
+  return fUnderFlowVertexZ;
+}
+
+inline UInt_t AliFemtoVertexMultAnalysisOnlyMixP1::OverflowMult() const
+{
+  return fOverFlowMult;
+}
+
+inline UInt_t AliFemtoVertexMultAnalysisOnlyMixP1::UnderflowMult() const
+{
+  return fUnderFlowMult;
+}
+
+#endif

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoVertexMultAnalysisOnlyMixP1.h
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoVertexMultAnalysisOnlyMixP1.h
@@ -1,16 +1,14 @@
 #ifndef AliFemtoVertexMultAnalysisOnlyMixP1_hh
 #define AliFemtoVertexMultAnalysisOnlyMixP1_hh
-
+//===============================================================================//
+// dongfang.wang@cern.ch
+// AliFemtoVertexMultAnalysisOnlyMixP1: Making pool which keep update/save
+// as long as the first particle has been found in this event!
+// Only difference with AliFemtoVertexMultAnalysis.cxx in line 217.
+//===============================================================================//
 
 #include "AliFemtoSimpleAnalysisOnlyMixP1.h"
 
-//////////////////////////////////////////////////////////////////////////////////
-// dongfang.wang@cern.ch                                                        //
-// AliFemtoVertexMultAnalysisOnlyMixP1: Making pool which keep update/save      //
-// only this event has first particle                                           //
-//////////////////////////////////////////////////////////////////////////////////
-
-// class wdf 2021.8.17 
 class AliFemtoVertexMultAnalysisOnlyMixP1 : public AliFemtoSimpleAnalysisOnlyMixP1{
 
     public:
@@ -48,12 +46,6 @@ class AliFemtoVertexMultAnalysisOnlyMixP1 : public AliFemtoSimpleAnalysisOnlyMix
         UInt_t fOverFlowMult;     ///< number of events encountered which had too large multiplicity
         UInt_t fUnderFlowMult;    ///< number of events encountered which had too small multiplicity
 
-    public:
-        // wdf for test
-        virtual bool Pass(float inputcut);
-        void Test(float InputNumber);
-    private:
-        float  number;
     //----------------------------------------------------------------------------------------------------------------
     //----------------------------------------------------------------------------------------------------------------
     //----------------------------------------------------------------------------------------------------------------

--- a/PWGCF/FEMTOSCOPY/AliFemto/CMakeLists.txt
+++ b/PWGCF/FEMTOSCOPY/AliFemto/CMakeLists.txt
@@ -126,6 +126,8 @@ set(SRCS
   AliFemtoCutMonitorParticleYPt_pion.cxx  
   AliFemtoCutMonitorParticleYPt_proton.cxx
   AliFemtoEventReaderAODKinematicsMultSelection.cxx
+  AliFemtoSimpleAnalysisOnlyMixP1.cxx
+  AliFemtoVertexMultAnalysisOnlyMixP1.cxx
   )
 
 # Headers from sources

--- a/PWGCF/FEMTOSCOPY/AliFemto/CMakeLists.txt
+++ b/PWGCF/FEMTOSCOPY/AliFemto/CMakeLists.txt
@@ -189,6 +189,8 @@ set(HDRS ${HDRS}
   AliFemtoTrioFctnCollection.h
   AliFemtoEventReaderNanoAOD.h
   AliFemtoEventReaderNanoAODChain.h
+  AliFemtoSimpleAnalysisOnlyMixP1.h
+  AliFemtoVertexMultAnalysisOnlyMixP1.h
   )
 
 set ( FSRCS

--- a/PWGCF/FEMTOSCOPY/AliFemto/PWGCFfemtoscopyLinkDef.h
+++ b/PWGCF/FEMTOSCOPY/AliFemto/PWGCFfemtoscopyLinkDef.h
@@ -115,6 +115,9 @@
 #pragma link C++ class AliFemtoEventReaderNanoAOD+;
 #pragma link C++ class AliFemtoEventReaderNanoAODChain+;
 #pragma link C++ class AliFemtoEventReaderAODKinematicsMultSelection+;
+// Dong-Fang: 2021.9.14
+#pragma link C++ class AliFemtoSimpleAnalysisOnlyMixP1+;
+#pragma link C++ class AliFemtoVertexMultAnalysisOnlyMixP1+;
 
 #pragma link C++ class AliFemtoConfigObject-;
 #pragma link C++ class AliFemtoConfigObject::Painter;
@@ -126,9 +129,7 @@
 #pragma link C++ class std::vector<AliFemtoConfigObject>::iterator;
 #pragma link C++ class std::vector<std::pair<double, double>>;
 
-// Dong-Fang: 2021.9.14
-#pragma link C++ class AliFemtoSimpleAnalysisOnlyMixP1;
-#pragma link C++ class AliFemtoVertexMultAnalysisOnlyMixP1;
+
 // ^ these std:: classes required here for use in ROOT-5 macros (ROOT-6 should be ok)
 
 #endif

--- a/PWGCF/FEMTOSCOPY/AliFemto/PWGCFfemtoscopyLinkDef.h
+++ b/PWGCF/FEMTOSCOPY/AliFemto/PWGCFfemtoscopyLinkDef.h
@@ -125,6 +125,10 @@
 #pragma link C++ class std::vector<AliFemtoConfigObject>;
 #pragma link C++ class std::vector<AliFemtoConfigObject>::iterator;
 #pragma link C++ class std::vector<std::pair<double, double>>;
+
+// Dong-Fang: 2021.9.14
+#pragma link C++ class AliFemtoSimpleAnalysisOnlyMixP1;
+#pragma link C++ class AliFemtoVertexMultAnalysisOnlyMixP1;
 // ^ these std:: classes required here for use in ROOT-5 macros (ROOT-6 should be ok)
 
 #endif

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoTrackCutPdtHe3.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoTrackCutPdtHe3.cxx
@@ -1,3 +1,8 @@
+//==============================================================\\
+// dowang track cut for p-d/t/He3 analysis                      \\
+// deuteron part refer to AliFemtoWRzTrackCut.h                 \\
+//==============================================================\\
+
 #include "AliFemtoTrackCutPdtHe3.h"
 AliFemtoTrackCutPdtHe3::AliFemtoTrackCutPdtHe3():
 AliFemtoESDTrackCut()
@@ -189,56 +194,54 @@ bool AliFemtoTrackCutPdtHe3::Pass(const AliFemtoTrack* track)
             return false;
     
     if (fMostProbable) {
+        
         int imost=0;
         //****N Sigma Method****
         if (fPIDMethod==0) {
             if (fMostProbable == 4) { // proton nsigma-PID required contour adjusting (in LHC10h)
-                if (IsProtonNSigma(track->P().Mag(), fNsigmaP, track->NSigmaTPCP(), track->NSigmaTOFP()) ) 
-                {
+                if (IsProtonNSigma(track->P().Mag(), fNsigmaP, track->NSigmaTPCP(), track->NSigmaTOFP()) ) {
                     imost = 4;
                 }
-                else if (fMostProbable == 13) 
-                {   //cut on Nsigma deuteron
-                    if (IsDeuteronNSigma(track->P().Mag(),fNsigmaD, track->MassTOF(), fNsigmaMass, track->NSigmaTPCD(), track->NSigmaTOFD()) 
-                        && !IsElectronNSigmaRejection(track->P().Mag(),track->NSigmaTPCE())
-                        && !IsPionNSigmaRejection(track->P().Mag(),track->NSigmaTPCPi(), track->NSigmaTOFPi()) 
-                        && !IsKaonNSigmaRejection(track->P().Mag(),track->NSigmaTPCK(), track->NSigmaTOFK()) 
-                        && !IsProtonNSigmaRejection(track->P().Mag(),track->NSigmaTPCP(), track->NSigmaTOFP()) 
-                    )
+            }
+            else if (fMostProbable == 13){   //cut on Nsigma deuteron
+                if (IsDeuteronNSigma(track->P().Mag(),fNsigmaD, track->MassTOF(), fNsigmaMass, track->NSigmaTPCD(), track->NSigmaTOFD())
+                    && !IsElectronNSigmaRejection(track->P().Mag(),track->NSigmaTPCE())
+                    && !IsPionNSigmaRejection(track->P().Mag(),track->NSigmaTPCPi(), track->NSigmaTOFPi())
+                    && !IsKaonNSigmaRejection(track->P().Mag(),track->NSigmaTPCK(), track->NSigmaTOFK())
+                    && !IsProtonNSigmaRejection(track->P().Mag(),track->NSigmaTPCP(), track->NSigmaTOFP())){
                         imost = 13;
-                    // wwwww!
                 }
-                else if (fMostProbable == 14) 
-                {   //cut on Nsigma triton
-                    if (IsTritonNSigma(track->P().Mag(),fNsigmaD, track->MassTOF(), fNsigmaMass, track->NSigmaTPCT(), track->NSigmaTOFT()) 
-                        && !IsElectronNSigmaRejection(track->P().Mag(),track->NSigmaTPCE())
-                        && !IsPionNSigmaRejection(track->P().Mag(),track->NSigmaTPCPi(), track->NSigmaTOFPi()) 
-                        && !IsKaonNSigmaRejection(track->P().Mag(),track->NSigmaTPCK(), track->NSigmaTOFK()) 
-                        && !IsProtonNSigmaRejection(track->P().Mag(),track->NSigmaTPCP(), track->NSigmaTOFP()) 
-                    )
-                        imost = 13;
-                    // wwwww!
+            }
+            else if (fMostProbable == 14){   //cut on Nsigma triton
+                if (IsTritonNSigma(track->P().Mag(),fNsigmaD, track->MassTOF(), fNsigmaMass, track->NSigmaTPCT(), track->NSigmaTOFT())
+                    && !IsElectronNSigmaRejection(track->P().Mag(),track->NSigmaTPCE())
+                    && !IsPionNSigmaRejection(track->P().Mag(),track->NSigmaTPCPi(), track->NSigmaTOFPi())
+                    && !IsKaonNSigmaRejection(track->P().Mag(),track->NSigmaTPCK(), track->NSigmaTOFK())
+                    && !IsProtonNSigmaRejection(track->P().Mag(),track->NSigmaTPCP(), track->NSigmaTOFP())){
+                    imost = 14;
                 }
-                else if (fMostProbable == 15) 
-                {   //cut on Nsigma He3
-                    if (IsHe3NSigma(track->P().Mag(),fNsigmaD, track->MassTOF(), fNsigmaMass, track->NSigmaTPCH(), track->NSigmaTOFH()) 
-                        && !IsElectronNSigmaRejection(track->P().Mag(),track->NSigmaTPCE())
-                        && !IsPionNSigmaRejection(track->P().Mag(),track->NSigmaTPCPi(), track->NSigmaTOFPi()) 
-                        && !IsKaonNSigmaRejection(track->P().Mag(),track->NSigmaTPCK(), track->NSigmaTOFK()) 
-                        && !IsProtonNSigmaRejection(track->P().Mag(),track->NSigmaTPCP(), track->NSigmaTOFP()) 
-                    )
-                        imost = 13;
-                    // wwwww!
+                   
+            }
+            else if (fMostProbable == 15){
+                if (IsHe3NSigma(track->P().Mag(),fNsigmaD, track->MassTOF(), fNsigmaMass, track->NSigmaTPCH(), track->NSigmaTOFH())
+                    && !IsElectronNSigmaRejection(track->P().Mag(),track->NSigmaTPCE())
+                    && !IsPionNSigmaRejection(track->P().Mag(),track->NSigmaTPCPi(), track->NSigmaTOFPi())
+                    && !IsKaonNSigmaRejection(track->P().Mag(),track->NSigmaTPCK(), track->NSigmaTOFK())
+                    && !IsProtonNSigmaRejection(track->P().Mag(),track->NSigmaTPCP(), track->NSigmaTOFP())){
+                        imost = 15;
                 }
+
             }
             if (imost != fMostProbable) {
                 return false;
             }
+            
         }
-
-    }
     fNTracksPassed++ ;
+   
     return true;
+    
+    }
     
 }
 bool AliFemtoTrackCutPdtHe3::IsProtonNSigma(float mom, float fNsigma, float nsigmaTPCP, float nsigmaTOFP)

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoTrackCutPdtHe3.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoTrackCutPdtHe3.cxx
@@ -1,0 +1,376 @@
+#include "AliFemtoTrackCutPdtHe3.h"
+AliFemtoTrackCutPdtHe3::AliFemtoTrackCutPdtHe3():
+AliFemtoESDTrackCut()
+{
+    fNsigmaP    = 3.;
+    fNsigmaD    = 3.;
+    fNsigmaT    = 3.;
+    fNsigmaHe3  = 3.;
+    fNsigmaRejection = 3.;
+}
+
+AliFemtoTrackCutPdtHe3::AliFemtoTrackCutPdtHe3(const AliFemtoTrackCutPdtHe3 &aCut) : 
+AliFemtoESDTrackCut(aCut)
+{
+    //copy constructor 
+    fNsigmaP = aCut.fNsigmaP;
+    fNsigmaD = aCut.fNsigmaD;
+    fNsigmaT = aCut.fNsigmaT;
+    fNsigmaHe3 = aCut.fNsigmaHe3;
+    fNsigmaRejection = aCut.fNsigmaRejection;
+
+}
+
+AliFemtoTrackCutPdtHe3::~AliFemtoTrackCutPdtHe3()
+{
+  // Destructor
+}
+
+
+AliFemtoTrackCutPdtHe3& AliFemtoTrackCutPdtHe3::operator=(const AliFemtoTrackCutPdtHe3& aCut)
+{
+    // assignment operator
+    if (this == &aCut)
+        return *this;
+
+    AliFemtoESDTrackCut::operator=(aCut);
+
+    fNsigmaP = aCut.fNsigmaP;
+    fNsigmaD = aCut.fNsigmaD;
+    fNsigmaT = aCut.fNsigmaD;
+    fNsigmaHe3 = aCut.fNsigmaHe3;
+
+    fNsigmaRejection = aCut.fNsigmaRejection;
+
+    return *this;
+}
+
+bool AliFemtoTrackCutPdtHe3::Pass(const AliFemtoTrack* track)
+{
+    if (fStatus && (track->Flags() & fStatus) != fStatus) {
+        return false;
+    }
+    if (fRemoveKinks && (track->KinkIndex(0) || track->KinkIndex(1) || track->KinkIndex(2))) {
+        return false;
+    }
+    if (fRemoveITSFake && track->ITSncls() < 0) {
+        return false;
+    }
+    if (fminTPCclsF > track->TPCnclsF()) {
+        return false;
+    }
+    if (fminTPCncls > track->TPCncls()) {
+        return false;
+    }
+    if (fminITScls > track->ITSncls()) {
+        return false;
+    }
+
+    if (fMaxImpactXY < TMath::Abs(track->ImpactD())) {
+        return false;
+    }
+    if (fMinImpactXY > TMath::Abs(track->ImpactD())) {
+        return false;
+    }
+    if (fMaxImpactZ < TMath::Abs(track->ImpactZ())) {
+        return false;
+    }
+    if (fMaxSigmaToVertex < track->SigmaToVertex()) {
+        return false;
+    }
+
+    if (track->ITSncls() > 0 && (track->ITSchi2() / track->ITSncls()) > fMaxITSchiNdof) {
+        return false;
+    }
+
+    if (track->TPCchi2perNDF() > fMaxTPCchiNdof) {
+        return false;
+    }
+
+    // ITS cluster requirenments
+    for (Int_t i = 0; i < 3; i++) {
+        if (!CheckITSClusterRequirement(fCutClusterRequirementITS[i], track->HasPointOnITSLayer(i * 2), track->HasPointOnITSLayer(i*2+1))) {
+        return false;
+        }
+    }
+
+    if (fLabel) {
+        if (track->Label() < 0) {
+        fNTracksFailed++;
+        return false;
+        }
+    }
+    if (fCharge != 0 && (track->Charge() != fCharge)) {
+        fNTracksFailed++;
+        return false;
+    }
+
+
+    Bool_t tTPCPidIn = (track->Flags() & AliFemtoTrack::kTPCpid) > 0;
+    Bool_t tITSPidIn = (track->Flags() & AliFemtoTrack::kITSpid) > 0;
+    Bool_t tTOFPidIn = (track->Flags() & AliFemtoTrack::kTOFpid) > 0;
+
+    const double momentum = track->P().Mag();
+
+    if (fMinPforTOFpid > 0
+        && fMinPforTOFpid < momentum && momentum < fMaxPforTOFpid
+        && !tTOFPidIn) {
+        fNTracksFailed++;
+        return false;
+    }
+
+    if (fMinPforTPCpid > 0
+        && fMinPforTPCpid < momentum && momentum < fMaxPforTPCpid
+        && !tTPCPidIn) {
+        fNTracksFailed++;
+        return false;
+    }
+
+    if (fMinPforITSpid > 0
+        && fMinPforITSpid < momentum && momentum < fMaxPforITSpid
+        && !tITSPidIn) {
+        fNTracksFailed++;
+        return false;
+    }
+
+
+    float tEnergy = ::sqrt(track->P().Mag2() + fMass * fMass);
+    float tRapidity = 0;
+    if (tEnergy-track->P().z() != 0 && (tEnergy + track->P().z()) / (tEnergy-track->P().z()) > 0)
+        tRapidity = 0.5 * ::log((tEnergy + track->P().z())/(tEnergy-track->P().z()));
+    float tPt = track->P().Perp();
+    float tEta = track->P().PseudoRapidity();
+
+    if (fMaxImpactXYPtOff < 999.0) {
+        if ((fMaxImpactXYPtOff + fMaxImpactXYPtNrm*TMath::Power(tPt, fMaxImpactXYPtPow)) < TMath::Abs(track->ImpactD())) {
+        fNTracksFailed++;
+        return false;
+        }
+    }
+
+    if ((tRapidity < fRapidity[0]) || (tRapidity > fRapidity[1])) {
+        fNTracksFailed++;
+        return false;
+    }
+    if ((tEta < fEta[0]) || (tEta > fEta[1])) {
+        fNTracksFailed++;
+        return false;
+    }
+    if ((tPt < fPt[0]) || (tPt > fPt[1])) {
+        fNTracksFailed++;
+        return false;
+    }
+
+
+    if ((track->PidProbElectron() < fPidProbElectron[0]) || (track->PidProbElectron() > fPidProbElectron[1])) {
+        fNTracksFailed++;
+        return false;
+    }
+    if ((track->PidProbPion() < fPidProbPion[0]) || (track->PidProbPion() > fPidProbPion[1])) {
+        fNTracksFailed++;
+        return false;
+    }
+    if ((track->PidProbKaon() < fPidProbKaon[0]) || (track->PidProbKaon() > fPidProbKaon[1])) {
+        fNTracksFailed++;
+        return false;
+    }
+    if ((track->PidProbProton() < fPidProbProton[0]) || (track->PidProbProton() > fPidProbProton[1])) {
+        fNTracksFailed++;
+        return false;
+    }
+    if ((track->PidProbMuon() < fPidProbMuon[0]) || (track->PidProbMuon() > fPidProbMuon[1])) {
+        fNTracksFailed++;
+        return false;
+    }
+
+    //****N Sigma Method -- electron rejection****
+    if (fElectronRejection)
+        if (!IsElectron(track->NSigmaTPCE(),track->NSigmaTPCPi(),track->NSigmaTPCK(), track->NSigmaTPCP()))
+            return false;
+    
+    if (fMostProbable) {
+        int imost=0;
+        //****N Sigma Method****
+        if (fPIDMethod==0) {
+            if (fMostProbable == 4) { // proton nsigma-PID required contour adjusting (in LHC10h)
+                if (IsProtonNSigma(track->P().Mag(), fNsigmaP, track->NSigmaTPCP(), track->NSigmaTOFP()) ) 
+                {
+                    imost = 4;
+                }
+                else if (fMostProbable == 13) 
+                {   //cut on Nsigma deuteron
+                    if (IsDeuteronNSigma(track->P().Mag(),fNsigmaD, track->MassTOF(), fNsigmaMass, track->NSigmaTPCD(), track->NSigmaTOFD()) 
+                        && !IsElectronNSigmaRejection(track->P().Mag(),track->NSigmaTPCE())
+                        && !IsPionNSigmaRejection(track->P().Mag(),track->NSigmaTPCPi(), track->NSigmaTOFPi()) 
+                        && !IsKaonNSigmaRejection(track->P().Mag(),track->NSigmaTPCK(), track->NSigmaTOFK()) 
+                        && !IsProtonNSigmaRejection(track->P().Mag(),track->NSigmaTPCP(), track->NSigmaTOFP()) 
+                    )
+                        imost = 13;
+                    // wwwww!
+                }
+                else if (fMostProbable == 14) 
+                {   //cut on Nsigma triton
+                    if (IsTritonNSigma(track->P().Mag(),fNsigmaD, track->MassTOF(), fNsigmaMass, track->NSigmaTPCT(), track->NSigmaTOFT()) 
+                        && !IsElectronNSigmaRejection(track->P().Mag(),track->NSigmaTPCE())
+                        && !IsPionNSigmaRejection(track->P().Mag(),track->NSigmaTPCPi(), track->NSigmaTOFPi()) 
+                        && !IsKaonNSigmaRejection(track->P().Mag(),track->NSigmaTPCK(), track->NSigmaTOFK()) 
+                        && !IsProtonNSigmaRejection(track->P().Mag(),track->NSigmaTPCP(), track->NSigmaTOFP()) 
+                    )
+                        imost = 13;
+                    // wwwww!
+                }
+                else if (fMostProbable == 15) 
+                {   //cut on Nsigma He3
+                    if (IsHe3NSigma(track->P().Mag(),fNsigmaD, track->MassTOF(), fNsigmaMass, track->NSigmaTPCH(), track->NSigmaTOFH()) 
+                        && !IsElectronNSigmaRejection(track->P().Mag(),track->NSigmaTPCE())
+                        && !IsPionNSigmaRejection(track->P().Mag(),track->NSigmaTPCPi(), track->NSigmaTOFPi()) 
+                        && !IsKaonNSigmaRejection(track->P().Mag(),track->NSigmaTPCK(), track->NSigmaTOFK()) 
+                        && !IsProtonNSigmaRejection(track->P().Mag(),track->NSigmaTPCP(), track->NSigmaTOFP()) 
+                    )
+                        imost = 13;
+                    // wwwww!
+                }
+            }
+            if (imost != fMostProbable) {
+                return false;
+            }
+        }
+
+    }
+    fNTracksPassed++ ;
+    return true;
+    
+}
+bool AliFemtoTrackCutPdtHe3::IsProtonNSigma(float mom, float fNsigma, float nsigmaTPCP, float nsigmaTOFP)
+{
+    if (mom > 0.5) {
+//        if (TMath::Hypot( nsigmaTOFP, nsigmaTPCP )/TMath::Sqrt(2) < 3.0)
+        if(mom < 2.0) {
+	        if (TMath::Hypot( nsigmaTOFP, nsigmaTPCP ) < fNsigma)
+	            return true;
+        }
+        else
+	        if (TMath::Hypot( nsigmaTOFP, nsigmaTPCP ) < fNsigma)
+	            return true;	
+	}
+    else {
+        if (TMath::Abs(nsigmaTPCP) < fNsigma)
+            return true;
+    }
+
+
+}
+bool AliFemtoTrackCutPdtHe3::IsDeuteronNSigma(float mom, float fNsigma, float massTOFPDG, float sigmaMass, float nsigmaTPCD, float nsigmaTOFD)
+{
+    //double massPDGD=1.8756;
+    if (fNsigmaTPCTOF) {
+        //Identyfication with only TPC for mom<1.4 and TPC&TOF for mom>1.4
+        if (mom > 1.4){
+            if ((TMath::Abs(nsigmaTPCD) < fNsigma) && (TMath::Abs(nsigmaTOFD) < fNsigma))
+                return true;
+        }
+        else{
+            if (TMath::Abs(nsigmaTPCD) < fNsigma)
+                return true;
+        }
+        
+    }
+    else{
+        if (TMath::Abs(nsigmaTPCD) < fNsigma)
+            return true;
+    } 
+  
+}
+bool AliFemtoTrackCutPdtHe3::IsTritonNSigma(float mom, float fNsigma, float massTOFPDG, float sigmaMass, float nsigmaTPCT, float nsigmaTOFT)
+{
+    //double massPDGD=2.8089;
+    if (fNsigmaTPCTOF) {
+        //Identyfication with only TPC for mom<1.4 and TPC&TOF for mom>1.4
+        if (mom > 1.2){
+            if ((TMath::Abs(nsigmaTPCT) < fNsigma) && (TMath::Abs(nsigmaTOFT) < fNsigma))
+                return true;
+        }
+        else{
+            if (TMath::Abs(nsigmaTPCT) < fNsigma)
+                return true;
+        }
+        
+    }
+    else{
+        if (TMath::Abs(nsigmaTPCT) < fNsigma)
+            return true;
+    } 
+  
+}
+bool AliFemtoTrackCutPdtHe3::IsHe3NSigma(float mom, float fNsigma, float massTOFPDG, float sigmaMass, float nsigmaTPCHe3, float nsigmaTOFHe3)
+{
+    //double massPDGD=2.8089;
+    if (fNsigmaTPCTOF) {
+
+        if (TMath::Abs(nsigmaTPCHe3) < fNsigma)
+            return true;
+        
+        
+    }
+    else{
+        if (TMath::Abs(nsigmaTPCHe3) < fNsigma)
+            return true;
+    } 
+  
+}
+
+//rejection methods
+bool AliFemtoTrackCutPdtHe3::IsElectronNSigmaRejection(float mom, float nsigmaTPCE)
+{
+  if(TMath::Abs(nsigmaTPCE) < fNsigmaRejection)
+    return true;
+ 
+
+  return false;
+}
+
+bool AliFemtoTrackCutPdtHe3::IsPionNSigmaRejection(float mom, float nsigmaTPCPi, float nsigmaTOFPi)
+{
+  if(fNsigmaTPConly){
+    if(TMath::Abs(nsigmaTPCPi) < fNsigmaRejection)
+      return true;
+  }
+  else{
+    if(TMath::Hypot( nsigmaTOFPi, nsigmaTPCPi ) < fNsigmaRejection)
+      return true;
+  }
+
+  return false;
+}
+
+
+bool AliFemtoTrackCutPdtHe3::IsKaonNSigmaRejection(float mom, float nsigmaTPCK, float nsigmaTOFK)
+{
+  if(fNsigmaTPConly){
+    if(TMath::Abs(nsigmaTPCK) < fNsigmaRejection)
+      return true;
+  }
+  else{
+    if(TMath::Hypot( nsigmaTOFK, nsigmaTPCK ) < fNsigmaRejection)
+      return true;
+  }
+
+  return false;
+}
+
+bool AliFemtoTrackCutPdtHe3::IsProtonNSigmaRejection(float mom, float nsigmaTPCP, float nsigmaTOFP)
+{
+  if(fNsigmaTPConly){
+    if(TMath::Abs(nsigmaTPCP) < fNsigmaRejection)
+      return true;
+  }
+  else{
+    if(TMath::Hypot( nsigmaTOFP, nsigmaTPCP ) < fNsigmaRejection)
+      return true;
+  }
+ 
+  return false;
+}
+
+
+

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoTrackCutPdtHe3.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoTrackCutPdtHe3.cxx
@@ -260,7 +260,7 @@ bool AliFemtoTrackCutPdtHe3::IsProtonNSigma(float mom, float fNsigma, float nsig
         if (TMath::Abs(nsigmaTPCP) < fNsigma)
             return true;
     }
-
+    return false;
 
 }
 bool AliFemtoTrackCutPdtHe3::IsDeuteronNSigma(float mom, float fNsigma, float massTOFPDG, float sigmaMass, float nsigmaTPCD, float nsigmaTOFD)
@@ -282,7 +282,7 @@ bool AliFemtoTrackCutPdtHe3::IsDeuteronNSigma(float mom, float fNsigma, float ma
         if (TMath::Abs(nsigmaTPCD) < fNsigma)
             return true;
     } 
-  
+    return false;
 }
 bool AliFemtoTrackCutPdtHe3::IsTritonNSigma(float mom, float fNsigma, float massTOFPDG, float sigmaMass, float nsigmaTPCT, float nsigmaTOFT)
 {
@@ -303,22 +303,20 @@ bool AliFemtoTrackCutPdtHe3::IsTritonNSigma(float mom, float fNsigma, float mass
         if (TMath::Abs(nsigmaTPCT) < fNsigma)
             return true;
     } 
-  
+    return false;
 }
 bool AliFemtoTrackCutPdtHe3::IsHe3NSigma(float mom, float fNsigma, float massTOFPDG, float sigmaMass, float nsigmaTPCHe3, float nsigmaTOFHe3)
 {
     //double massPDGD=2.8089;
     if (fNsigmaTPCTOF) {
-
         if (TMath::Abs(nsigmaTPCHe3) < fNsigma)
             return true;
-        
-        
     }
     else{
         if (TMath::Abs(nsigmaTPCHe3) < fNsigma)
             return true;
-    } 
+    }
+    return false;
   
 }
 

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoTrackCutPdtHe3.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoTrackCutPdtHe3.h
@@ -1,0 +1,43 @@
+#ifndef AliFemtoTrackCutPdtHe3_hh
+#define AliFemtoTrackCutPdtHe3_hh
+
+#include "AliFemtoESDTrackCut.h"
+
+
+// wdf 2020.8.17
+// deuteron part refer to AliFemtoWRzTrackCut.h
+
+class AliFemtoTrackCutPdtHe3 : public AliFemtoESDTrackCut{
+
+    public:
+        AliFemtoTrackCutPdtHe3();
+        AliFemtoTrackCutPdtHe3(const AliFemtoTrackCutPdtHe3 &aCut);
+        virtual ~AliFemtoTrackCutPdtHe3();
+        AliFemtoTrackCutPdtHe3& operator =(const AliFemtoTrackCutPdtHe3 &aCut);
+        virtual bool Pass(const AliFemtoTrack* aTrack);
+
+    private:
+        float fNsigmaP;
+        float fNsigmaD;
+        float fNsigmaT;
+        float fNsigmaHe3;
+
+        float fNsigmaRejection;
+
+        bool IsProtonNSigma(float mom, float fNsigma, float nsigmaTPCP, float nsigmaTOFP);
+        bool IsDeuteronNSigma(float mom, float fNsigma, float massTOFPDG, float sigmaMass, float nsigmaTPCD, float nsigmaTOFD);
+        bool IsTritonNSigma(float mom, float fNsigma, float massTOFPDG, float sigmaMass, float nsigmaTPCT, float nsigmaTOFT);
+        bool IsHe3NSigma(float mom, float fNsigma, float massTOFPDG, float sigmaMass, float nsigmaTPCHe3, float nsigmaTOFHe3);
+        // dE/dx
+        bool IsDeuteronTPCdEdx(float mom, float dEdx, float maxmom);
+
+        // reject
+        bool IsElectronNSigmaRejection(float mom, float nsigmaTPCE);
+        bool IsPionNSigmaRejection(float mom, float nsigmaTPCPi, float nsigmaTOFPi);
+        bool IsKaonNSigmaRejection(float mom, float nsigmaTPCK, float nsigmaTOFK);
+        bool IsProtonNSigmaRejection(float mom, float nsigmaTPCP, float nsigmaTOFP);
+        
+
+};
+
+#endif

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoTrackCutPdtHe3.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoTrackCutPdtHe3.h
@@ -3,9 +3,10 @@
 
 #include "AliFemtoESDTrackCut.h"
 
-
-// wdf 2020.8.17
-// deuteron part refer to AliFemtoWRzTrackCut.h
+//==============================================================\\
+// dowang track cut for p-d/t/He3 analysis                      \\
+// deuteron part refer to AliFemtoWRzTrackCut.h                 \\
+//==============================================================\\
 
 class AliFemtoTrackCutPdtHe3 : public AliFemtoESDTrackCut{
 
@@ -15,7 +16,10 @@ class AliFemtoTrackCutPdtHe3 : public AliFemtoESDTrackCut{
         virtual ~AliFemtoTrackCutPdtHe3();
         AliFemtoTrackCutPdtHe3& operator =(const AliFemtoTrackCutPdtHe3 &aCut);
         virtual bool Pass(const AliFemtoTrack* aTrack);
-
+        // label
+        void SetMostProbableDeuteron();
+        void SetMostProbableTriton();
+        void SetMostProbableHe3();
     private:
         float fNsigmaP;
         float fNsigmaD;
@@ -23,6 +27,7 @@ class AliFemtoTrackCutPdtHe3 : public AliFemtoESDTrackCut{
         float fNsigmaHe3;
 
         float fNsigmaRejection;
+
 
         bool IsProtonNSigma(float mom, float fNsigma, float nsigmaTPCP, float nsigmaTOFP);
         bool IsDeuteronNSigma(float mom, float fNsigma, float massTOFPDG, float sigmaMass, float nsigmaTPCD, float nsigmaTOFD);
@@ -39,5 +44,7 @@ class AliFemtoTrackCutPdtHe3 : public AliFemtoESDTrackCut{
         
 
 };
-
+inline void AliFemtoTrackCutPdtHe3::SetMostProbableDeuteron() { fMostProbable = 13; }
+inline void AliFemtoTrackCutPdtHe3::SetMostProbableTriton() { fMostProbable = 14; }
+inline void AliFemtoTrackCutPdtHe3::SetMostProbableHe3() { fMostProbable = 15; }
 #endif

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/CMakeLists.txt
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/CMakeLists.txt
@@ -169,6 +169,7 @@ set(SRCS
   AliFemtoCorrFctnPairsForCorrFit.cxx
   AliFemtoWRzTrackCut.cxx
   AliFemtoCorrFctnDYDPhiSimpleWithCorrections.cxx
+  AliFemtoTrackCutPdtHe3.cxx	# p-d/t/He3 track cut
   )
 
 

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/PWGCFfemtoscopyUserLinkDef.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/PWGCFfemtoscopyUserLinkDef.h
@@ -198,3 +198,6 @@
 #pragma link C++ class AliFemtoCorrFctnPairsForCorrFit;
 #pragma link C++ class AliFemtoWRzTrackCut;
 #pragma link C++ class AliFemtoCorrFctnDYDPhiSimpleWithCorrections;
+
+// p-d/t/He3 track cut
+#pragma link C++ class AliFemtoTrackCutPdtHe3;


### PR DESCRIPTION
There are some files add to AliPhysics in order to analysis p-d/t/He3 Femtoscopy in Pb-Pb 5.02TeV.
In general, 3 new class added and made a relevant supplement to NanoAOD Reader.
1-> in "/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoSimpleAnalysisOnlyMixP1.h(.cxx)";
  -> in "/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoVertexMultAnalysisOnlyMixP1.h(.cxx)";
       These two class are made for special mix method, which only mix the first particle and save event as 
       long as this event has the first particle.
2-> in "/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoTrackCutPdtHe3.h(.cxx)";
       A very rough track cut for deuteron/triton/He3.
3-> in "/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoEventReaderNanoAOD.cxx"
       In old Reader, the storage of triton/He3 TPC/TOF NSigma is not implemented.
       Therefore, only relevant information stored in NanoAOD data can be stored.