### PR TITLE
AO2D converter fix for using event cuts for both ESD/AOD.

### DIFF
--- a/RUN3/AliAnalysisTaskAO2Dconverter.cxx
+++ b/RUN3/AliAnalysisTaskAO2Dconverter.cxx
@@ -409,7 +409,7 @@ void AliAnalysisTaskAO2Dconverter::UserExec(Option_t *)
   }
 
   // This call is necessary to initialize event cuts according to the current run number
-  bool alieventcut = fEventCuts.AcceptEvent(fESD);
+  bool alieventcut = fEventCuts.AcceptEvent(fVEvent);
   
   // In case of ESD we skip events like in the AOD filtering, for AOD this is not needed
   // We can use event cuts to avoid cases where we have zero reconstructed tracks


### PR DESCRIPTION
There was a recent change for accepting events based on cuts on ESD event, not working for AOD. This fixes for the general ESD/AOD case.