### PR TITLE
Adding luminsity calculation tool for normatask output

### DIFF
--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerLuminosity.cxx
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerLuminosity.cxx
@@ -1,0 +1,275 @@
+/************************************************************************************
+ * Copyright (C) 2012, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+#include <array>
+#include <iostream>
+#include <memory>
+#include <TFile.h>
+#include <TDirectoryFile.h>
+#include <TH1.h>
+#include <TH2.h>
+#include <TKey.h>
+#include <TList.h>
+#include "AliEmcalTriggerLuminosity.h"
+
+ClassImp(PWG::EMCAL::AliEmcalTriggerLuminosity)
+
+using namespace PWG::EMCAL;
+
+AliEmcalTriggerLuminosity::AliEmcalTriggerLuminosity():
+  TObject(),
+  fCollisionType(CollisionType_t::kUnknown),
+  fYear(-1),
+  fLuminosityHist(nullptr),
+  fClusterCounters(),
+  fLuminosities()
+{
+
+}
+
+AliEmcalTriggerLuminosity::AliEmcalTriggerLuminosity(const char *fname, const char *directory):
+  TObject(),
+  fCollisionType(),
+  fYear(-1),
+  fLuminosityHist(nullptr),
+  fClusterCounters(),
+  fLuminosities()
+{
+  InitFromFile(fname, directory);
+}
+
+AliEmcalTriggerLuminosity::~AliEmcalTriggerLuminosity() {
+  delete fLuminosityHist; 
+  for(auto clustercounter : fClusterCounters) delete clustercounter.second;
+}
+
+void AliEmcalTriggerLuminosity::LoadHistograms(const TList &histlist) {
+  fLuminosityHist = static_cast<TH2 *>(histlist.FindObject("hTriggerLuminosity"));
+  if(fLuminosityHist) fLuminosityHist->SetDirectory(nullptr);
+  for(auto en : histlist) {
+    std::string histname = en->GetName();
+    if(histname.find("hClusterCounter") != std::string::npos) {
+      std::string triggerclass = histname.substr(15);
+      auto clustercounter = static_cast<TH1 *>(en);
+      clustercounter->SetDirectory(nullptr);
+      fClusterCounters[triggerclass] = clustercounter;
+    }
+  }
+
+  auto yearhist = dynamic_cast<TH1 *>(histlist.FindObject("hYear"));
+  if(yearhist) {
+    fYear = determineYear(yearhist);
+    std::cout << "Auto-detected year " << fYear << std::endl; 
+  } else {
+    std::cout << "Output does not contain the histogram for years, the year must be set manually" << std::endl;
+  }
+  auto collhist = dynamic_cast<TH1 *>(histlist.FindObject("hCollisionSystem"));
+  if(collhist) {
+    fCollisionType = determineCollisionType(collhist);
+    std::cout << "Auto-detected collsion system " << getCollisionLabel(fCollisionType) << std::endl; 
+  } else { 
+    std::cout << "Output does not contain the histogram for collision systems, the collision system must be set manually" << std::endl;
+  }
+}
+
+void AliEmcalTriggerLuminosity::InitFromFile(const char *filename, const char *dirname) {
+  std::unique_ptr<TFile> reader(TFile::Open(filename, "READ"));
+  if(!reader || reader->IsZombie()) throw InputDataException(filename, dirname);
+  auto dirkey = reader->GetListOfKeys()->FindObject(dirname);
+  if(!dirkey) throw InputDataException(filename, dirname);
+  if(dirkey->IsA() != TDirectoryFile::Class()) throw InputDataException(filename, dirname);
+  reader->cd(dirname);
+  auto histlist = static_cast<TList *>(static_cast<TKey *>(gDirectory->GetListOfKeys()->At(0))->ReadObj());
+  if(!histlist) throw InputDataException(filename, dirname);
+  LoadHistograms(*histlist);
+}
+
+void AliEmcalTriggerLuminosity::Evaluate() {
+  fLuminosities.clear();
+  std::vector<std::string> errorfields;
+  if(fYear == 0) errorfields.push_back("year");
+  if(fCollisionType == CollisionType_t::kUnknown) errorfields.push_back("collision type");
+  if(!fLuminosityHist) errorfields.push_back("lumihist");
+  if(!fClusterCounters.size()) errorfields.push_back("clustercounter");
+  if(errorfields.size()) throw UninitException(errorfields);
+  switch (fCollisionType)
+  {
+  case CollisionType_t::kPP13TeV:
+    evaluatePP13TeV();
+    break;
+
+  case CollisionType_t::kPPB8TeV:
+    evaluatePPB8TeV();
+    break;
+  
+  default:
+    std::cout << "Evaluation for collision system " << getCollisionLabel(fCollisionType) << " not (yet) implemented" << std::endl;
+    break;
+  }
+}
+
+double AliEmcalTriggerLuminosity::GetLuminosityForTrigger(const char *trigger) {
+  auto found = fLuminosities.find(trigger);
+  if(found == fLuminosities.end()) throw TriggerNotFoundException(trigger);
+  return found->second;
+}
+
+void AliEmcalTriggerLuminosity::evaluatePP13TeV() {
+  TH1 *counterEG1 = fClusterCounters["EG1"];
+  std::vector<std::string> errorfields;
+  if(!counterEG1) errorfields.push_back("counter EG1");
+  if(errorfields.size()) throw UninitException(errorfields);
+
+	double corrCENTNOTRD = getTriggerClusterCounts(counterEG1, "CENTNOTRD") / getTriggerClusterCounts(counterEG1, "CENTNOPMD");
+
+	std::cout << "Correction CENTNOTRD: " << corrCENTNOTRD << std::endl;
+
+	// normalize by reference cross section
+  std::map<int, double> xsecsMB {{2016, 58.44}, {2017, 58.10}, {2018, 57.52}};
+  auto found = xsecsMB.find(fYear);
+  if(found == xsecsMB.end()) throw AmbiguityException("Crosssection");
+	double xrefMB =  found->second,
+	       barnToPB = 1e9,
+	       xrefPB = xrefMB * barnToPB;
+  for(int ib = 0; ib < fLuminosityHist->GetXaxis()->GetNbins(); ib++) {
+    std::string triggerclass = fLuminosityHist->GetXaxis()->GetBinLabel(ib+1);
+    std::unique_ptr<TH1> sliceTrigger(fLuminosityHist->ProjectionY("sliceTrigger", ib+1, ib+1));
+    double rawcounts = sliceTrigger->Integral();
+    double clustercorrection = 1.;
+    if(triggerclass.find("G1") != std::string::npos || triggerclass.find("J1") != std::string::npos) {
+      clustercorrection = corrCENTNOTRD;
+    }
+    double correctedCounts = rawcounts * clustercorrection;
+    double luminosity = correctedCounts / xrefPB;
+    std::cout << "Trigger class " << triggerclass << ": raw counts " << rawcounts << ", corrected counts " << correctedCounts << ", luminosity " << luminosity << " pb-1" << std::endl; 
+    fLuminosities[triggerclass] = luminosity;
+  }
+}
+
+void AliEmcalTriggerLuminosity::evaluatePPB8TeV() {
+  TH1 *counterEMC7 = fClusterCounters["EMC7"],
+      *counterEG1 = fClusterCounters["EG1"];
+  std::vector<std::string> errorfields;
+  if(!counterEMC7) errorfields.push_back("counter EMC7");
+  if(!counterEG1) errorfields.push_back("counter EG1");
+  if(errorfields.size()) throw UninitException(errorfields);
+
+	double corrCENTNOPMD = getTriggerClusterCounts(counterEMC7, "CENTNOPMD") / getTriggerClusterCounts(counterEMC7, "CENT");
+	double corrCENTNOTRD = getTriggerClusterCounts(counterEG1, "CENTNOTRD") / getTriggerClusterCounts(counterEG1, "CENTNOPMD");
+  double corrCombined = corrCENTNOPMD * corrCENTNOTRD;
+
+	std::cout << "Correction CENTNOPMD: " << corrCENTNOPMD << std::endl;
+	std::cout << "Correction CENTNOTRD: " << corrCENTNOTRD << std::endl;
+  std::cout << "Combined Correction:  " << corrCombined << std::endl;
+
+	// normalize by reference cross section
+	double xrefBarn = 2.09,
+	       barnToNB = 1e9,
+	       xrefNB = xrefBarn * barnToNB;
+  for(int ib = 0; ib < fLuminosityHist->GetXaxis()->GetNbins(); ib++) {
+    std::string triggerclass = fLuminosityHist->GetXaxis()->GetBinLabel(ib+1);
+    std::unique_ptr<TH1> sliceTrigger(fLuminosityHist->ProjectionY("sliceTrigger", ib+1, ib+1));
+    double rawcounts = sliceTrigger->Integral();
+    double clustercorrection = 1.;
+    if(triggerclass.find("MC7") != std::string::npos || triggerclass.find("G2") != std::string::npos || triggerclass.find("J2") != std::string::npos) {
+      clustercorrection = corrCENTNOPMD;
+    } else if(triggerclass.find("G1") != std::string::npos || triggerclass.find("J1") != std::string::npos) {
+      clustercorrection = corrCombined;
+    }
+    double correctedCounts = rawcounts * clustercorrection;
+    double luminosity = correctedCounts / xrefNB;
+    std::cout << "Trigger class " << triggerclass << ": raw counts " << rawcounts << ", corrected counts " << correctedCounts << ", luminosity " << luminosity << " nb-1" << std::endl; 
+    fLuminosities[triggerclass] = luminosity;
+  }
+}
+
+double AliEmcalTriggerLuminosity::getTriggerClusterCounts(TH1 * clustercounter, const std::string &clustername) const {
+  int binID = clustercounter->GetXaxis()->FindBin(clustername.data());
+  if(binID <= 0 || binID > clustercounter->GetXaxis()->GetNbins()) return 0;
+  return clustercounter->GetBinContent(binID);
+}
+
+int AliEmcalTriggerLuminosity::determineYear(const TH1 * const yearhist) const {
+  std::vector<int> binsNonZero;
+  for(int ib = 0; ib < yearhist->GetXaxis()->GetNbins(); ib++) {
+    if(yearhist->GetBinContent(ib+1)) {
+      binsNonZero.push_back(ib);
+    }
+  }
+  if(binsNonZero.size() > 1) throw AmbiguityException("year");
+  return static_cast<int>(yearhist->GetXaxis()->GetBinCenter(binsNonZero[0]+1));
+}
+
+AliEmcalTriggerLuminosity::CollisionType_t AliEmcalTriggerLuminosity::determineCollisionType(const TH1 *const collisionhist) const {
+  std::vector<int> binsNonZero;
+  for(int ib = 0; ib < collisionhist->GetXaxis()->GetNbins(); ib++) {
+    if(collisionhist->GetBinContent(ib+1)) {
+      binsNonZero.push_back(ib);
+    }
+  }
+  if(binsNonZero.size() > 1) throw AmbiguityException("year");
+  std::string bintitle = collisionhist->GetXaxis()->GetBinLabel(binsNonZero[0]+1);  
+  return getCollisionType(bintitle);
+}
+
+std::string AliEmcalTriggerLuminosity::getCollisionLabel(AliEmcalTriggerLuminosity::CollisionType_t coltype) const {
+  switch(coltype) {
+    case CollisionType_t::kPP13TeV: return "pp, 13 TeV";
+    case CollisionType_t::kPP5TeV: return "pp, 5.02 TeV"; 
+    case CollisionType_t::kPPB5TeV: return "p-Pb, 5.02 TeV";
+    case CollisionType_t::kPPB8TeV: return "p-Pb, 8.16 TeV";
+    case CollisionType_t::kPBPB5TeV: return "Pb-Pb, 5.02 TeV";
+    default: return "Unknown collision type";
+  }
+}
+
+AliEmcalTriggerLuminosity::CollisionType_t AliEmcalTriggerLuminosity::getCollisionType(const std::string &collabel) const {
+  std::map<std::string, CollisionType_t> collisionsystems = {{"pp, 13 TeV", CollisionType_t::kPP13TeV}, 
+                                                             {"pp, 5.02 TeV", CollisionType_t::kPP5TeV}, 
+                                                             {"p-Pb, 5.02 TeV", CollisionType_t::kPPB5TeV}, 
+                                                             {"p-Pb, 8.16 TeV", CollisionType_t::kPPB8TeV}, 
+                                                             {"Pb-Pb, 5.02 TeV", CollisionType_t::kPBPB5TeV}};
+  auto found = collisionsystems.find(collabel);
+  if(found == collisionsystems.end()) return CollisionType_t::kUnknown;
+  return found->second;
+}
+
+void AliEmcalTriggerLuminosity::UninitException::buildErrorMessage(){
+  std::stringstream msgbuilder;
+  msgbuilder << "Fields uninitialized: ";
+  bool first = true;
+  // Thanks ALICE offline for forcing us to go the hard way
+  for(const auto &field : fFields){
+    if(first) {
+      first = false;
+    } else {
+      msgbuilder << ", ";
+    }
+    msgbuilder << field;
+  }
+  fMessage = msgbuilder.str();
+
+}

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerLuminosity.h
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerLuminosity.h
@@ -1,0 +1,371 @@
+/************************************************************************************
+ * Copyright (C) 2021, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+#include <TObject.h>
+#include <exception>
+#include <map>
+#include <sstream>
+#include <string>
+#include <vector>
+
+class TH1;
+class TH2;
+class TList;
+
+namespace PWG {
+
+namespace EMCAL {
+
+/**
+ * @class AliEmcalTriggerLuminosity
+ * @brief Calculator for the integrated fuminosity of EMCAL triggers based on normalization task output
+ * @ingroup EMCALTRGFW
+ * @author Markus Fasel <markus.fasel@cern.ch>, Oak Ridge National Laboratory
+ * @since Sept 30, 2021 
+ */
+class AliEmcalTriggerLuminosity : public TObject {
+public:
+
+  /**
+   * @class UninitException
+   * @brief Handling errors in evaluation due to uninitialized data
+   * 
+   * Handled fields can be
+   * - Collision system (relevant for livetime correction)
+   * - Year (relevant for reference cross section)
+   * - Raw event counter
+   * - Cluster counters (relevant for livetime correction)
+   * Uninitialzied counters are handled specifically to the dataset
+   * while all other fields are handled in the Evaluate function.
+   */
+  class UninitException : public std::exception {
+    public:
+      /**
+       * @brief Constructor
+       * @param fields List of required information which were uninitialized
+       */
+      UninitException(const std::vector<std::string> &fields) : std::exception(), fFields(fields), fMessage("") {
+        buildErrorMessage();
+      }
+
+      /**
+       * @brief Destructor
+       */
+      virtual ~UninitException() throw() {}
+
+      /**
+       * @brief Display error message
+       * @return Error message
+       */
+      virtual const char *what() const throw() { return fMessage.c_str(); }
+
+      /**
+       * @brief Access to list of uninitialized fields
+       * @return List of required information which were uninitialized
+       */
+      const std::vector<std::string> &getFields() const { return fFields; }
+
+    private:
+      std::vector<std::string> fFields;   ///< Fields which were required but missing
+      std::string fMessage;               ///< Buffer for error message
+
+      /**
+       * @brief Internal helper building the error message
+       * 
+       * Displaying all fields which were required but not set. Handled
+       * as helper function to move this part to the implementation file
+       * in order to be able to make use of c++11 code which cannot be handled
+       * by stupid ROOT5.
+       */
+      void buildErrorMessage();
+  };
+
+  /**
+   * @class InputDataException
+   * @brief Handling errors due to invalid input files (task output not from normalizatinon task)
+   */
+  class InputDataException : public std::exception {
+    public:
+      /**
+       * @brief Constructor
+       * @param filename Name of the file raising the exception
+       * @param directory Name of the directory raising the exception
+       */
+      InputDataException(const char *filename, const char *directory): std::exception(), fFilename(filename), fMessage("") {
+        std::stringstream msgbuilder;
+        msgbuilder << "No trigger norm data found in file " << fFilename << ", directory " << fDirname;
+        fMessage = msgbuilder.str();
+      }
+
+      /**
+       * @brief Destructor
+       */
+      virtual ~InputDataException() throw() {}
+
+      /**
+       * @brief Get name of the file raising the exception
+       * @return Filename
+       */
+      const std::string &getFilename() const { return fFilename; }
+
+      /**
+       * @brief Get the name of the directory raising the exception
+       * @return Directory name  
+       */
+      const std::string &getDirname() const { return fDirname; }
+
+      /**
+       * @brief Display error message
+       * @return Error message
+       */
+      virtual const char *what() const throw() { return fMessage.c_str(); }
+
+    private:
+      std::string fFilename;      ///< Name of the file read
+      std::string fDirname;
+      std::string fMessage;       ///< Buffer for error message
+  };
+
+  /**
+   * @class TriggerNotFoundException
+   * @brief Handling errors requesting non-existing trigger classes
+   */
+  class TriggerNotFoundException : public std::exception {
+    public:
+      /**
+       * @brief Constructor
+       * @param trigger Trigger class raising the exception
+       */
+      TriggerNotFoundException(const char *trigger) : std::exception(), fTriggerClass(trigger), fMessage() {
+        std::stringstream msgbuilder;
+        msgbuilder << "Luminosity not found for trigger " << fTriggerClass;
+        fMessage = msgbuilder.str();
+      }
+
+      /**
+       * @brief Destructor
+       */
+      virtual ~TriggerNotFoundException() throw() {}
+
+      /**
+       * @brief Display error message
+       * @return Error message
+       */
+      virtual const char *what() const throw() { return fMessage.c_str(); }
+
+      /**
+       * @brief Access to trigger class raising the exception
+       * @return Name of the trigger class
+       */
+      const std::string &getTriggerClass() const { return fTriggerClass; }
+
+    private:
+      std::string fTriggerClass;    ///< Trigger class raising the exception
+      std::string fMessage;         ///< Buffer for error message
+  };
+
+  /**
+   * @class AmbiguityException
+   * @brief Handling of ambiguous information in certain fields (year, collision system)
+   */
+  class AmbiguityException : public std::exception { 
+    public:
+      /**
+       * @brief Constructor
+       * @param field Field with ambiguous information
+       */
+      AmbiguityException(const char *field) : std::exception(), fField(field), fMessage() {
+        std::stringstream msgbuilder;
+        msgbuilder << "Ambiguity in " <<  field;
+        fMessage = msgbuilder.str();
+      }
+
+      /**
+       * @brief Destructor
+       */
+      virtual ~AmbiguityException() throw() {}
+
+      /**
+       * @brief Display error message
+       * @return Error message
+       */
+      virtual const char *what() const throw() { return fMessage.c_str(); }
+
+    private:
+      std::string fField;           ///< Fields (year, collision system) with ambiguous information
+      std::string fMessage;         ///< Buffer for error message
+  };
+  
+  /**
+   * @enum CollisionType_t
+   * @brief Collision systems supported by the normalization task 
+   */
+  enum CollisionType_t {
+    kPP13TeV,         ///< pp, \f$ \sqrt{s}\f$ = 13 TeV
+    kPP5TeV,          ///< pp, \f$ \sqrt{s}\f$ = 5.02 TeV
+    kPPB5TeV,         ///< p-Pb, \f$ \sqrt{s_{NN}}\f$ = 5.02 TeV
+    kPPB8TeV,         ///< p-Pb, \f$ \sqrt{s_{NN}}\f$ = 8.16 TeV
+    kPBPB5TeV,        ///< Pb-Pb, \f$ \sqrt{s_{NN}}\f$ = 5.02 TeV
+    kUnknown          ///< Unknown collision system
+  };
+
+  /**
+   * @brief Construct a new Ali Emcal Trigger Luminosity object
+   */
+  AliEmcalTriggerLuminosity();
+
+  /**
+   * @brief Constructor, initializing from a file with normalization task output
+   * @param filename Name of the file with the normalization task output
+   * @param dirname  Directory of the normalization task output inside the file
+   * @throw AmbiguityException Year or collision system contain ambiguous information
+   * @throw InputDataException Input data is not from the normalization task
+   */
+  AliEmcalTriggerLuminosity(const char *filename, const char *dirname  = "EmcalTriggerNormtask");
+
+  /**
+   * @brief Destructor
+   */
+  virtual ~AliEmcalTriggerLuminosity();
+
+  /**
+   * @brief Load normalization histograms from an input list
+   * @param histlist List with the normalization histograms
+   * @throw AmbiguityException Year or collision system contain ambiguous information
+   */
+  void LoadHistograms(const TList &histlist);
+
+  /**
+   * @brief Initialize with normalization task output from an input file
+   * @param filename File with the normmalization task output
+   * @param dirname Directory in file where to find the normalization task output
+   * @throw AmbiguityException Year or collision system contain ambiguous information
+   * @throw InputDataException Input data is not from the normalization task
+   */
+  void InitFromFile(const char *filename, const char *dirname);
+
+  /**
+   * @brief Evaluate all luminosities
+   * @throw UninitException Several required information was not initialized
+   * 
+   * Evaluating luminosities based on year and collision system of the 
+   * data used for the normalization task output. Luminosities are calculated
+   * for all trigger classes in the normalization histogram
+   */
+  void Evaluate();
+
+  /**
+   * @brief Get the integrated luminosity evaluated for a certain trigger 
+   * @param trigger Trigger for which to determine the luminosity
+   * @return Integrated luminosity
+   * @throw TriggerNotFoundException in case of access to unsupported trigger
+   * 
+   * Access to luminosities calculated in Evaluate.
+   */
+  double GetLuminosityForTrigger(const char *trigger);
+
+  /**
+   * @brief Set the collision system of the data used in the input file
+   * @param ycoltypeear Collision system of the data used in the input file
+   * 
+   * Only necessary for old normalization task results. In new normalization task results
+   * this is taken automatically from corresponding histograms
+   */
+  void SetCollisionType(CollisionType_t coltype) { fCollisionType = coltype; }
+
+  /**
+   * @brief Set the year of the data used in the input file
+   * @param year Year of the data used in the input file
+   * 
+   * Only necessary for old normalization task results. In new normalization task results
+   * this is taken automatically from corresponding histograms
+   */
+  void SetYear(int year) { fYear = year; }
+
+protected:
+
+  /**
+   * @brief Luminosity evaluation method for pp, $\sqrt{s} = 13 TeV\f$, 2016-2018
+   */
+  void evaluatePP13TeV();
+
+  /**
+   * @brief Luminosity evaluation method for p-Pb, $\sqrt{s_{NN}} = 8.16 TeV\f$, 2016
+   */
+  void evaluatePPB8TeV();
+
+  /**
+   * @brief Determine year of the input data from year counter histogram
+   * @param yearhist Year counter histogram
+   * @return  Year of the dataset
+   */
+  int determineYear(const TH1 * const yearhist) const;
+
+  /**
+   * @brief Determine collision system of the input data from collision system counter histogram
+   * @param collisionhist Collision system counter from normalization task
+   * @return Collision system of the dataset
+   */
+  CollisionType_t determineCollisionType(const TH1 *const collisionhist) const;
+
+  /**
+   * @brief Converter for collision type to string
+   * @param coltype CollisionType_t representation 
+   * @return Collision type label
+   */
+  std::string getCollisionLabel(CollisionType_t coltype) const;
+
+  /**
+   * @brief Converter for collision type from string
+   * @param collabel String representation of collision type
+   * @return CollisionType_t representation
+   */
+  CollisionType_t getCollisionType(const std::string &collabel) const; 
+  
+  /**
+   * @brief Get numnber of events recorded in a certain trigger cluster for a trigger class
+   * @param clustercounter Input cluster counter histogram
+   * @param clustername Name of the trigger cluster
+   * @return Number of events
+   */
+  double getTriggerClusterCounts(TH1 * clustercounter, const std::string &clustername) const;
+
+private:
+  AliEmcalTriggerLuminosity(const AliEmcalTriggerLuminosity &);
+  AliEmcalTriggerLuminosity &operator=(const AliEmcalTriggerLuminosity &);
+
+  CollisionType_t fCollisionType;                       ///< Collision system of the input file
+  int fYear;                                            ///< Year of the input file
+  TH2 *fLuminosityHist;                                 ///< Raw luminosity histogram
+  std::map<std::string, TH1 *> fClusterCounters;        ///< Cluster counter histogram for various trigger classes
+  std::map<std::string, double> fLuminosities;          ///< Evaluated integrated luminosities for all trigger classes
+
+  ClassDef(AliEmcalTriggerLuminosity, 1);
+};
+
+}
+
+}

--- a/PWG/EMCAL/EMCALtrigger/CMakeLists.txt
+++ b/PWG/EMCAL/EMCALtrigger/CMakeLists.txt
@@ -40,6 +40,7 @@ set(SRCS
   AliEmcalTriggerDecisionContainer.cxx
   AliEmcalTriggerSelectionCuts.cxx
   AliEmcalTriggerSelection.cxx
+  AliEmcalTriggerLuminosity.cxx
   AliEmcalTriggerQATask.cxx
   AliEmcalTriggerSimQATask.cxx
   AliEMCALTriggerOfflineQAPP.cxx

--- a/PWG/EMCAL/EMCALtrigger/PWGEMCALtriggerLinkDef.h
+++ b/PWG/EMCAL/EMCALtrigger/PWGEMCALtriggerLinkDef.h
@@ -21,6 +21,7 @@
 #pragma link C++ class PWG::EMCAL::AliEmcalTriggerDecisionContainer+;
 #pragma link C++ class PWG::EMCAL::AliEmcalTriggerSelectionCuts++;
 #pragma link C++ class PWG::EMCAL::AliEmcalTriggerSelection+;
+#pragma link C++ class PWG::EMCAL::AliEmcalTriggerLuminosity+;
 #pragma link C++ class PWG::EMCAL::Triggerinfo+;
 #pragma link C++ class PWG::EMCAL::AliEmcalTriggerMaskHandlerOCDB+;
 #pragma link C++ class PWG::EMCAL::AliEmcalFastorMaskContainer+;


### PR DESCRIPTION
Automatically calculating the integrated luminosty
for certain known collision systems from the standard
output of the normalization task.