### PR TITLE
Fix the logic error in the candidate's loop

### DIFF
--- a/PWGHF/vertexingHF/vHFML/AliAnalysisTaskSEDmesonTree.cxx
+++ b/PWGHF/vertexingHF/vHFML/AliAnalysisTaskSEDmesonTree.cxx
@@ -571,7 +571,7 @@ void AliAnalysisTaskSEDmesonTree::UserExec(Option_t * /*option*/)
                     if (okSetVar && !(fReadMC && !isSignal && !isBkg && !isPrompt && !isFD && !isRefl)) // add tag in tree handler for signal from pileup events?
                         fMLhandler->FillTree();
                 }
-                break;
+                continue;
             }
             else
             {
@@ -604,7 +604,7 @@ void AliAnalysisTaskSEDmesonTree::UserExec(Option_t * /*option*/)
                 bool okSetVar = fMLhandler->SetVariables(dMeson, fAOD->GetMagneticField(), 0, pidHF);
                 if (okSetVar && !(fReadMC && !isSignal && !isBkg && !isPrompt && !isFD && !isRefl)) // add tag in tree handler for signal from pileup events?
                     fMLhandler->FillTree();
-                break;
+                continue;
             }
         }
 


### PR DESCRIPTION
The candidate's loop should be continued when the first candidate be matched