### PR TITLE
Reduce verbosity from geometry initialization

### DIFF
--- a/RUN3/AliAnalysisTaskAO2Dconverter.cxx
+++ b/RUN3/AliAnalysisTaskAO2Dconverter.cxx
@@ -32,6 +32,8 @@
 #include <TSystem.h>
 #include "AliAnalysisTask.h"
 #include "AliAnalysisManager.h"
+#include "AliCDBManager.h"
+#include "AliCDBEntry.h"
 #include "AliVEvent.h"
 #include "AliESDEvent.h"
 #include "AliAODEvent.h"
@@ -39,6 +41,8 @@
 #include "AliESDVertex.h"
 #include "AliAODVertex.h"
 #include "AliCentrality.h"
+#include "AliDAQ.h"
+#include "AliGRPObject.h"
 #include "AliVMultiplicity.h"
 #include "AliEMCALGeometry.h"
 #include "AliEMCALTriggerDataGrid.h"
@@ -219,6 +223,7 @@ AliAnalysisTaskAO2Dconverter::AliAnalysisTaskAO2Dconverter(const char* name)
     fTrackFilter(Form("AO2Dconverter%s", name), Form("fTrackFilter%s", name)),
     fEventCuts{},
     fTriggerAnalysis(),
+    fGRP(nullptr),
     collision(),
     eventextra(),
     bc(),
@@ -294,7 +299,15 @@ void AliAnalysisTaskAO2Dconverter::NotifyRun(){
       }
     }
   }
-
+  AliCDBManager *cdb = AliCDBManager::Instance();
+  if(cdb->IsDefaultStorageSet() && cdb->GetRun() > 0) {
+    // CDB manage initialized
+    // Get GRP
+    AliCDBEntry *en = cdb->Get("GRP/GRP/Data");
+    if(en) {
+      fGRP = static_cast<AliGRPObject *>(en->GetObject());
+    }
+  }
 }
 
 
@@ -2020,101 +2033,129 @@ void AliAnalysisTaskAO2Dconverter::FillEventInTF()
   } // end loop on calo cells
   eventextra.fNentries[kCalo] = ncalocells_filled;
 
-
-  // Trigger data for EMCAL:
-  // - For full payload (monitoring) events store all non-0 L1 ADCs
-  // - For regular events store non-0 L1 ADCs of the 3 leading Gamma patches
-  auto geo = AliEMCALGeometry::GetInstance();
-  if(!geo) {
-    // singleton not yet initialized - initialize it for the first time
-    // based on the current run number expecting data from different years
-    // will not be mixed in the same job
-    geo = AliEMCALGeometry::GetInstanceFromRunNumber(fVEvent->GetRunNumber()); // Needed for EMCAL trigger mapping
+  bool fillEMCtriggers = true;
+  bool fillEMCheaderMedian = true;
+  Int_t ncalotriggers_filled = 0;
+  TString triggerclasses = fInputEvent->GetFiredTriggerClasses();
+  if(!(triggerclasses.Contains("CENT") || triggerclasses.Contains("ALL") || triggerclasses.Contains("-FAST-") || triggerclasses.Contains("CALO"))) {
+    // Don't write EMCAL trigger table for clusters where EMCAL was neither trigger nor readout detector
+    fillEMCtriggers = false;
   }
-  AliVCaloTrigger *calotriggers = fVEvent->GetCaloTrigger("EMCAL");
-  Bool_t fullPayload = gRandom->Uniform() < fFractionL1MonitorEventsEMCAL;
-  calotrigger.fIndexBCs = fBCCount;
-  calotrigger.fFastOrAbsID = 10001;
-  calotrigger.fLnAmplitude = fullPayload ? 1 : 0;
-  calotrigger.fTriggerBits = 0;
-  calotrigger.fCaloType = 1;
-  FillTree(kCaloTrigger);
-  // Median for EMCAL
-  calotrigger.fFastOrAbsID = 10002;
-  calotrigger.fLnAmplitude = calotriggers->GetMedian(0);
-  FillTree(kCaloTrigger);
-  // Median for DCAL
-  calotrigger.fFastOrAbsID = 10003;
-  calotrigger.fLnAmplitude = calotriggers->GetMedian(1);
-  FillTree(kCaloTrigger);
-
-  calotriggers->Reset();
-  Int_t ncalotriggers_filled = 3; // total number of EMCAL triggers filled per event, offset 3 for the global event properties for EMCAL
-  int col, row, fastorID, l1timesums;
-  if(fullPayload) {
-    // Full payload - store all ADCs
-    while (calotriggers->Next())
-    {
-      calotriggers->GetPosition(col, row);
-      calotriggers->GetL1TimeSum(l1timesums);
-      if(l1timesums <=0)
-        continue;
-      geo->GetTriggerMapping()->GetAbsFastORIndexFromPositionInEMCAL(col, row, fastorID);
-      calotrigger.fFastOrAbsID = fastorID;
-      calotrigger.fLnAmplitude = l1timesums;
-      FillTree(kCaloTrigger);
-      if (fTreeStatus[kCaloTrigger])
-        ncalotriggers_filled++;
+  if(fGRP) {
+    // In case global run parameters are available write EMCAL trigger 
+    // entries only in case EMCAL was a readout nor a trigger detector
+    // in order to reduce the data volume used for header words
+    TString detectorstring = AliDAQ::ListOfTriggeredDetectors(fGRP->GetDetectorMask());
+    if(!detectorstring.Contains("EMCAL")) {
+      fillEMCtriggers = false;
+    } else {
+      // Don't fill median header words for small system (STU not in median mode)
+      TString beamtype = fGRP->GetBeamType();
+      if((beamtype == "p-p" || beamtype == "p-A" || beamtype == "A-p")) { 
+        fillEMCheaderMedian = false;
+      }
     }
-  } else {
-    TClonesArray *emcalpatches = dynamic_cast<TClonesArray *>(fInputEvent->FindListObject("EmcalTriggers"));
-    if(emcalpatches) {
-      AliEMCALTriggerDataGrid<int> l1adcs;
-      l1adcs.Allocate(48, 104);
-      // Pre-sort the ADCs in the data grid in order to find the ADCs belonging to the 3 leading patches later
+  }
+  if(fillEMCtriggers) {
+    // Trigger data for EMCAL:
+    // - For full payload (monitoring) events store all non-0 L1 ADCs
+    // - For regular events store non-0 L1 ADCs of the 3 leading Gamma patches
+    auto geo = AliEMCALGeometry::GetInstance();
+    if(!geo) {
+      // singleton not yet initialized - initialize it for the first time
+      // based on the current run number expecting data from different years
+      // will not be mixed in the same job
+      geo = AliEMCALGeometry::GetInstanceFromRunNumber(fVEvent->GetRunNumber()); // Needed for EMCAL trigger mapping
+    }
+    AliVCaloTrigger *calotriggers = fVEvent->GetCaloTrigger("EMCAL");
+    Bool_t fullPayload = gRandom->Uniform() < fFractionL1MonitorEventsEMCAL;
+    calotrigger.fIndexBCs = fBCCount;
+    calotrigger.fFastOrAbsID = 10001;
+    calotrigger.fLnAmplitude = fullPayload ? 1 : 0;
+    calotrigger.fTriggerBits = 0;
+    calotrigger.fCaloType = 1;
+    FillTree(kCaloTrigger);
+    int nheader = 1;
+    if(fillEMCheaderMedian) {
+      // Median for EMCAL
+      calotrigger.fFastOrAbsID = 10002;
+      calotrigger.fLnAmplitude = calotriggers->GetMedian(0);
+      FillTree(kCaloTrigger);
+      // Median for DCAL
+      calotrigger.fFastOrAbsID = 10003;
+      calotrigger.fLnAmplitude = calotriggers->GetMedian(1);
+      FillTree(kCaloTrigger);
+      nheader += 2;
+    }
+
+    calotriggers->Reset();
+    ncalotriggers_filled = nheader; // total number of EMCAL triggers filled per event, offset 1 or 3 for the global event properties for EMCAL
+    int col, row, fastorID, l1timesums;
+    if(fullPayload) {
+      // Full payload - store all ADCs
       while (calotriggers->Next())
       {
         calotriggers->GetPosition(col, row);
         calotriggers->GetL1TimeSum(l1timesums);
-        if(l1timesums <=0)
+        if(l1timesums <=0) 
           continue;
-        l1adcs(col, row) = l1timesums;
+        geo->GetTriggerMapping()->GetAbsFastORIndexFromPositionInEMCAL(col, row, fastorID);
+        calotrigger.fFastOrAbsID = fastorID;
+        calotrigger.fLnAmplitude = l1timesums;
+        FillTree(kCaloTrigger);
+        if (fTreeStatus[kCaloTrigger])
+          ncalotriggers_filled++;
       }
-      std::vector<AliEMCALTriggerPatchInfo *> allpatches;
-      for(int ipatch = 0; ipatch < emcalpatches->GetEntries(); ipatch++) {
-        AliEMCALTriggerPatchInfo *nextpatch = static_cast<AliEMCALTriggerPatchInfo *>(emcalpatches->At(ipatch));
-        if(nextpatch->IsGammaLowRecalc()) allpatches.emplace_back(nextpatch);
-      }
-      // sort patches in descending order according to the patch ADC
-      std::sort(allpatches.begin(), allpatches.end(), [](const AliEMCALTriggerPatchInfo *lhs, const AliEMCALTriggerPatchInfo *rhs) { return lhs->GetADCAmp() > rhs->GetADCAmp(); } );
-      std::vector<int> fastOrIDsInTree;  // in order to avoid double counting
-      int npatches = 0;
-      for(auto patch : allpatches) {
-        for(int icol = patch->GetColStart(); icol < patch->GetColStart() + patch->GetPatchSize(); icol++) {
-          for(int irow = patch->GetRowStart(); irow < patch->GetRowStart() + patch->GetPatchSize(); irow++) {
-            int adc = l1adcs(icol, irow);
-            if(adc > 0) {
-              geo->GetTriggerMapping()->GetAbsFastORIndexFromPositionInEMCAL(icol, irow, fastorID);
-              if(std::find(fastOrIDsInTree.begin(), fastOrIDsInTree.end(), fastorID) == fastOrIDsInTree.end()) {
-                // FastOr not present in other (selected) trigger patch - add to tree
-                calotrigger.fFastOrAbsID = fastorID;
-                calotrigger.fLnAmplitude = adc;
-                FillTree(kCaloTrigger);
-                if (fTreeStatus[kCaloTrigger])
-                  ncalotriggers_filled++;
-                fastOrIDsInTree.emplace_back(fastorID);
+    } else {
+      TClonesArray *emcalpatches = dynamic_cast<TClonesArray *>(fInputEvent->FindListObject("EmcalTriggers"));
+      if(emcalpatches) {
+        AliEMCALTriggerDataGrid<int> l1adcs;
+        l1adcs.Allocate(48, 104);
+        // Pre-sort the ADCs in the data grid in order to find the ADCs belonging to the 3 leading patches later
+        while (calotriggers->Next())
+        {
+          calotriggers->GetPosition(col, row);
+          calotriggers->GetL1TimeSum(l1timesums);
+          if(l1timesums <=0) 
+            continue;
+          l1adcs(col, row) = l1timesums;
+        }
+        std::vector<AliEMCALTriggerPatchInfo *> allpatches;
+        for(int ipatch = 0; ipatch < emcalpatches->GetEntries(); ipatch++) {
+          AliEMCALTriggerPatchInfo *nextpatch = static_cast<AliEMCALTriggerPatchInfo *>(emcalpatches->At(ipatch));
+          if(nextpatch->IsGammaLowRecalc()) allpatches.emplace_back(nextpatch);
+        }
+        // sort patches in descending order according to the patch ADC
+        std::sort(allpatches.begin(), allpatches.end(), [](const AliEMCALTriggerPatchInfo *lhs, const AliEMCALTriggerPatchInfo *rhs) { return lhs->GetADCAmp() > rhs->GetADCAmp(); } );
+        std::vector<int> fastOrIDsInTree;  // in order to avoid double counting
+        int npatches = 0;
+        for(auto patch : allpatches) {
+          for(int icol = patch->GetColStart(); icol < patch->GetColStart() + patch->GetPatchSize(); icol++) {
+            for(int irow = patch->GetRowStart(); irow < patch->GetRowStart() + patch->GetPatchSize(); irow++) {
+              int adc = l1adcs(icol, irow);
+              if(adc > 0) {
+                geo->GetTriggerMapping()->GetAbsFastORIndexFromPositionInEMCAL(icol, irow, fastorID);
+                if(std::find(fastOrIDsInTree.begin(), fastOrIDsInTree.end(), fastorID) == fastOrIDsInTree.end()) {
+                  // FastOr not present in other (selected) trigger patch - add to tree
+                  calotrigger.fFastOrAbsID = fastorID;
+                  calotrigger.fLnAmplitude = adc;
+                  FillTree(kCaloTrigger);
+                  if (fTreeStatus[kCaloTrigger])
+                    ncalotriggers_filled++;
+                  fastOrIDsInTree.emplace_back(fastorID);
+                }
               }
             }
           }
+          npatches++;
+          if(npatches == 3) {
+            // select at maximum the 3 leading trigger patches
+            break;
+          }
         }
-        npatches++;
-        if(npatches == 3) {
-          // select at maximum the 3 leading trigger patches
-          break;
-        }
+      } else {
+        AliErrorStream() << "Needs EMCAL patches (from EMCAL trigger maker) for the selection of the FastORs belonging to the 3 leading gamma patches" << std::endl;
       }
-    } else {
-      AliErrorStream() << "Needs EMCAL patches (from EMCAL trigger maker) for the selection of the FastORs belonging to the 3 leading gamma patches" << std::endl;
     }
   }
   eventextra.fNentries[kCaloTrigger] = ncalotriggers_filled;

--- a/RUN3/AliAnalysisTaskAO2Dconverter.cxx
+++ b/RUN3/AliAnalysisTaskAO2Dconverter.cxx
@@ -2024,7 +2024,13 @@ void AliAnalysisTaskAO2Dconverter::FillEventInTF()
   // Trigger data for EMCAL:
   // - For full payload (monitoring) events store all non-0 L1 ADCs
   // - For regular events store non-0 L1 ADCs of the 3 leading Gamma patches
-  AliEMCALGeometry *geo = AliEMCALGeometry::GetInstanceFromRunNumber(fVEvent->GetRunNumber()); // Needed for EMCAL trigger mapping
+  auto geo = AliEMCALGeometry::GetInstance();
+  if(!geo) {
+    // singleton not yet initialized - initialize it for the first time
+    // based on the current run number expecting data from different years
+    // will not be mixed in the same job
+    geo = AliEMCALGeometry::GetInstanceFromRunNumber(fVEvent->GetRunNumber()); // Needed for EMCAL trigger mapping
+  }
   AliVCaloTrigger *calotriggers = fVEvent->GetCaloTrigger("EMCAL");
   Bool_t fullPayload = gRandom->Uniform() < fFractionL1MonitorEventsEMCAL;
   calotrigger.fIndexBCs = fBCCount;

--- a/RUN3/AliAnalysisTaskAO2Dconverter.h
+++ b/RUN3/AliAnalysisTaskAO2Dconverter.h
@@ -20,6 +20,7 @@
 class AliVEvent;
 class AliESDEvent;
 class AliAODEvent;
+class AliGRPObject;
 class TFile;
 class TDirectory;
 class TParticle;
@@ -178,6 +179,7 @@ private:
   Bool_t fUseEventCuts = kFALSE;         //! Use or not event cuts
   AliEventCuts fEventCuts;      //! Standard event cuts
   AliTriggerAnalysis fTriggerAnalysis; //! Trigger analysis object for event selection
+  AliGRPObject *fGRP;           //! Global run parameters
   AliVEvent *fVEvent = nullptr; //! input ESD or AOD event
   AliESDEvent *fESD  = nullptr; //! input ESD event
   AliAODEvent *fAOD  = nullptr; //! input AOD event


### PR DESCRIPTION
Check with GetInstance whether a geometry instance
has already been created for the current run, and only
if not call GetInstanceFromRunNumber to build the
geometry object.