### PR TITLE
Initialize random seed with 0

### DIFF
--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerKernel.h
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerKernel.h
@@ -36,6 +36,7 @@
 //#include <AliEMCALTriggerPatchInfoV1.h>
 
 class TF1;
+class TRandom;
 class TObjArray;
 class AliEMCALTriggerPatchInfo;
 class AliEMCALTriggerRawPatch;
@@ -579,6 +580,7 @@ protected:
 
   AliEMCALTriggerPatchFinder<double>       *fPatchFinder;                 ///< The actual patch finder
   AliEMCALTriggerAlgorithm<double>         *fLevel0PatchFinder;           ///< Patch finder for Level0 patches
+  TRandom                                  *fSmearEngine;                 ///< Random engine for energy smearing
   Int_t                                     fL0MinTime;                   ///< Minimum L0 time
   Int_t                                     fL0MaxTime;                   ///< Maximum L0 time
   Bool_t                                    fApplyL0TimeCut;              ///< Apply time cut (L0 time between fL0MinTime and fL0MaxTime) for L0 patch selection

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetEnergyScale.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetEnergyScale.cxx
@@ -234,7 +234,7 @@ void AliAnalysisTaskEmcalJetEnergyScale::UserCreateOutputObjects(){
   }
   for(auto h : *(fHistos->GetListOfHistograms())) fOutput->Add(h);
 
-  fSampleSplitter = new TRandom;
+  fSampleSplitter = new TRandom(0);
 
   PostData(1, fOutput);
 }

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalSoftDropResponse.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalSoftDropResponse.cxx
@@ -162,9 +162,9 @@ void AliAnalysisTaskEmcalSoftDropResponse::UserCreateOutputObjects()
   AliAnalysisTaskEmcalJet::UserCreateOutputObjects();
   double R = double(int(GetJetContainer(fNameDetLevelJetContainer.Data())->GetJetRadius() * 1000.))/1000.;  // Save cast from float to double truncating after 3rd decimal digit
 
-  fSampleSplitter = new TRandom;
+  fSampleSplitter = new TRandom(0);
   if (fSampleFraction < 1.)
-    fSampleTrimmer = new TRandom;
+    fSampleTrimmer = new TRandom(0);
 
   if (!fPartLevelPtBinning)
     fPartLevelPtBinning = GetDefaultPartLevelPtBinning(fBinningMode);


### PR DESCRIPTION
Obviously ROOT initializes gRandom with a random seed taken
from the ROOT version. Better use random seed 0 based on the
description in the ROOT documentation.