### PR TITLE
PWGGA/GammaConv: AliAnalysisTaskOmegaToPiZeroGamma

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskOmegaToPiZeroGamma.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskOmegaToPiZeroGamma.cxx
@@ -4662,37 +4662,37 @@ void AliAnalysisTaskOmegaToPiZeroGamma::CalculateBackground(){
 //________________________________________________________________________
 void AliAnalysisTaskOmegaToPiZeroGamma::CalculateOmegaRotationBackground(Int_t iCurrentGamma, Int_t iCurrentPi0){
 
-  Double_t tempBGCandidateWeight       = fWeightJetJetMC;
-
-  Double_t rotationAngle = TMath::Pi()/2.0; // rotaion angle 90°
-
-  TLorentzVector lvRotationPhoton3;      // photon candidate from omega which gets rotated
-  TLorentzVector lvRotationPhoton2;      // photon candidate from pion which gets rotated
-  TLorentzVector lvRotationPhoton1;      // photon candidate from pion which gets rotated
-  TLorentzVector lvRotationPion;        // pion candidate which gets rotated
-  TVector3 lvRotationOmega;             // reconstructed mother particle from photon and pion
-  // Needed for TGenPhaseSpace
-  TVector3 tvEtaPhiGamma, tvEtaPhiPion, tvEtaPhiGammaDecay, tvEtaPhiPionDecay, tvNormBeforeDecay, tvNormAfterDecay;
-  Float_t asymBeforeDecay = 0.;
-  Float_t asymAfterDecay = 0.;
-  Double_t massPi0Gamma[2] = {0,((AliAODConversionMother*)(fPi0Candidates->At(iCurrentPi0)))->M()};
-  Double_t mass2Photons[2] = {0, 0};
-
-  Int_t cellIDRotatedPhoton3 = -1; // cell ID of the theoretical cluster after rotation (photon candidate from omega)
-  Int_t cellIDRotatedPhoton2 = -1; // cell ID of the theoretical cluster after rotation (photon candidate from pion)
-  Int_t cellIDRotatedPhoton1 = -1; // cell ID of the theoretical cluster after rotation (photon candidate from pion)
-
-  std::vector<std::array<Double_t, 2>> vSwappingInvMassPT;
-  std::vector<std::array<Double_t, 2>> vSwappingInvMassPTAlphaCut;
-  vSwappingInvMassPT.clear();
-  vSwappingInvMassPTAlphaCut.clear();
-  vSwappingInvMassPT.resize(0);
-  vSwappingInvMassPTAlphaCut.resize(0);
-  Double_t tempMultWeightSwapping = 1; // weight taking multiplicity of event into account
-
-  // curcial requierment is that the event has at least 4 cluster candidates and one Pi0 candidate
-  if( (fClusterCandidates->GetEntries() > 3 ) &&  (fPi0Candidates->GetEntries() > 0) )
+  // curcial requierment is that the event has at least 5 cluster candidates and one Pi0 candidate
+  if( (fClusterCandidates->GetEntries() > 4 ) &&  (fPi0Candidates->GetEntries() > 0) )
   {
+    
+    Double_t tempBGCandidateWeight       = fWeightJetJetMC;
+
+    Double_t rotationAngle = TMath::Pi()/2.0; // rotaion angle 90°
+
+    TLorentzVector lvRotationPhoton3;      // photon candidate from omega which gets rotated
+    TLorentzVector lvRotationPhoton2;      // photon candidate from pion which gets rotated
+    TLorentzVector lvRotationPhoton1;      // photon candidate from pion which gets rotated
+    TLorentzVector lvRotationPion;        // pion candidate which gets rotated
+    TVector3 lvRotationOmega;             // reconstructed mother particle from photon and pion
+    // Needed for TGenPhaseSpace
+    TVector3 tvEtaPhiGamma, tvEtaPhiPion, tvEtaPhiGammaDecay, tvEtaPhiPionDecay, tvNormBeforeDecay, tvNormAfterDecay;
+    Float_t asymBeforeDecay = 0.;
+    Float_t asymAfterDecay = 0.;
+    Double_t massPi0Gamma[2] = {0,((AliAODConversionMother*)(fPi0Candidates->At(iCurrentPi0)))->M()};
+    Double_t mass2Photons[2] = {0, 0};
+
+    Int_t cellIDRotatedPhoton3 = -1; // cell ID of the theoretical cluster after rotation (photon candidate from omega)
+    Int_t cellIDRotatedPhoton2 = -1; // cell ID of the theoretical cluster after rotation (photon candidate from pion)
+    Int_t cellIDRotatedPhoton1 = -1; // cell ID of the theoretical cluster after rotation (photon candidate from pion)
+
+    std::vector<std::array<Double_t, 2>> vSwappingInvMassPT;
+    std::vector<std::array<Double_t, 2>> vSwappingInvMassPTAlphaCut;
+    vSwappingInvMassPT.clear();
+    vSwappingInvMassPTAlphaCut.clear();
+    vSwappingInvMassPT.resize(0);
+    vSwappingInvMassPTAlphaCut.resize(0);
+    Double_t tempMultWeightSwapping = 1; // weight taking multiplicity of event into account
 
     AliAODConversionPhoton* currentEventRotatedPhoton3 = (AliAODConversionPhoton*)(fClusterCandidates->At(iCurrentGamma));
     if (currentEventRotatedPhoton3==NULL || !(currentEventRotatedPhoton3->GetIsCaloPhoton())) { return;}
@@ -5005,23 +5005,23 @@ void AliAnalysisTaskOmegaToPiZeroGamma::CalculateOmegaRotationBackground(Int_t i
 //________________________________________________________________________
 void AliAnalysisTaskOmegaToPiZeroGamma::CalculatePi0RotationBackground(){
 
-  Double_t rotationAngle = TMath::Pi()/2.0; //0.78539816339; // rotaion angle 90°
-
-  TLorentzVector lvRotationPhoton1;   // photon candidates which get rotated
-  TLorentzVector lvRotationPhoton2;   // photon candidates which get rotated
-  TVector3 lvRotationPion;            // reconstructed mother particle from the two photons
-  // Needed for TGenPhaseSpace
-  TVector3 tvEtaPhigamma1, tvEtaPhigamma2, tvEtaPhigamma1Decay, tvEtaPhigamma2Decay, tvNormBeforeDecay, tvNormAfterDecay;
-  Float_t asymBeforeDecay = 0.;
-  Float_t asymAfterDecay = 0.;
-  Double_t massGamma[2] = {0,0};
-
-  Int_t cellIDRotatedPhoton1 = -1; // cell ID of the cluster after rotation
-  Int_t cellIDRotatedPhoton2 = -1; // cell ID of the cluster after rotation
-
   // curcial requierment is that the event has at least 4 cluster candidates and
   // at least one pi0 candidate
-  if(fClusterCandidates->GetEntries() > 3) {
+  if( (fClusterCandidates->GetEntries() > 3) && (fPi0Candidates->GetEntries() > 0) ) {
+    
+    Double_t rotationAngle = TMath::Pi()/2.0; //0.78539816339; // rotaion angle 90°
+
+    TLorentzVector lvRotationPhoton1;   // photon candidates which get rotated
+    TLorentzVector lvRotationPhoton2;   // photon candidates which get rotated
+    TVector3 lvRotationPion;            // reconstructed mother particle from the two photons
+    // Needed for TGenPhaseSpace
+    TVector3 tvEtaPhigamma1, tvEtaPhigamma2, tvEtaPhigamma1Decay, tvEtaPhigamma2Decay, tvNormBeforeDecay, tvNormAfterDecay;
+    Float_t asymBeforeDecay = 0.;
+    Float_t asymAfterDecay = 0.;
+    Double_t massGamma[2] = {0,0};
+
+    Int_t cellIDRotatedPhoton1 = -1; // cell ID of the cluster after rotation
+    Int_t cellIDRotatedPhoton2 = -1; // cell ID of the cluster after rotation
 
     for(Int_t iCurrent1=0;iCurrent1<fClusterCandidates->GetEntries();iCurrent1++){
       AliAODConversionPhoton* currentEventRotatedPhoton1 = (AliAODConversionPhoton*)(fClusterCandidates->At(iCurrent1));

--- a/PWGGA/GammaConv/macros/AddTask_OmegaToPiZeroGamma_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_OmegaToPiZeroGamma_pp.C
@@ -420,6 +420,7 @@ void AddTask_OmegaToPiZeroGamma_pp(
     cuts.AddCut("00010113","00200009327000008250400000","411792109fe32220000","0163103w000000d0","0v631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout
   } else if( trainConfig == 2063) {
     // EG2 13TeV EMcal + Dcal, Background Variation (Swapping Method by Joshua)
+    cuts.AddCut("00010113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0s631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation, with constrains regarding the supermodule edges
     cuts.AddCut("00010113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0r631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation
     cuts.AddCut("00010113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0x631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
     cuts.AddCut("00010113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0z631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS (Pi0)
@@ -463,6 +464,7 @@ void AddTask_OmegaToPiZeroGamma_pp(
     cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","0163103w000000d0","0v631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout
   } else if( trainConfig == 2073) {
     // EG2 13TeV EMcal + Dcal, Background Variation (Swapping Method by Joshua)
+    cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0s631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation, with constrains regarding the supermodule edges
     cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0r631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation
     cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0x631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
     cuts.AddCut("0008e113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0z631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS (Pi0)
@@ -506,6 +508,7 @@ void AddTask_OmegaToPiZeroGamma_pp(
     cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","0163103w000000d0","0v631031000000d0"); // 4 sigma Pi0 selection plus Gamma dropout
   } else if( trainConfig == 2083) {
     // EG1 13TeV EMcal + Dcal, Background Variation (Swapping Method by Joshua)
+    cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0s631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation, with constrains regarding the supermodule edges
     cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0r631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough roation
     cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0x631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS with constraints
     cuts.AddCut("0008d113","00200009327000008250400000","411792109fe32220000","01631031000000d0","0z631031000000d0"); // 2 sigma Pi0 selection plus Gamma dropout, background scheme swapping method trough TGPS (Pi0)


### PR DESCRIPTION
- Reduced overhead for rotationbackground-methods
- Fixed number of photoncandidates needed for CalculateOmegaRotationBackground (from 4 to 5)
- Fixed number of Pi0Candidate needed for CalculatePi0RotationBackground (from none to 1)