### PR TITLE
Mtf branch fix warnings and errors for grid analysis

### DIFF
--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskIDFragmentationFunction.cxx
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskIDFragmentationFunction.cxx
@@ -370,6 +370,8 @@ void AliAnalysisTaskIDFragmentationFunction::UserCreateOutputObjects()
 
   if(fDebug > 1) Printf("AliAnalysisTaskIDFragmentationFunction::UserCreateOutputObjects()");
 
+  AliAnalysisTaskEmcalJet::UserCreateOutputObjects();
+  
   //
   // Create histograms / output container
   //

--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskIDFragmentationFunction.h
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskIDFragmentationFunction.h
@@ -312,8 +312,6 @@ public:
   UInt_t fRCTrials;
   TString* fUEMethods;                      //[fNumJetUEPIDtasks] Names for the underlying event methods
   Bool_t fUseRealJetArea;
-	
-  AliFJWrapper* 				fWrapper;
   
 private:
   AliAnalysisTaskIDFragmentationFunction(const  AliAnalysisTaskIDFragmentationFunction&);   //Not implemented in AliAnalysisTaskEmcalJet

--- a/PWGJE/EMCALJetTasks/UserTasks/AliHelperClassFastSimulation.cxx
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliHelperClassFastSimulation.cxx
@@ -119,8 +119,6 @@ void AliHelperClassFastSimulation::Run() {
 		
 		std::vector<fastjet::PseudoJet> constituents(fWrapper->GetJetConstituents(j));
 		
-		Double_t jetPt = jet->Pt();
-		
 		TObjArray* partArray = new TObjArray();
 		Int_t nOfParticles = 0;
 		
@@ -179,7 +177,7 @@ UInt_t AliHelperClassFastSimulation::GetNJets() {
 		return 0;
 }
 
-UInt_t AliHelperClassFastSimulation::GetNParticlesOfJet(Int_t jetNumber) {
+UInt_t AliHelperClassFastSimulation::GetNParticlesOfJet(UInt_t jetNumber) {
 	if (fParticlesArray && jetNumber <= GetNJets() - 1)
 		return ((TObjArray*)fParticlesArray->At(jetNumber))->GetEntriesFast();
 	else 

--- a/PWGJE/EMCALJetTasks/UserTasks/AliHelperClassFastSimulation.h
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliHelperClassFastSimulation.h
@@ -31,9 +31,12 @@ public:
 	AliFJWrapper* 				GetStandardJetWrapper();
 	
 	UInt_t 								GetNJets();
-	UInt_t                GetNParticlesOfJet(Int_t jetNumber);
+	UInt_t                GetNParticlesOfJet(UInt_t jetNumber);
 	
 private:
+  AliHelperClassFastSimulation(const AliHelperClassFastSimulation&)           ;  //Not implemented
+  AliHelperClassFastSimulation &operator=(const AliHelperClassFastSimulation&);  //Not implemented
+  
 	Double_t 							fFastSimEffFactor;
 	Double_t 							fFastSimResFactor;
 	Double_t 							fFastSimRes;

--- a/PWGJE/EMCALJetTasks/UserTasks/AliPieceWisePoly.h
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliPieceWisePoly.h
@@ -1,3 +1,6 @@
+#ifndef ALIPIECEWISEPOLY_H
+#define ALIPIECEWISEPOLY_H
+
 class TF1;
 
 class AliPieceWisePoly {
@@ -17,6 +20,9 @@ public:
   static void ReadFSParameters(TString parameterFile, TF1** effFunctions);
   
 private:
+  AliPieceWisePoly(const AliPieceWisePoly&)           ;  //Not implemented
+  AliPieceWisePoly &operator=(const AliPieceWisePoly&);  //Not implemented
+  
   Int_t doSmoothing;
   Int_t nParts;
   Double_t* cuts;
@@ -25,4 +31,5 @@ private:
   TF1* piecewisepolynom;
 };
 
+#endif
 


### PR DESCRIPTION
Fixes some warnings in AliHelperClassFastSimulation and AliPieceWisePoly and removes an unitialised data member in AliAnalysisTAskIDFragmentationFunction that lead to an bus error in grid analysis (and wasn't used anyway). Also adds header guard for AliPieceWisePoly.