### PR TITLE
PWGHF: Fixes new Dstar tasks

### DIFF
--- a/PWGHF/vertexingHF/vHFML/AliAnalysisTaskSECharmHadronMLSelector.cxx
+++ b/PWGHF/vertexingHF/vHFML/AliAnalysisTaskSECharmHadronMLSelector.cxx
@@ -22,6 +22,7 @@
 #include "AliHFMLResponseDplustoKpipi.h"
 #include "AliHFMLResponseDstoKKpi.h"
 #include "AliHFMLResponseD0toKpi.h"
+#include "AliHFMLResponseDstartoD0pi.h"
 #include "AliAODRecoDecayHF.h"
 #include "AliAODRecoDecayHF2Prong.h"
 #include "AliAODRecoDecayHF3Prong.h"
@@ -134,7 +135,7 @@ void AliAnalysisTaskSECharmHadronMLSelector::UserCreateOutputObjects()
             massD = TDatabasePDG::Instance()->GetParticle(431)->Mass();
             break;
         case kDstartoD0pi:
-            fMLResponse = new AliHFMLResponseD0toKpi("DstartoD0piMLResponse", "DstartoD0piMLResponse", fConfigPath.Data());
+            fMLResponse = new AliHFMLResponseDstartoD0pi("DstartoD0piMLResponse", "DstartoD0piMLResponse", fConfigPath.Data());
             fMLResponse->MLResponseInit();
             massD = TDatabasePDG::Instance()->GetParticle(413)->Mass() - TDatabasePDG::Instance()->GetParticle(421)->Mass();
             break; 
@@ -317,20 +318,21 @@ void AliAnalysisTaskSECharmHadronMLSelector::UserExec(Option_t * /*option*/)
     for(int iCand = 0; iCand < arrayCand->GetEntriesFast(); iCand++)
     {
         AliAODRecoDecayHF *chHad = dynamic_cast<AliAODRecoDecayHF *>(arrayCand->UncheckedAt(iCand));
+        AliAODRecoDecayHF *chHadWithVtx;
 
         bool unsetVtx = false;
         bool recVtx = false;
         AliAODVertex *origOwnVtx = nullptr;
 
         std::vector<double> scores{}, scoresSecond{};
-        int isSelected = IsCandidateSelected(chHad, &vHF, absPdgMom, unsetVtx, recVtx, origOwnVtx, scores, scoresSecond);
+        int isSelected = IsCandidateSelected(chHad, chHadWithVtx, &vHF, absPdgMom, unsetVtx, recVtx, origOwnVtx, scores, scoresSecond);
 
         if (!isSelected || (fDecChannel == kDstoKKpi && !((isSelected & 4) || (isSelected & 8))))
         {
             if (unsetVtx)
-                chHad->UnsetOwnPrimaryVtx();
+                chHadWithVtx->UnsetOwnPrimaryVtx();
             if (recVtx)
-                fRDCuts->CleanOwnPrimaryVtx(chHad, fAOD, origOwnVtx);
+                fRDCuts->CleanOwnPrimaryVtx(chHadWithVtx, fAOD, origOwnVtx);
             continue;
         }
 
@@ -370,9 +372,9 @@ void AliAnalysisTaskSECharmHadronMLSelector::UserExec(Option_t * /*option*/)
         }        
 
         if (unsetVtx)
-            chHad->UnsetOwnPrimaryVtx();
+            chHadWithVtx->UnsetOwnPrimaryVtx();
         if (recVtx)
-            fRDCuts->CleanOwnPrimaryVtx(chHad, fAOD, origOwnVtx);
+            fRDCuts->CleanOwnPrimaryVtx(chHadWithVtx, fAOD, origOwnVtx);
     }
 
     fHistNselCand->Fill(fChHadIdx.size());
@@ -382,7 +384,7 @@ void AliAnalysisTaskSECharmHadronMLSelector::UserExec(Option_t * /*option*/)
 }
 
 //________________________________________________________________________
-int AliAnalysisTaskSECharmHadronMLSelector::IsCandidateSelected(AliAODRecoDecayHF *&chHad, AliAnalysisVertexingHF *vHF,
+int AliAnalysisTaskSECharmHadronMLSelector::IsCandidateSelected(AliAODRecoDecayHF *&chHad, AliAODRecoDecayHF *&chHadWithVtx, AliAnalysisVertexingHF *vHF,
                                                                 int absPdgMom, bool &unsetVtx, bool &recVtx, AliAODVertex *&origOwnVtx,
                                                                 std::vector<double> &modelPred, std::vector<double> &modelPredSecond)
 {
@@ -411,28 +413,32 @@ int AliAnalysisTaskSECharmHadronMLSelector::IsCandidateSelected(AliAODRecoDecayH
             isSelBit = chHad->HasSelectionBit(AliRDHFCuts::kD0toKpiCuts);
             if (!isSelBit || !vHF->FillRecoCand(fAOD, dynamic_cast<AliAODRecoDecayHF2Prong *>(chHad)))
                 return 0;
+            chHadWithVtx = chHad;
             break;
         case kDplustoKpipi:
             isSelBit = chHad->HasSelectionBit(AliRDHFCuts::kDplusCuts);
             if (!isSelBit || !vHF->FillRecoCand(fAOD, dynamic_cast<AliAODRecoDecayHF3Prong *>(chHad)))
                 return 0;
+            chHadWithVtx = chHad;
             break;
         case kDstartoD0pi:
             if (!vHF->FillRecoCasc(fAOD, dynamic_cast<AliAODRecoCascadeHF *>(chHad), true))
                 return 0;
+            chHadWithVtx = dynamic_cast<AliAODRecoDecayHF*>(((AliAODRecoCascadeHF *)chHad)->Get2Prong());
             break;
         case kDstoKKpi:
             isSelBit = chHad->HasSelectionBit(AliRDHFCuts::kDsCuts);
             if (!isSelBit || !vHF->FillRecoCand(fAOD, dynamic_cast<AliAODRecoDecayHF3Prong *>(chHad)))
                 return 0;
+            chHadWithVtx = chHad;
             break;
 
     }
 
     unsetVtx = false;
-    if (!chHad->GetOwnPrimaryVtx())
+    if (!chHadWithVtx->GetOwnPrimaryVtx())
     {
-        chHad->SetOwnPrimaryVtx(dynamic_cast<AliAODVertex *>(fAOD->GetPrimaryVertex()));
+        chHadWithVtx->SetOwnPrimaryVtx(dynamic_cast<AliAODVertex *>(fAOD->GetPrimaryVertex()));
         unsetVtx = true;
         // NOTE: the own primary vertex should be unset, otherwise there is a memory leak
         // Pay attention if you use continue inside this loop!!!
@@ -444,7 +450,7 @@ int AliAnalysisTaskSECharmHadronMLSelector::IsCandidateSelected(AliAODRecoDecayH
     if (ptbin < 0)
     {
         if (unsetVtx)
-            chHad->UnsetOwnPrimaryVtx();
+            chHadWithVtx->UnsetOwnPrimaryVtx();
         return 0;
     }
 
@@ -452,7 +458,7 @@ int AliAnalysisTaskSECharmHadronMLSelector::IsCandidateSelected(AliAODRecoDecayH
     if (!isFidAcc)
     {
         if (unsetVtx)
-            chHad->UnsetOwnPrimaryVtx();
+            chHadWithVtx->UnsetOwnPrimaryVtx();
         return 0;
     }
 
@@ -460,7 +466,7 @@ int AliAnalysisTaskSECharmHadronMLSelector::IsCandidateSelected(AliAODRecoDecayH
     if (!isSelected)
     {
         if (unsetVtx)
-            chHad->UnsetOwnPrimaryVtx();
+            chHadWithVtx->UnsetOwnPrimaryVtx();
         return 0;
     }
 
@@ -469,12 +475,12 @@ int AliAnalysisTaskSECharmHadronMLSelector::IsCandidateSelected(AliAODRecoDecayH
 
     if (fRDCuts->GetIsPrimaryWithoutDaughters())
     {
-        if (chHad->GetOwnPrimaryVtx())
-            origOwnVtx = new AliAODVertex(*chHad->GetOwnPrimaryVtx());
-        if (fRDCuts->RecalcOwnPrimaryVtx(chHad, fAOD))
+        if (chHadWithVtx->GetOwnPrimaryVtx())
+            origOwnVtx = new AliAODVertex(*chHadWithVtx->GetOwnPrimaryVtx());
+        if (fRDCuts->RecalcOwnPrimaryVtx(chHadWithVtx, fAOD))
             recVtx = true;
         else
-            fRDCuts->CleanOwnPrimaryVtx(chHad, fAOD, origOwnVtx);
+            fRDCuts->CleanOwnPrimaryVtx(chHadWithVtx, fAOD, origOwnVtx);
     }
     
     // ML application

--- a/PWGHF/vertexingHF/vHFML/AliAnalysisTaskSECharmHadronMLSelector.h
+++ b/PWGHF/vertexingHF/vHFML/AliAnalysisTaskSECharmHadronMLSelector.h
@@ -65,7 +65,7 @@ private:
     AliAnalysisTaskSECharmHadronMLSelector(const AliAnalysisTaskSECharmHadronMLSelector &source);
     AliAnalysisTaskSECharmHadronMLSelector &operator=(const AliAnalysisTaskSECharmHadronMLSelector &source);
 
-    int IsCandidateSelected(AliAODRecoDecayHF *&chHad, AliAnalysisVertexingHF *vHF, int absPdgMom, bool &unsetVtx, bool &recVtx, AliAODVertex *&origOwnVtx, std::vector<double> &modelPred, std::vector<double> &modelPredSecond);
+    int IsCandidateSelected(AliAODRecoDecayHF *&chHad, AliAODRecoDecayHF *&chHadWithVtx, AliAnalysisVertexingHF *vHF, int absPdgMom, bool &unsetVtx, bool &recVtx, AliAODVertex *&origOwnVtx, std::vector<double> &modelPred, std::vector<double> &modelPredSecond);
 
     AliAODEvent* fAOD = nullptr;                            /// AOD event
 

--- a/PWGHF/vertexingHF/vHFML/AliAnalysisTaskSEDmesonTree.h
+++ b/PWGHF/vertexingHF/vHFML/AliAnalysisTaskSEDmesonTree.h
@@ -128,7 +128,7 @@ private:
     AliAnalysisTaskSEDmesonTree(const AliAnalysisTaskSEDmesonTree &source);
     AliAnalysisTaskSEDmesonTree &operator=(const AliAnalysisTaskSEDmesonTree &source);
 
-    int IsCandidateSelected(AliAODRecoDecayHF *&dMeson, AliAnalysisVertexingHF *vHF, bool &unsetVtx, bool &recVtx, AliAODVertex *&origownvtx, bool &isInSignalRegion);
+    int IsCandidateSelected(AliAODRecoDecayHF *&dMeson, AliAODRecoDecayHF *&dMesonWithVtx, AliAnalysisVertexingHF *vHF, bool &unsetVtx, bool &recVtx, AliAODVertex *&origownvtx, bool &isInSignalRegion);
     void FillMCGenAccHistos(TClonesArray *arrayMC, AliAODMCHeader *mcHeader, int Ntracklets);
     bool CheckDaugAcc(TClonesArray *arrayMC, int nProng, int *labDau);
     void CreateEffSparses();

--- a/PWGHF/vertexingHF/vHFML/AliAnalysisTaskSEDstarPolarization.cxx
+++ b/PWGHF/vertexingHF/vHFML/AliAnalysisTaskSEDstarPolarization.cxx
@@ -139,6 +139,7 @@ void AliAnalysisTaskSEDstarPolarization::UserExec(Option_t * /*option*/)
     }
 
     TClonesArray *arrayCand = nullptr;
+    TClonesArray *arrayCandDDau = nullptr;
     if (!fAOD && AODEvent() && IsStandardAOD())
     {
         // In case there is an AOD handler writing a standard AOD, use the AOD
@@ -152,14 +153,16 @@ void AliAnalysisTaskSEDstarPolarization::UserExec(Option_t * /*option*/)
             AliAODExtension *ext = dynamic_cast<AliAODExtension *>(aodHandler->GetExtensions()->FindObject("AliAOD.VertexingHF.root"));
             AliAODEvent *aodFromExt = ext->GetAOD();
             arrayCand = dynamic_cast<TClonesArray *>(aodFromExt->GetList()->FindObject("Dstar"));
+            arrayCandDDau = dynamic_cast<TClonesArray *>(aodFromExt->GetList()->FindObject("D0toKpi"));
         }
     }
     else if (fAOD)
     {
         arrayCand = dynamic_cast<TClonesArray *>(fAOD->GetList()->FindObject("Dstar"));
+        arrayCandDDau = dynamic_cast<TClonesArray *>(fAOD->GetList()->FindObject("D0toKpi"));
     }
 
-    if (!fAOD || !arrayCand)
+    if (!fAOD || !arrayCand || !arrayCandDDau)
     {
         AliWarning("Candidate branch not found!\n");
         PostData(1, fOutput);
@@ -239,18 +242,19 @@ void AliAnalysisTaskSEDstarPolarization::UserExec(Option_t * /*option*/)
     for (int iCand = 0; iCand < arrayCand->GetEntriesFast(); iCand++)
     {
         AliAODRecoCascadeHF *dStar = dynamic_cast<AliAODRecoCascadeHF *>(arrayCand->UncheckedAt(iCand));
+        AliAODRecoDecayHF2Prong *dZeroDau = dynamic_cast<AliAODRecoDecayHF2Prong *>(arrayCandDDau->UncheckedAt(dStar->GetProngID(1)));
 
         bool unsetVtx = false;
         bool recVtx = false;
         AliAODVertex *origOwnVtx = nullptr;
 
-        int isSelected = IsCandidateSelected(dStar, &vHF, unsetVtx, recVtx, origOwnVtx);
+        int isSelected = IsCandidateSelected(dStar, dZeroDau, &vHF, unsetVtx, recVtx, origOwnVtx);
         if (!isSelected)
         {
             if (unsetVtx)
-                dStar->UnsetOwnPrimaryVtx();
+                dZeroDau->UnsetOwnPrimaryVtx();
             if (recVtx)
-                fRDCuts->CleanOwnPrimaryVtx(dStar, fAOD, origOwnVtx);
+                fRDCuts->CleanOwnPrimaryVtx(dZeroDau, fAOD, origOwnVtx);
             continue;
         }
 
@@ -326,19 +330,19 @@ void AliAnalysisTaskSEDstarPolarization::UserExec(Option_t * /*option*/)
         }
 
         if (unsetVtx)
-            dStar->UnsetOwnPrimaryVtx();
+            dZeroDau->UnsetOwnPrimaryVtx();
         if (recVtx)
-            fRDCuts->CleanOwnPrimaryVtx(dStar, fAOD, origOwnVtx);
+            fRDCuts->CleanOwnPrimaryVtx(dZeroDau, fAOD, origOwnVtx);
     }
 
     PostData(1, fOutput);
 }
 
 //________________________________________________________________________
-int AliAnalysisTaskSEDstarPolarization::IsCandidateSelected(AliAODRecoCascadeHF *&dStar, AliAnalysisVertexingHF *vHF, bool &unsetVtx, bool &recVtx, AliAODVertex *&origOwnVtx)
+int AliAnalysisTaskSEDstarPolarization::IsCandidateSelected(AliAODRecoCascadeHF *&dStar, AliAODRecoDecayHF2Prong *&dZeroDau, AliAnalysisVertexingHF *vHF, bool &unsetVtx, bool &recVtx, AliAODVertex *&origOwnVtx)
 {
 
-    if (!dStar || !vHF)
+    if (!dStar || !dZeroDau || !vHF)
         return 0;
     fHistNEvents->Fill(11);
 
@@ -348,8 +352,11 @@ int AliAnalysisTaskSEDstarPolarization::IsCandidateSelected(AliAODRecoCascadeHF 
 
     for (int iDau = 0; iDau < nDau; iDau++)
     {
-        AliAODTrack *track = vHF->GetProng(fAOD, dStar, iDau);
-        arrDauTracks.AddAt(track, iDau);
+        AliAODTrack *track;
+        if (iDau == 0)
+            track = vHF->GetProng(fAOD, dStar, iDau);
+        else
+            track = vHF->GetProng(fAOD, dZeroDau, iDau-1); //D0<-D* daughters
     }
 
     if (!fRDCuts->PreSelect(arrDauTracks))
@@ -367,9 +374,9 @@ int AliAnalysisTaskSEDstarPolarization::IsCandidateSelected(AliAODRecoCascadeHF 
     fHistNEvents->Fill(12);
 
     unsetVtx = false;
-    if (!dStar->GetOwnPrimaryVtx())
+    if (!dZeroDau->GetOwnPrimaryVtx())
     {
-        dStar->SetOwnPrimaryVtx(dynamic_cast<AliAODVertex *>(fAOD->GetPrimaryVertex()));
+        dZeroDau->SetOwnPrimaryVtx(dynamic_cast<AliAODVertex *>(fAOD->GetPrimaryVertex()));
         unsetVtx = true;
         // NOTE: the own primary vertex should be unset, otherwise there is a memory leak
         // Pay attention if you use continue inside this loop!!!
@@ -381,7 +388,7 @@ int AliAnalysisTaskSEDstarPolarization::IsCandidateSelected(AliAODRecoCascadeHF 
     if (ptBin < 0)
     {
         if (unsetVtx)
-            dStar->UnsetOwnPrimaryVtx();
+            dZeroDau->UnsetOwnPrimaryVtx();
         return 0;
     }
 
@@ -389,7 +396,7 @@ int AliAnalysisTaskSEDstarPolarization::IsCandidateSelected(AliAODRecoCascadeHF 
     if (!isSelected)
     {
         if (unsetVtx)
-            dStar->UnsetOwnPrimaryVtx();
+            dZeroDau->UnsetOwnPrimaryVtx();
         return 0;
     }
 
@@ -398,12 +405,12 @@ int AliAnalysisTaskSEDstarPolarization::IsCandidateSelected(AliAODRecoCascadeHF 
 
     if (fRDCuts->GetIsPrimaryWithoutDaughters())
     {
-        if (dStar->GetOwnPrimaryVtx())
-            origOwnVtx = new AliAODVertex(*dStar->GetOwnPrimaryVtx());
-        if (fRDCuts->RecalcOwnPrimaryVtx(dStar, fAOD))
+        if (dZeroDau->GetOwnPrimaryVtx())
+            origOwnVtx = new AliAODVertex(*dZeroDau->GetOwnPrimaryVtx());
+        if (fRDCuts->RecalcOwnPrimaryVtx(dZeroDau, fAOD))
             recVtx = true;
         else
-            fRDCuts->CleanOwnPrimaryVtx(dStar, fAOD, origOwnVtx);
+            fRDCuts->CleanOwnPrimaryVtx(dZeroDau, fAOD, origOwnVtx);
     }
 
 

--- a/PWGHF/vertexingHF/vHFML/AliAnalysisTaskSEDstarPolarization.h
+++ b/PWGHF/vertexingHF/vHFML/AliAnalysisTaskSEDstarPolarization.h
@@ -64,7 +64,7 @@ private:
     AliAnalysisTaskSEDstarPolarization(const AliAnalysisTaskSEDstarPolarization &source);
     AliAnalysisTaskSEDstarPolarization &operator=(const AliAnalysisTaskSEDstarPolarization &source);
 
-    int IsCandidateSelected(AliAODRecoCascadeHF *&dStar, AliAnalysisVertexingHF *vHF, bool &unsetVtx, bool &recVtx, AliAODVertex *&origownvtx);
+    int IsCandidateSelected(AliAODRecoCascadeHF *&dStar, AliAODRecoDecayHF2Prong *&dZeroDau, AliAnalysisVertexingHF *vHF, bool &unsetVtx, bool &recVtx, AliAODVertex *&origownvtx);
     void FillMCGenAccHistos(TClonesArray *arrayMC, AliAODMCHeader *mcHeader, double centrality);
     bool CheckDaugAcc(TClonesArray *arrayMC, int nProng, int *labDau);
     void CreateEffSparses();


### PR DESCRIPTION
- Fixed a typo AliAnalysisTaskSECharmHadronMLSelector task (D0 -> Dstar)
- Fixed an error in case the tasks would run over PbPb with the PreSelect function enabled
- Fixed an issue that entered for the SetOwnPrimaryVtx(), RecalcOwnPrimaryVtx(), UnsetOwnPrimaryVtx(), and CleanOwnPrimaryVtx() calls. The same strategy as in the AliRDHFCutsDStartoKpipi.cxx class should be adopted, where these functions are called for the D0-daughter of the Dstar candidate

@fgrosa, your tasks so please have a look if you are ok with it :)