### PR TITLE
PWG/EMCal: Added correction component for cluster position correction

### DIFF
--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterPositionCorrection.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterPositionCorrection.cxx
@@ -1,0 +1,140 @@
+// AliEmcalCorrectionClusterPositionCorrection
+//
+
+#include "AliEmcalCorrectionClusterPositionCorrection.h"
+
+#include "AliInputEventHandler.h"
+#include "AliClusterContainer.h"
+#include "AliMCEvent.h"
+#include "AliMCEventHandler.h"
+#include "AliMCParticle.h"
+
+/// \cond CLASSIMP
+ClassImp(AliEmcalCorrectionClusterPositionCorrection);
+/// \endcond
+
+// Actually registers the class with the base class
+RegisterCorrectionComponent<AliEmcalCorrectionClusterPositionCorrection> AliEmcalCorrectionClusterPositionCorrection::reg("AliEmcalCorrectionClusterPositionCorrection");
+
+/**
+ * Default constructor
+ */
+AliEmcalCorrectionClusterPositionCorrection::AliEmcalCorrectionClusterPositionCorrection() :
+  AliEmcalCorrectionComponent("AliEmcalCorrectionClusterPositionCorrection"),
+  fClusterPositionDiffEta(0),
+  fClusterPositionDiffPhi(0),
+  fSMEtaValues(0),
+  fSMPhiValues(0),
+  fApplyToMC(0)
+{
+  for(unsigned int i = 0; i < 20; ++i){
+    fSMEtaValues.push_back(0); // set default values to 0 --> no shift is applied
+    fSMPhiValues.push_back(0); // set default values to 0 --> no shift is applied
+  }
+}
+
+/**
+ * Destructor
+ */
+AliEmcalCorrectionClusterPositionCorrection::~AliEmcalCorrectionClusterPositionCorrection()
+{
+}
+
+/**
+ * Initialize and configure the component.
+ */
+Bool_t AliEmcalCorrectionClusterPositionCorrection::Initialize()
+{
+  // Initialization
+  AliEmcalCorrectionComponent::Initialize();
+
+  fApplyToMC = false;
+  GetProperty("applyToMC", fApplyToMC);
+
+  GetProperty("setSMEtaValues", fSMEtaValues);
+
+  GetProperty("setSMPhiValues", fSMPhiValues);
+
+  return kTRUE;
+}
+
+/**
+ * Create run-independent objects for output. Called before running over events.
+ */
+void AliEmcalCorrectionClusterPositionCorrection::UserCreateOutputObjects()
+{
+  AliEmcalCorrectionComponent::UserCreateOutputObjects();
+
+  // Create my user objects.
+  if (fCreateHisto){
+    fClusterPositionDiffEta = new TH1F("fClusterPositionDiffEta","fClusterPositionDiffEta;#Delta#eta",400,-0.02, 0.02);
+    fOutput->Add(fClusterPositionDiffEta);
+    fClusterPositionDiffPhi = new TH1F("fClusterPositionDiffPhi","fClusterPositionDiffPhi;#Delta#eta",400,-0.02, 0.02);
+    fOutput->Add(fClusterPositionDiffPhi);
+
+    // Take ownership of output list
+    fOutput->SetOwner(kTRUE);
+  }
+}
+
+/**
+ * Called for each event to process the event data.
+ */
+Bool_t AliEmcalCorrectionClusterPositionCorrection::Run()
+{
+  AliEmcalCorrectionComponent::Run();
+
+  // only apply on MC clusters
+  if(!fMCEvent) return kTRUE;
+
+  // loop over clusters
+  AliVCluster *clus = 0;
+  AliClusterContainer * clusCont = 0;
+  TIter nextClusCont(&fClusterCollArray);
+  while ((clusCont = static_cast<AliClusterContainer*>(nextClusCont()))) {
+
+    if (!clusCont) return kFALSE;
+    auto clusItCont = clusCont->all_momentum();
+
+    for (AliClusterIterableMomentumContainer::iterator clusIterator = clusItCont.begin(); clusIterator != clusItCont.end(); ++clusIterator) {
+      clus = static_cast<AliVCluster *>(clusIterator->second);
+
+      if (!clus->IsEMCAL()) continue;
+
+      Float_t pos[3] = {0};
+      clus->GetPosition(pos);
+      // printf("cluster pos: x=%.04f y=%.04f z=%.04f\n",pos[0],pos[1],pos[2]);
+
+      TVector3 vecPos(pos);
+
+      Double_t clusPt = vecPos.Pt();
+      Double_t clusEta = vecPos.Eta();
+      Double_t clusPhi = vecPos.Phi();
+      Int_t iSM = fGeom->GetSuperModuleNumber(clus->GetCellAbsId(0));
+      if(fApplyToMC){
+        clusEta-= fSMEtaValues[iSM];
+        clusPhi-= fSMPhiValues[iSM];
+      } else {
+        clusEta+= fSMEtaValues[iSM];
+        clusPhi+= fSMPhiValues[iSM];
+      }
+      // shift the position of the cluster
+      vecPos.SetPtEtaPhi(clusPt, clusEta, clusPhi);
+
+      // Set position after correction
+      vecPos.GetXYZ(pos);
+      clus->SetPosition(pos);
+      // printf("TVector pos: x=%.04f y=%.04f z=%.04f\n",pos[0],pos[1],pos[2]);
+
+      Double_t clusEtaAfter = vecPos.Eta();
+      Double_t clusPhiAfter = vecPos.Phi();
+
+      if (fCreateHisto) {
+        fClusterPositionDiffEta->Fill(clusEtaAfter - clusEta);
+        fClusterPositionDiffPhi->Fill(clusPhiAfter - clusPhi);
+      }
+    }
+  }
+
+  return kTRUE;
+}

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterPositionCorrection.h
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterPositionCorrection.h
@@ -1,0 +1,61 @@
+#ifndef ALIEMCALCORRECTIONCLUSTERPOSITIONCORRECTION_H
+#define ALIEMCALCORRECTIONCLUSTERPOSITIONCORRECTION_H
+
+#include "AliEmcalCorrectionComponent.h"
+
+#include "AliEMCALRecoUtils.h"
+
+#include <AliEMCALGeometry.h>
+
+/**
+ * @class AliEmcalCorrectionClusterPositionCorrection
+ * @ingroup EMCALCORRECTIONFW
+ * @brief Cluster position correction in eta and phi
+ *
+ * This task corrects a small missalignemt between the central detectors and the emcal in eta and phi for each SM.
+ * The shifts were evaluated by calculating the mean difference between eta/phi of a matched track and the corresponding cluster
+
+ *
+ * Based on code in AliEmcalClusterMaker.
+ *
+ * @author Constantin Loizides, LBNL, AliEmcalClusterMaker
+ * @author Salvatore Aiola, LBNL, AliEmcalClusterMaker
+ * @author James Mulligan <james.mulligan@yale.edu>, Yale University, centralize EMCal corrections using components
+ * @author Raymond Ehlers <raymond.ehlers@yale.edu>, Yale University, centralize EMCal corrections using components
+ * @date Jul 8, 2016
+ */
+
+
+class AliEmcalCorrectionClusterPositionCorrection : public AliEmcalCorrectionComponent {
+ public:
+
+  AliEmcalCorrectionClusterPositionCorrection();
+  virtual ~AliEmcalCorrectionClusterPositionCorrection();
+
+  // Sets up and runs the task
+  Bool_t Initialize();
+  void UserCreateOutputObjects();
+  Bool_t Run();
+
+protected:
+  TH1F                  *fClusterPositionDiffEta;         //!<! shift of cluster position  in eta
+  TH1F                  *fClusterPositionDiffPhi;         //!<! shift of cluster position  in phi
+
+  std::vector<Double_t> fSMEtaValues;                     //!<! vector containing position shifts in eta
+  std::vector<Double_t> fSMPhiValues;                     //!<! vector containing position shifts in phi
+
+  Bool_t                fApplyToMC;                       //!<! switch if correction should be applied on data or MC
+
+ private:
+  AliEmcalCorrectionClusterPositionCorrection(const AliEmcalCorrectionClusterPositionCorrection &);               // Not implemented
+  AliEmcalCorrectionClusterPositionCorrection &operator=(const AliEmcalCorrectionClusterPositionCorrection &);    // Not implemented
+
+  // Allows the registration of the class so that it is availble to be used by the correction task.
+  static RegisterCorrectionComponent<AliEmcalCorrectionClusterPositionCorrection> reg;
+
+  /// \cond CLASSIMP
+  ClassDef(AliEmcalCorrectionClusterPositionCorrection, 1); // EMCal cluster low energy efficiency correction component
+  /// \endcond
+};
+
+#endif /* ALIEMCALCORRECTIONCLUSTERPOSITIONCORRECTION_H */

--- a/PWG/EMCAL/EMCALtasks/CMakeLists.txt
+++ b/PWG/EMCAL/EMCALtasks/CMakeLists.txt
@@ -82,6 +82,7 @@ set(SRCS
   AliEmcalCorrectionClusterNonLinearity.cxx
   AliEmcalCorrectionClusterNonLinearityMCAfterburner.cxx
   AliEmcalCorrectionClusterLowEnergyEfficiency.cxx
+  AliEmcalCorrectionClusterPositionCorrection.cxx
   AliEmcalCorrectionClusterExotics.cxx
   AliEmcalCorrectionClusterTrackMatcher.cxx
   AliEmcalCorrectionClusterHadronicCorrection.cxx

--- a/PWG/EMCAL/EMCALtasks/PWGEMCALtasksLinkDef.h
+++ b/PWG/EMCAL/EMCALtasks/PWGEMCALtasksLinkDef.h
@@ -48,6 +48,7 @@
 #pragma link C++ class  AliEmcalCorrectionClusterNonLinearity+;
 #pragma link C++ class  AliEmcalCorrectionClusterNonLinearityMCAfterburner+;
 #pragma link C++ class  AliEmcalCorrectionClusterLowEnergyEfficiency+;
+#pragma link C++ class  AliEmcalCorrectionClusterPositionCorrection+;
 #pragma link C++ class  AliEmcalCorrectionClusterExotics+;
 #pragma link C++ class  AliEmcalCorrectionClusterTrackMatcher+;
 #pragma link C++ class  AliEmcalCorrectionClusterHadronicCorrection+;

--- a/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
+++ b/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
@@ -253,6 +253,16 @@ ClusterLowEnergyEfficiency:                         # Cluster number of cell eff
         - defaultCells                              # This object is defined above in the cells section of the input objects
     clusterContainersNames:                         # Names of the cluster input objects which should be attached to the correction
         - defaultClusterContainer_1                 # This object is defined above in the cluster section of the input objects
+ClusterPositionCorrection:                          # Cluster position correction
+    enabled: false                                  # Whether to enable the task
+    createHistos: false                             # Whether the task should create output histograms
+    setSMEtaValues: [0., 0., 0., 0., 0.,   0., 0., 0., 0., 0.,   0., 0., 0., 0., 0.,   0., 0., 0., 0., 0.]      # eta position shifts per SM
+    setSMPhiValues: [0., 0., 0., 0., 0.,   0., 0., 0., 0., 0.,   0., 0., 0., 0., 0.,   0., 0., 0., 0., 0.]      # phi position shifts per SM
+    applyToMC: true                                 # if set to true, data-MC position correction is used; if set to false MC-data position correction is used
+    cellsNames:                                     # Names of the cells input objects which should be attached to the correction
+        - defaultCells                              # This object is defined above in the cells section of the input objects
+    clusterContainersNames:                         # Names of the cluster input objects which should be attached to the correction
+        - defaultClusterContainer_1                 # This object is defined above in the cluster section of the input objects
 ClusterTrackMatcher:                                # Cluster-track matcher component
     enabled: false                                  # Whether to enable the task
     createHistos: false                             # Whether the task should create output histograms
@@ -350,6 +360,7 @@ executionOrder:
     - ClusterNonLinearity
     - ClusterNonLinearityMCAfterburner
     - ClusterLowEnergyEfficiency
+    - ClusterPositionCorrection
     - ClusterTrackMatcher
     - ClusterHadronicCorrection
     - ClusterEnergyVariation


### PR DESCRIPTION
- New correction component to correct the cluster position
- Shifts are evaluated by comparing the position of matched tracks to
the cluster
- Shifts are very small and will not affect most analyses, however for
pi0 reconstruction with PCM-EMCal, this correction is necessary as
otherwise the pi0 peak width differs in data and MC
- Correction can be applied to data or to MC