### PR TITLE
[ALIROOT-8678] Add support for weighted pythia productions

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.cxx
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.cxx
@@ -120,6 +120,7 @@ AliAnalysisTaskEmcal::AliAnalysisTaskEmcal() :
   fIsPythia(kFALSE),
   fIsHerwig(kFALSE),
   fIsHepMC(kFALSE),
+  fIsWeighted(kFALSE),
   fGetPtHardBinFromName(kTRUE),
   fSelectPtHardBin(-999),
   fMinMCLabel(0),
@@ -244,6 +245,7 @@ AliAnalysisTaskEmcal::AliAnalysisTaskEmcal(const char *name, Bool_t histo) :
   fIsPythia(kFALSE),
   fIsHerwig(kFALSE),
   fIsHepMC(kFALSE),
+  fIsWeighted(kFALSE),
   fGetPtHardBinFromName(kTRUE),
   fSelectPtHardBin(-999),
   fMinMCLabel(0),
@@ -573,6 +575,10 @@ void AliAnalysisTaskEmcal::UserCreateOutputObjects()
 
 Bool_t AliAnalysisTaskEmcal::FillGeneralHistograms()
 {
+  double weight = 1.;
+  if(fIsWeighted) {
+    weight = GetEventWeightFromHeader();
+  }
   if (fIsPythia || fIsHerwig || fIsHepMC) {
     // Protection: In case the pt-hard bin handling is not initialized we fall back to the
     // global pt-hard bin (usually 0) in order to aviod mismatch between histograms before
@@ -580,20 +586,20 @@ Bool_t AliAnalysisTaskEmcal::FillGeneralHistograms()
     fHistEventsAfterSel->Fill(fPtHardInitialized ? fPtHardBinGlobal : fPtHardBin, 1);
     fHistTrialsAfterSel->Fill(fPtHardInitialized ? fPtHardBinGlobal : fPtHardBin, fNTrials);
     fHistXsectionAfterSel->Fill(fPtHardInitialized ? fPtHardBinGlobal : fPtHardBin, fXsection);
-    fHistPtHard->Fill(fPtHard);
+    fHistPtHard->Fill(fPtHard, weight);
     if(fPtHardInitialized){
-    	fHistPtHardCorr->Fill(fPtHardBin, fPtHard);
-    	fHistPtHardCorrGlobal->Fill(fPtHardBinGlobal, fPtHard);
-    	fHistPtHardBinCorr->Fill(fPtHardBin, fPtHardBinGlobal);
+    	fHistPtHardCorr->Fill(fPtHardBin, fPtHard, weight);
+    	fHistPtHardCorrGlobal->Fill(fPtHardBinGlobal, fPtHard, weight);
+    	fHistPtHardBinCorr->Fill(fPtHardBin, fPtHardBinGlobal, weight);
     }
   }
 
 
-  fHistZVertex->Fill(fVertex[2]);
+  fHistZVertex->Fill(fVertex[2], weight);
 
   if (fForceBeamType != kpp) {
-    fHistCentrality->Fill(fCent);
-    fHistEventPlane->Fill(fEPV0);
+    fHistCentrality->Fill(fCent, weight);
+    fHistEventPlane->Fill(fEPV0, weight);
   }
 
   std::unique_ptr<TObjArray> triggerClasses(InputEvent()->GetFiredTriggerClasses().Tokenize(" "));
@@ -2101,10 +2107,11 @@ void AliAnalysisTaskEmcal::SetMCProductionType(MCProductionType_t prodtype) {
     case MCProductionType_t::kMCHerwig6: SetIsHerwig(true); break;
     case MCProductionType_t::kMCHepMCMB: SetIsHepMC(true); break;
     case MCProductionType_t::kMCHepMCPtHard: SetIsHepMC(true); break;
+    case MCProductionType_t::kMCPythiaWeighted: SetIsPythia(true); SetIsWeighted(true); break;
     case MCProductionType_t::kNoMC: break;
   };
   // In case of min. bias production reduce to 1 pt-hard bin
-  if(prodtype == MCProductionType_t::kMCPythiaMB || prodtype == MCProductionType_t::kMCHepMCMB) {
+  if(prodtype == MCProductionType_t::kMCPythiaMB || prodtype == MCProductionType_t::kMCHepMCMB || prodtype == MCProductionType_t::kMCPythiaWeighted) {
     SetNumberOfPtHardBins(1);
     TArrayI mbbinning(2);
     mbbinning[0] = 0;
@@ -2170,6 +2177,9 @@ AliAnalysisTaskEmcal::MCProductionType_t AliAnalysisTaskEmcal::ConfigureMCDatase
     "lhc18h1"                                                                                                                     // MB pp 13 TeV, 2018, low-B
 
   };
+  std::vector<std::string> datasetsPythiaWeighted = {
+    "lhc21j5"
+  };
 
   bool foundDataset = false;
   for(auto dset : datasetsPthard20Pythia) {
@@ -2229,6 +2239,16 @@ AliAnalysisTaskEmcal::MCProductionType_t AliAnalysisTaskEmcal::ConfigureMCDatase
     for(auto dset : datasetsMBPythia){
       if(namedataset.Contains(dset)) {
         prodtype = MCProductionType_t::kMCPythiaMB;
+        foundDataset = true;
+        break;
+      }
+    }
+  }
+
+  if(!foundDataset) {
+    for(auto dset : datasetsPythiaWeighted){
+      if(namedataset.Contains(dset)) {
+        prodtype = MCProductionType_t::kMCPythiaWeighted;
         foundDataset = true;
         break;
       }

--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.h
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.h
@@ -304,6 +304,7 @@ class AliAnalysisTaskEmcal : public AliAnalysisTaskSE {
     kMCHerwig6,
     kMCHepMCPtHard,
     kMCHepMCMB,
+    kMCPythiaWeighted,
     kNoMC
   };
 
@@ -482,6 +483,18 @@ class AliAnalysisTaskEmcal : public AliAnalysisTaskSE {
    * @param i If true the production is handled as a pt-hard production
    */
   void                        SetIsHepMC(Bool_t i)                                 { fIsHepMC          = i                              ; }
+
+  /**
+   * @brief Define production as event-weighted production
+   * 
+   * Production is event weighted. In this case the pt-hard spectrum is biased
+   * as events with a high-pt hard are simulated with a higher probability than
+   * expected. In order to get the physical spectrum shape the histograms have
+   * to be filled with the event weight from the event header as weight.
+   * 
+   * @param isWeighted If true the production is an event-weighed production
+   */
+  void                        SetIsWeighted(Bool_t isWeighted)                     { fIsWeighted       = isWeighted                     ; }             
 
   /**
    * @brief Set type of the MC production
@@ -677,6 +690,12 @@ class AliAnalysisTaskEmcal : public AliAnalysisTaskSE {
    * @return Event weight (-1 if not a PPYTHIA- or HepMC-based production) 
    */
   double                      GetEventWeightFromHeader()                      const;
+
+  /**
+   * @brief Check whether the task was configured for running on an event-weighed sample
+   * @return true if the sample is event weighted, false otherwise 
+   */
+  bool                        IsWeighted()                                    const { return fIsWeighted; }
 
   /**
    * @brief Switch on pt-hard bin scaling
@@ -1362,6 +1381,7 @@ class AliAnalysisTaskEmcal : public AliAnalysisTaskSE {
   Bool_t                      fIsPythia;                   ///< trigger, if it is a PYTHIA production
   Bool_t                      fIsHerwig;                   ///< trigger, if it is a HERWIG production
   Bool_t                      fIsHepMC;                    ///< trigger, if it is a HepMC-based production
+  Bool_t                      fIsWeighted;                 ///< Weighted production, event weight in histograms
   Bool_t                      fGetPtHardBinFromName;       ///< Obtain pt-hard bin from file path
   Int_t                       fSelectPtHardBin;            ///< select one pt hard bin for analysis
   Int_t                       fMinMCLabel;                 ///< minimum MC label value for the tracks/clusters being considered MC particles


### PR DESCRIPTION
- Add field, setter and tester for weighted prod
- Include type weighed prod in ConfigureMCDataset
- Fill general histograms with weight (1 default, event
   weight in case the production is configured as weighted
   pythia