### PR TITLE
AliAnalysisTaskJetExtractor: include calibrated event-plane angle

### DIFF
--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskJetExtractor.cxx
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskJetExtractor.cxx
@@ -547,7 +547,10 @@ AliAnalysisTaskJetExtractor::AliAnalysisTaskJetExtractor() :
   fDoDetLevelMatching(kFALSE),
   fDoPartLevelMatching(kFALSE),
   fSimpleSecVertices(),
-  fqnVectorReader(0)
+  fqnVectorReader(0),
+  fQ2VectorValue(0.),
+  fEPangleV0(0.)
+
 {
   fRandomGenerator = new TRandom3();
   fRandomGeneratorCones = new TRandom3();
@@ -597,7 +600,9 @@ AliAnalysisTaskJetExtractor::AliAnalysisTaskJetExtractor(const char *name) :
   fDoDetLevelMatching(kFALSE),
   fDoPartLevelMatching(kFALSE),
   fSimpleSecVertices(),
-  fqnVectorReader(0)
+  fqnVectorReader(0),
+  fQ2VectorValue(0.),
+  fEPangleV0(0.)
 {
   fRandomGenerator = new TRandom3();
   fRandomGeneratorCones = new TRandom3();
@@ -919,11 +924,14 @@ Bool_t AliAnalysisTaskJetExtractor::Run()
       fJetTree->FillBuffer_Splittings(splittings_radiatorE, splittings_kT, splittings_theta, fSaveSecondaryVertices, splittings_secVtx_rank, splittings_secVtx_index);
     }
 
-    Float_t Q2VectorValue = 0;
-    if (fSaveQVector) Q2VectorValue = fqnVectorReader->Getq2V0();      
+    if (fSaveQVector) {
+       fQ2VectorValue = fqnVectorReader->Getq2V0();      
+       fEPangleV0 = fqnVectorReader->GetEPangleCF();    //include calibrated V0 Event Plane
+       }
+    if (!fSaveQVector)   fEPangleV0 = fEPV0;           //use uncalibrated V0 Event Plane
 
     // Fill jet to tree (here adding the minimum properties)
-    Bool_t accepted = fJetTree->AddJetToTree(jet, fSaveConstituents, fSaveConstituentsIP, fSaveCaloClusters, Q2VectorValue, vtx, GetJetContainer(0)->GetRhoVal(), GetJetContainer(0)->GetRhoMassVal(), fCent, fMultiplicity, eventID, InputEvent()->GetMagneticField(), fEPV0);
+    Bool_t accepted = fJetTree->AddJetToTree(jet, fSaveConstituents, fSaveConstituentsIP, fSaveCaloClusters, fQ2VectorValue, vtx, GetJetContainer(0)->GetRhoVal(), GetJetContainer(0)->GetRhoMassVal(), fCent, fMultiplicity, eventID, InputEvent()->GetMagneticField(), fEPangleV0);
     if(accepted)
       FillHistogram("hJetPtExtracted", jet->Pt() - GetJetContainer(0)->GetRhoVal()*jet->Area(), fCent);
     jetCount++;

--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskJetExtractor.h
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskJetExtractor.h
@@ -154,6 +154,8 @@ class AliAnalysisTaskJetExtractor : public AliAnalysisTaskEmcalJet {
   std::vector<SimpleSecondaryVertex> fSimpleSecVertices;  ///< Vector of secondary vertices
 
   AliAnalysisTaskJetQnVectors* fqnVectorReader;                         ///< Reader for the Qn vector
+  Double_t                     fQ2VectorValue;                          ///< Calibrated q2 value from V0
+  Double_t                     fEPangleV0;                              ///< Calibrated event-plane angle from V0
 
   // ################## HELPER FUNCTIONS
   Double_t                    GetDistance(Double_t eta1, Double_t eta2, Double_t phi1, Double_t phi2)
@@ -174,7 +176,7 @@ class AliAnalysisTaskJetExtractor : public AliAnalysisTaskEmcalJet {
   AliAnalysisTaskJetExtractor &operator=(const AliAnalysisTaskJetExtractor&); // not implemented
 
   /// \cond CLASSIMP
-  ClassDef(AliAnalysisTaskJetExtractor, 11) // Jet extraction task
+  ClassDef(AliAnalysisTaskJetExtractor, 12) // Jet extraction task
   /// \endcond
 };
 

--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskJetQnVectors.cxx
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskJetQnVectors.cxx
@@ -50,7 +50,8 @@ AliAnalysisTaskJetQnVectors::AliAnalysisTaskJetQnVectors() :
     fPrevEventRun(-1),
     fTriggerClass(""),
     fTriggerMask(AliVEvent::kAny),
-    fq2V0(0)
+    fq2V0(0),
+    fEPangleCF(0)
 {
     //
     // default constructor
@@ -85,7 +86,8 @@ AliAnalysisTaskJetQnVectors::AliAnalysisTaskJetQnVectors(const char *name, int h
     fPrevEventRun(-1),
     fTriggerClass(""),
     fTriggerMask(AliVEvent::kAny),
-    fq2V0(0)
+    fq2V0(0),
+    fEPangleCF(0)
 {
     //
     // standard constructor
@@ -267,6 +269,7 @@ void AliAnalysisTaskJetQnVectors::UserExec(Option_t */*option*/)
     double PsinFullV0 = -1., PsinV0A = -1., PsinV0C = -1.;
     fHFQnVecHandler->GetEventPlaneAngleTPC(PsinFullTPC,PsinPosTPC,PsinNegTPC);
     fHFQnVecHandler->GetEventPlaneAngleV0(PsinFullV0,PsinV0A,PsinV0C);
+    fEPangleCF = PsinFullV0;
 
     fHistEventPlaneTPC[0]->Fill(PsinFullTPC);
     fHistEventPlaneTPC[1]->Fill(PsinPosTPC);

--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskJetQnVectors.h
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskJetQnVectors.h
@@ -8,16 +8,10 @@
 
 //*************************************************************************************************
 // \class AliAnalysisTaskJetQnVectors
-// \brief task used to load the Qn calibrations and get the calibrated Qn vectors for HF analyses
+// \brief task used to load the Qn calibrations and get the calibrated Qn vectors for JE analyses
 // \authors:
-// F. Grosa, fabrizio.grosa@cern.ch
-// F. Catalano, fabio.catalano@cern.ch
-// A. Dobrin, alexandru.dobrin@cern.ch
-// A. Festanti, andrea.festanti@cern.ch
-// G. Luparello, grazia.luparello@cern.ch
-// F. Prino, prino@to.infn.it
-// A. Rossi, andrea.rossi@cern.ch
-// S. Trogolo, stefano.trogolo@cern.ch
+// C. Beattie, caitlin.beattie@cern.ch
+// M. Sas,     mike.sas@cern.ch
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 #include <TH1F.h>
@@ -56,6 +50,7 @@ public:
     void EnableQVecTPCVsCentrDistrHistosVsRun()                                                          {fEnableQvecTPCVsCentrDistr=true;}
 
     double Getq2V0()                                                                                     {return fq2V0;}
+    double GetEPangleCF()                                                                                {return fEPangleCF;}
 
 private:
 
@@ -93,8 +88,9 @@ private:
     unsigned long long fTriggerMask;                 /// trigger mask
 
     double fq2V0;                                    /// q2 vector from the V0     
+    double fEPangleCF;                               /// EP Angle with callibrations from V0
 
-    ClassDef(AliAnalysisTaskJetQnVectors, 4);
+    ClassDef(AliAnalysisTaskJetQnVectors, 5);
 };
 
 #endif


### PR DESCRIPTION
Updated the JetExtractor task to include an option for using a fully calibrated event-plane angle.