### PR TITLE
PWGHF: Fix PID option MLVarHandler

### DIFF
--- a/PWGHF/vertexingHF/vHFML/AliHFMLVarHandler.cxx
+++ b/PWGHF/vertexingHF/vHFML/AliHFMLVarHandler.cxx
@@ -155,7 +155,7 @@ void AliHFMLVarHandler::AddPidBranches(bool usePionHypo, bool useKaonHypo, bool 
     TString detName[knMaxDet4Pid] = {"TPC", "TOF"};
     TString rawPidName[knMaxDet4Pid] = {"dEdxTPC", "ToF"};
 
-    if(fPidOpt == kBayesPID || fPidOpt == kBayesAndNsigmaCombPID || kBayesAndNsigmaDetAndNsigmaCombPID) {
+    if(fPidOpt == kBayesPID || fPidOpt == kBayesAndNsigmaCombPID || fPidOpt == kBayesAndNsigmaDetAndNsigmaCombPID) {
         //initialise AliPIDCombined object for Bayesian PID
         if(!fPIDCombined)
             fPIDCombined = new AliPIDCombined();
@@ -200,7 +200,7 @@ void AliHFMLVarHandler::AddPidBranches(bool usePionHypo, bool useKaonHypo, bool 
                 fTreeVar->Branch(Form("start_time_res_prong%d", iProng), &fStartTimeResProng[iProng]);
             }
         }
-        if(fPidOpt == kBayesPID || fPidOpt == kBayesAndNsigmaCombPID || kBayesAndNsigmaDetAndNsigmaCombPID) {
+        if(fPidOpt == kBayesPID || fPidOpt == kBayesAndNsigmaCombPID || fPidOpt == kBayesAndNsigmaDetAndNsigmaCombPID) {
             for(unsigned int iPartHypo = 0; iPartHypo < knMaxHypo4Pid; iPartHypo++) {
                 if(!useHypo[iPartHypo]) 
                     continue;
@@ -273,7 +273,7 @@ bool AliHFMLVarHandler::SetPidVars(AliAODTrack* prongtracks[], AliAODPidHF* pidh
                         pidhf->GetnSigmaTOF(prongtracks[iProng], parthypo[iPartHypo], nSigmaTOF);
                         sig[iProng][kTOF][iPartHypo] = nSigmaTOF;
                     }
-                    if((fPidOpt == kNsigmaCombPID || fPidOpt == kNsigmaDetAndCombPID || fPidOpt == kBayesAndNsigmaCombPID || kBayesAndNsigmaDetAndNsigmaCombPID) && useTPC && useTOF) {
+                    if((fPidOpt == kNsigmaCombPID || fPidOpt == kNsigmaDetAndCombPID || fPidOpt == kBayesAndNsigmaCombPID || fPidOpt == kBayesAndNsigmaDetAndNsigmaCombPID) && useTPC && useTOF) {
                         sigComb[iProng][iPartHypo] = AliVertexingHFUtils::CombineNsigmaTPCTOF(sig[iProng][kTPC][iPartHypo], 
                                                                                               sig[iProng][kTOF][iPartHypo]);
                     }
@@ -300,7 +300,7 @@ bool AliHFMLVarHandler::SetPidVars(AliAODTrack* prongtracks[], AliAODPidHF* pidh
                 }
             }
         }
-        if(fPidOpt == kBayesPID || fPidOpt == kBayesAndNsigmaCombPID || kBayesAndNsigmaDetAndNsigmaCombPID) {
+        if(fPidOpt == kBayesPID || fPidOpt == kBayesAndNsigmaCombPID || fPidOpt == kBayesAndNsigmaDetAndNsigmaCombPID) {
             double probTPCTOF[AliPID::kSPECIES] = {-1.};
             AliPIDResponse* pidrespo = pidhf->GetPidResponse(); //FIXME: TPC postcalibrations for Pb-Pb not implemented in AliPIDResponse
             unsigned int detUsed = fPIDCombined->ComputeProbabilities(prongtracks[iProng], pidrespo, probTPCTOF);


### PR DESCRIPTION
The Bayes probability was always present in the TTree because of a "typo"