### PR TITLE
PWGHF: Update Dstar invmass range THnSparse

### DIFF
--- a/PWGHF/vertexingHF/vHFML/AliAnalysisTaskSEDmesonTree.cxx
+++ b/PWGHF/vertexingHF/vHFML/AliAnalysisTaskSEDmesonTree.cxx
@@ -1092,7 +1092,7 @@ void AliAnalysisTaskSEDmesonTree::CreateRecoSparses()
             break;
         case kDstartoD0pi:
             massMin = 0.138;
-            massMax = 0.160;
+            massMax = 0.188;
             massTitle = "#it{M}(K#pi#pi) #minus #it{M}(K#pi) (GeV/#it{c})";
             break;
     }


### PR DESCRIPTION
Increased upper limit of Dstar invariant mass in THnSparse to have more room for the multitrial fitter (+ now the bin width is 0.1 MeV/c^2 instead of 0.044)