### PR TITLE
[ALIROOT-8678] Add histogram for sum of weights before event selection

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.cxx
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.cxx
@@ -452,6 +452,11 @@ void AliAnalysisTaskEmcal::UserCreateOutputObjects()
     fHistXsection->GetYaxis()->SetTitle("xsection");
     fOutput->Add(fHistXsection);
 
+    fHistWeights = new TH1F("fHistWeights", "fHistWeights", fNPtHardBins, 0, fNPtHardBins);
+    fHistWeights->GetXaxis()->SetTitle("p_{T} hard bin");
+    fHistWeightsAfterSel->GetYaxis()->SetTitle("integrated weights");
+    fOutput->Add(fHistWeights);
+
     // Set the bin labels
     Bool_t binningAvailable = false;
     if(fPtHardBinning.GetSize() > 0) {
@@ -476,10 +481,12 @@ void AliAnalysisTaskEmcal::UserCreateOutputObjects()
         fHistTrialsAfterSel->GetXaxis()->SetBinLabel(i+1, Form("%d-%d",fPtHardBinning[i],fPtHardBinning[i+1]));
         fHistEventsAfterSel->GetXaxis()->SetBinLabel(i+1, Form("%d-%d",fPtHardBinning[i],fPtHardBinning[i+1]));
         fHistXsectionAfterSel->GetXaxis()->SetBinLabel(i+1, Form("%d-%d",fPtHardBinning[i],fPtHardBinning[i+1]));
+        fHistWeightsAfterSel->GetXaxis()->SetBinLabel(i+1, Form("%d-%d",fPtHardBinning[i],fPtHardBinning[i+1]));
 
         fHistTrials->GetXaxis()->SetBinLabel(i+1, Form("%d-%d",fPtHardBinning[i],fPtHardBinning[i+1]));
         fHistXsection->GetXaxis()->SetBinLabel(i+1, Form("%d-%d",fPtHardBinning[i],fPtHardBinning[i+1]));
         fHistEvents->GetXaxis()->SetBinLabel(i+1, Form("%d-%d",fPtHardBinning[i],fPtHardBinning[i+1]));
+        fHistWeights->GetXaxis()->SetBinLabel(i+1, Form("%d-%d",fPtHardBinning[i],fPtHardBinning[i+1]));
       }
     } else {
       AliErrorStream() << "No suitable binning available - skipping bin labels" << std::endl;
@@ -668,6 +675,10 @@ void AliAnalysisTaskEmcal::UserExec(Option_t *option)
   // as event counting for the cross section normalization
   // depends on it.
   if(fPtHard < fMinPtHard || fPtHard > fMaxPtHard) return;
+
+  // Fill weights before event selection
+  auto weight = GetEventWeightFromHeader();
+  fHistWeights->Fill(fPtHardInitialized ? fPtHardBinGlobal : fPtHardBin, weight);
 
   // Apply fallback for pythia cross section if needed
   if(fIsPythia && fUseXsecFromHeader && fPythiaHeader){

--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.h
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.h
@@ -1450,6 +1450,7 @@ class AliAnalysisTaskEmcal : public AliAnalysisTaskSE {
   TH1                        *fHistTrials;                 //!<!trials from pyxsec.root
   TH1                        *fHistEvents;                 //!<!total number of events per pt hard bin
   TProfile                   *fHistXsection;               //!<!x section from pyxsec.root
+  TH1                        *fHistWeights;                //!<! integrated weights per pt hard bin before selection
   TH1                        *fHistPtHard;                 //!<!\f$ p_{t}\f$-hard distribution
   TH2                        *fHistPtHardCorr;             //!<!Correlation between \f$ p_{t}\f$-hard value and bin
   TH2                        *fHistPtHardCorrGlobal;       //!<!Correlation between \f$ p_{t}\f$-hard value and global bin

--- a/PWG/EMCAL/EMCALbase/AliEmcalList.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEmcalList.cxx
@@ -118,7 +118,7 @@ void AliEmcalList::ScaleAllHistograms(TCollection *hlist, Double_t scalingFactor
     // Don't scale profiles and histograms used for scaling
     TString histogram_class (listObject->ClassName());
     TString histogram_name (listObject->GetName());
-    if ((histogram_name.Contains("fHistXsection") || histogram_name.Contains("fHistTrials") || histogram_name.Contains("fHistEvents")) && (!histogram_name.Contains("PtHard")))
+    if ((histogram_name.Contains("fHistXsection") || histogram_name.Contains("fHistTrials") || histogram_name.Contains("fHistEvents") || histogram_name.Contains("fHistWeights")) && (!histogram_name.Contains("PtHard")))
     {
       AliInfoStream() << "Histogram " << listObject->GetName() << " will not be scaled, because a scaling histogram" << std::endl;
       continue;


### PR DESCRIPTION
Needed in case of EMCAL trigger selection being part of the
event selection

In addition exclude histograms with sum of weights from the
automatic scaling.