### PR TITLE
An additional (temporary) function to reverse position of one particle in the pair

### DIFF
--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoSimpleAnalysis.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoSimpleAnalysis.cxx
@@ -183,7 +183,8 @@ AliFemtoSimpleAnalysis::AliFemtoSimpleAnalysis():
   fMinSizePartCollection(0),
   fVerbose(kTRUE),
   fPerformSharedDaughterCut(kFALSE),
-  fEnablePairMonitors(kFALSE)
+  fEnablePairMonitors(kFALSE),
+  freverseParticleVariables(kFALSE)
 {
   // Default constructor
   fCorrFctnCollection = new AliFemtoCorrFctnCollection;
@@ -205,7 +206,8 @@ AliFemtoSimpleAnalysis::AliFemtoSimpleAnalysis(const AliFemtoSimpleAnalysis& a):
   fMinSizePartCollection(a.fMinSizePartCollection),
   fVerbose(a.fVerbose),
   fPerformSharedDaughterCut(a.fPerformSharedDaughterCut),
-  fEnablePairMonitors(a.fEnablePairMonitors)
+  fEnablePairMonitors(a.fEnablePairMonitors),
+  freverseParticleVariables(a.freverseParticleVariables)
 {
   /// Copy constructor
 
@@ -402,7 +404,7 @@ AliFemtoSimpleAnalysis& AliFemtoSimpleAnalysis::operator=(const AliFemtoSimpleAn
   fVerbose = aAna.fVerbose;
   fPerformSharedDaughterCut = aAna.fPerformSharedDaughterCut;
   fEnablePairMonitors = aAna.fEnablePairMonitors;
-
+  freverseParticleVariables = aAna.freverseParticleVariables;
   return *this;
 }
 //______________________
@@ -648,6 +650,19 @@ void AliFemtoSimpleAnalysis::MakePairs(const char* typeIn,
       if (partCollection2 != nullptr) {
         tPair->SetTrack2(*tPartIter2);
 
+	if(freverseParticleVariables){
+	    //This works only if you set the variable on true (default=false). Temporary function. see the comment in .h file
+            AliFemtoParticle *fTrack2=(AliFemtoParticle*)*tPartIter2;
+	    AliFemtoLorentzVector p2 = (AliFemtoLorentzVector) fTrack2->FourMomentum();
+            p2.SetX(-1.0*p2.x());
+            p2.SetY(-1.0*p2.y());
+            p2.SetZ(-1.0*p2.z());
+            fTrack2->ResetFourMomentum(p2);
+            tPair->SetTrack2(fTrack2);
+	}
+
+
+
       // Swap between first and second particles to avoid biased ordering
       } else {
         tPair->SetTrack1(swpart ? *tPartIter2 : *tPartIter1);
@@ -846,3 +861,4 @@ TList* AliFemtoSimpleAnalysis::GetOutputList()
 
   return tOutputList;
 }
+

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoSimpleAnalysis.h
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoSimpleAnalysis.h
@@ -142,6 +142,8 @@ public:
 
   /// Calls Finish method on all correlation functions
   virtual void Finish();
+  
+  void SetReverseParticleVariables(bool value);
 
 protected:
 
@@ -177,6 +179,8 @@ protected:
   Bool_t fVerbose;
   Bool_t fPerformSharedDaughterCut;
   Bool_t fEnablePairMonitors;
+  
+  Bool_t freverseParticleVariables;                  ////set true if you want reverse z,y,z. This additional variable is just for some trains. After that it will be deleted. By default is false so, nothing change in other analyis, Wioleta Rzęsa wrzesa@cern.ch
 
 #ifdef __ROOT__
   /// \cond CLASSIMP
@@ -305,4 +309,9 @@ inline void AliFemtoSimpleAnalysis::SetEnablePairMonitors(Bool_t aEnable)
   fEnablePairMonitors = aEnable;
 }
 
+inline void AliFemtoSimpleAnalysis::SetReverseParticleVariables(Bool_t value)
+{
+  freverseParticleVariables=value;
+}
 #endif
+


### PR DESCRIPTION
Temporary because I will delete this change as soon as I calculate some trains with this function.
By default is not active (variable that switch it on is false)
The function changes variables that describe x, y and z of the track. I need it to calculate some special background for my analysis.