### PR TITLE
PWG/EMCAL: Added control histogram to cell track matcher

### DIFF
--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellTrackMatcherAndMIPSubtraction.h
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellTrackMatcherAndMIPSubtraction.h
@@ -43,6 +43,8 @@ protected:
   Double_t               fEmipMC;              ///< Energy of MIP used to subtract from cell, in case of MC
 
   Bool_t                 fDoPropagation;      ///< Bool to switch propagation on/off
+  Bool_t                 fDoMatchPrimaryOnly; ///< Bool to switch if secndaries/conversions (r>fMaxDistToVtxPrim cm) will be matched
+  Double_t               fMaxDistToVtxPrim;   ///< Maximum DCA in XY direction for a track to be counted as primary
 
   //#if !(defined(__CINT__) || defined(__MAKECINT__))
   // Handle mapping between index and containers
@@ -55,6 +57,7 @@ protected:
   TH2          *fCellNTrackMatch;              //!<!NTrackMatch distribution
   TH1          *fCellTrackMatchEbefore;        //!<!Ebefore distribution
   TH1          *fCellTrackMatchEafter;         //!<!Eafter distribution
+  TH2F         *fHistoMatchingEfficiency;      //!<! histo keeping track if cell was matched correctly or not as function of track momentum
 
  private:
   AliEmcalCorrectionCellTrackMatcherAndMIPSubtraction(const AliEmcalCorrectionCellTrackMatcherAndMIPSubtraction &);               // Not implemented
@@ -64,7 +67,7 @@ protected:
   static RegisterCorrectionComponent<AliEmcalCorrectionCellTrackMatcherAndMIPSubtraction> reg;
 
   /// \cond CLASSIMP
-  ClassDef(AliEmcalCorrectionCellTrackMatcherAndMIPSubtraction, 3); // EMCal cell track matcher
+  ClassDef(AliEmcalCorrectionCellTrackMatcherAndMIPSubtraction, 4); // EMCal cell track matcher
   /// \endcond
 };
 

--- a/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
+++ b/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
@@ -332,6 +332,8 @@ CellTrackMatcherAndMIPSubtraction:                  # Cell energy shift correcti
     EmipData: 0.2356                                # Energy to be subtracted, in case of a match, for cells in data
     EmipMC: 0.2824                                  # Energy to be subtracted, in case of a match, for cells in MC
     DoPropagation: false                            # Whether track propagation should be performed. In case of AODs its not recommended to enable it
+    MatchOnlyPrimaries: false                       # Whether only primary tracks (r < MaxDistToVtxPrimcm) should be matched. Needed as clusters from conversion electrons should be track matched
+    MaxDistToVtxPrim: 5                             # Maximum DCA in XY for which a track is considered primary
     cellsNames:                                     # Names of the cells input objects which should be attached to the correction
         - defaultCells                              # This object is defined above in the cells section of the input objects
     trackContainersNames:                           # Names of the track input objects which should be attached to the correection


### PR DESCRIPTION
- Control histogram to check how many cells are good matches and how
many are fake matches
- Added option to only run cell track matching for primaries (R < 5cm)
such that conversions can still be fully rejected. Electrons should
leave their full energy in the cluster instead of just the MIP