### PR TITLE
Mark PHOS cells as calo type 0

### DIFF
--- a/RUN3/AliAnalysisTaskAO2Dconverter.cxx
+++ b/RUN3/AliAnalysisTaskAO2Dconverter.cxx
@@ -2131,6 +2131,7 @@ void AliAnalysisTaskAO2Dconverter::FillEventInTF()
     calo.fAmplitude = AliMathBase::TruncateFloatFraction(amplitude/mPHOSCalib, 0xFFF); //12 bit
     calo.fTime = AliMathBase::TruncateFloatFraction(time, 0x1FFF);  //13 bit
     calo.fCellType = phoscells->GetHighGain(icp) ? 0. : 1.; 
+    calo.fCaloType = phoscells->GetType();
 
     FillTree(kCalo);
     if (fTreeStatus[kCalo])


### PR DESCRIPTION
PHOS cells were not marked. As EMCAL cells are processed
before PHOS the PHOS cells were assigned calo type 1 which
is the index for EMCAL cells, consequently PHOS cells were
appearing as EMCAL cells.