### PR TITLE
PWGGA/GammaConv: prevent array going out of bounds

### DIFF
--- a/PWGGA/GammaConvBase/AliAODConversionPhoton.cxx
+++ b/PWGGA/GammaConvBase/AliAODConversionPhoton.cxx
@@ -833,7 +833,7 @@ void AliAODConversionPhoton::SetCaloPhotonMCFlagsAOD(TClonesArray *AODMCTrackArr
     }
   }
 
-  if(mergedAnalysis && fNNeutralPionLabels>0 && fLeadingNeutralPionDaughterIndex!=0 && fNeutralPionEnergyFraction[fLeadingNeutralPionIndex]>cluster->GetClusterMCEdepFraction(0)){
+  if(mergedAnalysis && fNNeutralPionLabels>0 && fLeadingNeutralPionDaughterIndex!=0 && fLeadingNeutralPionIndex>=0 && fNeutralPionEnergyFraction[fLeadingNeutralPionIndex]>cluster->GetClusterMCEdepFraction(0)){
     // check if leading pi0 comes not from label 0 in cluster
     // for this do:
     // -> check if neutral pions were found in cluster

--- a/PWGGA/GammaConvBase/AliAODConversionPhoton.h
+++ b/PWGGA/GammaConvBase/AliAODConversionPhoton.h
@@ -92,7 +92,7 @@ class AliAODConversionPhoton : public AliAODConversionParticle, public AliConver
     Int_t GetCaloPhotonMotherMCLabel(Int_t i){return fCaloPhotonMotherMCLabels[i];}
     Int_t GetNNeutralPionMCLabels(){return fNNeutralPionLabels;}
     Int_t GetNeutralPionMCLabel(Int_t i){return fNeutralPionLabels[i];}
-    Float_t GetNeutralPionEnergyFraction(Int_t i){return fNeutralPionEnergyFraction[i];}
+    Float_t GetNeutralPionEnergyFraction(Int_t i){if(i >= 0)return fNeutralPionEnergyFraction[i]; else return 0;}
     Float_t GetLeadingNeutralPionIndex(){return fLeadingNeutralPionIndex;}
     Int_t GetLeadingNeutralPionDaughterIndex(){return fLeadingNeutralPionDaughterIndex;}
 


### PR DESCRIPTION
- Prevent fNeutralPionEnergyFraction to be called for index -1 which
causes a seg. fault

- This case seems to be very rare and only occured in 1 event in the
test