### PR TITLE
Switch on pileup cuts in AliTriggerAnalysis

### DIFF
--- a/RUN3/AliAnalysisTaskAO2Dconverter.cxx
+++ b/RUN3/AliAnalysisTaskAO2Dconverter.cxx
@@ -274,6 +274,7 @@ void AliAnalysisTaskAO2Dconverter::NotifyRun(){
   if (!triggerContainer) AliFatal("Cannot fetch OADB container for trigger analysis");
   AliOADBTriggerAnalysis* oadbTriggerAnalysis = (AliOADBTriggerAnalysis*) triggerContainer->GetObject(fCurrentRunNumber, "Default");
   fTriggerAnalysis.SetParameters(oadbTriggerAnalysis);
+  fTriggerAnalysis.ApplyPileupCuts(kTRUE);
   //read PHOS trigger bad map
   if (fUsePHOSBadMap){
     AliOADBContainer phosBadmapContainer(Form("phosTriggerBadMap"));


### PR DESCRIPTION
kIsPileupFromSPD and kIsV0PFPileup bits were always set to 0 in run2bcinfo.fEventCuts. Need to switch on pileup cuts in AliTriggerAnalysis
