### PR TITLE
Consistent use of pt-hard bin ID accross scaling histograms

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.cxx
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.cxx
@@ -701,8 +701,8 @@ void AliAnalysisTaskEmcal::UserExec(Option_t *option)
     }
     */
     fHistXsection->Fill(fPtHardBinGlobal, fPythiaHeader->GetXsection());
-    fHistTrials->Fill(fPtHardBin);
-    fHistEvents->Fill(fPtHardBin);
+    fHistTrials->Fill(fPtHardBinGlobal);
+    fHistEvents->Fill(fPtHardBinGlobal);
   }
 
   if(fIsHepMC && fHepMCHeader) {


### PR DESCRIPTION
Particularly important for MC-gen train to put weights in bin0.