### PR TITLE
Further fixes for mass hypothesis for reclustering

### DIFF
--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskJetDynamicalGrooming.cxx
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskJetDynamicalGrooming.cxx
@@ -1196,7 +1196,7 @@ void AliAnalysisTaskJetDynamicalGrooming::IterativeParents(AliEmcalJet* jet,
     //  - Det level: Use charged pion mass hypothesis. Called with isDetLevelInEmbedding == true, so uses pion mass
     //  - Part level: Use true mass in AliVParticle. Called with isData == false, so will use true mass
     double E = part->E();
-    if (isDetLevelInEmbedding || (isData && fJetShapeSub != kConstSub)) {
+    if (isDetLevelInEmbedding || (isData && fJetShapeSub != kConstSub && fJetShapeSub != kEventSub)) {
       //std::cout << "using charged pion mass hypothesis. " << std::boolalpha << "isData=" << isData << ", isDetLevelInEmbedding=" << isDetLevelInEmbedding << "\n";
       E = std::sqrt(std::pow(part->P(), 2) + std::pow(0.139, 2));
     }

--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskJetHardestKt.cxx
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskJetHardestKt.cxx
@@ -1064,7 +1064,7 @@ std::shared_ptr<SelectedSubjets> AliAnalysisTaskJetHardestKt::IterativeParents(A
     //  - Det level: Use charged pion mass hypothesis. Called with isDetLevelInEmbedding == true, so uses pion mass
     //  - Part level: Use true mass in AliVParticle. Called with isData == false, so will use true mass
     double E = part->E();
-    if (isDetLevelInEmbedding || (isData && fJetShapeSub != kConstSub)) {
+    if (isDetLevelInEmbedding || (isData && fJetShapeSub != kConstSub && fJetShapeSub != kEventSub)) {
       //std::cout << "using charged pion mass hypothesis. " << std::boolalpha << "isData=" << isData << ", isDetLevelInEmbedding=" << isDetLevelInEmbedding << "\n";
       E = std::sqrt(std::pow(part->P(), 2) + std::pow(0.139, 2));
     }


### PR DESCRIPTION
Need to skip the pion mass hypothesis for both jet-wise and event-wise
CS, but was missing the check for the event-wise case