### PR TITLE
Add option to cut separately on charged and neutral particle pt

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliMCParticleContainer.cxx
+++ b/PWG/EMCAL/EMCALbase/AliMCParticleContainer.cxx
@@ -39,7 +39,9 @@ ClassImp(AliMCParticleContainer);
 
 AliMCParticleContainer::AliMCParticleContainer():
   AliParticleContainer(),
-  fMCFlag(AliAODMCParticle::kPhysicalPrim)
+  fMCFlag(AliAODMCParticle::kPhysicalPrim),
+  fMinPtCharged(0.),
+  fMinPtNeutral(0.)
 {
   fBaseClassName = "AliAODMCParticle";
   SetClassName("AliAODMCParticle");
@@ -47,7 +49,9 @@ AliMCParticleContainer::AliMCParticleContainer():
 
 AliMCParticleContainer::AliMCParticleContainer(const char *name):
   AliParticleContainer(name),
-  fMCFlag(AliAODMCParticle::kPhysicalPrim)
+  fMCFlag(AliAODMCParticle::kPhysicalPrim),
+  fMinPtCharged(0.),
+  fMinPtNeutral(0.)
 {
   fBaseClassName = "AliAODMCParticle";
   SetClassName("AliAODMCParticle");
@@ -160,6 +164,19 @@ Bool_t AliMCParticleContainer::ApplyMCParticleCuts(const AliAODMCParticle* vp, U
     rejectionReason |= kMCFlag;
     return kFALSE;
   }
+  
+  if(fMinPtCharged > 0.) {
+    if((vp->Charge() != 0) && (TMath::Abs(vp->Pt()) < fMinPtCharged)) {
+    rejectionReason |= kPtCut;
+    return kFALSE;
+    }
+  }
+  if(fMinPtNeutral > 0.) {
+    if((vp->Charge() == 0) && (TMath::Abs(vp->Pt()) < fMinPtNeutral)) {
+    rejectionReason |= kPtCut;
+    return kFALSE;      
+    }
+  }
 
   return ApplyParticleCuts(vp, rejectionReason);
 }
@@ -184,5 +201,11 @@ const char* AliMCParticleContainer::GetTitle() const
 {
   static TString trackString;
   trackString = TString::Format("%s_pT%04d", GetArrayName().Data(), static_cast<int>(GetMinPt()*1000.0));
+  if(fMinPtCharged > 0.) {
+    trackString += TString::Format("_pTCh%04d", static_cast<int>(fMinPtCharged*1000.0));
+  }
+  if(fMinPtNeutral > 0.) {
+    trackString += TString::Format("_pTNe%04d", static_cast<int>(fMinPtNeutral*1000.0));
+  }
   return trackString.Data();
 }

--- a/PWG/EMCAL/EMCALbase/AliMCParticleContainer.h
+++ b/PWG/EMCAL/EMCALbase/AliMCParticleContainer.h
@@ -224,6 +224,18 @@ class AliMCParticleContainer : public AliParticleContainer {
   void                        SetMCFlag(UInt_t m)                             { fMCFlag          = m ; }
 
   /**
+   * @brief Set min. pt cut applied on charged particles
+   * @param minpt Min. pt (in GeV/c)
+   */
+  void                        SetMinPtCharged(Double_t minpt)                 { fMinPtCharged = minpt; }
+
+  /**
+   * @brief Set min. pt cut applied on neutral particles
+   * @param minpt Min. pt (in GeV/c)
+   */
+  void                        SetMinPtNeutral(Double_t minpt)                 { fMinPtNeutral = minpt; }
+
+  /**
    * @brief Require particle to be a physical primary particle
    * @param s If true only physical primary particles are selected 
    */
@@ -274,13 +286,15 @@ class AliMCParticleContainer : public AliParticleContainer {
   virtual TString             GetDefaultArrayName(const AliVEvent * const ev) const { return "mcparticles"; }
 
   UInt_t                      fMCFlag;                        ///< select MC particles with flags
+  Double_t                    fMinPtCharged;                  ///< min. charged particle pt
+  Double_t                    fMinPtNeutral;                  ///< min. neutral particle pt
 
  private:
   AliMCParticleContainer(const AliMCParticleContainer& obj); // copy constructor
   AliMCParticleContainer& operator=(const AliMCParticleContainer& other); // assignment
 
   /// \cond CLASSIMP
-  ClassDef(AliMCParticleContainer,1);
+  ClassDef(AliMCParticleContainer,2);
   /// \endcond
 };
 


### PR DESCRIPTION
Cut implemented in
AliMCParticleContainer as it is relevant
only in case of simulation. The title string is only modified in case a cut
is set, in order to keep backward comp
for existing tasks.