### PR TITLE
Add virtual function for user code to be filled before event selection

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.cxx
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.cxx
@@ -711,6 +711,8 @@ void AliAnalysisTaskEmcal::UserExec(Option_t *option)
     fHistEvents->Fill(fPtHardBinGlobal);
   }
 
+  UserRunBeforeEventSelection();
+
   if (IsEventSelected()) {
     if (fGeneralHistograms) fHistEventCount->Fill("Accepted",1);
   }

--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.h
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.h
@@ -1233,6 +1233,18 @@ class AliAnalysisTaskEmcal : public AliAnalysisTaskSE {
    * @return True if event is selected, false otherwise
    */
   virtual Bool_t              Run()                             { return kTRUE                 ; }
+
+  /**
+   * @brief Run function before event selection 
+   * 
+   * User can implement code i.e. for filling histograms before event selection.
+   * Usually the function is used to fill particle level histograms without bias
+   * from the detector level event selection which is applied before the Run function.
+   * 
+   * No selections are applied in the function, therefore no return type is expected.
+   * Selections must be done in the run function.
+   */
+  virtual void                UserRunBeforeEventSelection()     { }
     
   // Static utilities
   /**


### PR DESCRIPTION
Provide funtion "UserRunBeforeEventSelection" for
user code before event selection. Notably
this is used to fill part. level histograms
without bias from det. level event selection