### PR TITLE
Allows JEQnVectorHandler to work for any harmonic, not just n =2

### DIFF
--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskJetQnVectors.cxx
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskJetQnVectors.cxx
@@ -52,6 +52,9 @@ AliAnalysisTaskJetQnVectors::AliAnalysisTaskJetQnVectors() :
     fq2V0M(0),
     fq2V0A(0),
     fq2V0C(0),
+    fEPangleFullTPC(0),
+    fEPanglePosTPC(0),
+    fEPangleNegTPC(0),
     fEPangleV0M(0),
     fEPangleV0A(0),
     fEPangleV0C(0),
@@ -99,6 +102,9 @@ AliAnalysisTaskJetQnVectors::AliAnalysisTaskJetQnVectors(const char *name, int h
     fq2V0M(0),
     fq2V0A(0),
     fq2V0C(0),
+    fEPangleFullTPC(0),
+    fEPanglePosTPC(0),
+    fEPangleNegTPC(0),
     fEPangleV0M(0),
     fEPangleV0A(0),
     fEPangleV0C(0),
@@ -314,6 +320,11 @@ void AliAnalysisTaskJetQnVectors::UserExec(Option_t */*option*/)
     double PsinFullV0 = -1., PsinV0A = -1., PsinV0C = -1.;
     fJEQnVecHandler->GetEventPlaneAngleTPC(PsinFullTPC,PsinPosTPC,PsinNegTPC);
     fJEQnVecHandler->GetEventPlaneAngleV0(PsinFullV0,PsinV0A,PsinV0C);
+
+    fEPangleFullTPC = PsinFullTPC;
+    fEPanglePosTPC = PsinPosTPC;
+    fEPangleNegTPC = PsinNegTPC;
+
     fEPangleV0M = PsinFullV0;
     fEPangleV0A = PsinV0A;
     fEPangleV0C = PsinV0C;

--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskJetQnVectors.h
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskJetQnVectors.h
@@ -51,6 +51,9 @@ public:
     double Getq2V0M()                                                                                    {return fq2V0M;}
     double Getq2V0A()                                                                                    {return fq2V0A;}
     double Getq2V0C()                                                                                    {return fq2V0C;}
+    double GetEPangleFullTPC()                                                                           {return fEPangleFullTPC;}
+    double GetEPanglePosTPC()                                                                            {return fEPanglePosTPC;}
+    double GetEPangleNegTPC()                                                                            {return fEPangleNegTPC;}
     double GetEPangleV0M()                                                                               {return fEPangleV0M;}
     double GetEPangleV0A()                                                                               {return fEPangleV0A;}
     double GetEPangleV0C()                                                                               {return fEPangleV0C;}
@@ -103,6 +106,9 @@ private:
     double fq2V0M;                                   /// q2 vector from the V0M   
     double fq2V0A;                                   /// q2 vector from the V0A    
     double fq2V0C;                                   /// q2 vector from the V0C     
+    double fEPangleFullTPC;                          /// EP Angle with calibrations from TPC Full
+    double fEPanglePosTPC;                           /// EP Angle with calibrations from TPC eta>0
+    double fEPangleNegTPC;                           /// EP Angle with calibrations from TPC eta<0
     double fEPangleV0M;                              /// EP Angle with calibrations from V0M
     double fEPangleV0C;                              /// EP Angle with calibrations from V0A
     double fEPangleV0A;                              /// EP Angle with calibrations from V0C

--- a/PWGJE/EMCALJetTasks/UserTasks/AliJEQnVectorHandler.h
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliJEQnVectorHandler.h
@@ -96,7 +96,7 @@ class AliJEQnVectorHandler : public TObject
     void ComputeQvecQnFrameworkV0();
     void ComputeQvecTPC();
     void ComputeQvecV0();
-    double ComputeEventPlaneAngle(double Qx, double Qy) const {return (TMath::Pi()+TMath::ATan2(-Qy,-Qx))/2;}  
+    double ComputeEventPlaneAngle(double Qx, double Qy) const {return (TMath::Pi()+TMath::ATan2(-Qy,-Qx))/fHarmonic;}
     
     short GetVertexZbin() const;
     short GetCentBin() const;


### PR DESCRIPTION
Allows JEQnVectorHandler to work for any harmonic, not just n = 2
Adds TPC Full, negative, positive to extractable event planes
Should not change anything for n=2 harmonic