### PR TITLE
Adding in functionality for 2018 EP Calibration

### DIFF
--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHCorrelations.cxx
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHCorrelations.cxx
@@ -5,6 +5,7 @@
 
 #include "AliAnalysisTaskEmcalJetHCorrelations.h"
 
+
 #include <bitset>
 
 #include <TH1F.h>
@@ -53,6 +54,7 @@ AliAnalysisTaskEmcalJetHCorrelations::AliAnalysisTaskEmcalJetHCorrelations() :
   fTriggerType(AliVEvent::kEMCEJE), fMixingEventType(AliVEvent::kMB | AliVEvent::kCentral | AliVEvent::kSemiCentral),
   fDisableFastPartition(kFALSE),
   fRandom(0),
+  fqnVectorReader(0),
   fEfficiencyPeriodIdentifier(AliAnalysisTaskEmcalJetHUtils::kDisableEff),
   fArtificialTrackInefficiency(1.0),
   fNoMixedEventJESCorrection(kFALSE),
@@ -65,6 +67,7 @@ AliAnalysisTaskEmcalJetHCorrelations::AliAnalysisTaskEmcalJetHCorrelations() :
   fHistManager(),
   fHistJetHTrackPtraw(nullptr),
   fHistJetHTrackPt(nullptr),
+  fHistEPAngle(nullptr),
   fHistJetEtaPhi(nullptr),
   fHistJetHEtaPhi(nullptr),
   fhnMixedEvents(nullptr),
@@ -90,6 +93,7 @@ AliAnalysisTaskEmcalJetHCorrelations::AliAnalysisTaskEmcalJetHCorrelations(const
   fTriggerType(AliVEvent::kEMCEJE), fMixingEventType(AliVEvent::kMB | AliVEvent::kCentral | AliVEvent::kSemiCentral),
   fDisableFastPartition(kFALSE),
   fRandom(0),
+  fqnVectorReader(0),
   fEfficiencyPeriodIdentifier(AliAnalysisTaskEmcalJetHUtils::kDisableEff),
   fArtificialTrackInefficiency(1.0),
   fNoMixedEventJESCorrection(kFALSE),
@@ -102,6 +106,7 @@ AliAnalysisTaskEmcalJetHCorrelations::AliAnalysisTaskEmcalJetHCorrelations(const
   fHistManager(name),
   fHistJetHTrackPtraw(nullptr),
   fHistJetHTrackPt(nullptr),
+  fHistEPAngle(nullptr),
   fHistJetEtaPhi(nullptr),
   fHistJetHEtaPhi(nullptr),
   fhnMixedEvents(nullptr),
@@ -217,11 +222,13 @@ void AliAnalysisTaskEmcalJetHCorrelations::UserCreateOutputObjects()
   // Create histograms
   fHistJetHTrackPtraw = new TH1F("fHistJetHTrackPtraw", "P_{T} distribution", 1000, 0.0, 100.0);
   fHistJetHTrackPt = new TH1F("fHistJetHTrackPt", "P_{T} distribution (events w/ jet > 15 GeV)", 1000, 0.0, 100.0);
+  fHistEPAngle = new TH1F("fHistEPAngle", "#Psi_{2} distribution for 2018 calib",100,-TMath::Pi(),3.*TMath::Pi());
   fHistJetEtaPhi = new TH2F("fHistJetEtaPhi","Jet eta-phi",900,-1.8,1.8,720,-3.2,3.2);
   fHistJetHEtaPhi = new TH2F("fHistJetHEtaPhi","Jet-Hadron deta-dphi",900,-1.8,1.8,720,-1.6,4.8);
 
   fOutput->Add(fHistJetHTrackPtraw);
   fOutput->Add(fHistJetHTrackPt);
+  fOutput->Add(fHistEPAngle);
   fOutput->Add(fHistJetEtaPhi);
   fOutput->Add(fHistJetHEtaPhi);
 
@@ -430,6 +437,8 @@ Bool_t AliAnalysisTaskEmcalJetHCorrelations::Run()
   Double_t deltaEta = 0;
   Double_t deltaR = 0;
   Double_t epAngle = 0;
+  // Event plane angle from V0C
+  Double_t EP_angle_from_calib = 0;
   // Event activity (centrality or multipilicity)
   Double_t eventActivity = 0;
   // Efficiency correction
@@ -441,6 +450,12 @@ Bool_t AliAnalysisTaskEmcalJetHCorrelations::Run()
 
   // Determine the trigger for the current event
   UInt_t eventTrigger = RetrieveTriggerMask();
+
+  //new way of getting qnvectors 
+  fqnVectorReader=(AliAnalysisTaskJetQnVectors*)AliAnalysisManager::GetAnalysisManager()->GetTask("AliAnalysisTaskJetQnVectors");
+  if(!fqnVectorReader){printf("Error: No AliAnalysisTaskJetQnVectors");return 0;} // GetQnVectorReader
+  EP_angle_from_calib = fqnVectorReader->GetEPangleV0C();
+  fHistEPAngle->Fill(EP_angle_from_calib);
 
   AliDebugStream(5) << "Beginning main processing. Number of jets: " << jets->GetNJets() << ", accepted jets: " << jets->GetNAcceptedJets() << "\n";
 
@@ -492,7 +507,10 @@ Bool_t AliAnalysisTaskEmcalJetHCorrelations::Run()
     leadJet = kFALSE;
     if (jet == leadingJet) leadJet = kTRUE;
     biasedJet = BiasedJet(jet);
-    epAngle = PWGJE::EMCALJetTasks::AliAnalysisTaskEmcalJetHUtils::RelativeEPAngle(jet->Phi(), fEPV0);
+    
+
+    //new way of getting qnvectors  
+    epAngle = PWGJE::EMCALJetTasks::AliAnalysisTaskEmcalJetHUtils::RelativeEPAngle(jet->Phi(), EP_angle_from_calib);     
 
     // Fill jet properties
     fHistJetEtaPhi->Fill(jet->Eta(), jet->Phi());
@@ -633,7 +651,10 @@ Bool_t AliAnalysisTaskEmcalJetHCorrelations::Run()
           leadJet = kFALSE;
           if (jet == leadingJet) { leadJet = kTRUE; }
           biasedJet = BiasedJet(jet);
-          epAngle = PWGJE::EMCALJetTasks::AliAnalysisTaskEmcalJetHUtils::RelativeEPAngle(jet->Phi(), fEPV0);
+
+        
+          //new way of getting qnvectors 
+          epAngle = PWGJE::EMCALJetTasks::AliAnalysisTaskEmcalJetHUtils::RelativeEPAngle(jet->Phi(), EP_angle_from_calib);
 
           // Make sure event contains a biased jet above our threshold (reduce stats of sparse)
           if (jetPt < 15 || biasedJet == kFALSE) continue;

--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHCorrelations.h
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHCorrelations.h
@@ -190,7 +190,7 @@ class AliAnalysisTaskEmcalJetHCorrelations : public AliAnalysisTaskEmcalJet {
   void                   GetDeltaEtaDeltaPhiDeltaR(AliTLorentzVector & particleOne, AliVParticle * particleTwo, Double_t & deltaEta, Double_t & deltaPhi, Double_t & deltaR);
   Double_t               GetRelativeEPAngle(Double_t jetAngle, Double_t epAngle) const;
   //for new EP angle calibration
-  AliAnalysisTaskJetQnVectors*   fqnVectorReader;  ///< Reader for the Qn vector
+  AliAnalysisTaskJetQnVectors*   fqnVectorReader;  //!<! Reader for the Qn vector
   // Test for biased jet
   Bool_t                 BiasedJet(AliEmcalJet * jet);
   // Corrections

--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHCorrelations.h
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHCorrelations.h
@@ -31,6 +31,7 @@ class AliEventPoolManager;
 #include "THistManager.h"
 #include "AliAnalysisTaskEmcalJet.h"
 #include "AliAnalysisTaskEmcalJetHUtils.h"
+#include "AliAnalysisTaskJetQnVectors.h"
 class AliTLorentzVector;
 class AliEmcalJet;
 class AliJetContainer;
@@ -188,6 +189,8 @@ class AliAnalysisTaskEmcalJetHCorrelations : public AliAnalysisTaskEmcalJet {
   void                   InitializeArraysToZero();
   void                   GetDeltaEtaDeltaPhiDeltaR(AliTLorentzVector & particleOne, AliVParticle * particleTwo, Double_t & deltaEta, Double_t & deltaPhi, Double_t & deltaR);
   Double_t               GetRelativeEPAngle(Double_t jetAngle, Double_t epAngle) const;
+  //for new EP angle calibration
+  AliAnalysisTaskJetQnVectors*   fqnVectorReader;  ///< Reader for the Qn vector
   // Test for biased jet
   Bool_t                 BiasedJet(AliEmcalJet * jet);
   // Corrections
@@ -237,6 +240,7 @@ class AliAnalysisTaskEmcalJetHCorrelations : public AliAnalysisTaskEmcalJet {
   THistManager           fHistManager;             ///<  Histogram manager
   TH1                   *fHistJetHTrackPtraw;      //!<! Track pt spectrum (for all tracks !)
   TH1                   *fHistJetHTrackPt;         //!<! Track pt spectrum  (for jet pT > 15 GeV)
+  TH1                   *fHistEPAngle;             //!<! Spectrum of EP angles measured with 2018 method
   TH2                   *fHistJetEtaPhi;           //!<! Jet eta-phi distribution
   TH2                   *fHistTrackEtaPhi[7];      //!<! Track eta-phi distribution (the array corresponds to track pt)
   TH2                   *fHistJetHEtaPhi;          //!<! Eta-phi distribution of jets which are in jet-hadron correlations


### PR DESCRIPTION


Modified Files:

AliAnalysisTaskEmcalJetHCorrelations.h
AliAnalysisTaskEmcalJetHCorrelations.cxx

Description:

JetHCorrelations - Adding in functionality for code to talk to AliAnalysisTaskJetQnVectors which is the preferred EP calibration for the 2018 data set. Used EP pulled from V0C.
