### PR TITLE
PWG/EMCAL: Added Cell energy and time compression component

### DIFF
--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEnergyCompression.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEnergyCompression.cxx
@@ -1,0 +1,177 @@
+// AliEmcalCorrectionCellEnergyCompression
+//
+
+#include <TGrid.h>
+#include <TFile.h>
+
+#include "AliEmcalCorrectionCellEnergyCompression.h"
+
+/// \cond CLASSIMP
+ClassImp(AliEmcalCorrectionCellEnergyCompression);
+/// \endcond
+
+// Actually registers the class with the base class
+RegisterCorrectionComponent<AliEmcalCorrectionCellEnergyCompression> AliEmcalCorrectionCellEnergyCompression::reg("AliEmcalCorrectionCellEnergyCompression");
+
+/**
+ * Default constructor
+ */
+AliEmcalCorrectionCellEnergyCompression::AliEmcalCorrectionCellEnergyCompression() :
+  AliEmcalCorrectionComponent("AliEmcalCorrectionCellEnergyCompression"),
+  fCellEnergyCompressionLoss(NULL),
+  fCellTimeCompressionLoss(NULL),
+  fDoEnergyCompression(false),
+  fEnergy(0.),
+  fTruncationMaxE(250),
+  fEnergyCompression(0.0153),
+  fCompressionBias(0.),
+  fDoTimeCompression(false),
+  fTime(0.),
+  fTimeCompression(0.1),
+  fTimeShift(0.5)
+{
+}
+
+/**
+ * Destructor
+ */
+AliEmcalCorrectionCellEnergyCompression::~AliEmcalCorrectionCellEnergyCompression()
+{
+}
+
+/**
+ * Initialize and configure the component.
+ */
+Bool_t AliEmcalCorrectionCellEnergyCompression::Initialize()
+{
+  // Initialization
+  AliEmcalCorrectionComponent::Initialize();
+
+  GetProperty("DoEnergyCompression", fDoEnergyCompression);
+  GetProperty("TruncationMaxE", fTruncationMaxE);
+  GetProperty("EnergyCompression", fEnergyCompression);
+  GetProperty("CompressionBias", fCompressionBias);
+
+  GetProperty("DoTimeCompression", fDoTimeCompression);
+  GetProperty("TimeCompression", fTimeCompression);
+  GetProperty("TimeShift", fTimeShift);
+
+  return kTRUE;
+}
+
+/**
+ * Create run-independent objects for output. Called before running over events.
+ */
+void AliEmcalCorrectionCellEnergyCompression::UserCreateOutputObjects()
+{
+  AliEmcalCorrectionComponent::UserCreateOutputObjects();
+
+  // Create my user objects.
+  if (fCreateHisto){
+    fCellEnergyCompressionLoss = new TH1F("CellEnergyCompressionLoss","CellEnergyCompressionLoss;E_{before} - E_{after} (MeV)",400, -20, 20);
+    fOutput->Add(fCellEnergyCompressionLoss);
+    fCellTimeCompressionLoss = new TH1F("CellTimeCompressionLoss","CellTimeCompressionLoss;t_{before} - t_{after} (ns)",400, -20, 20);
+    fOutput->Add(fCellTimeCompressionLoss);
+
+    // Take ownership of output list
+    fOutput->SetOwner(kTRUE);
+  }
+}
+
+/**
+ * Called before the first event to initialize the correction.
+ */
+void AliEmcalCorrectionCellEnergyCompression::ExecOnce()
+{
+}
+
+/**
+ * Called for each event to process the event data.
+ */
+Bool_t AliEmcalCorrectionCellEnergyCompression::Run()
+{
+  AliEmcalCorrectionComponent::Run();
+
+  Short_t  absId  =-1;
+  Double_t ecell = 0;
+  Double_t tcell = 0;
+  Double_t efrac = 0;
+  Int_t  mclabel = -1;
+
+  // Loop over all EMCal cells
+  for (Int_t iCell = 0; iCell < fCaloCells->GetNumberOfCells(); iCell++){
+
+    // Get cell
+    Bool_t getCellResult = fCaloCells->GetCell(iCell, absId, ecell, tcell, mclabel, efrac);
+    if (!getCellResult) {
+      AliWarning(TString::Format("Could not get cell %i from cell collection %s", iCell, fCaloCells->GetName()));
+    }
+
+    // Get high gain attribute in addition to cell
+    // NOTE: GetCellHighGain() uses the cell position, not cell index, and thus should _NOT_ be used!
+    Bool_t cellHighGain = fCaloCells->GetHighGain(iCell);
+
+    if(fDoEnergyCompression){
+      Double_t ecellNoComp = ecell;
+      SetEnergy(ecell);
+      ecell = GetEnergy();
+      if(fCreateHisto){
+        fCellEnergyCompressionLoss->Fill(1000*(ecellNoComp - ecell));
+      }
+    }
+    if(fDoTimeCompression){
+      Double_t tcellNoComp = tcell;
+      SetTime(tcell);
+      tcell = GetTime();
+      if(fCreateHisto){
+        fCellTimeCompressionLoss->Fill(1e9*(tcellNoComp - tcell));
+      }
+    }
+
+    if (ecell > 0.) {
+      fCaloCells->SetCell(iCell, absId, ecell, tcell, mclabel, efrac, cellHighGain);
+    }
+
+  }
+
+  return kTRUE;
+}
+
+/**
+ * Set Energy. For data compression, energy is stored in int16_t (Short_t) (as in O2 DataFormats/EMCAL/...Cell.cxx)
+ */
+void AliEmcalCorrectionCellEnergyCompression::SetEnergy(Double_t e)
+{
+  double truncatedEnergy = e;
+  if (truncatedEnergy < 0.) {
+    truncatedEnergy = 0.;
+  } else if (truncatedEnergy > fTruncationMaxE) {
+    truncatedEnergy = fTruncationMaxE;
+  }
+
+  fEnergy = static_cast<Short_t>((truncatedEnergy / fEnergyCompression) + fCompressionBias);
+}
+
+/**
+ * Get Energy. Reconvert to double
+ */
+Double_t AliEmcalCorrectionCellEnergyCompression::GetEnergy() const
+{
+  return fEnergy * fEnergyCompression;
+}
+
+/**
+ * Set Time. For data compression, energy is stored in int16_t (Short_t) (as in O2 DataFormats/EMCAL/...Cell.cxx)
+ */
+void AliEmcalCorrectionCellEnergyCompression::SetTime(Double_t t)
+{
+  fTime = static_cast<Short_t>((t + fTimeShift) / fTimeCompression);
+}
+
+/**
+* Get Time. Reconvert to double
+*/
+Double_t AliEmcalCorrectionCellEnergyCompression::GetTime() const
+{
+  return fTime * fTimeCompression;
+}

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEnergyCompression.h
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEnergyCompression.h
@@ -1,0 +1,63 @@
+#ifndef ALIEMCALCORRECTIONCELLENERGYCOMPRESSION_H
+#define ALIEMCALCORRECTIONCELLENERGYCOMPRESSION_H
+
+#include "AliEmcalCorrectionComponent.h"
+
+#include "TF1.h"
+
+/**
+ * @class AliEmcalCorrectionCellEnergyCompression
+ * @ingroup EMCALCORRECTIONFW
+ * @brief Cell energy Compression component in the EMCal correction framework.
+ *
+ * This component is to test different compression algorithms as planned to be used in O2.
+ * The cell energy is multiplied with a certain Compression factor (typially 1/0.0153) and is then stored as int16_t (Short_t)
+ * To retrieve the energy the int16_t (Short_t) is devided by the Compression factor
+ * All
+ * @author Joshua Koenig, joshua.konig@cern.ch
+ * @date Apr 25 2022
+ */
+
+class AliEmcalCorrectionCellEnergyCompression : public AliEmcalCorrectionComponent {
+ public:
+  AliEmcalCorrectionCellEnergyCompression();
+  virtual ~AliEmcalCorrectionCellEnergyCompression();
+
+  // Sets up and runs the task
+  Bool_t Initialize();
+  void UserCreateOutputObjects();
+  void ExecOnce();
+  Bool_t Run();
+
+protected:
+  void SetEnergy(Double_t e);
+  Double_t GetEnergy() const;
+  void SetTime(Double_t t);
+  Double_t GetTime() const;
+
+  TH1F                  *fCellEnergyCompressionLoss;            //!<! difference between energy with no compression and with compression
+  TH1F                  *fCellTimeCompressionLoss;              //!<! difference between cell time with no compression and with compression
+
+  Bool_t                 fDoEnergyCompression;                  ///< switch to turn on energy Compression
+  Short_t                fEnergy;                               ///< current energy
+  Double_t               fTruncationMaxE;                       ///< Maximum cell energy
+  Double_t               fEnergyCompression;                    ///< Energy Compression
+  Double_t               fCompressionBias;                      ///< bias added to energy before converting it to int16_t (Short_t)
+  Bool_t                 fDoTimeCompression;                    ///< switch to turn on time Compression
+  Short_t                fTime;                                 ///< current time
+  Double_t               fTimeCompression;                      ///< Time Compression
+  Double_t               fTimeShift;                            ///< Time shift (~600ns for Run2 before time calib)
+
+ private:
+  AliEmcalCorrectionCellEnergyCompression(const AliEmcalCorrectionCellEnergyCompression &);               // Not implemented
+  AliEmcalCorrectionCellEnergyCompression &operator=(const AliEmcalCorrectionCellEnergyCompression &);    // Not implemented
+
+  // Allows the registration of the class so that it is available to be used by the correction task.
+  static RegisterCorrectionComponent<AliEmcalCorrectionCellEnergyCompression> reg;
+
+  /// \cond CLASSIMP
+  ClassDef(AliEmcalCorrectionCellEnergyCompression, 1); // EMCal cell energy variation component
+  /// \endcond
+};
+
+#endif /* ALIEMCALCORRECTIONCELLENERGYCOMPRESSION_H */

--- a/PWG/EMCAL/EMCALtasks/CMakeLists.txt
+++ b/PWG/EMCAL/EMCALtasks/CMakeLists.txt
@@ -72,6 +72,7 @@ set(SRCS
   AliEmcalCorrectionComponent.cxx
   AliEmcalCorrectionCellBadChannel.cxx
   AliEmcalCorrectionCellEnergy.cxx
+  AliEmcalCorrectionCellEnergyCompression.cxx
   AliEmcalCorrectionCellTrackMatcherAndMIPSubtraction.cxx
   AliEmcalCorrectionCellSingleChannelCalibration.cxx
   AliEmcalCorrectionCellTimeCalib.cxx

--- a/PWG/EMCAL/EMCALtasks/PWGEMCALtasksLinkDef.h
+++ b/PWG/EMCAL/EMCALtasks/PWGEMCALtasksLinkDef.h
@@ -38,6 +38,7 @@
 #pragma link C++ class  AliEmcalCorrectionComponent+;
 #pragma link C++ class  AliEmcalCorrectionCellBadChannel+;
 #pragma link C++ class  AliEmcalCorrectionCellEnergy+;
+#pragma link C++ class  AliEmcalCorrectionCellEnergyCompression+;
 #pragma link C++ class  AliEmcalCorrectionCellTrackMatcherAndMIPSubtraction+;
 #pragma link C++ class  AliEmcalCorrectionCellSingleChannelCalibration+;
 #pragma link C++ class  AliEmcalCorrectionCellTimeCalib+;

--- a/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
+++ b/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
@@ -82,6 +82,18 @@ CellSingleChannelCalibration:                       # Cell Single Channel Energy
     customRecalibFilePath: ""                       # Full path including .root file for custom recalibration object
     cellsNames:                                     # Names of the cells input objects which should be attached to the correction
         - defaultCells                              # This object is defined above in the cells section of the input objects
+CellEnergyCompression:                              # Cell Energy Compression correction component. Task is to test different compression options like it is done in O2
+    enabled: false                                  # Whether to enable the task
+    createHistos: false                             # Whether the task should create output histograms
+    DoEnergyCompression: false                      # Enable to test energy Compression
+    TruncationMaxE: 250.                            # Maximum energy that can be reached for a cell
+    EnergyCompression: 0.0153                       # Energy Compression for a cell (such that E/Compression -> integer)
+    CompressionBias: 0.                             # Value that is added to the energy before the energy is converted to an integer
+    DoTimeCompression: false                        # Enable to test energy Compression
+    TimeCompression: 1                              # Time Compression for a cell (such that t/Compression -> integer)
+    TimeShift: 600                                  # Time shift to center main peak around 0 for lower disk space
+    cellsNames:                                     # Names of the cells input objects which should be attached to the correction
+        - defaultCells                              # This object is defined above in the cells section of the input objects
 CellBadChannel:                                     # Bad channel removal at the cell level component
     enabled: false                                  # Whether to enable the task
     createHistos: false                             # Whether the task should create output histograms
@@ -358,6 +370,7 @@ executionOrder:
     - CellEmulateCrosstalk
     - CellEnergy
     - CellEnergyVariation
+    - CellEnergyCompression
     - CellTrackMatcherAndMIPSubtraction
     - CellBadChannel
     - CellTimeCalib


### PR DESCRIPTION
- Component to try settings for a compression algorithm used in
O2/DataFormats/EMCAL/...Cell.cxx
- Cell energy/time gets multiplied with a certain resolution factor and
then gets transformed in an integer
- All values for resolution etc. can be set in the yaml file