### PR TITLE
MeanPtV2 and 2PC tasks

### DIFF
--- a/PWGCF/FLOW/GF/AliAnalysisTaskJetQ.h
+++ b/PWGCF/FLOW/GF/AliAnalysisTaskJetQ.h
@@ -37,14 +37,15 @@ class AliAnalysisTaskJetQ : public AliAnalysisTaskSE
         void SetVtxZBins(Int_t nBins, Double_t *bins) {setupAxis(nBins,bins,fVzBins,fVzAxis); };
         void SetPtBins(Int_t nBins, Double_t *bins) {setupAxis(nBins,bins,fPtBins,fPtAxis); };
         void SetEventMixingCapacity(Int_t nTotEv, Int_t nTotTr, Int_t frReady, Int_t nMinEv) { fEvMixPars[0]=nTotEv; fEvMixPars[1]=nTotTr; fEvMixPars[2]=frReady; fEvMixPars[3]=nMinEv; }; //Fraction is given in %, so should be an integer number!
+        void SetTriggerPt(const Double_t &ptMin, const Double_t &ptMax) {fPtTriggMin=ptMin; fPtTriggMax=ptMax;};
     private:
         AliAnalysisTaskJetQ(const AliAnalysisTaskJetQ&); // not implemented
         AliAnalysisTaskJetQ& operator=(const AliAnalysisTaskJetQ&); // not implemented
         Bool_t CheckTrigger(Double_t);
         Bool_t AcceptAOD(AliAODEvent*, Double_t lvtxXYZ[3]);
         Int_t FindGivenPt(const Double_t &ptMin, const Double_t &ptMax);
-        Int_t FillCorrelations(Int_t &triggerIndex, const Double_t &ptAsMin, const Double_t &ptAsMax);
-        Int_t FillMixedEvent(Int_t &triggerIndex, AliEventPool *inpool);
+        Int_t FillCorrelations(Int_t &triggerIndex, const Double_t &ptAsMin, const Double_t &ptAsMax, Double_t &vzValue);
+        Int_t FillMixedEvent(Int_t &triggerIndex, AliEventPool *inpool, Double_t &vzValue);
         void fill2DHist(TH1 *&inh, Double_t &xval, Double_t &yval) { ((TH2*)inh)->Fill(xval,yval); };
         void fill3DHist(TH1 *&inh, Double_t &xval, Double_t &yval, Double_t &zval) { ((TH3*)inh)->Fill(xval,yval,zval); };
 
@@ -65,6 +66,10 @@ class AliAnalysisTaskJetQ : public AliAnalysisTaskSE
         vector<Double_t> fCentBins;
         vector<Double_t> fVzBins;
         vector<Double_t> fPtBins;
+        Double_t fPtAssocMin;
+        Double_t fPtAssocMax;
+        Double_t fPtTriggMin;
+        Double_t fPtTriggMax;
         Bool_t fPtDif;
         AliEventCuts fEventCuts;
         Int_t fEvMixPars[4];

--- a/PWGCF/FLOW/GF/AliAnalysisTaskMeanPtV2Corr.cxx
+++ b/PWGCF/FLOW/GF/AliAnalysisTaskMeanPtV2Corr.cxx
@@ -283,7 +283,7 @@ void AliAnalysisTaskMeanPtV2Corr::UserCreateOutputObjects(){
         etaDig.ReplaceAll(".","");
         TString l_name = period+"ch_Eta_"+etaDig+sysPF;
         fEfficiencies[i] = (TH1D*)effList->FindObject(l_name.Data());
-        if(!fEfficiencies) printf(Form("Could not find efficiency %s!\n",l_name.Data()));
+        if(!fEfficiencies[i]) printf(Form("Could not find efficiency %s!\n",l_name.Data()));
         fEfficiencies[i] = (TH1D*)fEfficiencies[i]->Clone(Form("Efficiency_%s",etaDig.Data()));
         fEfficiencies[i]->SetDirectory(0);
         TH1D *hTemp = (TH1D*)fdList->FindObject(l_name.Data());


### PR DESCRIPTION
MeanPtV2: check for efficiency is now done for efficiency in question, not for the whole array
2PC (JetQ): added vertex z as a dimension to output histograms. Added external setters for trigger particles. Assoc. pt range is given by the range of pT axis (will likely clash if we want to do pt-differential?)