### PR TITLE
Add optional pt cut on charged and cluster constituents in SD

### DIFF
--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisEmcalSoftdropHelper.h
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisEmcalSoftdropHelper.h
@@ -76,10 +76,10 @@ public:
   TBinning *GetZgBinning(double zcut) const;
   TBinning *GetRgBinning(double R) const;
 
-  std::vector<PWGJE::EMCALJetTasks::AliAnalysisEmcalSoftdropHelperImpl::SoftdropResults> IterativeDecluster(const AliEmcalJet &jet, double jetradius, bool isPartLevel, SoftdropParams sdparams, AliVCluster::VCluUserDefEnergy_t energydef, double *vertex, bool dropMass0Jets);
+  std::vector<PWGJE::EMCALJetTasks::AliAnalysisEmcalSoftdropHelperImpl::SoftdropResults> IterativeDecluster(const AliEmcalJet &jet, double jetradius, bool isPartLevel, SoftdropParams sdparams, AliVCluster::VCluUserDefEnergy_t energydef, double *vertex, bool dropMass0Jets, double minPtCharged = 0., double minEcluster = 0.);
 
-  SoftdropResults MakeSoftdrop(const AliEmcalJet &jet, double jetradius, bool isPartLevel, SoftdropParams sdparams, AliVCluster::VCluUserDefEnergy_t energydef, double *vertex, bool dropMass0Jets);
-  SoftdropResults MakeSoftdropStandAlone(const AliEmcalJet &jet, double jetradius, bool isPartLevel, SoftdropParams sdparams, AliVCluster::VCluUserDefEnergy_t energydef, double *vertex, bool dropMass0Jets);
+  SoftdropResults MakeSoftdrop(const AliEmcalJet &jet, double jetradius, bool isPartLevel, SoftdropParams sdparams, AliVCluster::VCluUserDefEnergy_t energydef, double *vertex, bool dropMass0Jets, double minPtTrack = 0., double minEcluster = 0.);
+  SoftdropResults MakeSoftdropStandAlone(const AliEmcalJet &jet, double jetradius, bool isPartLevel, SoftdropParams sdparams, AliVCluster::VCluUserDefEnergy_t energydef, double *vertex, bool dropMass0Jets, double minPtTrack = 0., double minEcluster = 0.);
 
   ClassDef(AliAnalysisEmcalSoftdropHelperImpl, 1);
 };

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalSoftDropData.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalSoftDropData.cxx
@@ -63,6 +63,8 @@ AliAnalysisTaskEmcalSoftDropData::AliAnalysisTaskEmcalSoftDropData() :
   fUseChargedConstituents(kTRUE),
   fUseNeutralConstituents(kTRUE), 
   fDropMass0Jets(false),
+  fMinPtTracksSD(0.),
+  fMinEClustersSD(0.),
   fHistos(nullptr),
   fPtBinning(nullptr)
 {
@@ -82,6 +84,8 @@ AliAnalysisTaskEmcalSoftDropData::AliAnalysisTaskEmcalSoftDropData(EMCAL_STRINGV
   fUseChargedConstituents(kTRUE),
   fUseNeutralConstituents(kTRUE),
   fDropMass0Jets(false),
+  fMinPtTracksSD(0.),
+  fMinEClustersSD(0.),
   fHistos(nullptr),
   fPtBinning(nullptr)
 {
@@ -227,8 +231,8 @@ Bool_t AliAnalysisTaskEmcalSoftDropData::Run() {
     }
     try {
       FillJetQA(*jet, energydef);
-      auto sdparams = MakeSoftdrop(*jet, jets->GetJetRadius(), false, {(AliAnalysisEmcalSoftdropHelperImpl::EReclusterizer_t)fReclusterizer, fBeta, fZcut, fUseChargedConstituents, fUseNeutralConstituents}, energydef, fVertex, fDropMass0Jets);
-      auto splittings = IterativeDecluster(*jet, jets->GetJetRadius(), false, {(AliAnalysisEmcalSoftdropHelperImpl::EReclusterizer_t)fReclusterizer, fBeta, fZcut, fUseChargedConstituents, fUseNeutralConstituents}, energydef, fVertex, fDropMass0Jets);
+      auto sdparams = MakeSoftdrop(*jet, jets->GetJetRadius(), false, {(AliAnalysisEmcalSoftdropHelperImpl::EReclusterizer_t)fReclusterizer, fBeta, fZcut, fUseChargedConstituents, fUseNeutralConstituents}, energydef, fVertex, fDropMass0Jets, fMinPtTracksSD, fMinEClustersSD);
+      auto splittings = IterativeDecluster(*jet, jets->GetJetRadius(), false, {(AliAnalysisEmcalSoftdropHelperImpl::EReclusterizer_t)fReclusterizer, fBeta, fZcut, fUseChargedConstituents, fUseNeutralConstituents}, energydef, fVertex, fDropMass0Jets, fMinPtTracksSD, fMinEClustersSD);
       bool untagged = sdparams.fZg < fZcut;
       AliDebugStream(2) << "Found jet with pt " << jet->Pt() << " and zg " << sdparams.fZg << std::endl;
       Double_t pointZg[3] = {sdparams.fZg, jet->Pt(), -1},

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalSoftDropData.h
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalSoftDropData.h
@@ -63,6 +63,8 @@ public:
   void SetSelectTrigger(UInt_t triggerbits, const char *triggerstring) { fTriggerBits = triggerbits; fTriggerString = triggerstring; }
   void SetUseDownscaleWeight(Bool_t doUse) { fUseDownscaleWeight = doUse; }
   void SetDropMass0Jets(bool doDrop) { fDropMass0Jets = doDrop; }
+  void SetMinPtTracksSD(double pt) { fMinPtTracksSD = pt; }
+  void SetMinEClustersSD(double e) { fMinEClustersSD = e; }
 
   void ConfigureDetJetSelection(Double_t minJetPt, Double_t maxTrackPt, Double_t maxClusterPt, Double_t minAreaPerc);
 
@@ -89,6 +91,8 @@ private:
   Bool_t                        fUseChargedConstituents;    ///< Use also charged constituents
   Bool_t                        fUseNeutralConstituents;    ///< Use also neutral constituents
   Bool_t                        fDropMass0Jets;             ///< Drop jets with mass 0
+  Double_t                      fMinPtTracksSD;             ///< Min. pt of track constituent for softdrop
+  Double_t                      fMinEClustersSD;            ///< Min. E of EMCAL clusters constituent for softdrop
   THistManager                  *fHistos;                   //!<! Histogram handler
   TBinning                      *fPtBinning;                ///< Detector level pt binning
 

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalSoftDropResponse.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalSoftDropResponse.cxx
@@ -75,6 +75,8 @@ AliAnalysisTaskEmcalSoftDropResponse::AliAnalysisTaskEmcalSoftDropResponse() : A
                                                                                fUseNeutralConstituents(true),
                                                                                fUseStandardOutlierRejection(false),
                                                                                fDropMass0Jets(false),
+                                                                               fMinPtTracksSD(0.),
+                                                                               fMinEClustersSD(0.),
                                                                                fJetTypeOutliers(kOutlierPartJet),
                                                                                fNameMCParticles("mcparticles"),
                                                                                fSampleSplitter(nullptr),
@@ -117,6 +119,8 @@ AliAnalysisTaskEmcalSoftDropResponse::AliAnalysisTaskEmcalSoftDropResponse(const
                                                                                                fUseNeutralConstituents(true),
                                                                                                fUseStandardOutlierRejection(false),
                                                                                                fDropMass0Jets(false),
+                                                                                               fMinPtTracksSD(0.),
+                                                                                               fMinEClustersSD(0.),
                                                                                                fJetTypeOutliers(kOutlierPartJet),
                                                                                                fNameMCParticles("mcparticles"),
                                                                                                fSampleSplitter(nullptr),
@@ -804,8 +808,8 @@ bool AliAnalysisTaskEmcalSoftDropResponse::Run()
     SoftdropResults softdropDet = {0., 0., 0., 0., 0., 0}, softdropPart = {0., 0., 0., 0., 0., 0};
     std::vector<SoftdropResults> splittingsDet, splittingsPart;
     try {
-      softdropDet = MakeSoftdrop(*detjet, detLevelJets->GetJetRadius(),false, sdsettings, (AliVCluster::VCluUserDefEnergy_t)clusters->GetDefaultClusterEnergy(), fVertex, fDropMass0Jets);
-      splittingsDet = IterativeDecluster(*detjet, detLevelJets->GetJetRadius(), false, sdsettings, (AliVCluster::VCluUserDefEnergy_t)clusters->GetDefaultClusterEnergy(), fVertex, fDropMass0Jets);
+      softdropDet = MakeSoftdrop(*detjet, detLevelJets->GetJetRadius(),false, sdsettings, (AliVCluster::VCluUserDefEnergy_t)clusters->GetDefaultClusterEnergy(), fVertex, fDropMass0Jets, fMinPtTracksSD, fMinEClustersSD);
+      splittingsDet = IterativeDecluster(*detjet, detLevelJets->GetJetRadius(), false, sdsettings, (AliVCluster::VCluUserDefEnergy_t)clusters->GetDefaultClusterEnergy(), fVertex, fDropMass0Jets, fMinPtTracksSD, fMinEClustersSD);
     } catch(...) {
       // Failed SoftDrop for det. level jet.
       if(fForceBeamType != kpp) {
@@ -1337,8 +1341,8 @@ bool AliAnalysisTaskEmcalSoftDropResponse::Run()
         // check if for the matched det. level jet we can determine the SoftDrop
         // check this condition first in case not the same acceptance type is required
         try {
-          softdropDet = MakeSoftdrop(*detjet, detLevelJets->GetJetRadius(),false, sdsettings, (AliVCluster::VCluUserDefEnergy_t)clusters->GetDefaultClusterEnergy(), fVertex, fDropMass0Jets);
-          splittingsDet = IterativeDecluster(*detjet, detLevelJets->GetJetRadius(),false, sdsettings, (AliVCluster::VCluUserDefEnergy_t)clusters->GetDefaultClusterEnergy(), fVertex, fDropMass0Jets);
+          softdropDet = MakeSoftdrop(*detjet, detLevelJets->GetJetRadius(),false, sdsettings, (AliVCluster::VCluUserDefEnergy_t)clusters->GetDefaultClusterEnergy(), fVertex, fDropMass0Jets, fMinPtTracksSD, fMinEClustersSD);
+          splittingsDet = IterativeDecluster(*detjet, detLevelJets->GetJetRadius(),false, sdsettings, (AliVCluster::VCluUserDefEnergy_t)clusters->GetDefaultClusterEnergy(), fVertex, fDropMass0Jets, fMinPtTracksSD, fMinEClustersSD);
           tag = kMatchedJetNoAcceptance;
           if(detjet->GetJetAcceptanceType() & partLevelJets->GetAcceptanceType()){
             tag = kPairAccepted;

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalSoftDropResponse.h
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalSoftDropResponse.h
@@ -81,6 +81,8 @@ public:
   void SetJetTypeOutlierCut(EJetTypeOutliers_t jtype) { fJetTypeOutliers = jtype; }
   void SetRequirePartLevelJetInAcceptance(bool doRequest) { fRequirePartJetInAcceptance = doRequest; }
   void SetDropMass0Jets(bool doDrop) { fDropMass0Jets = doDrop; }
+  void SetMinPtTracksSD(double pt) { fMinPtTracksSD = pt; }
+  void SetMinEClustersSD(double e) { fMinEClustersSD = e; }
 
   // Switches for histogram groups
   void SetFillPlotsResiduals(Bool_t doFill) { fFillPlotsResiduals = doFill; }
@@ -117,6 +119,8 @@ private:
   Bool_t                        fUseNeutralConstituents;    ///< Use neutral constituents for softdrop
   Bool_t                        fUseStandardOutlierRejection; ///< Use standard outlier rejection (from AliAnalysisTaskEmcal)
   Bool_t                        fDropMass0Jets;             ///< Drop jets with mass 0
+  Double_t                      fMinPtTracksSD;             ///< Min. pt of track constituent for softdrop
+  Double_t                      fMinEClustersSD;            ///< Min. E of EMCAL clusters constituent for softdrop
   EJetTypeOutliers_t            fJetTypeOutliers;           ///< Jet type used for outlier detection
   TString                       fNameMCParticles;           ///< Name of the MC particle container
   TRandom                       *fSampleSplitter;           ///< Sample splitter


### PR DESCRIPTION
Add cut on the pt of the track
constituents and on E of the
cluster constituents (optional)
applied before reclustering the
jet to extract the SD observables.
Cuts can be varied independently.
Affect only the SD params, not
the jet energy.