### PR TITLE
HFjet - find MC daughters recursively

### DIFF
--- a/PWGHF/treeHF/AliHFJetFinder.cxx
+++ b/PWGHF/treeHF/AliHFJetFinder.cxx
@@ -321,7 +321,7 @@ void AliHFJetFinder::FindJets(TClonesArray *array, AliAODRecoDecayHF *cand, Doub
 }
 
 // Find all measurable decay products in generator level
-void AliHFJetFinder::FindMCdaughters(TClonesArray *array, AliAODMCParticle *mcpart, std::vector<Int_t>& daughter_vec){
+void AliHFJetFinder::FindMCDaughters(TClonesArray *array, AliAODMCParticle *mcpart, std::vector<Int_t>& daughter_vec){
   AliAODMCParticle *daughter;
   for (Int_t i = 0; i < mcpart->GetNDaughters(); i++) {
     Int_t daughterLabel = mcpart->GetDaughterLabel(i);
@@ -331,7 +331,7 @@ void AliHFJetFinder::FindMCdaughters(TClonesArray *array, AliAODMCParticle *mcpa
     if(daughter->IsPhysicalPrimary()){
       daughter_vec.push_back(daughter->GetLabel());
     }else{
-      FindMCdaughters(array, daughter, daughter_vec);
+      FindMCDaughters(array, daughter, daughter_vec);
     }
   }
 }
@@ -348,7 +348,7 @@ void AliHFJetFinder::FindMCJets(TClonesArray *array, AliAODMCParticle *mcpart) {
   if (mcpart){
   
     daughter_vec.clear();
-    FindMCdaughters(array, mcpart,daughter_vec);
+    FindMCDaughters(array, mcpart,daughter_vec);
 
     fFastJetWrapper->AddInputVector(mcpart->Px(), mcpart->Py(), mcpart->Pz(), mcpart->E(),0);
     charge.first=0;

--- a/PWGHF/treeHF/AliHFJetFinder.h
+++ b/PWGHF/treeHF/AliHFJetFinder.h
@@ -61,6 +61,7 @@ class AliHFJetFinder : public TObject
   std::vector<AliHFJet> GetJets(TClonesArray *array);
   std::vector<AliHFJet> GetMCJets(TClonesArray *array);
   void FindJets(TClonesArray *array, AliAODRecoDecayHF *cand=nullptr, Double_t invmass=0);
+  void FindMCdaughters(TClonesArray *array, AliAODMCParticle *mcpart, std::vector<Int_t>& daughter_vec);
   void FindMCJets(TClonesArray *array, AliAODMCParticle *mcpart=nullptr);
   #if !defined(__CINT__) && !defined(__MAKECINT__)
   void SetJetVariables(AliHFJet& hfjet, const std::vector<fastjet::PseudoJet>& constituents, const fastjet::PseudoJet& jet, Int_t jetID, AliAODRecoDecayHF *cand=nullptr);

--- a/PWGHF/treeHF/AliHFJetFinder.h
+++ b/PWGHF/treeHF/AliHFJetFinder.h
@@ -61,7 +61,7 @@ class AliHFJetFinder : public TObject
   std::vector<AliHFJet> GetJets(TClonesArray *array);
   std::vector<AliHFJet> GetMCJets(TClonesArray *array);
   void FindJets(TClonesArray *array, AliAODRecoDecayHF *cand=nullptr, Double_t invmass=0);
-  void FindMCdaughters(TClonesArray *array, AliAODMCParticle *mcpart, std::vector<Int_t>& daughter_vec);
+  void FindMCDaughters(TClonesArray *array, AliAODMCParticle *mcpart, std::vector<Int_t>& daughter_vec);
   void FindMCJets(TClonesArray *array, AliAODMCParticle *mcpart=nullptr);
   #if !defined(__CINT__) && !defined(__MAKECINT__)
   void SetJetVariables(AliHFJet& hfjet, const std::vector<fastjet::PseudoJet>& constituents, const fastjet::PseudoJet& jet, Int_t jetID, AliAODRecoDecayHF *cand=nullptr);


### PR DESCRIPTION
Fix issue in the response matrix of Ds-jet.

In `AliHFJetFinder::FindMCJets`, the daughters of HF candidates are read and stored from AliAODMCParticle by GetNDaughters() and GetDaughterLabel(i). But in the source code of `AliAODMCParticle`, it only deals with __2 prongs__ decay case. So for Ds to KKpi, the daughters are phi meson and pion, which means the __Kaon pair is not removed from MC particle array in generator level.__

Comparison with local running on test datasets. Use __relative difference of jet pT between detector reco. and gen. level.
![image](https://user-images.githubusercontent.com/25733253/169502593-d618ccc4-c984-41dc-b67b-5bc30d4053f3.png)
