### PR TITLE
PWG/EMCAL: Add option to apply Eta dependent cell scale

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.h
+++ b/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.h
@@ -175,6 +175,7 @@ public:
   void     SetUseTowerShaperNonlinarityCorrection(Bool_t doCorr)     { fUseShaperNonlin = doCorr ; }
   void     SetUseDetermineLowGain(Bool_t doCorr)     { fUseDetermineLowGain = doCorr ; }
   void     SetUseTowerAdditionalScaleCorrection(Bool_t doCorr)       { fUseAdditionalScale = doCorr;}
+  void     SetUseTowerAdditionalScaleCorrectionEtaDep(Bool_t doCorr) { fUseAdditionalScaleEtaDep = doCorr;}
   void     SetTowerAdditionalScaleCorrection(Int_t i, Float_t val)   { if(i < 3 && i >= 0) fAdditionalScaleSM[i] = val;
                                                                        else AliInfo(Form("fAdditionalScaleSM index %d larger than 3 or negative, do nothing\n",i));}
 
@@ -637,8 +638,9 @@ private:
   Bool_t     fUseShaperNonlin;           ///< Shaper non linearity correction for towers
   Bool_t     fUseDetermineLowGain;       ///< If set on true, wether a cell is low gain or high gain is not taken from cell info but calculated directly from cell ADC value
   AliEMCALCalibData* fCalibData;         ///< EMCAL calib data
-  Bool_t     fUseAdditionalScale;        ///< Switch for additional scale on cell level. Should not be used for standard Analyses
-  Float_t    fAdditionalScaleSM[3];      ///< Value for additional scale on cell level. Should not be used for standard Analyses
+  Bool_t     fUseAdditionalScale;        ///< Switch for additional scale on cell level. 
+  Bool_t     fUseAdditionalScaleEtaDep;  ///< Switch for eta-dependent (with and without TRD support structure) scale on cell level. Should not be used for standard Analyses
+  Float_t    fAdditionalScaleSM[3];      ///< Value for additional scale on cell level. 
 
   // Energy smearing for MC
   Bool_t     fSmearClusterEnergy;        ///< Smear cluster energy, to be done only for simulated data to match real data
@@ -757,7 +759,7 @@ private:
   Bool_t     fMCGenerToAcceptForTrack;   ///<  Activate the removal of tracks entering the track matching that come from a particular generator
 
   /// \cond CLASSIMP
-  ClassDef(AliEMCALRecoUtils, 43) ;
+  ClassDef(AliEMCALRecoUtils, 44) ;
   /// \endcond
 
 };

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEnergy.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEnergy.cxx
@@ -32,6 +32,7 @@ AliEmcalCorrectionCellEnergy::AliEmcalCorrectionCellEnergy() :
   ,fUseShaperCorrection(0)
   ,fUseDetermineLowGain(0)
   ,fUseAdditionalScale(kFALSE)
+  ,fUseAdditionalScaleEtaDep(kFALSE)
   ,fAdditionalScaleSM(0)
   ,fCustomRecalibFilePath("")
   ,fLoad1DRecalibFactors(0)
@@ -76,6 +77,9 @@ Bool_t AliEmcalCorrectionCellEnergy::Initialize()
   // check the YAML configuration if an additional cell correction scale is requested (default is 1 -> no scale shift)
   GetProperty("enableAdditionalScale",fUseAdditionalScale);
 
+  // check the YAML configuration if an additional cell correction scale is requested (default is 1 -> no scale shift)
+  GetProperty("enableAdditionalScaleEtaDep",fUseAdditionalScaleEtaDep);
+  
   // check the YAML configuration for values for additional scale (default is 1 for each SM category )
   GetProperty("additionalScaleValuesSM",fAdditionalScaleSM);
 
@@ -540,6 +544,10 @@ Bool_t AliEmcalCorrectionCellEnergy::CheckIfRunChanged()
   if(fUseAdditionalScale)
   {
     fRecoUtils->SetUseTowerAdditionalScaleCorrection(kTRUE);
+    if(fUseAdditionalScaleEtaDep)
+    {
+      fRecoUtils->SetUseTowerAdditionalScaleCorrectionEtaDep(kTRUE);
+    }
     for(int i = 0; i < 3; ++i){
       fRecoUtils->SetTowerAdditionalScaleCorrection(i, fAdditionalScaleSM[i]);
     }

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEnergy.h
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEnergy.h
@@ -49,7 +49,8 @@ private:
   Bool_t                 fDisableTempCalib;          ///< Off by default, disables temp calibration totally
   Bool_t                 fUseShaperCorrection;       ///< Off by default the correction for the shaper nonlinearity
   Bool_t                 fUseDetermineLowGain;       ///< Instead of using cell info, determine if cell is LG or HG from ADC values
-  Bool_t                 fUseAdditionalScale;        ///< Off by default, enables an energy scale shift on cell level. Highly experimental!
+  Bool_t                 fUseAdditionalScale;        ///< Eenables an energy scale shift on cell level
+  Bool_t                 fUseAdditionalScaleEtaDep;  ///< Off by default, enables an energy scale shift on cell level for cells behing TRD suport. Highly experimental!
   std::vector<Float_t>   fAdditionalScaleSM;         ///< values for additionalScale shift for 3 different types of SM: Full, 2/3 and 1/3
   TString                fCustomRecalibFilePath;     ///< Empty string by default the path to the OADB file of the custom energy recalibration
   Bool_t                 fLoad1DRecalibFactors;      ///< Flag to load 1D energy recalibration factors
@@ -61,7 +62,7 @@ private:
   static RegisterCorrectionComponent<AliEmcalCorrectionCellEnergy> reg;
 
   /// \cond CLASSIMP
-  ClassDef(AliEmcalCorrectionCellEnergy, 10); // EMCal cell energy correction component
+  ClassDef(AliEmcalCorrectionCellEnergy, 11); // EMCal cell energy correction component
   /// \endcond
 };
 

--- a/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
+++ b/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
@@ -72,7 +72,8 @@ CellEnergy:                                         # Cell Energy correction com
     enableLGDetermination: false                    # Use own determination if a cell is HG or LG and not info stored in cell by using ADC values
     customRecalibFilePath: ""                       # Full path including .root file for custom recalibration object
     load1DRecalibFactors: false                     # Flag to load a 1D energy recalibration histogram
-    enableAdditionalScale: false                    # Set an additional energy scale shift on cell level. HIGHLY EXPERIMENTAL and should not be used for standard analyses!
+    enableAdditionalScale: false                    # Set an additional energy scale shift on cell level.
+    enableAdditionalScaleEtaDep: false              # Set an additional energy scale shift on cell with an eta dependence (behind trd support and not behind TRD support). HIGHLY EXPERIMENTAL and should not be used for standard analyses!
     additionalScaleValuesSM: [1.0, 1.0, 1.0]        # Set values for additional scale on cell level for Full SM, 2/3 SM, and 1/3 SM
     cellsNames:                                     # Names of the cells input objects which should be attached to the correction
         - defaultCells                              # This object is defined above in the cells section of the input objects


### PR DESCRIPTION
- Modules behind TRD support structure are more affected by energy loss
and photon conversions in material in front of them
- In energy calibration all cells were treated the same and were
calibrated to one value
- To test the effect of properly calibrating these cells to an expected
value (lower pi0 mass peak as heavily affected by conversions), this new
eta dependent scale is introduced.
- The scale factors are stored in the SMDependent scale factor vector as
the SM dependnt scale factors are not applied in that case
- Highly experimental and should not be used for analysis at this point!