### PR TITLE
PWGGA/GammaConv: Add NonLin for lowB with dedicated cell scale

### DIFF
--- a/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_pp.C
@@ -2806,6 +2806,10 @@ void AddTask_GammaConvCalo_pp(
     cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411792109fe30220000","0r63103100000010"); // INT7, old FT
     cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411792109fe3n220000","0r63103100000010"); // INT7, old FT
 
+    // low B with dedicated cell scale
+  } else if (trainConfig == 2197){ // low Bfield
+    cuts.AddCutPCMCalo("00010113","0dm00089f9730000iih0404000","411799409fe32220000","0r63103100000010"); // INT7, dedicated lowB cell scale FT
+    cuts.AddCutPCMCalo("00010113","0dm00089f9730000iih0404000","411799409fe30220000","0r63103100000010"); // INT7, dedicated lowB cell scale FT
 
   // PCM-EDC systematics
   } else if (trainConfig == 2200){ // PCM based systematics

--- a/PWGGA/GammaConvBase/AliCaloPhotonCuts.cxx
+++ b/PWGGA/GammaConvBase/AliCaloPhotonCuts.cxx
@@ -8781,7 +8781,8 @@ void AliCaloPhotonCuts::ApplyNonLinearity(AliVCluster* cluster, Int_t isMC, AliV
           energy /= FunctionNL_OfficialTB_100MeV_MC_V2(energy);
           // fine tuning for pp 13 TeV lowB
           if (fCurrentMC==kPP13T16P1Pyt8LowB || fCurrentMC==kPP13T17P1Pyt8LowB || fCurrentMC==kPP13T18P1Pyt8LowB ){
-            energy /= FunctionNL_kSDM(energy, 0.988503, -3.10024, -0.28337);
+            // energy /= FunctionNL_kSDM(energy, 0.988503, -3.10024, -0.28337);
+            energy /= FunctionNL_kSDM(energy, 0.979428, -3.20181, -0.360978); // settings only to be used with dedicated lowB cell scale factors, (EXPERIMENTAL!)
             energy /= 1.0025;
             if(cluster->GetNCells() == 1){ // different fine tuning for 1 cell clusters
               energy /= 0.99;


### PR DESCRIPTION
- Cell scale was previously determined on nomB data/MC. Now we evaluated
the cell scale on lowB data directly. Therefore the NonLin correction
also has to change
- Experimental at this point. Dont use for physics analyses