### PR TITLE
Fix default OADB container in case of pp 13 TeV

### DIFF
--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerTask.cxx
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerTask.cxx
@@ -245,10 +245,8 @@ void AliEmcalTriggerMakerTask::ExecOnce(){
       // Configuration starting with LHC15f
       fTriggerMaker->ConfigureForPP2015();
       dataset = "pp 2015-2018";
-      if(!MCEvent()) {
-        // In case of data load masked fastORs from OADB
-        fMaskedFastorOADB = "oadb";
-      }
+      // Load additional masked FastORs from OADB (of course only if not specified explicitly, to allow for new maskings to be tested)
+      if(!fMaskedFastorOADB.Length()) fMaskedFastorOADB = "oadb";
     } else if((runnumber >= 244824 && runnumber <= 246994) || (runnumber >= 295581)){
       fTriggerMaker->ConfigureForPbPb2015();
       dataset = "Pb-Pb 2015";
@@ -374,7 +372,7 @@ void AliEmcalTriggerMakerTask::RunChanged(Int_t newrun){
   if(fBadFEEChannelOADB.Length()) InitializeBadFEEChannels();
   fTriggerMaker->ClearFastORBadChannels();
   if(fLoadFastORMaskingFromOCDB) InitializeFastORMaskingFromOCDB(newrun);
-  if(fMaskedFastorOADB.Length()) InitializeFastORMaskingFromOADB();
+  if(fMaskedFastorOADB.Length() && (fUseDeadFastORsOADB || fUseBadFastORsOADB)) InitializeFastORMaskingFromOADB();
   // QA: Monitor all channels which are masked in the current run
   if(fDoQA && fQAHistos){
     Int_t globCol(-1), globRow(-1) ;


### PR DESCRIPTION
Condition overwrote custom settings of the OADB
container with "oadb", setting of specific OADB files
was therefore ignored.

In addition: Set default case for the OADB container
also for MC pp 13 TeV - this will have an effect only
in case the user specified loading the FastOR mask
of dead or bad FastORs explicitly. This will not be set
to default to the moment since it requires the trigger
maker and trigger selection task to run in data,
otherwise results will be inconsistent