### PR TITLE
Removed minimal booking of kaons tracks for syst purity

### DIFF
--- a/PWGCF/FEMTOSCOPY/macros/AddTaskFemtoNanoLKr.C
+++ b/PWGCF/FEMTOSCOPY/macros/AddTaskFemtoNanoLKr.C
@@ -97,8 +97,8 @@ AliAnalysisTaskSE *AddTaskFemtoNanoLKr(
 
     if (suffix != "0") {
         evtCuts->SetMinimalBooking(true);
-        TrackPosKaonCuts->SetMinimalBooking(true);
-        TrackNegKaonCuts->SetMinimalBooking(true);
+        TrackPosKaonCuts->SetMinimalBooking(false);
+        TrackNegKaonCuts->SetMinimalBooking(false);
         v0Cuts->SetMinimalBooking(true);
         Antiv0Cuts->SetMinimalBooking(true);
     }


### PR DESCRIPTION
MinimalBooking of Kaons cuts set to false, to get the histograms and compute purity for systematics
TrackPosKaonCuts->SetMinimalBooking(false);
TrackNegKaonCuts->SetMinimalBooking(false);
        