### PR TITLE
PWGGA/GammaConv: Various changes to in-Jet analysis

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.h
@@ -426,103 +426,103 @@ class AliAnalysisTaskGammaCalo : public AliAnalysisTaskSE {
     Float_t               fPi0Pt;
     Float_t               fPi0InvMass;
 
-    TH1F**                 fHistoPtJet;                                          // Histogram of Jet Pt
-    TH1F**                 fHistoJetEta;                                         // Histogram of Jet Eta
-    TH1F**                 fHistoJetPhi;                                         // Histogram of Jet Phi
-    TH1F**                 fHistoJetArea;                                        // Histogram of Jet Area
-    TH1F**                 fHistoNJets;                                          // Histogram of number of jets
-    TH1F**                 fHistoEventwJets;                                     // Histogram of number of events with jets > 0
-    TH1F**                 fHistoJetPi0PtRatio;                                  // Histogram of PtPi0/PtJet
-    TH1F**                 fHistoDoubleCounting;                                 // Histogram if NM candidates are defined within multiple jets
-    TH2F**                 fHistoJetMotherInvMassPt;                             // Histogram of NM candidates with a jet in the event
-    TH2F**                 fHistoPi0InJetMotherInvMassPt;                        // Histogram of NM candidates that are inside a jet
-    TH2F**                 fHistoMotherBackJetInvMassPt;                         // Histogram of Backgrouns candidates that are involved with jets
-    TH2F**                 fHistoRJetPi0Cand;                                    // Histogram of RJetPi0Cand vs Pt
-    TH2F**                 fHistoEtaPhiJetPi0Cand;                               // Histogram of delta eta and delta phi distr between jet and NM candidates
-    TH2F**                 fHistoEtaPhiJetWithPi0Cand;                           // Histogram of delta eta and delta phi distr when pi0 is inside a jet
-    TH2F**                 fHistoJetFragmFunc;                                   // Histogram to determine fragmentation function
-    TH2F**                 fHistoJetFragmFuncZInvMass;                           // Histogram of Inv Mass distribution with z
-    TH2F**                 fHistoTruevsRecJetPt;                                 // Histogram of true jet pt vs reconstructed jet pt
-    TH2F**                 fHistoTruePi0JetMotherInvMassPt;                      // Histogram of true pi0s in an event with a jet
-    TH2F**                 fHistoTruePi0InJetMotherInvMassPt;                    // Histogram of true pi0s in a jet
-    TH2F**                 fHistoTruePrimaryPi0JetInvMassPt;                     // Histogram of true primary pi0s in an event with a jet
-    TH2F**                 fHistoTruePrimaryPi0inJetInvMassPt;                   // Histogram of true primary pi0s in a jet
-    TH2F**                 fHistoTruePrimaryPi0InJetInvMassTruePt;               // Histogram of true primary pi0s in a jet with their true pt
-    TH1F**                 fHistoTrueDoubleCountingPi0Jet;                       // Histogram of when a true pi0 is defined to be in multiple jets
-    TH2F**                 fHistoTrueEtaJetMotherInvMassPt;                      // Histogram of true etas in an event with a jet
-    TH2F**                 fHistoTrueEtaInJetMotherInvMassPt;                    // Histogram of true etas in a jet
-    TH2F**                 fHistoTruePrimaryEtaJetInvMassPt;                     // Histogram of true primary etas in an event with a jet
-    TH2F**                 fHistoTruePrimaryEtainJetInvMassPt;                   // Histogram of true primary etas in a jet
-    TH1F**                 fHistoTrueDoubleCountingEtaJet;                       // Histogram of when a true eta is defined to be in multiple jets
-    TH2F**                 fHistoTruePi0JetFragmFunc;                            // Histogram to determine true pi0 fragmentation function
-    TH2F**                 fHistoTruePi0JetFragmFuncZInvMass;                    // Histogram to determine true pi0 Inv Mass distribution with z
-    TH2F**                 fHistoTrueEtaJetFragmFunc;                            // Histogram to determine true eta fragmentation function
-    TH2F**                 fHistoTrueEtaJetFragmFuncZInvMass;                    // Histogram to determine true eta Inv Mass distribution with z
-    TH2F**                 fHistoMCPi0GenVsNClus;                                // pi0 produced on gen level vs Nclus for merging studies
-    TH2F**                 fHistoMCPi0GenFoundInOneCluster;                      // pi0 produced on gen level where both decay photons were found in same cluster (merged)
-    TH2F**                 fHistoMCPi0GenFoundInTwoCluster;                      // pi0 produced on gen level where both decay photons were found in different clusters
-    TH2F**                fHistoMCEtaGenFoundInOneCluster;                      // pi0 produced on gen level where both decay photons were found in same cluster (merged)
-    TH2F**                 fHistoMCEtaGenFoundInTwoCluster;                      // pi0 produced on gen level where both decay photons were found in different clusters
-    TH2F**                 fHistoMCGammaConvRvsPt;                      // pi0 produced on gen level where both decay photons were found in different clusters
-    TH1F**                 fHistoMCPi0JetInAccPt;                                // Histogram with weighted pi0 in a jet event in acceptance, pT
-    TH1F**                 fHistoMCPi0inJetInAccPt;                              // Histogram with weighted pi0 in a jet in acceptance, pT
-    TH1F**                 fHistoMCEtaJetInAccPt;                                // Histogram with weighted eta in a jet event in acceptance, pT
-    TH1F**                 fHistoMCEtainJetInAccPt;                              // Histogram with weighted eta in a jet in acceptance, pT
-    TH1F**                 fHistoMCPi0JetEventGenerated;                         // Histogram with mesons in a jet event generated, pT
-    TH1F**                 fHistoMCPi0inJetGenerated;                            // Histogram with mesons in a jet generated, pT
-    TH1F**                 fHistoMCEtaJetEventGenerated;                         // Histogram with mesons in a jet event generated, pT
-    TH1F**                 fHistoMCEtainJetGenerated;                            // Histogram with mesons in a jet generated, pT
-    TH2F**                 fHistoTrueSecondaryPi0FromK0sJetInvMassPt;            // Histogram with validated secondary mothers from K0s in an event with a jet, invMass, pt
-    TH2F**                 fHistoTrueSecondaryPi0FromK0sinJetInvMassPt;          // Histogram with validated secondary mothers from K0s in a jet, invMass, pt
-    TH2F**                 fHistoTrueSecondaryPi0FromLambdaJetInvMassPt;         // Histogram with validated secondary mothers from lambda in an event with a jet, invMass, pt
-    TH2F**                 fHistoTrueSecondaryPi0FromLambdainJetInvMassPt;       // Histogram with validated secondary mothers from lambda in a jet, invMass, pt
-    TH2F**                 fHistoTrueSecondaryPi0FromK0lJetInvMassPt;            // Histogram with validated secondary mothers from K0l in an event with a jet, invMass, pt
-    TH2F**                 fHistoTrueSecondaryPi0FromK0linJetInvMassPt;          // Histogram with validated secondary mothers from K0l in a jet, invMass, pt
-    TH2F**                 fHistoTrueSecondaryPi0InvJetMassPt;                   // Histogram with validated secondary mothers in an event with a jet, invMass, pt
-    TH2F**                 fHistoTrueSecondaryPi0InvinJetMassPt;                 // Histogram with validated secondary mothers in a jet, invMass, pt
-    TH2F**                 fHistoMotherPi0inJetPtY;                              // Histogram with the rapidity of the validated pi0s in jets
-    TH2F**                 fHistoMotherEtainJetPtY;                              // Histogram with the rapidity of the validated etas in jets
-    TH2F**                 fHistoMotherPi0inJetPtPhi;                            // Histogram with the phi of the validated pi0s in jets
-    TH2F**                 fHistoMotherEtainJetPtPhi;                            // Histogram with the phi of the validated etas in jets
-    TH1F**                 fNumberOfClusters;                                    // Histogram with total number of clusters
-    TH1F**                 fNumberOfClustersinJets;                              // Histogram with number of clusters in jets
-    TH2F**                 fEnergyRatio;                                         // Histogram with ratio of energy deposited in cluster
-    TH2F**                 fEnergyRatioinJets;                                   // Histogram with ratio of energy deposited in cluster in jets
-    TH2F**                 fEnergyRatioGamma1;                                   // Histogram with ratio of energy deposited in cluster when first label is a photon
-    TH2F**                 fEnergyRatioGamma1inJets;                             // Histogram with ratio of energy deposited in cluster when first label is a photon in jets
-    TH2F**                 fEnergyRatioGammaAnywhere;                            // Histogram with ratio of energy deposited in cluster when a label is photon
-    TH2F**                 fEnergyRatioGammaAnywhereinJets;                      // Histogram with ratio of energy deposited in cluster when a label is photon in jets
-    TH2F**                 fEnergyDeposit;                                       // Histogram with total energy deposited in cluster
-    TH2F**                 fEnergyDepositinJets;                                 // Histogram with total energy deposited in cluster in jets
-    TH2F**                 fEnergyDepGamma1;                                     // Histogram with total energy deposited when first label is photon
-    TH2F**                 fEnergyDepGamma1inJets;                               // Histogram with total energy deposited when first label is photon in jets
-    TH2F**                 fEnergyDepGammaAnywhere;                              // Histogram with total energy deposited when a label is photon
-    TH2F**                 fEnergyDepGammaAnywhereinJets;                        // Histogram with total energy deposited when a label is photon in jets
-    TH1F**                 fEnergyRatioGamma1Helped;                             // Histogram with energy of photon when it is helped by other particles
-    TH1F**                 fEnergyRatioGamma1HelpedinJets;                       // Histogram with energy of photon when it is helped by other particles in jets
-    TH2F**                 fClusterEtaPhiJets;                                   // Histogram of phi and eta distribution of clusters in jets
-    TH2F**                 fHistoUnfoldingAsData;                                // Histogram to use for jet pi0 unfolding
-    TH2F**                 fHistoUnfoldingMissed;                                // Histogram to use for jet pi0 unfolding
-    TH2F**                 fHistoUnfoldingReject;                                // Histogram to use for jet pi0 unfolding
-    TH2F**                 fHistoUnfoldingAsDataInvMassZ;                        // Histogram to use for jet pi0 unfolding for z inmass
-    TH2F**                 fHistoUnfoldingMissedInvMassZ;                        // Histogram to use for jet pi0 unfolding for z inmass
-    TH2F**                 fHistoUnfoldingRejectInvMassZ;                        // Histogram to use for jet pi0 unfolding for z inmass
+    TH1F**                 fHistoPtJet;                                          //! Histogram of Jet Pt
+    TH1F**                 fHistoJetEta;                                         //! Histogram of Jet Eta
+    TH1F**                 fHistoJetPhi;                                         //! Histogram of Jet Phi
+    TH1F**                 fHistoJetArea;                                        //! Histogram of Jet Area
+    TH1F**                 fHistoNJets;                                          //! Histogram of number of jets
+    TH1F**                 fHistoEventwJets;                                     //! Histogram of number of events with jets > 0
+    TH1F**                 fHistoJetPi0PtRatio;                                  //! Histogram of PtPi0/PtJet
+    TH1F**                 fHistoDoubleCounting;                                 //! Histogram if NM candidates are defined within multiple jets
+    TH2F**                 fHistoJetMotherInvMassPt;                             //! Histogram of NM candidates with a jet in the event
+    TH2F**                 fHistoPi0InJetMotherInvMassPt;                        //! Histogram of NM candidates that are inside a jet
+    TH2F**                 fHistoMotherBackJetInvMassPt;                         //! Histogram of Backgrouns candidates that are involved with jets
+    TH2F**                 fHistoRJetPi0Cand;                                    //! Histogram of RJetPi0Cand vs Pt
+    TH2F**                 fHistoEtaPhiJetPi0Cand;                               //! Histogram of delta eta and delta phi distr between jet and NM candidates
+    TH2F**                 fHistoEtaPhiJetWithPi0Cand;                           //! Histogram of delta eta and delta phi distr when pi0 is inside a jet
+    TH2F**                 fHistoJetFragmFunc;                                   //! Histogram to determine fragmentation function
+    TH2F**                 fHistoJetFragmFuncZInvMass;                           //! Histogram of Inv Mass distribution with z
+    TH2F**                 fHistoTruevsRecJetPt;                                 //! Histogram of true jet pt vs reconstructed jet pt
+    TH2F**                 fHistoTruePi0JetMotherInvMassPt;                      //! Histogram of true pi0s in an event with a jet
+    TH2F**                 fHistoTruePi0InJetMotherInvMassPt;                    //! Histogram of true pi0s in a jet
+    TH2F**                 fHistoTruePrimaryPi0JetInvMassPt;                     //! Histogram of true primary pi0s in an event with a jet
+    TH2F**                 fHistoTruePrimaryPi0inJetInvMassPt;                   //! Histogram of true primary pi0s in a jet
+    TH2F**                 fHistoTruePrimaryPi0InJetInvMassTruePt;               //! Histogram of true primary pi0s in a jet with their true pt
+    TH1F**                 fHistoTrueDoubleCountingPi0Jet;                       //! Histogram of when a true pi0 is defined to be in multiple jets
+    TH2F**                 fHistoTrueEtaJetMotherInvMassPt;                      //! Histogram of true etas in an event with a jet
+    TH2F**                 fHistoTrueEtaInJetMotherInvMassPt;                    //! Histogram of true etas in a jet
+    TH2F**                 fHistoTruePrimaryEtaJetInvMassPt;                     //! Histogram of true primary etas in an event with a jet
+    TH2F**                 fHistoTruePrimaryEtainJetInvMassPt;                   //! Histogram of true primary etas in a jet
+    TH1F**                 fHistoTrueDoubleCountingEtaJet;                       //! Histogram of when a true eta is defined to be in multiple jets
+    TH2F**                 fHistoTruePi0JetFragmFunc;                            //! Histogram to determine true pi0 fragmentation function
+    TH2F**                 fHistoTruePi0JetFragmFuncZInvMass;                    //! Histogram to determine true pi0 Inv Mass distribution with z
+    TH2F**                 fHistoTrueEtaJetFragmFunc;                            //! Histogram to determine true eta fragmentation function
+    TH2F**                 fHistoTrueEtaJetFragmFuncZInvMass;                    //! Histogram to determine true eta Inv Mass distribution with z
+    TH2F**                 fHistoMCPi0GenVsNClus;                                //! pi0 produced on gen level vs Nclus for merging studies
+    TH2F**                 fHistoMCPi0GenFoundInOneCluster;                      //! pi0 produced on gen level where both decay photons were found in same cluster (merged)
+    TH2F**                 fHistoMCPi0GenFoundInTwoCluster;                      //! pi0 produced on gen level where both decay photons were found in different clusters
+    TH2F**                 fHistoMCEtaGenFoundInOneCluster;                      //! pi0 produced on gen level where both decay photons were found in same cluster (merged)
+    TH2F**                 fHistoMCEtaGenFoundInTwoCluster;                      //! pi0 produced on gen level where both decay photons were found in different clusters
+    TH2F**                 fHistoMCGammaConvRvsPt;                               //! pi0 produced on gen level where both decay photons were found in different clusters
+    TH1F**                 fHistoMCPi0JetInAccPt;                                //! Histogram with weighted pi0 in a jet event in acceptance, pT
+    TH1F**                 fHistoMCPi0inJetInAccPt;                              //! Histogram with weighted pi0 in a jet in acceptance, pT
+    TH1F**                 fHistoMCEtaJetInAccPt;                                //! Histogram with weighted eta in a jet event in acceptance, pT
+    TH1F**                 fHistoMCEtainJetInAccPt;                              //! Histogram with weighted eta in a jet in acceptance, pT
+    TH1F**                 fHistoMCPi0JetEventGenerated;                         //! Histogram with mesons in a jet event generated, pT
+    TH1F**                 fHistoMCPi0inJetGenerated;                            //! Histogram with mesons in a jet generated, pT
+    TH1F**                 fHistoMCEtaJetEventGenerated;                         //! Histogram with mesons in a jet event generated, pT
+    TH1F**                 fHistoMCEtainJetGenerated;                            //! Histogram with mesons in a jet generated, pT
+    TH2F**                 fHistoTrueSecondaryPi0FromK0sJetInvMassPt;            //! Histogram with validated secondary mothers from K0s in an event with a jet, invMass, pt
+    TH2F**                 fHistoTrueSecondaryPi0FromK0sinJetInvMassPt;          //! Histogram with validated secondary mothers from K0s in a jet, invMass, pt
+    TH2F**                 fHistoTrueSecondaryPi0FromLambdaJetInvMassPt;         //! Histogram with validated secondary mothers from lambda in an event with a jet, invMass, pt
+    TH2F**                 fHistoTrueSecondaryPi0FromLambdainJetInvMassPt;       //! Histogram with validated secondary mothers from lambda in a jet, invMass, pt
+    TH2F**                 fHistoTrueSecondaryPi0FromK0lJetInvMassPt;            //! Histogram with validated secondary mothers from K0l in an event with a jet, invMass, pt
+    TH2F**                 fHistoTrueSecondaryPi0FromK0linJetInvMassPt;          //! Histogram with validated secondary mothers from K0l in a jet, invMass, pt
+    TH2F**                 fHistoTrueSecondaryPi0InvJetMassPt;                   //! Histogram with validated secondary mothers in an event with a jet, invMass, pt
+    TH2F**                 fHistoTrueSecondaryPi0InvinJetMassPt;                 //! Histogram with validated secondary mothers in a jet, invMass, pt
+    TH2F**                 fHistoMotherPi0inJetPtY;                              //! Histogram with the rapidity of the validated pi0s in jets
+    TH2F**                 fHistoMotherEtainJetPtY;                              //! Histogram with the rapidity of the validated etas in jets
+    TH2F**                 fHistoMotherPi0inJetPtPhi;                            //! Histogram with the phi of the validated pi0s in jets
+    TH2F**                 fHistoMotherEtainJetPtPhi;                            //! Histogram with the phi of the validated etas in jets
+    TH1F**                 fNumberOfClusters;                                    //! Histogram with total number of clusters
+    TH1F**                 fNumberOfClustersinJets;                              //! Histogram with number of clusters in jets
+    TH2F**                 fEnergyRatio;                                         //! Histogram with ratio of energy deposited in cluster
+    TH2F**                 fEnergyRatioinJets;                                   //! Histogram with ratio of energy deposited in cluster in jets
+    TH2F**                 fEnergyRatioGamma1;                                   //! Histogram with ratio of energy deposited in cluster when first label is a photon
+    TH2F**                 fEnergyRatioGamma1inJets;                             //! Histogram with ratio of energy deposited in cluster when first label is a photon in jets
+    TH2F**                 fEnergyRatioGammaAnywhere;                            //! Histogram with ratio of energy deposited in cluster when a label is photon
+    TH2F**                 fEnergyRatioGammaAnywhereinJets;                      //! Histogram with ratio of energy deposited in cluster when a label is photon in jets
+    TH2F**                 fEnergyDeposit;                                       //! Histogram with total energy deposited in cluster
+    TH2F**                 fEnergyDepositinJets;                                 //! Histogram with total energy deposited in cluster in jets
+    TH2F**                 fEnergyDepGamma1;                                     //! Histogram with total energy deposited when first label is photon
+    TH2F**                 fEnergyDepGamma1inJets;                               //! Histogram with total energy deposited when first label is photon in jets
+    TH2F**                 fEnergyDepGammaAnywhere;                              //! Histogram with total energy deposited when a label is photon
+    TH2F**                 fEnergyDepGammaAnywhereinJets;                        //! Histogram with total energy deposited when a label is photon in jets
+    TH1F**                 fEnergyRatioGamma1Helped;                             //! Histogram with energy of photon when it is helped by other particles
+    TH1F**                 fEnergyRatioGamma1HelpedinJets;                       //! Histogram with energy of photon when it is helped by other particles in jets
+    TH2F**                 fClusterEtaPhiJets;                                   //! Histogram of phi and eta distribution of clusters in jets
+    TH2F**                 fHistoUnfoldingAsData;                                //! Histogram to use for jet pi0 unfolding
+    TH2F**                 fHistoUnfoldingMissed;                                //! Histogram to use for jet pi0 unfolding
+    TH2F**                 fHistoUnfoldingReject;                                //! Histogram to use for jet pi0 unfolding
+    TH2F**                 fHistoUnfoldingAsDataInvMassZ;                        //! Histogram to use for jet pi0 unfolding for z inmass
+    TH2F**                 fHistoUnfoldingMissedInvMassZ;                        //! Histogram to use for jet pi0 unfolding for z inmass
+    TH2F**                 fHistoUnfoldingRejectInvMassZ;                        //! Histogram to use for jet pi0 unfolding for z inmass
 
-    vector<Double_t>      fVectorJetPt;                                         // Vector of JetPt
-    vector<Double_t>      fVectorJetPx;                                         // Vector of JetPx
-    vector<Double_t>      fVectorJetPy;                                         // Vector of JetPy
-    vector<Double_t>      fVectorJetPz;                                         // Vector of JetPz
-    vector<Double_t>      fVectorJetEta;                                        // Vector of JetEta
-    vector<Double_t>      fVectorJetPhi;                                        // Vector of JetPhi
-    vector<Double_t>      fVectorJetArea;                                       // Vector of JetArea
-    vector<Double_t>      fTrueVectorJetPt;                                     // Vector of True JetPt
-    vector<Double_t>      fTrueVectorJetPx;                                     // Vector of True JetPx
-    vector<Double_t>      fTrueVectorJetPy;                                     // Vector of True JetPy
-    vector<Double_t>      fTrueVectorJetPz;                                     // Vector of True JetPz
-    vector<Double_t>      fTrueVectorJetEta;                                    // Vector of True JetEta
-    vector<Double_t>      fTrueVectorJetPhi;                                    // Vector of True JetPhi
+    vector<Double_t>      fVectorJetPt;                                         //! Vector of JetPt
+    vector<Double_t>      fVectorJetPx;                                         //! Vector of JetPx
+    vector<Double_t>      fVectorJetPy;                                         //! Vector of JetPy
+    vector<Double_t>      fVectorJetPz;                                         //! Vector of JetPz
+    vector<Double_t>      fVectorJetEta;                                        //! Vector of JetEta
+    vector<Double_t>      fVectorJetPhi;                                        //! Vector of JetPhi
+    vector<Double_t>      fVectorJetArea;                                       //! Vector of JetArea
+    vector<Double_t>      fTrueVectorJetPt;                                     //! Vector of True JetPt
+    vector<Double_t>      fTrueVectorJetPx;                                     //! Vector of True JetPx
+    vector<Double_t>      fTrueVectorJetPy;                                     //! Vector of True JetPy
+    vector<Double_t>      fTrueVectorJetPz;                                     //! Vector of True JetPz
+    vector<Double_t>      fTrueVectorJetEta;                                    //! Vector of True JetEta
+    vector<Double_t>      fTrueVectorJetPhi;                                    //! Vector of True JetPhi
 
-    std::map<Int_t, Int_t> MapRecJetsTrueJets;                                  // Map containing the reconstructed jet index in vector and mapping it to true Jet index
+    std::map<Int_t, Int_t> MapRecJetsTrueJets;                                  //! Map containing the reconstructed jet index in vector and mapping it to true Jet index
 
     // tree for identified particle properties
     TTree**               tTrueInvMassROpenABPtFlag;                            //! array of trees with
@@ -616,7 +616,7 @@ class AliAnalysisTaskGammaCalo : public AliAnalysisTaskSE {
     AliAnalysisTaskGammaCalo(const AliAnalysisTaskGammaCalo&);                  // Prevent copy-construction
     AliAnalysisTaskGammaCalo &operator=(const AliAnalysisTaskGammaCalo&);       // Prevent assignment
 
-    ClassDef(AliAnalysisTaskGammaCalo, 90);
+    ClassDef(AliAnalysisTaskGammaCalo, 91);
 };
 
 #endif

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvCalo.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvCalo.h
@@ -69,6 +69,7 @@ class AliAnalysisTaskGammaConvCalo : public AliAnalysisTaskSE {
     void ProcessConversionPhotonsForMissingTags     ();
     void ProcessConversionPhotonsForMissingTagsAOD  ();
     void ProcessJets();
+    void InitJets();
 
     // switches for additional analysis streams or outputs
     void SetDoPrimaryTrackMatching      ( Bool_t flag )                                     { fDoPrimaryTrackMatching = flag              ;}
@@ -519,6 +520,8 @@ class AliAnalysisTaskGammaConvCalo : public AliAnalysisTaskSE {
     vector<Double_t>      fTrueVectorJetEta;                                    //! Vector of True JetEta
     vector<Double_t>      fTrueVectorJetPhi;                                    //! Vector of True JetPhi
 
+    std::map<Int_t, Int_t> MapRecJetsTrueJets;                                  //! Map containing the reconstructed jet index in vector and mapping it to true Jet index
+
     // variable to keep track of multiple & missing reco
     vector<Int_t>           fVectorRecTruePi0s;                                 //! array of strings containing the stack position of the reconstructed validated pi0
     vector<Int_t>           fVectorRecTrueEtas;                                 //! array of strings containing the stack position of the reconstructed validated eta
@@ -613,7 +616,7 @@ class AliAnalysisTaskGammaConvCalo : public AliAnalysisTaskSE {
     AliAnalysisTaskGammaConvCalo(const AliAnalysisTaskGammaConvCalo&); // Prevent copy-construction
     AliAnalysisTaskGammaConvCalo &operator=(const AliAnalysisTaskGammaConvCalo&); // Prevent assignment
 
-    ClassDef(AliAnalysisTaskGammaConvCalo, 71);
+    ClassDef(AliAnalysisTaskGammaConvCalo, 72);
 };
 
 #endif

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvV1.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvV1.h
@@ -52,6 +52,7 @@ class AliAnalysisTaskGammaConvV1 : public AliAnalysisTaskSE {
     void ProcessPhotonBDT();
     void ProcessClusters();
     void ProcessJets();
+    void InitJets();
     void ProcessPhotonsHighPtHadronAnalysis();
     void CalculatePi0Candidates();
     void CalculateBackground();
@@ -319,7 +320,7 @@ class AliAnalysisTaskGammaConvV1 : public AliAnalysisTaskSE {
     TH2F**                            fHistoTrueJetFragmFuncZInvMass;                       // Histogram to determine true Inv Mass distribution with z
     TH1F**                            fHistoMCPi0JetInAccPt;                                // Histogram with weighted pi0 in a jet event in acceptance, pT
     TH1F**                            fHistoMCPi0inJetInAccPt;                              // Histogram with weighted pi0 in a jet in acceptance, pT
-    TH1F**                            fHistoMCPi0WOWeightinJetInAccPt;                      // Histogram with pi0 without weights in a jet in acceptance, pT                            
+    TH1F**                            fHistoMCPi0WOWeightinJetInAccPt;                      // Histogram with pi0 without weights in a jet in acceptance, pT
     TH1F**                            fHistoMCEtaJetInAccPt;                                // Histogram with weighted eta in a jet event in acceptance, pT
     TH1F**                            fHistoMCEtainJetInAccPt;                              // Histogram with weighted eta in a jet in acceptance, pT
     TH1F**                            fHistoMCPi0JetEventGenerated;                         // Histogram with mesons in a jet event generated, pT
@@ -354,6 +355,8 @@ class AliAnalysisTaskGammaConvV1 : public AliAnalysisTaskSE {
     vector<Double_t>                  fTrueVectorJetPz;                                     // Vector of True JetPz
     vector<Double_t>                  fTrueVectorJetEta;                                    // Vector of True JetEta
     vector<Double_t>                  fTrueVectorJetPhi;                                    // Vector of True JetPhi
+
+    std::map<Int_t, Int_t> MapRecJetsTrueJets;                                  //! Map containing the reconstructed jet index in vector and mapping it to true Jet index
 
     TH2F**                            fHistoSPDClusterTrackletBackground;         //! array of histos with SPD tracklets vs SPD clusters for background rejection
     TH1F**                            fHistoNV0Tracks;                            //!
@@ -423,7 +426,7 @@ class AliAnalysisTaskGammaConvV1 : public AliAnalysisTaskSE {
 
     AliAnalysisTaskGammaConvV1(const AliAnalysisTaskGammaConvV1&); // Prevent copy-construction
     AliAnalysisTaskGammaConvV1 &operator=(const AliAnalysisTaskGammaConvV1&); // Prevent assignment
-    ClassDef(AliAnalysisTaskGammaConvV1, 55);
+    ClassDef(AliAnalysisTaskGammaConvV1, 56);
 };
 
 #endif

--- a/PWGGA/GammaConv/macros/AddTask_GammaCalo_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaCalo_pp.C
@@ -4429,39 +4429,39 @@ void AddTask_GammaCalo_pp(
   // pp 13 TeV Gammas in Jets
   //*************************************************************************************************
   } else if (trainConfig == 3100){  // EMCAL+DCAL clusters standard cuts, INT7, NL , std TM, swapping back.
-    cuts.AddCutCalo("00010113","411790109fe32220000","2r631031000000d0"); // INT7 NL 12 + TB dir. gamma
+    cuts.AddCutCalo("00010113","411790109fe30230000","2s631031000000d0"); // INT7 NL 12 + TB dir. gamma
   } else if (trainConfig == 3101){  // EMCAL+DCAL clusters standard cuts, INT7, NL , std TM, swapping back.
-    cuts.AddCutCalo("0008e113","411790109fe32220000","2r631031000000d0"); // INT7 NL 12 + TB dir. gamma
+    cuts.AddCutCalo("0008e113","411790109fe30230000","2s631031000000d0"); // INT7 NL 12 + TB dir. gamma
   } else if (trainConfig == 3102){  // EMCAL+DCAL clusters standard cuts, INT7, NL , std TM, swapping back.
-    cuts.AddCutCalo("0008d113","411790109fe32220000","2r631031000000d0"); // INT7 NL 12 + TB dir. gamma
+    cuts.AddCutCalo("0008d113","411790109fe30230000","2s631031000000d0"); // INT7 NL 12 + TB dir. gamma
 
   } else if (trainConfig == 3103){  // EMCAL+DCAL clusters No NCell cut, INT7, NL , std TM, swapping back.
-    cuts.AddCutCalo("00010113","411790109fe30220000","2r631031000000d0"); // INT7 NL 12 + TB dir. gamma
+    cuts.AddCutCalo("00010113","411790109fe30230000","3s631031000000d0"); // INT7 NL 12 + TB dir. gamma
   } else if (trainConfig == 3104){  // EMCAL+DCAL clusters  No NCell cut, INT7, NL , std TM, swapping back.
-    cuts.AddCutCalo("0008e113","411790109fe30220000","2r631031000000d0"); // INT7 NL 12 + TB dir. gamma
+    cuts.AddCutCalo("0008e113","411790109fe30230000","3s631031000000d0"); // INT7 NL 12 + TB dir. gamma
   } else if (trainConfig == 3105){  // EMCAL+DCAL clusters  No NCell cut, INT7, NL , std TM, swapping back.
-    cuts.AddCutCalo("0008d113","411790109fe30220000","2r631031000000d0"); // INT7 NL 12 + TB dir. gamma
+    cuts.AddCutCalo("0008d113","411790109fe30230000","3s631031000000d0"); // INT7 NL 12 + TB dir. gamma
   // jet mixing background
   } else if (trainConfig == 3106){  // EMCAL+DCAL clusters No NCell cut, INT7, NL , std TM, swapping back.
-    cuts.AddCutCalo("00010113","411790109fe30220000","2l631031000000d0"); // INT7 NL 12 + TB dir. gamma
+    cuts.AddCutCalo("00010113","411790109fe30230000","2l631031000000d0"); // INT7 NL 12 + TB dir. gamma
   } else if (trainConfig == 3107){  // EMCAL+DCAL clusters  No NCell cut, INT7, NL , std TM, swapping back.
-    cuts.AddCutCalo("0008e113","411790109fe30220000","2l631031000000d0"); // INT7 NL 12 + TB dir. gamma
+    cuts.AddCutCalo("0008e113","411790109fe30230000","2l631031000000d0"); // INT7 NL 12 + TB dir. gamma
   } else if (trainConfig == 3108){  // EMCAL+DCAL clusters  No NCell cut, INT7, NL , std TM, swapping back.
-    cuts.AddCutCalo("0008d113","411790109fe30220000","2l631031000000d0"); // INT7 NL 12 + TB dir. gamma
+    cuts.AddCutCalo("0008d113","411790109fe30230000","2l631031000000d0"); // INT7 NL 12 + TB dir. gamma
   // no track matching
   } else if (trainConfig == 3109){  // EMCAL+DCAL clusters No NCell cut, INT7, NL , std TM, swapping back.
-    cuts.AddCutCalo("00010113","4117901090e30220000","2l631031000000d0"); // INT7 NL 12 + TB dir. gamma
+    cuts.AddCutCalo("00010113","4117901090e30230000","2s631031000000d0"); // INT7 NL 12 + TB dir. gamma
   } else if (trainConfig == 3110){  // EMCAL+DCAL clusters  No NCell cut, INT7, NL , std TM, swapping back.
-    cuts.AddCutCalo("0008e113","4117901090e30220000","2l631031000000d0"); // INT7 NL 12 + TB dir. gamma
+    cuts.AddCutCalo("0008e113","4117901090e30230000","2s631031000000d0"); // INT7 NL 12 + TB dir. gamma
   } else if (trainConfig == 3111){  // EMCAL+DCAL clusters  No NCell cut, INT7, NL , std TM, swapping back.
-    cuts.AddCutCalo("0008d113","4117901090e30220000","2l631031000000d0"); // INT7 NL 12 + TB dir. gamma
+    cuts.AddCutCalo("0008d113","4117901090e30230000","2s631031000000d0"); // INT7 NL 12 + TB dir. gamma
   // E/p < 1.1 track matching
   } else if (trainConfig == 3112){  // EMCAL+DCAL clusters No NCell cut, INT7, NL , std TM, swapping back.
-    cuts.AddCutCalo("00010113","411790109pe30220000","2l631031000000d0"); // INT7 NL 12 + TB dir. gamma
+    cuts.AddCutCalo("00010113","411790109pe30230000","2s631031000000d0"); // INT7 NL 12 + TB dir. gamma
   } else if (trainConfig == 3113){  // EMCAL+DCAL clusters  No NCell cut, INT7, NL , std TM, swapping back.
-    cuts.AddCutCalo("0008e113","411790109pe30220000","2l631031000000d0"); // INT7 NL 12 + TB dir. gamma
+    cuts.AddCutCalo("0008e113","411790109pe30230000","2s631031000000d0"); // INT7 NL 12 + TB dir. gamma
   } else if (trainConfig == 3114){  // EMCAL+DCAL clusters  No NCell cut, INT7, NL , std TM, swapping back.
-    cuts.AddCutCalo("0008d113","411790109pe30220000","2l631031000000d0"); // INT7 NL 12 + TB dir. gamma
+    cuts.AddCutCalo("0008d113","411790109pe30230000","2s631031000000d0"); // INT7 NL 12 + TB dir. gamma
 
 
 

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_pp.C
@@ -4068,23 +4068,23 @@ void AddTask_GammaConvCalo_pp(
   //PCM-EMC in Jet
   //*************************************************************************************************
   } else if ( trainConfig == 4000){ // min bias (std) reference
-    cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411790109fe32220000","0r63103100000010");
+    cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411790109fe30230000","0r63103100000010");
   } else if ( trainConfig == 4001){ // EG2 (std) reference
-    cuts.AddCutPCMCalo("0008e113","0dm00009f9730000dge0404000","411790109fe32220000","0r63103100000010");
+    cuts.AddCutPCMCalo("0008e113","0dm00009f9730000dge0404000","411790109fe30230000","0r63103100000010");
   } else if ( trainConfig == 4002){ // EG1 (std) reference
-    cuts.AddCutPCMCalo("0008d113","0dm00009f9730000dge0404000","411790109fe32220000","0r63103100000010");
+    cuts.AddCutPCMCalo("0008d113","0dm00009f9730000dge0404000","411790109fe30230000","0r63103100000010");
   } else if ( trainConfig == 4003){ // min bias in Jet
-    cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411790109fe32220000","2l63103100000010");
+    cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411790109fe30230000","2r63103100000010");
   } else if ( trainConfig == 4004){ // EG2 in Jet
-    cuts.AddCutPCMCalo("0008e113","0dm00009f9730000dge0404000","411790109fe32220000","2l63103100000010");
+    cuts.AddCutPCMCalo("0008e113","0dm00009f9730000dge0404000","411790109fe30230000","2r63103100000010");
   } else if ( trainConfig == 4005){ // EG1 in Jet
-    cuts.AddCutPCMCalo("0008d113","0dm00009f9730000dge0404000","411790109fe32220000","2l63103100000010");
+    cuts.AddCutPCMCalo("0008d113","0dm00009f9730000dge0404000","411790109fe30230000","2r63103100000010");
   } else if ( trainConfig == 4006){ // min bias with Jet QA
-    cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411790109fe32220000","3l63103100000010");
+    cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411790109fe30230000","3r63103100000010");
   } else if ( trainConfig == 4007){ // EG2 with Jet QA
-    cuts.AddCutPCMCalo("0008e113","0dm00009f9730000dge0404000","411790109fe32220000","3l63103100000010");
+    cuts.AddCutPCMCalo("0008e113","0dm00009f9730000dge0404000","411790109fe30230000","3r63103100000010");
   } else if ( trainConfig == 4008){ // EG1 with Jet QA
-    cuts.AddCutPCMCalo("0008d113","0dm00009f9730000dge0404000","411790109fe32220000","3l63103100000010");
+    cuts.AddCutPCMCalo("0008d113","0dm00009f9730000dge0404000","411790109fe30230000","3r63103100000010");
 
 
 


### PR DESCRIPTION
- Outsource determination if particle is in Jet into dedicated function
in MesonCuts
- This change also affects that the same pi0 cannot be filled multiple
times into the same histogram (that was the case before if the same pi0
is inside multiple jet cones). Now its always filled for the closest
jet.
- Changed definition when a true pi0 is in a jet (before it was in jet
if it is in a true jet, now its in a reconstructed jet). This definition
is closer to data and therefore one can now really check how many pi0
in-Jet candidates are real pi0s.
- Added InitJet function to initialize all jet vectors just once per
event
- Added option for rotation background to GammaConv task