### PR TITLE
PWGGA/GammaConv: Added INEL>0 option to PureMC task

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskGammaPureMC.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaPureMC.cxx
@@ -140,7 +140,8 @@ AliAnalysisTaskGammaPureMC::AliAnalysisTaskGammaPureMC(): AliAnalysisTaskSE(),
   fIsMC(1),
   fMaxpT(100),
   fDoMultStudies(0),
-  fNTracksInV0Acc(0)
+  fNTracksInV0Acc(0),
+  fIsEvtINELgtZERO(0)
 {
 
 }
@@ -234,7 +235,8 @@ AliAnalysisTaskGammaPureMC::AliAnalysisTaskGammaPureMC(const char *name):
   fIsMC(1),
   fMaxpT(100),
   fDoMultStudies(0),
-  fNTracksInV0Acc(0)
+  fNTracksInV0Acc(0),
+  fIsEvtINELgtZERO(0)
 {
   // Define output slots here
   DefineOutput(1, TList::Class());
@@ -655,20 +657,35 @@ void AliAnalysisTaskGammaPureMC::ProcessMultiplicity()
 {
   // set number of tracks in V0 acceptance to 0
   fNTracksInV0Acc = 0;
+  // set INEL>0 to false
+  fIsEvtINELgtZERO = false;
+
   // Loop over all primary MC particle
   for(Long_t i = 0; i < fMCEvent->GetNumberOfTracks(); i++) {
     AliVParticle* particle     = nullptr;
     particle                    = (AliVParticle *)fMCEvent->GetTrack(i);
     if (!particle) continue;
 
-    // selected charged primary particles
-    if(particle->Charge() != 0 && particle->IsPhysicalPrimary()){
+    // selected charged primary particles in V0 acceptance
+    if(particle->IsPhysicalPrimary() && particle->Charge() != 0){
       if(IsInV0Acceptance(particle)){
         fNTracksInV0Acc++;
       }
+      // check if event is INEL>0
+      if(!fIsEvtINELgtZERO){
+        if(std::abs(particle->Eta()) < 1){
+          fIsEvtINELgtZERO = true;
+        }
+      }
     }
   }
-  fHistV0Mult->Fill(fNTracksInV0Acc);
+  if(fDoMultStudies == 2){
+    if(fIsEvtINELgtZERO == true){
+      fHistV0Mult->Fill(fNTracksInV0Acc);
+    }
+  } else {
+    fHistV0Mult->Fill(fNTracksInV0Acc);
+  }
 }
 
 //________________________________________________________________________
@@ -722,7 +739,13 @@ void AliAnalysisTaskGammaPureMC::ProcessMCParticles()
       if(fDoMultStudies){
         if(std::abs(particle->Y()) <= 0.8){
           if(!IsSecondary(motherParticle)){
-            fHistPtV0MultPi0GG->Fill(particle->Pt(), fNTracksInV0Acc);
+            if(fDoMultStudies == 2){ // select only INEL>0 events for multiplicity
+              if(fIsEvtINELgtZERO == true){
+                fHistPtV0MultPi0GG->Fill(particle->Pt(), fNTracksInV0Acc);
+              }
+            } else {
+              fHistPtV0MultPi0GG->Fill(particle->Pt(), fNTracksInV0Acc);
+            }
           }
         }
       }
@@ -733,7 +756,13 @@ void AliAnalysisTaskGammaPureMC::ProcessMCParticles()
       if(fDoMultStudies){
         if(std::abs(particle->Y()) <= 0.8){
           if(!IsSecondary(motherParticle)){
-            fHistPtV0MultEtaGG->Fill(particle->Pt(), fNTracksInV0Acc);
+            if(fDoMultStudies == 2){ // select only INEL>0 events for multiplicity
+              if(fIsEvtINELgtZERO == true){
+                fHistPtV0MultEtaGG->Fill(particle->Pt(), fNTracksInV0Acc);
+              }
+            } else {
+              fHistPtV0MultEtaGG->Fill(particle->Pt(), fNTracksInV0Acc);
+            }
           }
         }
       }
@@ -743,7 +772,13 @@ void AliAnalysisTaskGammaPureMC::ProcessMCParticles()
       if(fDoMultStudies){
         if(std::abs(particle->Y()) <= 0.8){
           if(!IsSecondary(motherParticle)){
-            fHistPtV0MultEtaPrimeGG->Fill(particle->Pt(), fNTracksInV0Acc);
+            if(fDoMultStudies == 2){ // select only INEL>0 events for multiplicity
+              if(fIsEvtINELgtZERO == true){
+                fHistPtV0MultEtaPrimeGG->Fill(particle->Pt(), fNTracksInV0Acc);
+              }
+            } else {
+              fHistPtV0MultEtaPrimeGG->Fill(particle->Pt(), fNTracksInV0Acc);
+            }
           }
         }
       }

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaPureMC.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaPureMC.h
@@ -72,7 +72,7 @@ class AliAnalysisTaskGammaPureMC : public AliAnalysisTaskSE {
     void SetLogBinningXTH2(TH2* histoRebin);
     void SetIsK0(Int_t isK0){fIsK0 = isK0;}
     void SetMaxPt(Double_t pTmax){fMaxpT = pTmax;}
-    void SetDoMultStudies(Bool_t tmp){fDoMultStudies = tmp;}
+    void SetDoMultStudies(Int_t tmp){fDoMultStudies = tmp;}
 
   protected:
     TList*                fOutputContainer;           //! Output container
@@ -169,15 +169,15 @@ class AliAnalysisTaskGammaPureMC : public AliAnalysisTaskSE {
 	  Int_t				          fIsK0;					  // k0 flag
     Int_t                 fIsMC;            // MC flag
     Double_t              fMaxpT;           // Max pT flag
-    Int_t                 fDoMultStudies;   // enable multiplicity dependent studies (0 -> No mult studies, 1 -> Mult estimation with V0, 2 -> Mult estimation with SPD)
+    Int_t                 fDoMultStudies;   // enable multiplicity dependent studies (0 -> No mult studies, 1 -> Mult estimation with V0, 2 -> Mult estimation with V0 and INEL>0 criterium for multiplicity)
     Int_t                 fNTracksInV0Acc;  // number of tracks in V0A+C acceptance for multiplicity studies
-
+    Bool_t                fIsEvtINELgtZERO; // flag if event is INEL>0
 
   private:
     AliAnalysisTaskGammaPureMC(const AliAnalysisTaskGammaPureMC&); // Prevent copy-construction
     AliAnalysisTaskGammaPureMC &operator=(const AliAnalysisTaskGammaPureMC&); // Prevent assignment
 
-    ClassDef(AliAnalysisTaskGammaPureMC, 6);
+    ClassDef(AliAnalysisTaskGammaPureMC, 7);
 };
 
 #endif


### PR DESCRIPTION
- Mode fDoMultStudies=2 now only selects INEL>0 events for mult studies.
INEL>0 means at least one primary charged particle in |eta|<1.
- This is needed as in data we select the INEL>0 event class