### PR TITLE
Fixed the way 100 GeV track cut behaves

### DIFF
--- a/PWGCF/Correlations/JCORRAN/Pro/AliJCDijetAna.cxx
+++ b/PWGCF/Correlations/JCORRAN/Pro/AliJCDijetAna.cxx
@@ -275,7 +275,7 @@ int AliJCDijetAna::CalculateJets(TClonesArray *inList, AliJCDijetHistos *fhistos
         AliJBaseTrack *trk = (AliJBaseTrack*)inList->At(utrack);
         pt = trk->Pt();
         eta = trk->Eta();
-        if (pt>fParticlePtCut && pt<fParticlePtCutMax && TMath::Abs(eta) < fParticleEtaCut){
+        if (pt>fParticlePtCut && TMath::Abs(eta) < fParticleEtaCut){
             if(ftrackingIneff>0.0 && randomGenerator->Uniform(0.0,1.0) < ftrackingIneff) continue;
             phi = trk->Phi() > TMath::Pi() ? trk->Phi()-2*TMath::Pi() : trk->Phi();
             if(DeltaR(randConeEta, eta, randConePhi, phi) < fJetCone) randConePt += pt;
@@ -301,8 +301,24 @@ int AliJCDijetAna::CalculateJets(TClonesArray *inList, AliJCDijetHistos *fhistos
     if(bThisIsTrueMC) {
         rawJets = tempJets;
     } else {
-        for (utrack = 0; utrack < tempJets.size(); utrack++) {
-            if(tempJets.at(utrack).area()>areaCut) rawJets.push_back(tempJets.at(utrack));
+        for (ujet = 0; ujet < tempJets.size(); ujet++) {
+            if(tempJets.at(ujet).area()>areaCut) {  //Check first that jet area is large enough
+                fhistos->fh_events[lCBin]->Fill("area cut ok",1.0);
+                ucount=0;
+                for(uconst=0;uconst<tempJets.at(ujet).constituents().size(); uconst++) {
+                    if(tempJets.at(ujet).constituents().at(uconst).pt() > fParticlePtCutMax ) { // Check if jet has 100 GeV constituents
+                        ucount++;
+                    }
+                }
+                if(ucount==0) {
+                    fhistos->fh_events[lCBin]->Fill("100GeV const cut ok",1.0);
+                    rawJets.push_back(tempJets.at(ujet));
+                } else {
+                    fhistos->fh_events[lCBin]->Fill("100GeV const cut fails",1.0);
+                }
+            } else { //if area cut fails
+                fhistos->fh_events[lCBin]->Fill("area cut fails",1.0);
+            }
         }
     }
 
@@ -1170,6 +1186,10 @@ void AliJCDijetAna::InitHistos(AliJCDijetHistos *histos, bool bIsMC, int nCentBi
         histos->fh_events[iBin]->Fill("kt acc. dijets",0.0);
         histos->fh_events[iBin]->Fill("kt deltaphi cut dijets",0.0);
         histos->fh_events[iBin]->Fill("pt_hard bin cuts",0.0);
+        histos->fh_events[iBin]->Fill("area cut ok",0.0);
+        histos->fh_events[iBin]->Fill("area cut fails",0.0);
+        histos->fh_events[iBin]->Fill("100GeV const cut ok",0.0);
+        histos->fh_events[iBin]->Fill("100GeV const cut fails",0.0);
         histos->fh_events[iBin]->Fill("localRho dropped leading jet",0.0);
         histos->fh_events[iBin]->Fill("localRho dropped subleading jet",0.0);
         histos->fh_events[iBin]->Fill("localRho dropped subleading jet (Alt)",0.0);

--- a/PWGCF/Correlations/JCORRAN/Pro/AliJCDijetAna.h
+++ b/PWGCF/Correlations/JCORRAN/Pro/AliJCDijetAna.h
@@ -105,7 +105,7 @@ class AliJCDijetAna : public TObject
         unsigned noTracks;
         bool removed;
         //For loops:
-        unsigned utrack, uktjet, ujet, ujet2, uconst, udijet, ujetDetMC;
+        unsigned utrack, uktjet, ujet, ujet2, uconst, udijet, ujetDetMC, ucount;
         std::vector<bool> bHasDijet;
         std::vector<bool> bHasDeltaPhiDijet;
         bool bHasDeltaPhiSubLeadJet;


### PR DESCRIPTION
Previously: Remove over 100 GeV tracks from event.
Now: Remove jets with over 100 GeV constituents.