### PR TITLE
[PAG/Flow] flag to use bootstrap

### DIFF
--- a/PWGCF/FLOW/GF/AliAnalysisTaskCorrForNonlinearFlow.cxx
+++ b/PWGCF/FLOW/GF/AliAnalysisTaskCorrForNonlinearFlow.cxx
@@ -169,6 +169,7 @@ AliAnalysisTaskCorrForNonlinearFlow::AliAnalysisTaskCorrForNonlinearFlow():
     hDCAz(0),
     hITSclusters(0),
     hChi2(0),
+    fBootstrapStat(false),
     rand(2333)
 {
 }
@@ -272,6 +273,7 @@ AliAnalysisTaskCorrForNonlinearFlow::AliAnalysisTaskCorrForNonlinearFlow(const c
   hDCAz(0),
   hITSclusters(0),
   hChi2(0),
+  fBootstrapStat(false),
   rand(2333)
 {
 
@@ -402,6 +404,7 @@ AliAnalysisTaskCorrForNonlinearFlow::AliAnalysisTaskCorrForNonlinearFlow(const c
   hDCAz(0),
   hITSclusters(0),
   hChi2(0),
+  fBootstrapStat(false),
   rand(2333)
 {
 
@@ -470,8 +473,13 @@ void AliAnalysisTaskCorrForNonlinearFlow::UserCreateOutputObjects() {
     const Int_t sizePtTrig = fPtBinsTrigCharged.size() - 1;
     // const Int_t sizePtAss = fPtBinsAss.size() - 1;
     const Int_t sizeCent = fCentBins.size() - 1;
-    const Int_t sizeOfSamples = 30; // (Int_t) fNOfSamples; 
-    const Int_t iBinning[] = {sizeEta,72,10,sizeOfSamples,sizePtTrig,sizeCent};
+    Int_t sizeOfSamples = 1; // (Int_t) fNOfSamples; 
+    Int_t sizeOfVtxZbins = 10; // (Int_t) fNOfSamples; 
+    if (fBootstrapStat) {
+	    sizeOfSamples = 30;
+	    sizeOfVtxZbins  = 1;
+    }
+    const Int_t iBinning[] = {sizeEta,72,sizeOfVtxZbins,sizeOfSamples,sizePtTrig,sizeCent};
 
     fListOfProfile = new TList();
     fListOfProfile->SetOwner();
@@ -500,7 +508,7 @@ void AliAnalysisTaskCorrForNonlinearFlow::UserCreateOutputObjects() {
     }
     fhChargedSE->SetBinLimits(1, binning_dphi);
     fhChargedSE->SetBinLimits(2, -10,10);
-    fhChargedSE->SetBinLimits(3,  0.,30.);
+    fhChargedSE->SetBinLimits(3,  -0.5,sizeOfSamples-0.5);
     fhChargedSE->SetBinLimits(4, fPtBinsTrigCharged.data());
     fhChargedSE->SetBinLimits(5, fCentBins.data());
     fhChargedSE->SetVarTitle(0, "#Delta#eta");
@@ -519,7 +527,7 @@ void AliAnalysisTaskCorrForNonlinearFlow::UserCreateOutputObjects() {
     }
     fhChargedME->SetBinLimits(1, binning_dphi);
     fhChargedME->SetBinLimits(2, -10.,10.);
-    fhChargedME->SetBinLimits(3,  0.,30.);
+    fhChargedSE->SetBinLimits(3,  -0.5,sizeOfSamples-0.5);
     fhChargedME->SetBinLimits(4, fPtBinsTrigCharged.data());
     fhChargedME->SetBinLimits(5, fCentBins.data());
     fhChargedME->SetVarTitle(0, "#Delta#eta");
@@ -546,7 +554,10 @@ void AliAnalysisTaskCorrForNonlinearFlow::NotifyRun() {
 // ---------------------------------------------------------------------------------
 void AliAnalysisTaskCorrForNonlinearFlow::UserExec(Option_t *) {
   // Mingrui: apply the bootstrap later
-  bootstrap_value = rand.Integer(30);
+  int sizeOfSamples = 1;
+  if (fBootstrapStat) sizeOfSamples = 30;
+  bootstrap_value = rand.Integer(sizeOfSamples);
+  cout << bootstrap_value << endl;
 
   // Check if it can pass the trigger
   //..apply physics selection

--- a/PWGCF/FLOW/GF/AliAnalysisTaskCorrForNonlinearFlow.cxx
+++ b/PWGCF/FLOW/GF/AliAnalysisTaskCorrForNonlinearFlow.cxx
@@ -470,15 +470,18 @@ void AliAnalysisTaskCorrForNonlinearFlow::UserCreateOutputObjects() {
     for (int i = 0; i < fCentBins.size(); i++) fCentBins[i] += 0.5;
     std::vector<Double_t>   fzVtxBins = {-10.0, 0, 10.0};
     const Int_t sizeEta = (anaType.EqualTo("TPCTPC") ? 33 : 43) -1;
-    const Int_t sizePtTrig = fPtBinsTrigCharged.size() - 1;
     // const Int_t sizePtAss = fPtBinsAss.size() - 1;
     const Int_t sizeCent = fCentBins.size() - 1;
     Int_t sizeOfSamples = 1; // (Int_t) fNOfSamples; 
     Int_t sizeOfVtxZbins = 10; // (Int_t) fNOfSamples; 
     if (fBootstrapStat) {
 	    sizeOfSamples = 30;
-	    sizeOfVtxZbins  = 1;
+	    fPtBinsTrigCharged.clear();
+	    fPtBinsTrigCharged.push_back(0.2);
+	    fPtBinsTrigCharged.push_back(3.0);
+
     }
+    Int_t sizePtTrig = fPtBinsTrigCharged.size() - 1;
     const Int_t iBinning[] = {sizeEta,72,sizeOfVtxZbins,sizeOfSamples,sizePtTrig,sizeCent};
 
     fListOfProfile = new TList();
@@ -557,7 +560,6 @@ void AliAnalysisTaskCorrForNonlinearFlow::UserExec(Option_t *) {
   int sizeOfSamples = 1;
   if (fBootstrapStat) sizeOfSamples = 30;
   bootstrap_value = rand.Integer(sizeOfSamples);
-  cout << bootstrap_value << endl;
 
   // Check if it can pass the trigger
   //..apply physics selection

--- a/PWGCF/FLOW/GF/AliAnalysisTaskCorrForNonlinearFlow.h
+++ b/PWGCF/FLOW/GF/AliAnalysisTaskCorrForNonlinearFlow.h
@@ -109,6 +109,7 @@ class AliAnalysisTaskCorrForNonlinearFlow : public AliAnalysisTaskSE {
 		virtual void   SetPeriod(TString period){fPeriod = period;}
 		virtual void   SetSystFlag(int syst){fCurrSystFlag = syst;} 
 		virtual int    GetSystFlag(){return fCurrSystFlag;}
+		virtual void   UseBootstrap(bool ftest = true){fBootstrapStat = ftest;}
 
 		Double_t RangePhi(Double_t DPhi);
 		Double_t GetDPhiStar(Double_t phi1, Double_t pt1, Double_t charge1, Double_t phi2, Double_t pt2, Double_t charge2, Double_t radius);
@@ -184,6 +185,7 @@ class AliAnalysisTaskCorrForNonlinearFlow : public AliAnalysisTaskSE {
 		Int_t                   fPoolMaxNEvents;                        // Maximum number of events in a pool
 		Int_t                   fPoolMinNTracks;                        // Minimum number of tracks to mix
 		Int_t                   fMinEventsToMix;                        // Minimum numver of events to mix
+                Bool_t                  fBootstrapStat;                         // Flag to calculate statistical uncertainty with bootstrap
 
 		// Output objects
 		TList*			fListOfObjects;			//! Output list of objects
@@ -289,7 +291,7 @@ class AliAnalysisTaskCorrForNonlinearFlow : public AliAnalysisTaskSE {
 		double fCentrality;            //!
 		Double_t fbSign;               //!
 
-		ClassDef(AliAnalysisTaskCorrForNonlinearFlow, 2); // Analysis task
+		ClassDef(AliAnalysisTaskCorrForNonlinearFlow, 3); // Analysis task
 };
 
 #endif


### PR DESCRIPTION
When using bootstrap, the memory consumption is large. We need to reduce the pt binning of trigger particles to 1 (0.2-3.0) to ensure the bootstrap works. 