### PR TITLE
PWGHF: Add Dstar and LF track for femto in treecreator

### DIFF
--- a/PWGHF/vertexingHF/macros/AddTaskHFTreeCreatorApply.C
+++ b/PWGHF/vertexingHF/macros/AddTaskHFTreeCreatorApply.C
@@ -8,6 +8,8 @@ AliAnalysisTaskSEHFTreeCreatorApply *AddTaskHFTreeCreatorApply(Bool_t readMC=kFA
                                                                Bool_t fillMGgenTrees=kFALSE,
                                                                Int_t fillTreeDs=0,
                                                                Int_t fillTreeLc2V0bachelor=0,
+                                                               Int_t fillTreeDstar=0,
+                                                               Int_t fillTreeParticle=0, //0=None, 1=pKpi, 2=p, 3=K, 4=pi
                                                                Int_t pidOpt=AliHFTreeHandlerApply::kNsigmaPID,
                                                                Int_t singletrackvarsopt=AliHFTreeHandlerApply::kRedSingleTrackVars,
                                                                Bool_t useDefaultDirName=kTRUE,
@@ -16,7 +18,7 @@ AliAnalysisTaskSEHFTreeCreatorApply *AddTaskHFTreeCreatorApply(Bool_t readMC=kFA
   //
   //
   
-  if(fillTreeDs && fillTreeLc2V0bachelor && confFileML != ""){
+  if(fillTreeDs && fillTreeLc2V0bachelor && fillTreeDstar && confFileML != ""){
     ::Error("AddTaskHFTreeCreatorApply", "Not possible to enable more than one hadron when applying.");
     return NULL;
   }
@@ -44,18 +46,24 @@ AliAnalysisTaskSEHFTreeCreatorApply *AddTaskHFTreeCreatorApply(Bool_t readMC=kFA
   if(!looseCutsDstoKKpi && fillTreeDs)        ::Fatal("AddTaskHFTreeCreatorApply", "looseCutsDstoKKpi : check your cut file");
   AliRDHFCutsLctoV0* looseCutsLc2V0bachelor        =(AliRDHFCutsLctoV0*)filecuts->Get("Lc2V0bachelorFilteringCuts");
   if(!looseCutsLc2V0bachelor && (fillTreeLc2V0bachelor || fillMixEvBkg))    ::Fatal("AddTaskHFTreeCreatorApply", "looseCutsLc2V0bachelor : check your cut file");
+  AliRDHFCutsDStartoKpipi* looseCutsDstartoKpipi   =(AliRDHFCutsDStartoKpipi*)filecuts->Get("DstartoKpipiFilteringCuts");
+  if(!looseCutsDstartoKpipi && fillTreeDstar)    ::Fatal("AddTaskHFTreeCreator", "looseCutsDstartoKpipi : check your cut file");
   AliRDHFCutsDstoKKpi*     analysisCutsDstoKKpi    =(AliRDHFCutsDstoKKpi*)filecuts->Get("DstoKKpiAnalysisCuts");
   if(!analysisCutsDstoKKpi && fillTreeDs)     ::Fatal("AddTaskHFTreeCreatorApply", "analysisCutsDstoKKpi : check your cut file");
   AliRDHFCutsLctoV0* analysisCutsLc2V0bachelor=(AliRDHFCutsLctoV0*)filecuts->Get("Lc2V0bachelorAnalysisCuts");
   if(!analysisCutsLc2V0bachelor && (fillTreeLc2V0bachelor || fillMixEvBkg)) ::Fatal("AddTaskHFTreeCreatorApply", "analysisCutsLc2V0bachelor : check your cut file");
+  AliRDHFCutsDStartoKpipi* analysisCutsDstartoKpipi=(AliRDHFCutsDStartoKpipi*)filecuts->Get("DstartoKpipiAnalysisCuts");
+  if(!analysisCutsDstartoKpipi && fillTreeDstar) ::Fatal("AddTaskHFTreeCreator", "analysisCutsDstartoKpipi : check your cut file");
   
   TList *cutsList=new TList();
   cutsList->SetOwner(kTRUE);
   cutsList->SetName("cut_objects");
   cutsList->Add(looseCutsDstoKKpi);
   cutsList->Add(looseCutsLc2V0bachelor);
+  cutsList->Add(looseCutsDstartoKpipi);
   cutsList->Add(analysisCutsDstoKKpi);
   cutsList->Add(analysisCutsLc2V0bachelor);
+  cutsList->Add(analysisCutsDstartoKpipi);
   
   AliAnalysisTaskSEHFTreeCreatorApply *task = new AliAnalysisTaskSEHFTreeCreatorApply("TreeCreatorTask",cutsList);
   
@@ -68,8 +76,11 @@ AliAnalysisTaskSEHFTreeCreatorApply *AddTaskHFTreeCreatorApply(Bool_t readMC=kFA
   task->SetWriteOnlySignalTree(writeOnlySignalTree);
   task->SetFillDsTree(fillTreeDs);
   task->SetFillLc2V0bachelorTree(fillTreeLc2V0bachelor);
+  task->SetFillDstarTree(fillTreeDstar);
+  task->SetFillParticleTree(fillTreeParticle);
   task->SetPIDoptDsTree(pidOpt);
   task->SetPIDoptLc2V0bachelorTree(pidOpt);
+  task->SetPIDoptDstarTree(pidOpt);
   task->SetTreeSingleTrackVarsOpt(singletrackvarsopt);
   if(fillMixEvBkg){
     task->SetSaveMixedEventBkg(kTRUE);
@@ -91,8 +102,11 @@ AliAnalysisTaskSEHFTreeCreatorApply *AddTaskHFTreeCreatorApply(Bool_t readMC=kFA
   TString treeDsname = "coutputTreeDs";
   TString treeLc2V0bachelorname = "coutputTreeLc2V0bachelor";
   TString treeLc2V0bachelornameMixEv = "coutputTreeLc2V0bachelorMixEv";
+  TString treeDstarname = "coutputTreeDstar";
+  TString treeParticlename = "coutputTreeParticle";
   TString treeGenDsname = "coutputTreeGenDs";
   TString treeGenLc2V0bachelorname = "coutputTreeGenLc2V0bachelor";
+  TString treeGenDstarname = "coutputTreeGenDstar";
   
   inname += finDirname.Data();
   histoname += finDirname.Data();
@@ -103,8 +117,11 @@ AliAnalysisTaskSEHFTreeCreatorApply *AddTaskHFTreeCreatorApply(Bool_t readMC=kFA
   treeDsname += finDirname.Data();
   treeLc2V0bachelorname += finDirname.Data();
   treeLc2V0bachelornameMixEv += finDirname.Data();
+  treeDstarname += finDirname.Data();
+  treeParticlename += finDirname.Data();
   treeGenDsname += finDirname.Data();
   treeGenLc2V0bachelorname += finDirname.Data();
+  treeGenDstarname += finDirname.Data();
   
   AliAnalysisDataContainer *cinput = mgr->CreateContainer(inname,TChain::Class(),AliAnalysisManager::kInputContainer);
   TString outputfile = AliAnalysisManager::GetCommonFileName();
@@ -122,6 +139,9 @@ AliAnalysisTaskSEHFTreeCreatorApply *AddTaskHFTreeCreatorApply(Bool_t readMC=kFA
   AliAnalysisDataContainer *coutputTreeLc2V0bachelor = 0x0;
   AliAnalysisDataContainer *coutputTreeLc2V0bachelorMixEv = 0x0;
   AliAnalysisDataContainer *coutputTreeGenLc2V0bachelor = 0x0;
+  AliAnalysisDataContainer *coutputTreeDstar = 0x0;
+  AliAnalysisDataContainer *coutputTreeGenDstar = 0x0;
+  AliAnalysisDataContainer *coutputTreeParticle = 0x0;
 
   if(fillTreeDs) {
     coutputTreeDs = mgr->CreateContainer(treeDsname,TTree::Class(),AliAnalysisManager::kOutputContainer,outputfile.Data());
@@ -146,6 +166,20 @@ AliAnalysisTaskSEHFTreeCreatorApply *AddTaskHFTreeCreatorApply(Bool_t readMC=kFA
     coutputTreeLc2V0bachelorMixEv->SetSpecialOutput();
   }
 
+  if(fillTreeDstar) {
+    coutputTreeDstar = mgr->CreateContainer(treeDstarname,TTree::Class(),AliAnalysisManager::kOutputContainer,outputfile.Data());
+    coutputTreeDstar->SetSpecialOutput();
+    if(readMC && fillMGgenTrees) {
+      coutputTreeGenDstar = mgr->CreateContainer(treeGenDstarname,TTree::Class(),AliAnalysisManager::kOutputContainer,outputfile.Data());
+      coutputTreeGenDstar->SetSpecialOutput();
+    }
+  }
+
+  if(fillTreeParticle){
+    coutputTreeParticle = mgr->CreateContainer(treeParticlename,TTree::Class(),AliAnalysisManager::kOutputContainer,outputfile.Data());
+    coutputTreeParticle->SetSpecialOutput();
+  }
+
   mgr->ConnectInput(task,0,mgr->GetCommonInputContainer());
   mgr->ConnectOutput(task,1,coutputEntries);
   mgr->ConnectOutput(task,2,coutputCounter);
@@ -161,6 +195,13 @@ AliAnalysisTaskSEHFTreeCreatorApply *AddTaskHFTreeCreatorApply(Bool_t readMC=kFA
     if(readMC && fillMGgenTrees) mgr->ConnectOutput(task,9,coutputTreeGenLc2V0bachelor);
   }
   if(fillMixEvBkg) mgr->ConnectOutput(task,10,coutputTreeLc2V0bachelorMixEv);
+  if(fillTreeDstar) {
+    mgr->ConnectOutput(task,11,coutputTreeDstar);
+    if(readMC && fillMGgenTrees) mgr->ConnectOutput(task,12,coutputTreeGenDstar);
+  }
+  if(fillTreeParticle){
+    mgr->ConnectOutput(task,13,coutputTreeParticle);
+  }
 
   return task;
 }

--- a/PWGHF/vertexingHF/vHFML/AliAnalysisTaskSEHFTreeCreatorApply.cxx
+++ b/PWGHF/vertexingHF/vHFML/AliAnalysisTaskSEHFTreeCreatorApply.cxx
@@ -64,8 +64,11 @@
 #include "AliHFTreeHandlerApply.h"
 #include "AliHFTreeHandlerApplyDstoKKpi.h"
 #include "AliHFTreeHandlerApplyLc2V0bachelor.h"
+#include "AliHFTreeHandlerApplyDstartoKpipi.h"
+#include "AliParticleTreeHandlerApply.h"
 #include "AliHFMLResponseDstoKKpi.h"
 #include "AliHFMLResponseLctoV0bachelor.h"
+#include "AliHFMLResponseDstartoD0pi.h"
 #include "AliAnalysisTaskSEHFTreeCreatorApply.h"
 #include "AliAODPidHF.h"
 #include "AliESDUtils.h"
@@ -104,10 +107,13 @@ fCounter(0x0),
 fListCuts(cutsList),
 fFiltCutsDstoKKpi(0x0),
 fFiltCutsLc2V0bachelor(0x0),
+fFiltCutsDstartoKpipi(0x0),
 fCutsDstoKKpi(0x0),
 fCutsLc2V0bachelor(0x0),
+fCutsDstartoKpipi(0x0),
 fEvSelectionCuts(0x0),
 fReadMC(0),
+fDebugMode(0),
 fUseSelectionBit(kTRUE),
 fSys(0),
 fAODProtection(0),
@@ -115,20 +121,27 @@ fWriteOnlySignal(kFALSE),
 fFillMCGenTrees(kTRUE),
 fWriteVariableTreeDs(0),
 fWriteVariableTreeLc2V0bachelor(0),
+fWriteVariableTreeDstar(0),
 fVariablesTreeDs(0x0),
 fVariablesTreeLc2V0bachelor(0x0),
 fVariablesTreeLc2V0bachelorMixEv(0x0),
+fVariablesTreeDstar(0x0),
 fGenTreeDs(0x0),
 fGenTreeLc2V0bachelor(0x0),
+fGenTreeDstar(0x0),
 fTreeEvChar(0x0),
 fTreeHandlerDs(0x0),
 fTreeHandlerLc2V0bachelor(0x0),
 fTreeHandlerLc2V0bachelorMixEv(0x0),
+fTreeHandlerDstar(0x0),
+fTreeHandlerParticle(0x0),
 fTreeHandlerGenDs(0x0),
 fTreeHandlerGenLc2V0bachelor(0x0),
+fTreeHandlerGenDstar(0x0),
 fPIDresp(0x0),
 fPIDoptDs(AliHFTreeHandlerApply::kRawAndNsigmaPID),
 fPIDoptLc2V0bachelor(AliHFTreeHandlerApply::kRawAndNsigmaPID),
+fPIDoptDstar(AliHFTreeHandlerApply::kRawAndNsigmaPID),
 fBC(0),
 fOrbit(0),
 fPeriod(0),
@@ -137,6 +150,7 @@ fEventIDExt(0),
 fEventIDLong(0),
 fFileName(""),
 fDirNumber(0),
+fMagField(0),
 fCentrality(-999.),
 fzVtxReco(0.),
 fzVtxGen(0.),
@@ -175,6 +189,7 @@ fnV0MCorr(0),
 fnV0MEqCorr(0),
 fPercV0M(0.),
 fMultV0M(0.),
+fRefMultComb08(0.),
 fRefMult(9.26),
 fRefMultSHM(9.26),
 fMultEstimatorAvg(),
@@ -204,6 +219,8 @@ fMaxPtCandDownsampling(999.),
 fConfigPath(""),
 fMLResponse(0x0),
 fReducePbPbBranches(false),
+fReduceHMV0Branches(false),
+fOnlyDedicatedBranches(false),
 fSaveSTDSelection(false),
 fSaveMixedEventBkg(false),
 fNumberOfEventsForMixing(10),
@@ -214,21 +231,27 @@ fPoolIndex(-9999),
 fNextResVec(),
 fReservoirsReady(),
 fReservoirP(),
-fMLResponseMixEv(0x0)
+fMLResponseMixEv(0x0),
+fAODMapSize(0),
+fAODMap(0)
 {
 
   if (fListCuts) {
     fFiltCutsDstoKKpi     =(AliRDHFCutsDstoKKpi*)fListCuts->FindObject("DstoKKpiFilteringCuts");
     fFiltCutsLc2V0bachelor=(AliRDHFCutsLctoV0*)fListCuts->FindObject("Lc2V0bachelorFilteringCuts");
+    fFiltCutsDstartoKpipi =(AliRDHFCutsDStartoKpipi*)fListCuts->FindObject("DstartoKpipiFilteringCuts");
     fCutsDstoKKpi         =(AliRDHFCutsDstoKKpi*)fListCuts->FindObject("DstoKKpiAnalysisCuts");
     fCutsLc2V0bachelor    =(AliRDHFCutsLctoV0*)fListCuts->FindObject("Lc2V0bachelorAnalysisCuts");
+    fCutsDstartoKpipi     =(AliRDHFCutsDStartoKpipi*)fListCuts->FindObject("DstartoKpipiAnalysisCuts");
 
     if(fWriteVariableTreeDs) fEvSelectionCuts = (AliRDHFCuts*)fFiltCutsDstoKKpi->Clone();
     else if(fWriteVariableTreeLc2V0bachelor) fEvSelectionCuts = (AliRDHFCuts*)fFiltCutsLc2V0bachelor->Clone();
     else if(fSaveMixedEventBkg) fEvSelectionCuts = (AliRDHFCuts*)fFiltCutsLc2V0bachelor->Clone();
+    else if(fWriteVariableTreeDstar) fEvSelectionCuts = (AliRDHFCuts*)fFiltCutsDstartoKpipi->Clone();
     else {
       if(fFiltCutsDstoKKpi) fEvSelectionCuts = (AliRDHFCuts*)fFiltCutsDstoKKpi->Clone();
       else if(fFiltCutsLc2V0bachelor) fEvSelectionCuts = (AliRDHFCuts*)fFiltCutsLc2V0bachelor->Clone();
+      else if(fFiltCutsDstartoKpipi) fEvSelectionCuts = (AliRDHFCuts*)fFiltCutsDstartoKpipi->Clone();
       else printf("AliAnalysisTaskSEHFTreeCreatorApply:: Constructor: No event selection cuts could be stored, code will crash!\n");
     }
   }
@@ -254,6 +277,12 @@ fMLResponseMixEv(0x0)
   DefineOutput(9,TTree::Class());
   // Output slot #10 stores the tree of the Lc2V0bachelor candidate variables after track selection from Mixed Events
   DefineOutput(10,TTree::Class());
+  // Output slot #11 stores the tree of the Dstar candidate variables after track selection
+  DefineOutput(11,TTree::Class());
+  // Output slot #12 stores the tree of the gen Dstar variables
+  DefineOutput(12,TTree::Class());
+  // Output slot #13 stores the tree of the (femto) tracks after selection
+  DefineOutput(13,TTree::Class());
 
 }
 
@@ -272,10 +301,13 @@ AliAnalysisTaskSEHFTreeCreatorApply::~AliAnalysisTaskSEHFTreeCreatorApply()
   delete fCounter;
   delete fTreeHandlerDs;
   delete fTreeHandlerLc2V0bachelor;
+  delete fTreeHandlerDstar;
+  delete fTreeHandlerParticle;
   delete fTreeHandlerLc2V0bachelorMixEv;
 
   delete fTreeHandlerGenDs;
   delete fTreeHandlerGenLc2V0bachelor;
+  delete fTreeHandlerGenDstar;
   delete fTreeEvChar;
   
   delete fMLResponse;
@@ -392,6 +424,8 @@ void AliAnalysisTaskSEHFTreeCreatorApply::UserCreateOutputObjects()
   Int_t nEnabledTrees = 1; // event tree always enabled
   if(fWriteVariableTreeDs) nEnabledTrees++;
   if(fWriteVariableTreeLc2V0bachelor) nEnabledTrees++;
+  if(fWriteVariableTreeDstar) nEnabledTrees++;
+  if(fWriteVariableTreeParticle) nEnabledTrees++;
   if(fSaveMixedEventBkg) nEnabledTrees++;
   if(fReadMC && fFillMCGenTrees) {
     nEnabledTrees = (nEnabledTrees-1)*2+1;
@@ -403,46 +437,44 @@ void AliAnalysisTaskSEHFTreeCreatorApply::UserCreateOutputObjects()
   OpenFile(5);
   fTreeEvChar = new TTree("tree_event_char","tree_event_char");
   //set variables
-  fTreeEvChar->Branch("centrality", &fCentrality);
   fTreeEvChar->Branch("z_vtx_reco", &fzVtxReco);
-  fTreeEvChar->Branch("n_vtx_contributors", &fNcontributors);
-  fTreeEvChar->Branch("n_tracks", &fNtracks);
   fTreeEvChar->Branch("is_ev_rej", &fIsEvRej);
-  if(!fReducePbPbBranches){
-    fTreeEvChar->Branch("is_ev_rej_INT7", &fIsEvRej_INT7);
-    fTreeEvChar->Branch("is_ev_rej_HighMultSPD", &fIsEvRej_HighMultSPD);
-    fTreeEvChar->Branch("is_ev_rej_HighMultV0", &fIsEvRej_HighMultV0);
-  }
   fTreeEvChar->Branch("run_number", &fRunNumber);
   fTreeEvChar->Branch("ev_id", &fEventID);
   fTreeEvChar->Branch("ev_id_ext", &fEventIDExt);
-  fTreeEvChar->Branch("ev_id_long", &fEventIDLong);
-  fTreeEvChar->Branch("n_tracklets", &fnTracklets);
-  fTreeEvChar->Branch("V0Amult", &fnV0A);
-  fTreeEvChar->Branch("n_tpc_cls", &fnTPCCls);
+  fTreeEvChar->Branch("trigger_hasbit_INT7", &fTriggerBitINT7);
+  if(!fReduceHMV0Branches){
+    fTreeEvChar->Branch("n_tracks", &fNtracks);
+    fTreeEvChar->Branch("centrality", &fCentrality);
+    fTreeEvChar->Branch("n_vtx_contributors", &fNcontributors);
+    fTreeEvChar->Branch("trigger_hasbit_Central", &fTriggerBitCentral);
+    fTreeEvChar->Branch("trigger_hasbit_SemiCentral", &fTriggerBitSemiCentral);
+    fTreeEvChar->Branch("n_tracklets", &fnTracklets);
+    fTreeEvChar->Branch("ev_id_long", &fEventIDLong);
+  }
   if(!fReducePbPbBranches){
+    fTreeEvChar->Branch("magn_field", &fMagField);
+    fTreeEvChar->Branch("trigger_hasbit_HighMultV0", &fTriggerBitHighMultV0);
+    fTreeEvChar->Branch("ref_mult_comb08", &fRefMultComb08);
+    fTreeEvChar->Branch("perc_v0m", &fPercV0M);
+  }
+  if(!fReducePbPbBranches && !fReduceHMV0Branches){
+    fTreeEvChar->Branch("is_ev_rej_INT7", &fIsEvRej_INT7);
+    fTreeEvChar->Branch("is_ev_rej_HighMultSPD", &fIsEvRej_HighMultSPD);
+    fTreeEvChar->Branch("is_ev_rej_HighMultV0", &fIsEvRej_HighMultV0);
     fTreeEvChar->Branch("trigger_bitmap", &fTriggerMask);
     fTreeEvChar->Branch("trigger_online_INT7", &fTriggerOnlineINT7);
     fTreeEvChar->Branch("trigger_online_HighMultSPD", &fTriggerOnlineHighMultSPD);
     fTreeEvChar->Branch("trigger_online_HighMultV0", &fTriggerOnlineHighMultV0);
-  }
-  fTreeEvChar->Branch("trigger_hasbit_INT7", &fTriggerBitINT7);
-  if(!fReducePbPbBranches){
     fTreeEvChar->Branch("trigger_hasbit_HighMultSPD", &fTriggerBitHighMultSPD);
-    fTreeEvChar->Branch("trigger_hasbit_HighMultV0", &fTriggerBitHighMultV0);
-  }
-  fTreeEvChar->Branch("trigger_hasbit_Central", &fTriggerBitCentral);
-  fTreeEvChar->Branch("trigger_hasbit_SemiCentral", &fTriggerBitSemiCentral);
-  if(!fReducePbPbBranches){
     fTreeEvChar->Branch("trigger_classes", &fTriggerClasses);
     fTreeEvChar->Branch("trigger_hasclass_INT7", &fTriggerClassINT7);
     fTreeEvChar->Branch("trigger_hasclass_HighMultSPD", &fTriggerClassHighMultSPD);
     fTreeEvChar->Branch("trigger_hasclass_HighMultV0", &fTriggerClassHighMultV0m);
-  }
-  fTreeEvChar->Branch("z_vtx_gen", &fzVtxGen);
-  if(!fReducePbPbBranches){
     fTreeEvChar->Branch("n_tracklets_corr", &fnTrackletsCorr);
     fTreeEvChar->Branch("n_tracklets_corr_shm", &fnTrackletsCorrSHM);
+    fTreeEvChar->Branch("n_tpc_cls", &fnTPCCls);
+    fTreeEvChar->Branch("V0Amult", &fnV0A);
     fTreeEvChar->Branch("v0m", &fnV0M);
     fTreeEvChar->Branch("v0m_eq", &fnV0MEq);
     fTreeEvChar->Branch("v0m_corr", &fnV0MCorr);
@@ -450,8 +482,10 @@ void AliAnalysisTaskSEHFTreeCreatorApply::UserCreateOutputObjects()
     fTreeEvChar->Branch("mult_gen", &fMultGen);
     fTreeEvChar->Branch("mult_gen_v0a", &fMultGenV0A);
     fTreeEvChar->Branch("mult_gen_v0c", &fMultGenV0C);
-    fTreeEvChar->Branch("perc_v0m", &fPercV0M);
     fTreeEvChar->Branch("mult_v0m", &fMultV0M);
+  }
+  if(fReadMC){
+    fTreeEvChar->Branch("z_vtx_gen", &fzVtxGen);
   }
   fTreeEvChar->SetMaxVirtualSize(1.e+8/nEnabledTrees);
   
@@ -464,6 +498,7 @@ void AliAnalysisTaskSEHFTreeCreatorApply::UserCreateOutputObjects()
     OpenFile(6);
     TString nameoutput = "tree_Ds";
     fTreeHandlerDs = new AliHFTreeHandlerApplyDstoKKpi(fPIDoptDs);
+    if(fConfigPath != "") fTreeHandlerDs->SetIncludeML(true);
     fTreeHandlerDs->SetOptSingleTrackVars(fTreeSingleTrackVarsOpt);
     if(fReadMC && fWriteOnlySignal) fTreeHandlerDs->SetFillOnlySignal(fWriteOnlySignal);
     if(fEnableNsigmaTPCDataCorr) fTreeHandlerDs->EnableNsigmaTPCDataDrivenCorrection(fSystemForNsigmaTPCDataCorr);
@@ -476,6 +511,7 @@ void AliAnalysisTaskSEHFTreeCreatorApply::UserCreateOutputObjects()
       OpenFile(7);
       TString nameoutput = "tree_Ds_gen";
       fTreeHandlerGenDs = new AliHFTreeHandlerApplyDstoKKpi(0);
+      fTreeHandlerGenDs->SetOnlyDedicatedBranches(fOnlyDedicatedBranches);
       fGenTreeDs = (TTree*)fTreeHandlerGenDs->BuildTreeMCGen(nameoutput,nameoutput);
       fGenTreeDs->SetMaxVirtualSize(1.e+8/nEnabledTrees);
       fTreeEvChar->AddFriend(fGenTreeDs);
@@ -490,6 +526,7 @@ void AliAnalysisTaskSEHFTreeCreatorApply::UserCreateOutputObjects()
     OpenFile(8);
     TString nameoutput = "tree_Lc2V0bachelor";
     fTreeHandlerLc2V0bachelor = new AliHFTreeHandlerApplyLc2V0bachelor(fPIDoptLc2V0bachelor);
+    if(fConfigPath != "") fTreeHandlerLc2V0bachelor->SetIncludeML(true);
     fTreeHandlerLc2V0bachelor->SetOptSingleTrackVars(fTreeSingleTrackVarsOpt);
     if(fReadMC && fWriteOnlySignal) fTreeHandlerLc2V0bachelor->SetFillOnlySignal(fWriteOnlySignal);
     if(fEnableNsigmaTPCDataCorr) fTreeHandlerLc2V0bachelor->EnableNsigmaTPCDataDrivenCorrection(fSystemForNsigmaTPCDataCorr);
@@ -502,6 +539,7 @@ void AliAnalysisTaskSEHFTreeCreatorApply::UserCreateOutputObjects()
       OpenFile(9);
       TString nameoutput = "tree_Lc2V0bachelor_gen";
       fTreeHandlerGenLc2V0bachelor = new AliHFTreeHandlerApplyLc2V0bachelor(0);
+      fTreeHandlerGenLc2V0bachelor->SetOnlyDedicatedBranches(fOnlyDedicatedBranches);
       fGenTreeLc2V0bachelor = (TTree*)fTreeHandlerGenLc2V0bachelor->BuildTreeMCGen(nameoutput,nameoutput);
       fGenTreeLc2V0bachelor->SetMaxVirtualSize(1.e+8/nEnabledTrees);
       fTreeEvChar->AddFriend(fGenTreeLc2V0bachelor);
@@ -517,6 +555,7 @@ void AliAnalysisTaskSEHFTreeCreatorApply::UserCreateOutputObjects()
     OpenFile(10);
     TString nameoutputMixEv = "tree_MixEv_Lc2V0bachelor";
     fTreeHandlerLc2V0bachelorMixEv = new AliHFTreeHandlerApplyLc2V0bachelor(AliHFTreeHandlerApplyLc2V0bachelor::kNoPID);
+    if(fConfigPath != "") fTreeHandlerLc2V0bachelorMixEv->SetIncludeML(true);
     fTreeHandlerLc2V0bachelorMixEv->SetOptSingleTrackVars(fTreeSingleTrackVarsOpt);
     fTreeHandlerLc2V0bachelorMixEv->SetFillOnlySignal(kFALSE);
     if(fEnableNsigmaTPCDataCorr) fTreeHandlerLc2V0bachelorMixEv->EnableNsigmaTPCDataDrivenCorrection(fSystemForNsigmaTPCDataCorr);
@@ -526,6 +565,47 @@ void AliAnalysisTaskSEHFTreeCreatorApply::UserCreateOutputObjects()
     fVariablesTreeLc2V0bachelorMixEv = (TTree*)fTreeHandlerLc2V0bachelorMixEv->BuildTree(nameoutputMixEv,nameoutputMixEv);
     fVariablesTreeLc2V0bachelorMixEv->SetMaxVirtualSize(1.e+8/nEnabledTrees);
     fTreeEvChar->AddFriend(fVariablesTreeLc2V0bachelorMixEv);
+  }
+
+  if(fWriteVariableTreeDstar){
+    if(fConfigPath != ""){
+      fMLResponse = new AliHFMLResponseDstartoD0pi("DstartoD0piMLResponse", "DstartoD0piMLResponse", fConfigPath.Data());
+      fMLResponse->MLResponseInit();
+    }
+
+    OpenFile(11);
+    TString nameoutput = "tree_Dstar";
+    fTreeHandlerDstar = new AliHFTreeHandlerApplyDstartoKpipi(fPIDoptDstar);
+    if(fConfigPath != "") fTreeHandlerDstar->SetIncludeML(true);
+    fTreeHandlerDstar->SetOptSingleTrackVars(fTreeSingleTrackVarsOpt);
+    if(fReadMC && fWriteOnlySignal) fTreeHandlerDstar->SetFillOnlySignal(fWriteOnlySignal);
+    if(fEnableNsigmaTPCDataCorr) fTreeHandlerDstar->EnableNsigmaTPCDataDrivenCorrection(fSystemForNsigmaTPCDataCorr);
+    fTreeHandlerDstar->SetOnlyDedicatedBranches(fOnlyDedicatedBranches);
+    fVariablesTreeDstar = (TTree*)fTreeHandlerDstar->BuildTree(nameoutput,nameoutput);
+    fVariablesTreeDstar->SetMaxVirtualSize(1.e+8/nEnabledTrees);
+    fTreeEvChar->AddFriend(fVariablesTreeDstar);
+    
+    if(fFillMCGenTrees && fReadMC) {
+      OpenFile(12);
+      TString nameoutput = "tree_Dstar_gen";
+      fTreeHandlerGenDstar = new AliHFTreeHandlerApplyDstartoKpipi(0);
+      fTreeHandlerGenDstar->SetOnlyDedicatedBranches(fOnlyDedicatedBranches);
+      fGenTreeDstar = (TTree*)fTreeHandlerGenDstar->BuildTreeMCGen(nameoutput,nameoutput);
+      fGenTreeDstar->SetMaxVirtualSize(1.e+8/nEnabledTrees);
+      fTreeEvChar->AddFriend(fGenTreeDstar);
+    }
+  }
+
+  if(fWriteVariableTreeParticle){
+    OpenFile(13);
+    TString nameoutput = "tree_Particle";
+    fTreeHandlerParticle = new AliParticleTreeHandlerApply();
+    fTreeHandlerParticle->SetOnlyDedicatedBranches(fOnlyDedicatedBranches);
+    fTreeHandlerParticle->SetIsMC(fReadMC);
+    fTreeHandlerParticle->SetIsDebugMode(fDebugMode);
+    fVariablesTreeParticle = (TTree*)fTreeHandlerParticle->BuildTree(nameoutput,nameoutput);
+    fVariablesTreeParticle->SetMaxVirtualSize(1.e+8/nEnabledTrees);
+    fTreeEvChar->AddFriend(fVariablesTreeParticle);
   }
 
   //Set seed of gRandom
@@ -545,6 +625,13 @@ void AliAnalysisTaskSEHFTreeCreatorApply::UserCreateOutputObjects()
     if(fFillMCGenTrees && fReadMC) PostData(9,fGenTreeLc2V0bachelor);
   }
   if(fSaveMixedEventBkg) PostData(10,fVariablesTreeLc2V0bachelorMixEv);
+  if(fWriteVariableTreeDstar){
+    PostData(11,fVariablesTreeDstar);
+    if(fFillMCGenTrees && fReadMC) PostData(12,fGenTreeDstar);
+  }
+  if(fWriteVariableTreeParticle){
+    PostData(13,fVariablesTreeParticle);
+  }
 
   return;
 }
@@ -651,19 +738,24 @@ void AliAnalysisTaskSEHFTreeCreatorApply::UserExec(Option_t */*option*/){
   
   Bool_t isSameEvSelDs=kTRUE;
   Bool_t isSameEvSelLc2V0bachelor=kTRUE;
+  Bool_t isSameEvSelDstar=kTRUE;
 
   if(fWriteVariableTreeDs)
     isSameEvSelDs=!((fFiltCutsDstoKKpi->IsEventSelected(aod) && !fCutsDstoKKpi->IsEventSelected(aod))||(!fFiltCutsDstoKKpi->IsEventSelected(aod) && fCutsDstoKKpi->IsEventSelected(aod)));
   if(fWriteVariableTreeLc2V0bachelor || fSaveMixedEventBkg)
     isSameEvSelLc2V0bachelor=!((fFiltCutsLc2V0bachelor->IsEventSelected(aod) && !fCutsLc2V0bachelor->IsEventSelected(aod))||(!fFiltCutsLc2V0bachelor->IsEventSelected(aod) && fCutsLc2V0bachelor->IsEventSelected(aod)));
+  if(fWriteVariableTreeDstar)
+    isSameEvSelDstar=!((fFiltCutsDstartoKpipi->IsEventSelected(aod) && !fCutsDstartoKpipi->IsEventSelected(aod))||(!fFiltCutsDstartoKpipi->IsEventSelected(aod) && fCutsDstartoKpipi->IsEventSelected(aod)));
   
-  Bool_t isSameEvSel = isSameEvSelDs && isSameEvSelLc2V0bachelor;
+  Bool_t isSameEvSel = isSameEvSelDs && isSameEvSelLc2V0bachelor && isSameEvSelDstar;
   if(!isSameEvSel) {
     Printf("AliAnalysisTaskSEHFTreeCreatorApply::UserExec: differences in the event selection cuts same meson");
     return;
   }
   
-  if((fWriteVariableTreeDs && (fWriteVariableTreeLc2V0bachelor || fSaveMixedEventBkg) && (fFiltCutsDstoKKpi->IsEventSelected(aod)!=fFiltCutsLc2V0bachelor->IsEventSelected(aod)))){
+  if((fWriteVariableTreeDs && (fWriteVariableTreeLc2V0bachelor || fSaveMixedEventBkg) && (fFiltCutsDstoKKpi->IsEventSelected(aod)!=fFiltCutsLc2V0bachelor->IsEventSelected(aod))) ||
+     (fWriteVariableTreeDstar && (fWriteVariableTreeLc2V0bachelor || fSaveMixedEventBkg) && (fFiltCutsDstartoKpipi->IsEventSelected(aod)!=fFiltCutsLc2V0bachelor->IsEventSelected(aod))) ||
+     (fWriteVariableTreeDstar && fWriteVariableTreeDs && (fFiltCutsDstartoKpipi->IsEventSelected(aod)!=fFiltCutsDstoKKpi->IsEventSelected(aod)))){
     Printf("AliAnalysisTaskSEHFTreeCreatorApply::UserExec: differences in the event selection cuts different meson");
     return;
   }
@@ -672,6 +764,7 @@ void AliAnalysisTaskSEHFTreeCreatorApply::UserExec(Option_t */*option*/){
   AliAODVertex *vtx = (AliAODVertex*)aod->GetPrimaryVertex();
   fNcontributors = vtx->GetNContributors();
   fzVtxReco = vtx->GetZ();
+  fMagField = aod->GetMagneticField();
   fNtracks = aod->GetNumberOfTracks();
   fRunNumber=aod->GetRunNumber();
 
@@ -778,6 +871,8 @@ void AliAnalysisTaskSEHFTreeCreatorApply::UserExec(Option_t */*option*/){
     fnV0MEqCorr = static_cast<Int_t>(AliESDUtils::GetCorrV0A(vzeroAEq, vtx->GetZ()) + AliESDUtils::GetCorrV0C(vzeroCEq, vtx->GetZ()));
   }
   
+  // multiplicity
+  fRefMultComb08 = (dynamic_cast<AliAODHeader*>(aod->GetHeader()))->GetRefMultiplicityComb08();
   // multiplicity percentiles
   const auto multSel = static_cast<AliMultSelection*>(aod->FindListObject("MultSelection"));
   fPercV0M = multSel ? multSel->GetMultiplicityPercentile("V0M") : -1.;
@@ -841,6 +936,8 @@ void AliAnalysisTaskSEHFTreeCreatorApply::UserExec(Option_t */*option*/){
   
   if(fWriteVariableTreeDs) Process3Prong(array3Prong,aod,mcArray,aod->GetMagneticField(),mcHeader);
   if(fWriteVariableTreeLc2V0bachelor) ProcessCasc(arrayCasc,aod,mcArray,aod->GetMagneticField(),mcHeader);
+  if(fWriteVariableTreeDstar) ProcessDstar(arrayDstar,aod,mcArray,aod->GetMagneticField(),mcHeader);
+  if(fWriteVariableTreeParticle) ProcessTrack(aod,mcArray,mcHeader);
   if(fSaveMixedEventBkg) DoEventMixingLc2V0bachelor(aod);
   
   // Post the data
@@ -857,6 +954,13 @@ void AliAnalysisTaskSEHFTreeCreatorApply::UserExec(Option_t */*option*/){
     if(fFillMCGenTrees && fReadMC) PostData(9,fGenTreeLc2V0bachelor);
   }
   if(fSaveMixedEventBkg) PostData(10,fVariablesTreeLc2V0bachelorMixEv);
+  if(fWriteVariableTreeDstar){
+    PostData(11,fVariablesTreeDstar);
+    if(fFillMCGenTrees && fReadMC) PostData(12,fGenTreeDstar);
+  }
+  if(fWriteVariableTreeParticle){
+    PostData(13,fVariablesTreeParticle);
+  }
 
   return;
 }
@@ -1342,6 +1446,266 @@ void AliAnalysisTaskSEHFTreeCreatorApply::ProcessCasc(TClonesArray *arrayCasc, A
   delete vHF;
   return;
 }
+//________________________________________________________________
+void AliAnalysisTaskSEHFTreeCreatorApply::ProcessDstar(TClonesArray *arrayDstar, AliAODEvent *aod, TClonesArray *arrMC, Float_t bfield, AliAODMCHeader *mcHeader){
+  
+  AliAODVertex *vtx1 = (AliAODVertex*)aod->GetPrimaryVertex();
+  
+  Int_t nCasc = arrayDstar->GetEntriesFast();
+  if(fDebug>2) printf("Number of D*-> D0 pi: %d\n",nCasc);
+  
+  Int_t pdgDgDStartopiKpi[3]={211,321,211};
+  Int_t pdgDgDStartoD0pi[2]={421,211};
+  Int_t pdgDgD0toKpi[2]={321,211};
+  Int_t nSelectedDstar=0;
+  Int_t nFilteredDstar=0;
+  
+  // vHF object is needed to call the method that refills the missing info of the candidates
+  // if they have been deleted in dAOD reconstruction phase
+  // in order to reduce the size of the file
+  AliAnalysisVertexingHF *vHF = new AliAnalysisVertexingHF();
+  
+  for (Int_t iCasc = 0; iCasc < nCasc; iCasc++) {
+    fNentries->Fill(28);
+    
+    //Dstar
+    Bool_t isDstartagged=kTRUE;
+    AliAODRecoCascadeHF *d = (AliAODRecoCascadeHF*)arrayDstar->UncheckedAt(iCasc);
+    if(fUseSelectionBit && d->GetSelectionMap()) if(!d->HasSelectionBit(AliRDHFCuts::kDstarCuts)){
+      isDstartagged=kFALSE;
+    }
+    
+    if (isDstartagged && fWriteVariableTreeDstar){
+      
+      //PreSelection to speed up task significantly when needed (PbPb `18 or ITSUpgrade)
+      Bool_t got_all_prongs = kTRUE;
+      TObjArray arrTracks(3);
+      if(fITSUpgradePreSelect || fFiltCutsDstartoKpipi->GetUsePreselect()){
+        TClonesArray* inputArrayD0 = (TClonesArray*)aod->GetList()->FindObject("D0toKpi");
+        if(!inputArrayD0){ got_all_prongs = kFALSE; break; }
+        AliAODRecoDecayHF2Prong* trackD0 = (AliAODRecoDecayHF2Prong*)inputArrayD0->At(d->GetProngID(1));
+
+        for(Int_t ipr=0;ipr<3;ipr++){
+          AliAODTrack *tr;
+          if(ipr == 0) tr=vHF->GetProng(aod,d,ipr); //soft pion
+          else         tr=vHF->GetProng(aod,trackD0,ipr-1); //D0 daughters
+          arrTracks.AddAt(tr,ipr);
+        }
+      }
+      Int_t preSelectedDstar = -1;
+      if(fITSUpgradePreSelect && got_all_prongs){
+        preSelectedDstar = AliVertexingHFUtils::PreSelectITSUpgrade(arrMC, mcHeader, arrTracks, 3, 413, pdgDgDStartopiKpi);
+        if(preSelectedDstar == 0) continue; //Mixture hijing + injected
+        if(preSelectedDstar == 2) continue; //Only MatchedToMC injected signal
+        if(fWriteOnlySignal == 1 && preSelectedDstar != 1) continue; //Only matched signal when only signal is requested
+      }
+      Int_t preSelectedDstarCuts = -1;
+      if(fFiltCutsDstartoKpipi->GetUsePreselect() && d->GetIsFilled() == 0 && got_all_prongs){
+        preSelectedDstarCuts = fFiltCutsDstartoKpipi->PreSelect(arrTracks);
+        if(preSelectedDstarCuts==0) continue;
+      }
+
+      fNentries->Fill(29);
+      nFilteredDstar++;
+      if((vHF->FillRecoCasc(aod,d,kTRUE))) {//Fill the data members of the candidate only if they are empty.
+        
+        if(fEnableCandDownsampling){
+          Double_t ptCand = d->Pt();
+          Double_t pseudoRand = ptCand * 1000. - (long)(ptCand * 1000);
+          if (pseudoRand > fFracToKeepCandDownsampling && ptCand < fMaxPtCandDownsampling) continue;
+        }
+
+        Int_t isSelectedFilt = fFiltCutsDstartoKpipi->IsSelected(d,AliRDHFCuts::kAll,aod); //selected
+        if(isSelectedFilt > 0){
+
+          Double_t modelPred = -1.;
+          AliAODPidHF *Pid_HF = fFiltCutsDstartoKpipi->GetPidHF();
+          Bool_t isSelectedMLFilt = kTRUE;
+          if(fMLResponse){
+            isSelectedMLFilt = fMLResponse->IsSelected(modelPred, d, aod->GetMagneticField(), Pid_HF, 0);
+          }
+          if(isSelectedMLFilt){
+
+            fNentries->Fill(30);
+            nSelectedDstar++;
+            
+            //test analysis cuts
+            Bool_t isSelAnCuts = kFALSE;
+            Bool_t isSelAnPidCuts = kFALSE;
+            Bool_t isSelAnTopolCuts = kFALSE;
+            Int_t isSelectedAnalysis = fCutsDstartoKpipi->IsSelected(d,AliRDHFCuts::kAll,aod);
+            Int_t isSelectedPidAnalysis = fCutsDstartoKpipi->IsSelectedPID(d);
+            Bool_t isUsePidAn = fCutsDstartoKpipi->GetIsUsePID();
+            if(isUsePidAn) fCutsDstartoKpipi->SetUsePID(kFALSE);
+            Int_t isSelectedTopoAnalysis = fCutsDstartoKpipi->IsSelected(d,AliRDHFCuts::kAll,aod);
+            Bool_t isSelTracksAnCuts=kFALSE;
+            Int_t isSelectedTrackAnalysis = fCutsDstartoKpipi->IsSelected(d,AliRDHFCuts::kTracks,aod);
+            if(isSelectedTrackAnalysis > 0) isSelTracksAnCuts=kTRUE;
+            if(isSelectedAnalysis) isSelAnCuts = kTRUE;
+            if(isSelectedPidAnalysis) isSelAnPidCuts = kTRUE;
+            if(isSelectedTopoAnalysis) isSelAnTopolCuts = kTRUE;
+            fCutsDstartoKpipi->SetUsePID(isUsePidAn);
+            
+            //For Dstar the removal of daughters is done only for D0 prongs.
+            AliAODRecoDecayHF2Prong* dd = (AliAODRecoDecayHF2Prong*)d->Get2Prong();
+            Bool_t unsetvtx=kFALSE;
+            if(!dd->GetOwnPrimaryVtx()){
+              dd->SetOwnPrimaryVtx(vtx1);
+              unsetvtx=kTRUE;
+              // NOTE: the own primary vertex should be unset, otherwise there is a memory leak
+              // Pay attention if you use continue inside this loop!!!
+            }
+            Bool_t recVtx=kFALSE;
+            AliAODVertex *origownvtx=0x0;
+            if(fFiltCutsDstartoKpipi->GetIsPrimaryWithoutDaughters()){
+              if(dd->GetOwnPrimaryVtx()) origownvtx=new AliAODVertex(*dd->GetOwnPrimaryVtx());
+              if(fFiltCutsDstartoKpipi->RecalcOwnPrimaryVtx(dd,aod))recVtx=kTRUE;
+              else fFiltCutsDstartoKpipi->CleanOwnPrimaryVtx(dd,aod,origownvtx);
+            }
+
+            Int_t labDstar = -1;
+            Int_t pdgDstar = -99;
+            Int_t origin= -1;
+            Float_t ptGenDstar = -99;
+            Bool_t isParticleFromOutOfBunchPileUpEvent = kFALSE;
+            //checking origin
+            AliAODMCParticle *partDstar=0x0;
+            if(fReadMC) {
+              labDstar = d->MatchToMC(413,421,pdgDgDStartoD0pi, pdgDgD0toKpi, arrMC);
+
+              if(labDstar>=0){
+                // PILEUP protection for PbPb2018: remove particles from pileup events in efficiency computation
+                isParticleFromOutOfBunchPileUpEvent = AliAnalysisUtils::IsParticleFromOutOfBunchPileupCollision(labDstar, mcHeader, arrMC);
+                partDstar = (AliAODMCParticle*)arrMC->At(labDstar);
+                pdgDstar = TMath::Abs(partDstar->GetPdgCode());
+                ptGenDstar = partDstar->Pt();
+                origin = AliVertexingHFUtils::CheckOrigin(arrMC,partDstar,!fITSUpgradeProduction);
+              }
+            }
+
+            bool issignal = kFALSE;
+            bool isbkg =    kFALSE;
+            bool isFD =     kFALSE;
+            bool isprompt = kFALSE;
+            bool isrefl =   kFALSE;
+            
+            if(fReadMC && !isParticleFromOutOfBunchPileUpEvent){
+              if(labDstar>=0){
+                if(origin==4 || origin==5) {
+                  if(origin==4) isprompt=kTRUE;
+                  else if(origin==5) isFD=kTRUE;
+                  if(pdgDstar==413){
+                    issignal=kTRUE;
+                  }
+                }
+              }//end labDstar check
+              else{//background
+                isbkg=kTRUE;
+              }
+              if(issignal || isbkg || isrefl){
+                fTreeHandlerDstar->SetCandidateType(issignal,isbkg,isprompt,isFD,isrefl);
+                fTreeHandlerDstar->SetDstarMCMatchedLabel(labDstar);
+              }
+            }//end read MC
+            if(!fReadMC || (issignal || isbkg || isrefl)) {
+              fTreeHandlerDstar->SetIsSelectedStd(isSelAnCuts,isSelAnTopolCuts,isSelAnPidCuts,isSelTracksAnCuts);
+              fTreeHandlerDstar->SetVariables(fRunNumber,fEventID,fEventIDExt,fEventIDLong,ptGenDstar,modelPred,d,bfield,0,fPIDresp,Pid_HF);
+              fTreeHandlerDstar->FillTree();
+            }
+            if(recVtx)fFiltCutsDstartoKpipi->CleanOwnPrimaryVtx(dd,aod,origownvtx);
+            if(unsetvtx) dd->UnsetOwnPrimaryVtx();
+          }//end is selected filt
+        } //end ML selection
+      } //end Dstar IsSelected
+      else {
+        fNentries->Fill(31); //monitor how often this fails
+      }
+    }//end Dstar
+  }//end loop on candidates
+  
+  delete vHF;
+  return;
+}
+//_________________________________________________________________
+void AliAnalysisTaskSEHFTreeCreatorApply::ProcessTrack(AliAODEvent *aod, TClonesArray *arrMC, AliAODMCHeader *mcHeader){
+
+  MapAODtracks(aod);
+  
+  for (Int_t iTrack = 0; iTrack < aod->GetNumberOfTracks(); iTrack++) {
+
+    AliAODTrack* tr = dynamic_cast<AliAODTrack*>(aod->GetTrack(iTrack));
+    if (!tr) AliFatal("Not a standard AOD");
+    
+    AliAODTrack* trGlobal;
+    int trackID = tr->GetID();
+    if (trackID < 0) {
+      trGlobal = dynamic_cast<AliAODTrack*>(aod->GetTrack(fAODMap[-trackID - 1]));
+    } else {
+      trGlobal = tr;
+    }
+
+    float nSigTPC, nSigTOF, nSigComb;
+    bool isnclstpcstd = false;
+    bool isnclstpctight = false;
+    bool isprotonstd = false;
+    bool isprotonpidloose = false;
+    bool isprotonpidtight = false;
+    if(fWriteVariableTreeParticle == 1 || fWriteVariableTreeParticle ==  2){
+      if(!(tr->GetTPCNcls() < fNClsTPCProton)) isnclstpcstd = true;
+      if(!(tr->GetTPCNcls() < fMaxNClsTPCProton)) isnclstpctight = true;
+      IsSelectedProton(tr, trGlobal, isprotonstd, isprotonpidloose, isprotonpidtight);
+      nSigTPC = fPIDresp->NumberOfSigmas(AliPIDResponse::kTPC, trGlobal, AliPID::kProton);
+      nSigTOF = fPIDresp->NumberOfSigmas(AliPIDResponse::kTOF, trGlobal, AliPID::kProton);
+      nSigComb = TMath::Sqrt(nSigTPC * nSigTPC + nSigTOF * nSigTOF);
+    }
+
+    bool iskaonstd = false;
+    bool iskaonpidloose = false;
+    bool iskaonpidtight = false;
+    if(fWriteVariableTreeParticle == 1 || fWriteVariableTreeParticle ==  3){
+      if(!(tr->GetTPCNcls() < fNClsTPCKaon)) isnclstpcstd = true;
+      if(!(tr->GetTPCNcls() < fMaxNClsTPCKaon)) isnclstpctight = true;
+      IsSelectedKaon(tr, trGlobal, iskaonstd, iskaonpidloose, iskaonpidtight);
+      nSigTPC = fPIDresp->NumberOfSigmas(AliPIDResponse::kTPC, trGlobal, AliPID::kKaon);
+      nSigTOF = fPIDresp->NumberOfSigmas(AliPIDResponse::kTOF, trGlobal, AliPID::kKaon);
+      nSigComb = TMath::Sqrt(nSigTPC * nSigTPC + nSigTOF * nSigTOF);
+    }
+
+    bool ispionstd = false;
+    bool ispionpidloose = false;
+    bool ispionpidtight = false;
+    if(fWriteVariableTreeParticle == 1 || fWriteVariableTreeParticle ==  4){
+      if(!(tr->GetTPCNcls() < fNClsTPCPion)) isnclstpcstd = true;
+      if(!(tr->GetTPCNcls() < fMaxNClsTPCProton)) isnclstpctight = true;
+      IsSelectedPion(tr, trGlobal, ispionstd, ispionpidloose, ispionpidtight);
+      nSigTPC = fPIDresp->NumberOfSigmas(AliPIDResponse::kTPC, trGlobal, AliPID::kPion);
+      nSigTOF = fPIDresp->NumberOfSigmas(AliPIDResponse::kTOF, trGlobal, AliPID::kPion);
+      nSigComb = TMath::Sqrt(nSigTPC * nSigTPC + nSigTOF * nSigTOF);
+    }
+
+    if((isprotonstd || isprotonpidloose || isprotonpidtight) ||
+       (iskaonstd   || iskaonpidloose   || iskaonpidtight  ) ||
+       (ispionstd   || ispionpidloose   || ispionpidtight  )){
+
+      fTreeHandlerParticle->SetSelectionType(0, isprotonstd, isprotonpidloose, isprotonpidtight);
+      fTreeHandlerParticle->SetSelectionType(1, iskaonstd, iskaonpidloose, iskaonpidtight);
+      fTreeHandlerParticle->SetSelectionType(2, ispionstd, ispionpidloose, ispionpidtight);
+      fTreeHandlerParticle->SetSelectionType(3, isnclstpcstd, true, isnclstpctight);
+      if(fWriteVariableTreeParticle > 1) fTreeHandlerParticle->SetPIDVariables(nSigTPC, nSigTOF, nSigComb);
+      fTreeHandlerParticle->SetVariables(fRunNumber, fEventID, fEventIDExt, fEventIDLong, tr, trGlobal);
+
+      if(fReadMC){
+        int isMClabel = TMath::Abs(tr->GetLabel());
+        AliAODMCParticle* mcPart = dynamic_cast<AliAODMCParticle*>(arrMC->At(isMClabel));
+        fTreeHandlerParticle->SetMCGenVariables(mcPart, isMClabel);
+      }
+
+      fTreeHandlerParticle->FillTree();
+    }
+  }
+
+  return;
+}
 //_________________________________________________________________
 void AliAnalysisTaskSEHFTreeCreatorApply::ProcessMCGen(TClonesArray *arrayMC, AliAODMCHeader *mcHeader){
   /// Fill MC gen trees
@@ -1351,7 +1715,7 @@ void AliAnalysisTaskSEHFTreeCreatorApply::ProcessMCGen(TClonesArray *arrayMC, Al
     AliAODMCParticle* mcPart = dynamic_cast<AliAODMCParticle*>(arrayMC->At(iPart));
     Int_t absPDG = TMath::Abs(mcPart->GetPdgCode());
     
-    if(absPDG == 431 || absPDG == 4122) {
+    if(absPDG == 431 || absPDG == 4122 || absPDG == 413) {
       Bool_t isPrimary = kFALSE;
       Bool_t isFeeddown = kFALSE;
 
@@ -1375,6 +1739,9 @@ void AliAnalysisTaskSEHFTreeCreatorApply::ProcessMCGen(TClonesArray *arrayMC, Al
       Int_t  labDau[3] = {-1,-1,-1};
       Bool_t isDaugInAcc = kFALSE;
       
+      Int_t pdg = mcPart->GetPdgCode();
+      Int_t pdg_mom = (static_cast<AliAODMCParticle*>(arrayMC->At(mcPart->GetMother())))->GetPdgCode();
+
       if(absPDG == 431 && fWriteVariableTreeDs) {
         deca = AliVertexingHFUtils::CheckDsDecay(arrayMC,mcPart,labDau);
         if(deca!=fWriteVariableTreeDs || labDau[0]<0 || labDau[1]<0) continue;
@@ -1391,6 +1758,16 @@ void AliAnalysisTaskSEHFTreeCreatorApply::ProcessMCGen(TClonesArray *arrayMC, Al
         fTreeHandlerGenLc2V0bachelor->SetCandidateType(kTRUE,kFALSE,isPrimary,isFeeddown,kFALSE);
         fTreeHandlerGenLc2V0bachelor->SetMCGenVariables(fRunNumber,fEventID,fEventIDExt,fEventIDLong, mcPart);
         fTreeHandlerGenLc2V0bachelor->FillTree();
+      } else if(absPDG == 413 && fWriteVariableTreeDstar) {
+        deca = AliVertexingHFUtils::CheckDstarDecay(arrayMC,mcPart,labDau);
+        if(deca!=1 || labDau[0]<0 || labDau[1]<0) continue;
+        isDaugInAcc = CheckDaugAcc(arrayMC,3,labDau,fITSUpgradeProduction);
+        fTreeHandlerGenDstar->SetDauInAcceptance(isDaugInAcc);
+        fTreeHandlerGenDstar->SetCandidateType(kTRUE,kFALSE,isPrimary,isFeeddown,kFALSE);
+        if(fTreeHandlerGenDstar->SetMCGenVariables(fRunNumber,fEventID,fEventIDExt,fEventIDLong, mcPart)){
+          fTreeHandlerGenDstar->SetMCGenVariablesextra(pdg, pdg_mom, iPart);
+        }
+        fTreeHandlerGenDstar->FillTree();
       }
     }
   }
@@ -1935,4 +2312,433 @@ unsigned int AliAnalysisTaskSEHFTreeCreatorApply::GetEvID() {
   unsigned int evID = (unsigned int)ev_number + (unsigned int)(fDirNumber<<17);
   fEventNumber++;
   return evID;
+}
+//________________________________________________________________
+void AliAnalysisTaskSEHFTreeCreatorApply::IsSelectedProton(AliAODTrack* tr, AliAODTrack* trGlobal, Bool_t &isprotonstd, Bool_t &isprotonpidloose, Bool_t &isprotonpidtight){
+
+  isprotonstd = false;
+  isprotonpidloose = false;
+  isprotonpidtight = false;
+
+  if(!tr) return;
+  if(!fPIDresp) return;
+  
+  if(TMath::Abs(tr->Charge()) != 1) return;
+
+  if(!( (fFilterBitProton & tr->GetFilterMap()) != 0)) return;
+  if(tr->Pt() < fPtMinProton || tr->Pt() > fPtMaxProton) return;
+  if(TMath::Abs(tr->Eta()) > fEtaMaxProton) return;
+  if(tr->GetTPCNcls() < fMinNClsTPCProton) return;
+  if(fTPCRefitProton && !tr->IsOn(AliAODTrack::kTPCrefit)) return;
+
+  Float_t trDCAXYProp, trDCAZProp;
+  trGlobal->GetImpactParameters(trDCAXYProp,trDCAZProp);
+  Float_t trDCAXY = tr->DCA(); 
+  Float_t trDCAZ = tr->ZAtDCA();
+  if(fDCARecalculationProton){
+    if(!(TMath::Abs(trDCAXYProp) < fDCAToVertexXYProton)) return;
+    if(!(TMath::Abs(trDCAZProp) < fDCAToVertexZProton)) return;
+  } else {
+    if(!(TMath::Abs(trDCAXY) < fDCAToVertexXYProton)) return;
+    if(!(TMath::Abs(trDCAZ) < fDCAToVertexZProton)) return;
+  }
+
+  if(fCutSharedClsProton){
+    const TBits sharedMap = tr->GetTPCSharedMap();
+    if ((sharedMap.CountBits()) >= 1) return;
+  }
+
+  if(fCutTPCCrossedRowsProton){
+    Double_t trTPCCrossedRows = tr->GetTPCClusterInfo(2, 1);
+    if(trTPCCrossedRows < fCrossedRowsProton) return;
+    Double_t trRatioCR;
+    if (!(tr->GetTPCNclsF() > 0)) {
+      trRatioCR = 0.;
+    } else {
+      trRatioCR = trTPCCrossedRows / float(tr->GetTPCNclsF());
+    }
+    if(trRatioCR < fRatioCrossedRowsProton) return;
+  }
+
+  if(trGlobal->GetTPCmomentum() < fMinPIDPtTPCCutProton){
+    AliPIDResponse::EDetPidStatus statusTPC = fPIDresp->CheckPIDStatus(AliPIDResponse::kTPC, trGlobal);
+    if (statusTPC != AliPIDResponse::kDetPidOk) return;
+
+    isprotonstd = true;
+    isprotonpidloose = true;
+    isprotonpidtight = true;
+
+    if(fRejLowPtPionsTOFProton){
+      AliPIDResponse::EDetPidStatus statusTOF = fPIDresp->CheckPIDStatus(AliPIDResponse::kTOF, trGlobal);
+      if (statusTOF == AliPIDResponse::kDetPidOk){
+        if(TMath::Abs(fPIDresp->NumberOfSigmas(AliPIDResponse::kTOF, trGlobal, AliPID::kPion)) < fPIDSigmaCutProton)
+          isprotonstd = false;
+        if(TMath::Abs(fPIDresp->NumberOfSigmas(AliPIDResponse::kTOF, trGlobal, AliPID::kPion)) < fMinPIDSigmaCutProton)
+          isprotonpidtight = false;
+        if(TMath::Abs(fPIDresp->NumberOfSigmas(AliPIDResponse::kTOF, trGlobal, AliPID::kPion)) < fMaxPIDSigmaCutProton)
+          isprotonpidloose = false;
+      }
+    }
+
+    if(isprotonstd){
+      if(!(TMath::Abs(fPIDresp->NumberOfSigmas(AliPIDResponse::kTPC, trGlobal, AliPID::kProton)) < fPIDSigmaCutProton))
+        isprotonstd = false;
+    }
+    if(isprotonpidtight){
+      if(!(TMath::Abs(fPIDresp->NumberOfSigmas(AliPIDResponse::kTPC, trGlobal, AliPID::kProton)) < fMinPIDSigmaCutProton))
+        isprotonpidtight = false;
+    }
+    if(isprotonpidloose){
+      if(!(TMath::Abs(fPIDresp->NumberOfSigmas(AliPIDResponse::kTPC, trGlobal, AliPID::kProton)) < fMaxPIDSigmaCutProton))
+        isprotonpidloose = false;
+    }
+  } else {
+    AliPIDResponse::EDetPidStatus statusTPC = fPIDresp->CheckPIDStatus(AliPIDResponse::kTPC, trGlobal);
+    if (statusTPC != AliPIDResponse::kDetPidOk) return;
+    AliPIDResponse::EDetPidStatus statusTOF = fPIDresp->CheckPIDStatus(AliPIDResponse::kTOF, trGlobal);
+    if (statusTOF != AliPIDResponse::kDetPidOk) return;
+
+    isprotonstd = true;
+    isprotonpidloose = true;
+    isprotonpidtight = true;
+
+    float nSigTPC = fPIDresp->NumberOfSigmas(AliPIDResponse::kTPC, trGlobal, AliPID::kProton);
+    float nSigTOF = fPIDresp->NumberOfSigmas(AliPIDResponse::kTOF, trGlobal, AliPID::kProton);
+    float nSigComb = TMath::Sqrt(nSigTPC * nSigTPC + nSigTOF * nSigTOF);
+
+    //Missing the SetCutTOFInvMass() selection implemented in AliFemtoDreamTrackCuts.cxx
+    if (!(nSigComb < fPIDSigmaCutProton))
+      isprotonstd = false;
+    if (!(nSigComb < fMinPIDSigmaCutProton))
+      isprotonpidtight = false;
+    if (!(nSigComb < fMaxPIDSigmaCutProton))
+      isprotonpidloose = false;
+
+    if(fCutSmallestSigProton && (isprotonstd || isprotonpidloose || isprotonpidtight)){
+      AliPID::EParticleType type[6] = { AliPID::kElectron, AliPID::kMuon, AliPID::kPion, AliPID::kKaon, AliPID::kProton, AliPID::kDeuteron };
+      float nSigmaComb[6];
+      for(int i = 0; i < 6; ++i) {
+        float nSigTPC2 = fPIDresp->NumberOfSigmas(AliPIDResponse::kTPC, trGlobal, type[i]);
+        float nSigTOF2 = fPIDresp->NumberOfSigmas(AliPIDResponse::kTOF, trGlobal, type[i]);
+        nSigmaComb[i] = TMath::Sqrt(pow(nSigTPC2, 2.) + pow(nSigTOF2, 2.));
+      }
+      int index = 0;
+      for(int i = 0; i < 6; ++i) {
+        if(nSigmaComb[index] > nSigmaComb[i]) index = i;
+      }
+      if(!(type[index] == AliPID::kProton)) {
+        isprotonstd = false;
+        isprotonpidloose = false;
+        isprotonpidtight = false;
+      }
+    }
+
+  }
+  return;
+}
+//________________________________________________________________
+void AliAnalysisTaskSEHFTreeCreatorApply::IsSelectedPion(AliAODTrack* tr, AliAODTrack* trGlobal, Bool_t &ispionstd, Bool_t &ispionpidloose, Bool_t &ispionpidtight){
+
+  ispionstd = false;
+  ispionpidloose = false;
+  ispionpidtight = false;
+
+  if(!tr) return;
+  if(!fPIDresp) return;
+  
+  if(TMath::Abs(tr->Charge()) != 1) return;
+
+  if(!( (fFilterBitPion & tr->GetFilterMap()) != 0)) return;
+  if(tr->Pt() < fPtMinPion || tr->Pt() > fPtMaxPion) return;
+  if(TMath::Abs(tr->Eta()) > fEtaMaxPion) return;
+  if(tr->GetTPCNcls() < fMinNClsTPCPion) return;
+  if(fTPCRefitPion && !tr->IsOn(AliAODTrack::kTPCrefit)) return;
+
+  Float_t trDCAXYProp, trDCAZProp;
+  trGlobal->GetImpactParameters(trDCAXYProp,trDCAZProp);
+  Float_t trDCAXY = tr->DCA(); 
+  Float_t trDCAZ = tr->ZAtDCA();
+  if(fDCARecalculationPion){
+    if(!(TMath::Abs(trDCAXYProp) < fDCAToVertexXYPion)) return;
+    if(!(TMath::Abs(trDCAZProp) < fDCAToVertexZPion)) return;
+  } else {
+    if(!(TMath::Abs(trDCAXY) < fDCAToVertexXYPion)) return;
+    if(!(TMath::Abs(trDCAZ) < fDCAToVertexZPion)) return;
+  }
+
+  if(fCutSharedClsPion){
+    const TBits sharedMap = tr->GetTPCSharedMap();
+    if ((sharedMap.CountBits()) >= 1) return;
+  }
+
+  if(fCutTPCCrossedRowsPion){
+    Double_t trTPCCrossedRows = tr->GetTPCClusterInfo(2, 1);
+    if(trTPCCrossedRows < fCrossedRowsPion) return;
+    Double_t trRatioCR;
+    if (!(tr->GetTPCNclsF() > 0)) {
+      trRatioCR = 0.;
+    } else {
+      trRatioCR = trTPCCrossedRows / float(tr->GetTPCNclsF());
+    }
+    if(trRatioCR < fRatioCrossedRowsPion) return;
+  }
+
+  if(trGlobal->GetTPCmomentum() < fMinPIDPtTPCCutPion){
+    AliPIDResponse::EDetPidStatus statusTPC = fPIDresp->CheckPIDStatus(AliPIDResponse::kTPC, trGlobal);
+    if (statusTPC != AliPIDResponse::kDetPidOk) return;
+
+    ispionstd = true;
+    ispionpidloose = true;
+    ispionpidtight = true;
+
+    if(ispionstd){
+      if(!(TMath::Abs(fPIDresp->NumberOfSigmas(AliPIDResponse::kTPC, trGlobal, AliPID::kPion)) < fPIDSigmaCutPion))
+        ispionstd = false;
+    }
+    if(ispionpidtight){
+      if(!(TMath::Abs(fPIDresp->NumberOfSigmas(AliPIDResponse::kTPC, trGlobal, AliPID::kPion)) < fMinPIDSigmaCutPion))
+        ispionpidtight = false;
+    }
+    if(ispionpidloose){
+      if(!(TMath::Abs(fPIDresp->NumberOfSigmas(AliPIDResponse::kTPC, trGlobal, AliPID::kPion)) < fMaxPIDSigmaCutPion))
+        ispionpidloose = false;
+    }
+  } else {
+    AliPIDResponse::EDetPidStatus statusTPC = fPIDresp->CheckPIDStatus(AliPIDResponse::kTPC, trGlobal);
+    if (statusTPC != AliPIDResponse::kDetPidOk) return;
+    AliPIDResponse::EDetPidStatus statusTOF = fPIDresp->CheckPIDStatus(AliPIDResponse::kTOF, trGlobal);
+    if (statusTOF != AliPIDResponse::kDetPidOk) return;
+
+    ispionstd = true;
+    ispionpidloose = true;
+    ispionpidtight = true;
+
+    float nSigTPC = fPIDresp->NumberOfSigmas(AliPIDResponse::kTPC, trGlobal, AliPID::kPion);
+    float nSigTOF = fPIDresp->NumberOfSigmas(AliPIDResponse::kTOF, trGlobal, AliPID::kPion);
+    float nSigComb = TMath::Sqrt(nSigTPC * nSigTPC + nSigTOF * nSigTOF);
+
+    //Missing the SetCutTOFInvMass() selection implemented in AliFemtoDreamTrackCuts.cxx
+    if (!(nSigComb < fPIDSigmaCutPion))
+      ispionstd = false;
+    if (!(nSigComb < fMinPIDSigmaCutPion))
+      ispionpidtight = false;
+    if (!(nSigComb < fMaxPIDSigmaCutPion))
+      ispionpidloose = false;
+
+    if(fCutSmallestSigPion && (ispionstd || ispionpidloose || ispionpidtight)){
+      AliPID::EParticleType type[6] = { AliPID::kElectron, AliPID::kMuon, AliPID::kPion, AliPID::kKaon, AliPID::kPion, AliPID::kDeuteron };
+      float nSigmaComb[6];
+      for(int i = 0; i < 6; ++i) {
+        float nSigTPC2 = fPIDresp->NumberOfSigmas(AliPIDResponse::kTPC, trGlobal, type[i]);
+        float nSigTOF2 = fPIDresp->NumberOfSigmas(AliPIDResponse::kTOF, trGlobal, type[i]);
+        nSigmaComb[i] = TMath::Sqrt(pow(nSigTPC2, 2.) + pow(nSigTOF2, 2.));
+      }
+      int index = 0;
+      for(int i = 0; i < 6; ++i) {
+        if(nSigmaComb[index] > nSigmaComb[i]) index = i;
+      }
+      if(!(type[index] == AliPID::kPion)) {
+        ispionstd = false;
+        ispionpidloose = false;
+        ispionpidtight = false;
+      }
+    }
+
+  }
+  return;
+}
+//________________________________________________________________
+void AliAnalysisTaskSEHFTreeCreatorApply::IsSelectedKaon(AliAODTrack* tr, AliAODTrack* trGlobal, Bool_t &iskaonstd, Bool_t &iskaonpidloose, Bool_t &iskaonpidtight){
+
+  iskaonstd = false;
+  iskaonpidloose = false;
+  iskaonpidtight = false;
+
+  if(!tr) return;
+  if(!fPIDresp) return;
+  
+  if(TMath::Abs(tr->Charge()) != 1) return;
+
+  if(!( (fFilterBitKaon & tr->GetFilterMap()) != 0)) return;
+  if(tr->Pt() < fPtMinKaon || tr->Pt() > fPtMaxKaon) return;
+  if(TMath::Abs(tr->Eta()) > fEtaMaxKaon) return;
+  if(tr->GetTPCNcls() < fMinNClsTPCKaon) return;
+  if(fTPCRefitKaon && !tr->IsOn(AliAODTrack::kTPCrefit)) return;
+
+  Float_t trDCAXYProp, trDCAZProp;
+  trGlobal->GetImpactParameters(trDCAXYProp,trDCAZProp);
+  Float_t trDCAXY = tr->DCA(); 
+  Float_t trDCAZ = tr->ZAtDCA();
+  if(fDCARecalculationKaon){
+    if(!(TMath::Abs(trDCAXYProp) < fDCAToVertexXYKaon)) return;
+    if(!(TMath::Abs(trDCAZProp) < fDCAToVertexZKaon)) return;
+  } else {
+    if(!(TMath::Abs(trDCAXY) < fDCAToVertexXYKaon)) return;
+    if(!(TMath::Abs(trDCAZ) < fDCAToVertexZKaon)) return;
+  }
+
+  if(fCutSharedClsKaon){
+    const TBits sharedMap = tr->GetTPCSharedMap();
+    if ((sharedMap.CountBits()) >= 1) return;
+  }
+
+  if(fCutTPCCrossedRowsKaon){
+    Double_t trTPCCrossedRows = tr->GetTPCClusterInfo(2, 1);
+    if(trTPCCrossedRows < fCrossedRowsKaon) return;
+    Double_t trRatioCR;
+    if (!(tr->GetTPCNclsF() > 0)) {
+      trRatioCR = 0.;
+    } else {
+      trRatioCR = trTPCCrossedRows / float(tr->GetTPCNclsF());
+    }
+    if(trRatioCR < fRatioCrossedRowsKaon) return;
+  }
+
+  if(fCutPIDkdKaon) {
+
+    Bool_t TPCyes = false;
+    AliPIDResponse::EDetPidStatus statusTPC = fPIDresp->CheckPIDStatus(AliPIDResponse::kTPC, trGlobal);
+    if (statusTPC == AliPIDResponse::kDetPidOk) TPCyes = true;
+    Bool_t TOFyes = false;
+    AliPIDResponse::EDetPidStatus statusTOF = fPIDresp->CheckPIDStatus(AliPIDResponse::kTOF, trGlobal);
+    if (statusTOF == AliPIDResponse::kDetPidOk) TOFyes = true;
+
+    bool passTOF = false;
+    bool passTOFloose = false;
+    bool passTOFtight = false;
+    bool passTPC = false;
+
+    float trMomTPC = trGlobal->GetTPCmomentum();
+
+    if(TPCyes) {
+      float TPCe = TMath::Abs(fPIDresp->NumberOfSigmas(AliPIDResponse::kTPC, trGlobal, AliPID::kElectron));
+      float TPCpi = TMath::Abs(fPIDresp->NumberOfSigmas(AliPIDResponse::kTPC, trGlobal, AliPID::kPion));
+      float TPCk = TMath::Abs(fPIDresp->NumberOfSigmas(AliPIDResponse::kTPC, trGlobal, AliPID::kKaon));
+
+      if(TOFyes) {
+        float TOFpi = TMath::Abs(fPIDresp->NumberOfSigmas(AliPIDResponse::kTOF, trGlobal, AliPID::kPion));
+        float COMBpi = sqrt(TPCpi*TPCpi+TOFpi*TOFpi);
+        float TOFk = TMath::Abs(fPIDresp->NumberOfSigmas(AliPIDResponse::kTOF, trGlobal, AliPID::kKaon));
+        float COMBk = sqrt(TPCk*TPCk+TOFk*TOFk);
+        
+        if(COMBk < fPIDkdCombKaon)        passTOF = true;
+        if(COMBk < fMaxPIDkdCombKaon)     passTOFloose = true;
+        if(COMBk < fMinPIDkdCombKaon)     passTOFtight = true;
+        if(trMomTPC > 1.2 && COMBk > 2){  passTOF = false; passTOFloose = false; passTOFtight = false; }
+        if(trMomTPC > 1.2 && COMBpi < 6){ passTOF = false; passTOFloose = false; passTOFtight = false; }
+      }
+
+      passTPC = true;
+      float maxMomTPC = 0.85;
+      // exclude TPC electrons
+      if(trMomTPC > 0.3 && trMomTPC < maxMomTPC && TPCe < 3) passTPC = false;
+      // exclude TPC pions
+      if(trMomTPC > 0.5 && TPCpi < 3)                        passTPC = false;
+      // own TPC sigma kaon selection
+      if(TPCk > 3)                                           passTPC = false;
+      // momentum limit for TPC selection
+      if(trMomTPC > maxMomTPC)                               passTPC = false;
+      // at the end leave the exclusion band
+      if(trMomTPC > 0.5 && trMomTPC < 0.65)                  passTPC = false;
+    }else{
+      passTPC=false;
+    }
+
+    iskaonstd = passTPC||passTOF;
+    iskaonpidloose = passTPC||passTOFloose;
+    iskaonpidtight = passTPC||passTOFtight;
+
+  } else if(trGlobal->GetTPCmomentum() < fMinPIDPtTPCCutKaon){
+    AliPIDResponse::EDetPidStatus statusTPC = fPIDresp->CheckPIDStatus(AliPIDResponse::kTPC, trGlobal);
+    if (statusTPC != AliPIDResponse::kDetPidOk) return;
+
+    iskaonstd = true;
+    iskaonpidloose = true;
+    iskaonpidtight = true;
+
+    if(fRejLowPtPionsTOFKaon){
+      AliPIDResponse::EDetPidStatus statusTOF = fPIDresp->CheckPIDStatus(AliPIDResponse::kTOF, trGlobal);
+      if (statusTOF == AliPIDResponse::kDetPidOk){
+        if(TMath::Abs(fPIDresp->NumberOfSigmas(AliPIDResponse::kTOF, trGlobal, AliPID::kPion)) < fPIDSigmaCutKaon)
+          iskaonstd = false;
+        if(TMath::Abs(fPIDresp->NumberOfSigmas(AliPIDResponse::kTOF, trGlobal, AliPID::kPion)) < fMinPIDSigmaCutKaon)
+          iskaonpidtight = false;
+        if(TMath::Abs(fPIDresp->NumberOfSigmas(AliPIDResponse::kTOF, trGlobal, AliPID::kPion)) < fMaxPIDSigmaCutKaon)
+          iskaonpidloose = false;
+      }
+    }
+
+    if(iskaonstd){
+      if(!(TMath::Abs(fPIDresp->NumberOfSigmas(AliPIDResponse::kTPC, trGlobal, AliPID::kKaon)) < fPIDSigmaCutKaon))
+        iskaonstd = false;
+    }
+    if(iskaonpidtight){
+      if(!(TMath::Abs(fPIDresp->NumberOfSigmas(AliPIDResponse::kTPC, trGlobal, AliPID::kKaon)) < fMinPIDSigmaCutKaon))
+        iskaonpidtight = false;
+    }
+    if(iskaonpidloose){
+      if(!(TMath::Abs(fPIDresp->NumberOfSigmas(AliPIDResponse::kTPC, trGlobal, AliPID::kKaon)) < fMaxPIDSigmaCutKaon))
+        iskaonpidloose = false;
+    }
+  } else {
+    AliPIDResponse::EDetPidStatus statusTPC = fPIDresp->CheckPIDStatus(AliPIDResponse::kTPC, trGlobal);
+    if (statusTPC != AliPIDResponse::kDetPidOk) return;
+    AliPIDResponse::EDetPidStatus statusTOF = fPIDresp->CheckPIDStatus(AliPIDResponse::kTOF, trGlobal);
+    if (statusTOF != AliPIDResponse::kDetPidOk) return;
+
+    iskaonstd = true;
+    iskaonpidloose = true;
+    iskaonpidtight = true;
+
+    float nSigTPC = fPIDresp->NumberOfSigmas(AliPIDResponse::kTPC, trGlobal, AliPID::kKaon);
+    float nSigTOF = fPIDresp->NumberOfSigmas(AliPIDResponse::kTOF, trGlobal, AliPID::kKaon);
+    float nSigComb = TMath::Sqrt(nSigTPC * nSigTPC + nSigTOF * nSigTOF);
+
+    //Missing the SetCutTOFInvMass() selection implemented in AliFemtoDreamTrackCuts.cxx
+    if (!(nSigComb < fPIDSigmaCutKaon))
+      iskaonstd = false;
+    if (!(nSigComb < fMinPIDSigmaCutKaon))
+      iskaonpidtight = false;
+    if (!(nSigComb < fMaxPIDSigmaCutKaon))
+      iskaonpidloose = false;
+
+    if(fCutSmallestSigKaon && (iskaonstd || iskaonpidloose || iskaonpidtight)){
+      AliPID::EParticleType type[6] = { AliPID::kElectron, AliPID::kMuon, AliPID::kPion, AliPID::kKaon, AliPID::kKaon, AliPID::kDeuteron };
+      float nSigmaComb[6];
+      for(int i = 0; i < 6; ++i) {
+        float nSigTPC2 = fPIDresp->NumberOfSigmas(AliPIDResponse::kTPC, trGlobal, type[i]);
+        float nSigTOF2 = fPIDresp->NumberOfSigmas(AliPIDResponse::kTOF, trGlobal, type[i]);
+        nSigmaComb[i] = TMath::Sqrt(pow(nSigTPC2, 2.) + pow(nSigTOF2, 2.));
+      }
+      int index = 0;
+      for(int i = 0; i < 6; ++i) {
+        if(nSigmaComb[index] > nSigmaComb[i]) index = i;
+      }
+      if(!(type[index] == AliPID::kKaon)) {
+        iskaonstd = false;
+        iskaonpidloose = false;
+        iskaonpidtight = false;
+      }
+    }
+
+  }
+  return;
+}
+//----------------------------------------------------------------------------------
+void AliAnalysisTaskSEHFTreeCreatorApply::MapAODtracks(AliVEvent *aod){
+  //assign and save in fAODMap the index of the AliAODTrack track
+  //ordering them on the basis of selected criteria
+
+  fAODMapSize = 100000;
+  fAODMap = new Int_t[fAODMapSize];
+  AliAODTrack *track=0;
+  memset(fAODMap,0,sizeof(Int_t)*fAODMapSize);
+  for(Int_t i=0; i<aod->GetNumberOfTracks(); i++) {
+    track = dynamic_cast<AliAODTrack*>(aod->GetTrack(i));
+    if(!track) AliFatal("Not a standard AOD");
+
+    Int_t ind = (Int_t)track->GetID();
+    if (ind>-1 && ind < fAODMapSize) fAODMap[ind] = i;
+  }
+  return;
 }

--- a/PWGHF/vertexingHF/vHFML/AliAnalysisTaskSEHFTreeCreatorApply.h
+++ b/PWGHF/vertexingHF/vHFML/AliAnalysisTaskSEHFTreeCreatorApply.h
@@ -26,11 +26,14 @@
 #include "AliAnalysisTaskSE.h"
 #include "AliRDHFCutsLctoV0.h"
 #include "AliRDHFCutsDstoKKpi.h"
+#include "AliRDHFCutsDStartoKpipi.h"
 #include "AliNormalizationCounter.h"
 #include "AliPIDResponse.h"
 #include "AliHFTreeHandlerApply.h"
 #include "AliHFTreeHandlerApplyLc2V0bachelor.h"
 #include "AliHFTreeHandlerApplyDstoKKpi.h"
+#include "AliHFTreeHandlerApplyDstartoKpipi.h"
+#include "AliParticleTreeHandlerApply.h"
 #include "AliHFMLResponse.h"
 
 class AliAODMCHeader;
@@ -55,6 +58,8 @@ public:
 
   void SetReadMC(Bool_t opt=kFALSE){fReadMC=opt;}
   Bool_t GetReadMC() const {return fReadMC;}
+  void SetDebugMode(Bool_t opt=kFALSE){fDebugMode=opt;}
+  Bool_t GetDebugMode() const {return fDebugMode;}
   void SetUseSelectionBit(Bool_t opt=kFALSE){fUseSelectionBit=opt;}
   Bool_t GetUseSelectionBit() const {return fUseSelectionBit;}
   void SetSystem(Int_t opt){fSys=opt;}
@@ -66,10 +71,16 @@ public:
   Int_t GetFillDsTree() const {return fWriteVariableTreeDs;}
   void SetFillLc2V0bachelorTree(Int_t opt){fWriteVariableTreeLc2V0bachelor=opt;}
   Int_t GetFillLc2V0bachelorTree() const {return fWriteVariableTreeLc2V0bachelor;}
+  void SetFillDstarTree(Int_t opt){fWriteVariableTreeDstar=opt;}
+  Int_t GetFillDstarTree() const {return fWriteVariableTreeDstar;}
+  void SetFillParticleTree(Int_t opt){fWriteVariableTreeParticle=opt;}
+  Int_t GetFillParticleTree() const {return fWriteVariableTreeParticle;}
   void SetPIDoptDsTree(Int_t opt){fPIDoptDs=opt;}
   Int_t GetPIDoptDsTree() const {return fPIDoptDs;}
   void SetPIDoptLc2V0bachelorTree(Int_t opt){fPIDoptLc2V0bachelor=opt;}
   Int_t GetPIDoptLc2V0bachelorTree() const {return fPIDoptLc2V0bachelor;}
+  void SetPIDoptDstarTree(Int_t opt){fPIDoptDstar=opt;}
+  Int_t GetPIDoptDstarTree() const {return fPIDoptDstar;}
   void SetWriteOnlySignalTree(Bool_t opt){fWriteOnlySignal=opt;}
   Bool_t GetWriteOnlySignalTree() const {return fWriteOnlySignal;}
   void SetFillMCGenTrees(Bool_t fillMCgen) {fFillMCGenTrees=fillMCgen;}
@@ -106,6 +117,10 @@ public:
   Int_t GetTreeSingleTrackVarsOpt() const {return fTreeSingleTrackVarsOpt;}
   void SetReducePbPbBranches(Bool_t b) { fReducePbPbBranches = b; }
   Bool_t GetReducePbPbBranches() const { return fReducePbPbBranches; }
+  void SetReduceHMV0Branches(Bool_t b) { fReduceHMV0Branches = b; }
+  Bool_t GetReduceHMV0Branches() const { return fReduceHMV0Branches; }
+  void SetOnlyDedicatedBranches(Bool_t b){ fOnlyDedicatedBranches = b; }
+  Bool_t GetOnlyDedicatedBranches() const { return fOnlyDedicatedBranches; }
   void SetSaveSTDSelection(Bool_t b) { fSaveSTDSelection = b; }
   Bool_t GetSaveSTDSelection() const { return fSaveSTDSelection; }
   void SetSaveMixedEventBkg(Bool_t b) { fSaveMixedEventBkg = b; }
@@ -157,6 +172,8 @@ public:
   
   void Process3Prong(TClonesArray *array3Prong, AliAODEvent *aod, TClonesArray *arrMC, Float_t bfield, AliAODMCHeader *mcHeader);
   void ProcessCasc(TClonesArray *arrayCasc, AliAODEvent *aod, TClonesArray *arrMC, Float_t bfield, AliAODMCHeader *mcHeader);
+  void ProcessDstar(TClonesArray *arrayDstar, AliAODEvent *aod, TClonesArray *arrMC, Float_t bfield, AliAODMCHeader *mcHeader);
+  void ProcessTrack(AliAODEvent *aod, TClonesArray *arrMC, AliAODMCHeader *mcHeader);
   void ProcessMCGen(TClonesArray *mcarray, AliAODMCHeader *mcHeader);
 
   void DoEventMixingLc2V0bachelor(AliAODEvent *aodEvent);
@@ -168,6 +185,84 @@ public:
   void SelectGoodTrackForReconstruction(AliAODEvent *aod, Int_t trkEntries, Int_t &nSeleTrks,Bool_t *seleFlags);
   AliAODVertex* ReconstructDisplVertex(const AliVVertex *primary, TObjArray *tracks, Double_t bField, Double_t dispersion);
   unsigned int GetEvID();
+
+  void MapAODtracks(AliVEvent *aod);
+  
+  void IsSelectedProton(AliAODTrack* tr, AliAODTrack* trGlobal, Bool_t &isprotonstd, Bool_t &isprotonpidloose, Bool_t &isprotonpidtight);
+  //Setters for changing proton selection variables
+  void SetFilterBitProton(int val){ fFilterBitProton = val; }
+  void SetPtMinProton(double val){ fPtMinProton = val; }
+  void SetPtMaxProton(double val){ fPtMaxProton = val; }
+  void SetEtaMaxProton(double val){ fEtaMaxProton = val; }
+  void SetMinNClsTPCProton(double val){ fMinNClsTPCProton = val; }
+  void SetNClsTPCProton(double val){ fNClsTPCProton = val; }
+  void SetMaxNClsTPCProton(double val){ fMaxNClsTPCProton = val; }
+  void SetDCARecalculationProton(bool val){ fDCARecalculationProton = val; }
+  void SetDCAToVertexXYProton(double val){ fDCAToVertexXYProton = val; }
+  void SetDCAToVertexZProton(double val){ fDCAToVertexZProton = val; }
+  void SetCutSharedClsProton(bool val){ fCutSharedClsProton = val; }
+  void SetCutTPCCrossedRowsProton(bool val){ fCutTPCCrossedRowsProton = val; }
+  void SetCrossedRowsProton(double val){ fCrossedRowsProton = val; }
+  void SetRatioCrossedRowsProton(double val){ fRatioCrossedRowsProton = val; }
+  void SetMinPIDPtTPCCutProton(double val){ fMinPIDPtTPCCutProton = val; }
+  void SetPIDSigmaCutProton(double val){ fPIDSigmaCutProton = val; }
+  void SetMinPIDSigmaCutProton(double val){ fMinPIDSigmaCutProton = val; }
+  void SetMaxPIDSigmaCutProton(double val){ fMaxPIDSigmaCutProton = val; }
+  void SetCutSmallestSigProton(bool val){ fCutSmallestSigProton = val; }
+  void SetRejLowPtPionsTOFProton(bool val){ fRejLowPtPionsTOFProton = val; }
+  void SetTPCRefitProton(bool val){ fTPCRefitProton = val; }
+
+  void IsSelectedPion(AliAODTrack* tr, AliAODTrack* trGlobal, Bool_t &ispionstd, Bool_t &ispionpidloose, Bool_t &ispionpidtight);
+  //Setters for changing pion selection variables
+  void SetFilterBitPion(int val){ fFilterBitPion = val; }
+  void SetPtMinPion(double val){ fPtMinPion = val; }
+  void SetPtMaxPion(double val){ fPtMaxPion = val; }
+  void SetEtaMaxPion(double val){ fEtaMaxPion = val; }
+  void SetMinNClsTPCPion(double val){ fMinNClsTPCPion = val; }
+  void SetNClsTPCPion(double val){ fNClsTPCPion = val; }
+  void SetMaxNClsTPCPion(double val){ fMaxNClsTPCPion = val; }
+  void SetDCARecalculationPion(bool val){ fDCARecalculationPion = val; }
+  void SetDCAToVertexXYPion(double val){ fDCAToVertexXYPion = val; }
+  void SetDCAToVertexZPion(double val){ fDCAToVertexZPion = val; }
+  void SetCutSharedClsPion(bool val){ fCutSharedClsPion = val; }
+  void SetCutTPCCrossedRowsPion(bool val){ fCutTPCCrossedRowsPion = val; }
+  void SetCrossedRowsPion(double val){ fCrossedRowsPion = val; }
+  void SetRatioCrossedRowsPion(double val){ fRatioCrossedRowsPion = val; }
+  void SetMinPIDPtTPCCutPion(double val){ fMinPIDPtTPCCutPion = val; }
+  void SetPIDSigmaCutPion(double val){ fPIDSigmaCutPion = val; }
+  void SetMinPIDSigmaCutPion(double val){ fMinPIDSigmaCutPion = val; }
+  void SetMaxPIDSigmaCutPion(double val){ fMaxPIDSigmaCutPion = val; }
+  void SetCutSmallestSigPion(bool val){ fCutSmallestSigPion = val; }
+  void SetRejLowPtPionsTOFPion(bool val){ fRejLowPtPionsTOFPion = val; }
+  void SetTPCRefitPion(bool val){ fTPCRefitPion = val; }
+
+  void IsSelectedKaon(AliAODTrack* tr, AliAODTrack* trGlobal, Bool_t &iskaonstd, Bool_t &iskaonpidloose, Bool_t &iskaonpidtight);
+  //Setters for changing kaon selection variables
+  void SetFilterBitKaon(int val){ fFilterBitKaon = val; }
+  void SetPtMinKaon(double val){ fPtMinKaon = val; }
+  void SetPtMaxKaon(double val){ fPtMaxKaon = val; }
+  void SetEtaMaxKaon(double val){ fEtaMaxKaon = val; }
+  void SetMinNClsTPCKaon(double val){ fMinNClsTPCKaon = val; }
+  void SetNClsTPCKaon(double val){ fNClsTPCKaon = val; }
+  void SetMaxNClsTPCKaon(double val){ fMaxNClsTPCKaon = val; }
+  void SetDCARecalculationKaon(bool val){ fDCARecalculationKaon = val; }
+  void SetDCAToVertexXYKaon(double val){ fDCAToVertexXYKaon = val; }
+  void SetDCAToVertexZKaon(double val){ fDCAToVertexZKaon = val; }
+  void SetCutSharedClsKaon(bool val){ fCutSharedClsKaon = val; }
+  void SetCutTPCCrossedRowsKaon(bool val){ fCutTPCCrossedRowsKaon = val; }
+  void SetCrossedRowsKaon(double val){ fCrossedRowsKaon = val; }
+  void SetRatioCrossedRowsKaon(double val){ fRatioCrossedRowsKaon = val; }
+  void SetMinPIDPtTPCCutKaon(double val){ fMinPIDPtTPCCutKaon = val; }
+  void SetPIDSigmaCutKaon(double val){ fPIDSigmaCutKaon = val; }
+  void SetMinPIDSigmaCutKaon(double val){ fMinPIDSigmaCutKaon = val; }
+  void SetMaxPIDSigmaCutKaon(double val){ fMaxPIDSigmaCutKaon = val; }
+  void SetCutSmallestSigKaon(bool val){ fCutSmallestSigKaon = val; }
+  void SetRejLowPtPionsTOFKaon(bool val){ fRejLowPtPionsTOFKaon = val; }
+  void SetCutPIDkdKaon(bool val){ fCutPIDkdKaon = val; }
+  void SetPIDkdCombKaon(double val){ fPIDkdCombKaon = val; }
+  void SetMinPIDkdCombKaon(double val){ fMinPIDkdCombKaon = val; }
+  void SetMaxPIDkdCombKaon(double val){ fMaxPIDkdCombKaon = val; }
+  void SetTPCRefitKaon(bool val){ fTPCRefitKaon = val; }
 
 private:
 
@@ -183,11 +278,14 @@ private:
   TList                   *fListCuts;                            /// list of cuts sent to output slot 2
   AliRDHFCutsDstoKKpi     *fFiltCutsDstoKKpi;                    /// DstoKKpi filtering (or loose) cuts
   AliRDHFCutsLctoV0       *fFiltCutsLc2V0bachelor;               /// Lc2V0bachelor filtering (or loose) cuts
+  AliRDHFCutsDStartoKpipi *fFiltCutsDstartoKpipi;                /// DstartoKpipi filtering (or loose) cuts
   AliRDHFCutsDstoKKpi     *fCutsDstoKKpi;                        /// DstoKKpi analysis cuts
   AliRDHFCutsLctoV0       *fCutsLc2V0bachelor;                   /// Lc2V0bachelor analysis cuts
+  AliRDHFCutsDStartoKpipi *fCutsDstartoKpipi;                    /// DstartoKpipi analysis cuts
   AliRDHFCuts             *fEvSelectionCuts;                     /// Event selection cuts
 
   Bool_t                  fReadMC;                               /// flag for MC array: kTRUE = read it, kFALSE = do not read it
+  Bool_t                  fDebugMode;                            /// flag to enter debug mode (to validate new against old task)
   Bool_t                  fUseSelectionBit;                      /// flag to use selection bit when looping over TClonesArray
   Int_t                   fSys;                                  /// fSys=0 -> p-p; fSys=1 ->PbPb
   Int_t                   fAODProtection;                        /// flag to activate protection against AOD-dAOD mismatch.
@@ -197,25 +295,34 @@ private:
   Bool_t                  fFillMCGenTrees;                        /// flag to enable fill of the generated trees
   Int_t                   fWriteVariableTreeDs;                   /// flag to decide whether to write the Ds variables on a tree variables
   Int_t                   fWriteVariableTreeLc2V0bachelor;        /// flag to decide whether to write the Lc->pK0s variables on a tree variables
+  Int_t                   fWriteVariableTreeDstar;                /// flag to decide whether to write the Dstar variables on a tree variables
+  Int_t                   fWriteVariableTreeParticle;             /// flag to decide whether to write the (femto) tracks variables on a tree variables
   // 0 don't fill
-  // 1 fill standard tree
+  // 1 fill standard tree (2=p, 3=K, 4=pi for (femto) track Tree)
 
   TTree                   *fVariablesTreeDs;                     //!<! tree of the candidate variables
   TTree                   *fVariablesTreeLc2V0bachelor;          //!<! tree of the candidate variables
   TTree                   *fVariablesTreeLc2V0bachelorMixEv;     //!<! tree of the candidate variables from mixed events
+  TTree                   *fVariablesTreeDstar;                  //!<! tree of the candidate variables
+  TTree                   *fVariablesTreeParticle;               //!<! tree of the (femto) tracks variables
   TTree                   *fGenTreeDs;                           //!<! tree of the gen Ds variables
   TTree                   *fGenTreeLc2V0bachelor;                //!<! tree of the gen Lc2V0bachelor variables
+  TTree                   *fGenTreeDstar;                        //!<! tree of the gen Dstar variables
   TTree                   *fTreeEvChar;                          //!<! tree of event variables
 
   AliHFTreeHandlerApplyDstoKKpi       *fTreeHandlerDs;                //!<! handler object for the tree with topological variables
   AliHFTreeHandlerApplyLc2V0bachelor  *fTreeHandlerLc2V0bachelor;     //!<! handler object for the tree with topological variables
   AliHFTreeHandlerApplyLc2V0bachelor  *fTreeHandlerLc2V0bachelorMixEv;//!<! handler object for the tree with topological variables from mixed events
+  AliHFTreeHandlerApplyDstartoKpipi   *fTreeHandlerDstar;             //!<! handler object for the tree with topological variables
+  AliParticleTreeHandlerApply         *fTreeHandlerParticle;          //!<! handler object for the tree with (femto) track variables
   AliHFTreeHandlerApplyDstoKKpi       *fTreeHandlerGenDs;             //!<! handler object for the tree with topological variables
   AliHFTreeHandlerApplyLc2V0bachelor  *fTreeHandlerGenLc2V0bachelor;  //!<! handler object for the tree with topological variables
+  AliHFTreeHandlerApplyDstartoKpipi   *fTreeHandlerGenDstar;          //!<! handler object for the tree with topological variables
 
   AliPIDResponse          *fPIDresp;                             /// PID response
   Int_t                   fPIDoptDs;                             /// PID option for Ds tree
   Int_t                   fPIDoptLc2V0bachelor;                  /// PID option for Lc2V0bachelor tree
+  Int_t                   fPIDoptDstar;                          /// PID option for Dstar tree
 
   UShort_t                fBC;                                   /// bunch crossing number
   Int_t                   fOrbit;                                /// orbit
@@ -226,6 +333,7 @@ private:
   TString                 fFileName;                             /// Store filename for an unique event ID
   unsigned int            fDirNumber;                            /// Store directory number for an unique event ID
 
+  Float_t                 fMagField;                             /// magnetic field
   Float_t                 fCentrality;                           /// event centrality
   Float_t                 fzVtxReco;                             /// reconstructed Zvtx
   Float_t                 fzVtxGen;                              /// generated Zvtx
@@ -264,6 +372,7 @@ private:
   Int_t                   fnV0MEqCorr;                           /// V0M multiplicity (equalized + corrected)
   Float_t                 fPercV0M;                              /// V0M multiplicity percentile
   Float_t                 fMultV0M;                              /// V0M multiplicity from mult selection task
+  Float_t                 fRefMultComb08;                        /// Combined reference multiplicity (tracklets + ITSTPC) in |eta|<0.8
 
   Double_t                fRefMult;                              /// reference multiplicity
   Double_t                fRefMultSHM;                           /// reference multiplicity
@@ -299,6 +408,8 @@ private:
   TString fConfigPath;                                           /// path to ML config file
   AliHFMLResponse* fMLResponse;                                  //!<! object to handle ML response
   Bool_t fReducePbPbBranches;                                    /// variable to disable unnecessary branches in PbPb
+  Bool_t fReduceHMV0Branches;                                    /// variable to disable unnecessary branches in HMV0
+  Bool_t fOnlyDedicatedBranches;                                 /// variable to disable unnecessary branches, 0=off, 3=on Dstar
   Bool_t fSaveSTDSelection;                                      /// variable to store candidates that pass std cuts as well, even when ML < MLcut
   
   //Mixed event (track level)
@@ -315,8 +426,84 @@ private:
   std::vector<std::vector<std::vector<TVector*>>> fReservoirP;   //!<! reservoir
   AliHFMLResponseLctoV0bachelor* fMLResponseMixEv;               //!<! object to handle ML response
   
+  Int_t fAODMapSize;                                             /// size of fAODMap
+  Int_t *fAODMap;                                                // [fAODMapSize] map between index and ID for AOD tracks
+  
+  //Proton selection variables, to match code in AliFemtoDreamTrackCuts.cxx
+  Int_t fFilterBitProton = 128;
+  Double_t fPtMinProton = 0.45;
+  Double_t fPtMaxProton = 4.05;
+  Double_t fEtaMaxProton = 0.85;
+  Double_t fMinNClsTPCProton = 70;
+  Double_t fNClsTPCProton = 80;
+  Double_t fMaxNClsTPCProton = 90;
+  Bool_t fDCARecalculationProton = true;
+  Double_t fDCAToVertexXYProton = 0.1;
+  Double_t fDCAToVertexZProton = 0.2;
+  Bool_t fCutSharedClsProton = true;
+  Bool_t fCutTPCCrossedRowsProton = true;
+  Double_t fCrossedRowsProton = 70;
+  Double_t fRatioCrossedRowsProton = 0.83;
+  Double_t fMinPIDPtTPCCutProton = 0.75;
+  Double_t fPIDSigmaCutProton = 3.0;
+  Double_t fMinPIDSigmaCutProton = 2.7;
+  Double_t fMaxPIDSigmaCutProton = 3.3;
+  Bool_t fCutSmallestSigProton = true;
+  Bool_t fRejLowPtPionsTOFProton = true;
+  Bool_t fTPCRefitProton = false;
+
+  //Pion selection variables, to match code in AliFemtoDreamTrackCuts.cxx
+  Int_t fFilterBitPion = 96;
+  Double_t fPtMinPion = 0.0;
+  Double_t fPtMaxPion = 4.0;
+  Double_t fEtaMaxPion = 0.85;
+  Double_t fMinNClsTPCPion = 70;
+  Double_t fNClsTPCPion = 80;
+  Double_t fMaxNClsTPCPion = 90;
+  Bool_t fDCARecalculationPion = true;
+  Double_t fDCAToVertexXYPion = 0.3;
+  Double_t fDCAToVertexZPion = 0.3;
+  Bool_t fCutSharedClsPion = false;
+  Bool_t fCutTPCCrossedRowsPion = false;
+  Double_t fCrossedRowsPion = 70;
+  Double_t fRatioCrossedRowsPion = 0.83;
+  Double_t fMinPIDPtTPCCutPion = 0.5;
+  Double_t fPIDSigmaCutPion = 3.0;
+  Double_t fMinPIDSigmaCutPion = 2.7;
+  Double_t fMaxPIDSigmaCutPion = 3.3;
+  Bool_t fCutSmallestSigPion = false;
+  Bool_t fRejLowPtPionsTOFPion = false;
+  Bool_t fTPCRefitPion = false;
+
+  //Kaon selection variables, to match code in AliFemtoDreamTrackCuts.cxx
+  Int_t fFilterBitKaon = 128;
+  Double_t fPtMinKaon = 0.1;
+  Double_t fPtMaxKaon = 4.0;
+  Double_t fEtaMaxKaon = 0.85;
+  Double_t fMinNClsTPCKaon = 70;
+  Double_t fNClsTPCKaon = 80;
+  Double_t fMaxNClsTPCKaon = 90;
+  Bool_t fDCARecalculationKaon = true;
+  Double_t fDCAToVertexXYKaon = 0.1;
+  Double_t fDCAToVertexZKaon = 0.2;
+  Bool_t fCutSharedClsKaon = true;
+  Bool_t fCutTPCCrossedRowsKaon = true;
+  Double_t fCrossedRowsKaon = 70;
+  Double_t fRatioCrossedRowsKaon = 0.8;
+  Double_t fMinPIDPtTPCCutKaon = 0.4;
+  Double_t fPIDSigmaCutKaon = 5.0;
+  Double_t fMinPIDSigmaCutKaon = 2.7;
+  Double_t fMaxPIDSigmaCutKaon = 3.3;
+  Bool_t fCutSmallestSigKaon = true;
+  Bool_t fRejLowPtPionsTOFKaon = false;
+  Bool_t fCutPIDkdKaon = true;
+  Double_t fPIDkdCombKaon = 3;
+  Double_t fMinPIDkdCombKaon = 2.7;
+  Double_t fMaxPIDkdCombKaon = 3.3;
+  Bool_t fTPCRefitKaon = false;
+
   /// \cond CLASSIMP
-  ClassDef(AliAnalysisTaskSEHFTreeCreatorApply,8);
+  ClassDef(AliAnalysisTaskSEHFTreeCreatorApply,9);
   /// \endcond
 };
 

--- a/PWGHF/vertexingHF/vHFML/AliHFTreeHandlerApply.h
+++ b/PWGHF/vertexingHF/vHFML/AliHFTreeHandlerApply.h
@@ -60,6 +60,7 @@ public:
     kRedSingleTrackVars, // only pT, p, eta, phi
     kRedSingleTrackVarsPbPb, //extra TPCclsPID
     kRedSingleTrackVarsPbPbExtreme, //only pt and spdhits
+    kRedSingleTrackVarsHMV0, //only pt, eta, and phi
     kAllSingleTrackVars // all single-track vars
   };
   
@@ -77,6 +78,7 @@ public:
   //for MC gen --> common implementation
   TTree* BuildTreeMCGen(TString name, TString title);
   bool SetMCGenVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, AliAODMCParticle* mcpart);
+  bool SetMCGenVariablesextra(int pdg, int pdg_mom, int mc_label);
 
   //to be called for each candidate
   void SetCandidateType(bool issignal, bool isbkg, bool isprompt, bool isFD, bool isreflected);
@@ -92,10 +94,12 @@ public:
   }
   
   //common methods
+  void SetIncludeML(bool includeML) {fIncludeML=includeML;}
   void SetOptPID(int PIDopt) {fPidOpt=PIDopt;}
   void SetOptSingleTrackVars(int opt) {fSingleTrackOpt=opt;}
   void SetFillOnlySignal(bool fillopt=true) {fFillOnlySignal=fillopt;}
   void SetDauInAcceptance(bool dauinacc = true) {fDauInAcceptance=dauinacc;}
+  void SetOnlyDedicatedBranches(bool b) { fOnlyDedicatedBranches = b; }
 
   void SetIsSelectedStd(bool isselected, bool isselectedTopo, bool isselectedPID, bool isselectedTracks) {
     if(isselected) fCandType |= kSelected;
@@ -192,6 +196,10 @@ protected:
   float fImpParXY;                                                     /// candidate impact parameter in the transverse plane
   float fDCA;                                                          /// DCA of candidates prongs
   
+  int fPDG;                                                            /// PDG code candidate
+  int fPDGmom;                                                         /// PDG code mother
+  int fMCLabel;                                                        /// Matched MC label
+
   float fPProng[knMaxProngs];                                          /// prong momentum
   int fSPDhitsProng[knMaxProngs];                                      /// prong hits in the SPD
   float fTPCPProng[knMaxProngs];                                       /// prong TPC momentum
@@ -211,6 +219,8 @@ protected:
   int fPIDNsigmaIntVector[knMaxProngs][knMaxDet4Pid+1][knMaxHypo4Pid]; /// PID nsigma variables (integers)
   float fPIDrawVector[knMaxProngs][knMaxDet4Pid];                      /// raw PID variables
   
+  bool fIncludeML;                                                     /// option to have the online applied ML score in TTree
+  bool fOnlyDedicatedBranches;                                         /// variable to disable unnecessary branches
   int fPidOpt;                                                         /// option for PID variables
   int fSingleTrackOpt;                                                 /// option for single-track variables
   bool fFillOnlySignal;                                                /// flag to enable only signal filling
@@ -237,7 +247,7 @@ protected:
   int fNEtabinsNsigmaTPCDataCorr;                                      /// number of eta bins for data-driven NsigmaTPC correction
   
   /// \cond CLASSIMP
-  ClassDef(AliHFTreeHandlerApply,2); ///
+  ClassDef(AliHFTreeHandlerApply,3); ///
   /// \endcond
 };
 #endif

--- a/PWGHF/vertexingHF/vHFML/AliHFTreeHandlerApplyDstartoKpipi.cxx
+++ b/PWGHF/vertexingHF/vHFML/AliHFTreeHandlerApplyDstartoKpipi.cxx
@@ -1,0 +1,183 @@
+/* Copyright(c) 1998-2008, ALICE Experiment at CERN, All rights reserved. *
+ * See cxx source for full Copyright notice                               */
+
+/* $Id$ */
+
+//*************************************************************************
+// \class AliHFTreeHandlerApplyDstartoKpipi
+// \brief helper class to handle a tree for Dstar cut optimisation and MVA analyses
+// \authors:
+// L. Vermunt, luuk.vermunt@cern.ch
+/////////////////////////////////////////////////////////////
+
+#include <TString.h>
+#include <TDatabasePDG.h>
+#include "AliHFTreeHandlerApplyDstartoKpipi.h"
+#include "AliAODRecoCascadeHF.h"
+
+/// \cond CLASSIMP
+ClassImp(AliHFTreeHandlerApplyDstartoKpipi);
+/// \endcond
+
+//________________________________________________________________
+AliHFTreeHandlerApplyDstartoKpipi::AliHFTreeHandlerApplyDstartoKpipi():
+AliHFTreeHandlerApplyDstartoKpipi(kNsigmaPID)
+{
+  //
+  // Default constructor
+  //
+}
+
+//________________________________________________________________
+AliHFTreeHandlerApplyDstartoKpipi::AliHFTreeHandlerApplyDstartoKpipi(int PIDopt):
+  AliHFTreeHandlerApply(PIDopt),
+  fCharge(-9999),
+  fCosThetaStar(-9999.),
+  fImpParProd(-9999.),
+  fNormd0MeasMinusExp(-9999.),
+  fAngleD0dkpPisoft(-9999.),
+  fDeltaInvMassD0(-9999.)
+{
+  //
+  // Standard constructor
+  //
+
+  //Only used in for-loops with a self-made AliAODtrack vector, so "Dstar pion + 2 D0-prongs" is fine
+  fNProngs=3; // --> cannot be changed
+  for(unsigned int iProng=0; iProng<fNProngs; iProng++){ 
+    fIDProng[iProng] = -9999;
+    fChargeProng[iProng] = -9999;
+    fImpParProng[iProng] = -9999.;
+  }
+}
+
+//________________________________________________________________
+AliHFTreeHandlerApplyDstartoKpipi::~AliHFTreeHandlerApplyDstartoKpipi()
+{
+  //
+  // Default Destructor
+  //
+}
+
+//________________________________________________________________
+TTree* AliHFTreeHandlerApplyDstartoKpipi::BuildTree(TString name, TString title)
+{
+  fIsMCGenTree=false;
+
+  if(fTreeVar) {
+    delete fTreeVar;
+    fTreeVar=nullptr;
+  }
+  fTreeVar = new TTree(name.Data(),title.Data());
+
+  //set common variables (please pay attention, filled with D0 and Dstar variables)
+  AddCommonDmesonVarBranches();
+
+  //set Dstar variables
+  if(!fOnlyDedicatedBranches){
+    fTreeVar->Branch("cos_t_star",&fCosThetaStar);
+    fTreeVar->Branch("angle_D0dkpPisoft",&fAngleD0dkpPisoft);
+    fTreeVar->Branch("delta_mass_D0",&fDeltaInvMassD0);
+    for(unsigned int iProng=0; iProng<fNProngs; iProng++){
+      fTreeVar->Branch(Form("imp_par_prong%d",iProng),&fImpParProng[iProng]);
+    }
+  }
+  fTreeVar->Branch("imp_par_prod",&fImpParProd);
+  fTreeVar->Branch("max_norm_d0d0exp",&fNormd0MeasMinusExp);
+  fTreeVar->Branch("charge_cand",&fCharge);
+  if(fFillOnlySignal) fTreeVar->Branch("mc_label", &fMCLabel);
+  for(unsigned int iProng=0; iProng<fNProngs; iProng++){
+    fTreeVar->Branch(Form("charge_prong%d",iProng),&fChargeProng[iProng]);
+    fTreeVar->Branch(Form("id_prong%d",iProng),&fIDProng[iProng]);
+  }
+
+  //set single-track variables
+  AddSingleTrackBranches();
+
+  //set PID variables
+  bool prongusepid[3] = {false, true, true};
+  if(!fOnlyDedicatedBranches) prongusepid[0] = true;
+  if(fPidOpt!=kNoPID) AddPidBranches(prongusepid,true,true,false,true,true);
+
+  return fTreeVar;
+}
+
+//________________________________________________________________
+bool AliHFTreeHandlerApplyDstartoKpipi::SetVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, float ptgen, float mlprob, AliAODRecoDecayHF* cand, float bfield, int /*masshypo*/, AliPIDResponse *pidrespo, AliAODPidHF* pidhf)
+{
+  if(!cand) return false;
+  if(fFillOnlySignal) { //if fill only signal and not signal candidate, do not store
+    if(!(fCandType&kSignal)) return true;
+  }
+  fRunNumber=runnumber;
+  fEvID=eventID;
+  fEvIDExt=eventID_Ext;
+  fEvIDLong=eventID_Long;
+  fPtGen=ptgen;
+  fMLProb=mlprob;
+  
+  fCandType &= ~kRefl; //protection --> Dstar ->Kpipi cannot be reflected
+
+  //topological variables (Dstar and D0 variables combined)
+  //common (Dstar)
+  fPt=((AliAODRecoCascadeHF*)cand)->Pt();
+  fY=((AliAODRecoCascadeHF*)cand)->YDstar();
+  fEta=((AliAODRecoCascadeHF*)cand)->Eta();
+  fPhi=((AliAODRecoCascadeHF*)cand)->Phi();
+  fCharge=((AliAODRecoCascadeHF*)cand)->Charge();
+  //common (D0)
+  AliAODRecoDecayHF2Prong *d0 = ((AliAODRecoCascadeHF*)cand)->Get2Prong();
+  fDecayLength=d0->DecayLength();
+  fDecayLengthXY=d0->DecayLengthXY();
+  fNormDecayLengthXY=d0->NormalizedDecayLengthXY()*(d0->P()/d0->Pt());
+  fCosP=d0->CosPointingAngle();
+  fCosPXY=d0->CosPointingAngleXY();
+  fImpParXY=d0->ImpParXY();
+  fDCA=d0->GetDCA();
+  fNormd0MeasMinusExp=ComputeMaxd0MeasMinusExp(d0,bfield);
+  fAngleD0dkpPisoft=((AliAODRecoCascadeHF*)cand)->AngleD0dkpPisoft();
+
+  AliAODTrack* prongtracks[3];
+  prongtracks[0] = (AliAODTrack*)((AliAODRecoCascadeHF*)cand)->GetBachelor();
+  fImpParProng[0]=cand->Getd0Prong(0);
+    
+  //D* -> D0 pi variables
+  fInvMass=((AliAODRecoCascadeHF*)cand)->DeltaInvMass();
+  fImpParProd=d0->Prodd0d0();
+
+  double massD0 = TDatabasePDG::Instance()->GetParticle(421)->Mass();
+  if( (((AliAODRecoCascadeHF*)cand)->Charge()) > 0) {
+    fCosThetaStar=d0->CosThetaStarD0();
+    fDeltaInvMassD0=TMath::Abs(d0->InvMassD0() - massD0);
+      
+    fImpParProng[1]=d0->Getd0Prong(0);
+    fImpParProng[2]=d0->Getd0Prong(1);
+    prongtracks[1] = (AliAODTrack*)d0->GetDaughter(0);
+    prongtracks[2] = (AliAODTrack*)d0->GetDaughter(1);
+  } else {
+    fCosThetaStar=d0->CosThetaStarD0bar();
+    fDeltaInvMassD0=TMath::Abs(d0->InvMassD0bar() - massD0);
+
+    fImpParProng[1]=d0->Getd0Prong(1);
+    fImpParProng[2]=d0->Getd0Prong(0);
+    prongtracks[1] = (AliAODTrack*)d0->GetDaughter(1);
+    prongtracks[2] = (AliAODTrack*)d0->GetDaughter(0);
+  }
+
+  for(int ipr = 0; ipr < fNProngs; ipr++){
+    fIDProng[ipr] = prongtracks[ipr]->GetID();
+    fChargeProng[ipr] = prongtracks[ipr]->Charge();
+  }
+    
+  //single track variables
+  bool setsingletrack = SetSingleTrackVars(prongtracks);
+  if(!setsingletrack) return false;
+
+  //pid variables
+  if(fPidOpt==kNoPID) return true;
+
+  bool setpid = SetPidVars(prongtracks,pidrespo,true,true,false,true,true,pidhf);
+  if(!setpid) return false;
+
+  return true;
+}

--- a/PWGHF/vertexingHF/vHFML/AliHFTreeHandlerApplyDstartoKpipi.h
+++ b/PWGHF/vertexingHF/vHFML/AliHFTreeHandlerApplyDstartoKpipi.h
@@ -1,0 +1,49 @@
+#ifndef ALIHFTREEHANDLERAPPLYDSTARTOKPIPI_H
+#define ALIHFTREEHANDLERAPPLYDSTARTOKPIPI_H
+
+/* Copyright(c) 1998-2008, ALICE Experiment at CERN, All rights reserved. *
+ * See cxx source for full Copyright notice                               */
+
+/* $Id$ */
+
+//*************************************************************************
+// \class AliHFTreeHandlerApplyDstartoKpipi
+// \brief helper class to handle a tree for Dstar cut optimisation and MVA analyses
+// \authors:
+// L. Vermunt, luuk.vermunt@cern.ch
+/////////////////////////////////////////////////////////////
+
+#include "AliHFTreeHandlerApply.h"
+
+class AliHFTreeHandlerApplyDstartoKpipi : public AliHFTreeHandlerApply
+{
+public:
+
+  AliHFTreeHandlerApplyDstartoKpipi();
+  AliHFTreeHandlerApplyDstartoKpipi(int PIDopt);
+  virtual ~AliHFTreeHandlerApplyDstartoKpipi();
+
+  AliHFTreeHandlerApplyDstartoKpipi(const AliHFTreeHandlerApplyDstartoKpipi &source) = delete;
+  AliHFTreeHandlerApplyDstartoKpipi& operator=(const AliHFTreeHandlerApplyDstartoKpipi &source) = delete;
+
+  virtual TTree* BuildTree(TString name="tree", TString title="tree");
+  virtual bool SetVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, float ptgen, float mlprob, AliAODRecoDecayHF* cand, float bfield, int masshypo=0, AliPIDResponse *pidrespo=nullptr, AliAODPidHF *pidhf=nullptr);
+  void SetDstarMCMatchedLabel(int label) { fMCLabel = label; }
+
+private:
+
+  int fIDProng[knMaxProngs];         /// prong track ID
+  int fChargeProng[knMaxProngs];     /// prong track charge
+  float fImpParProng[knMaxProngs];   /// prong impact parameter
+  int fCharge;                       /// Dstar charge
+  float fCosThetaStar;               /// candidate cos theta star
+  float fImpParProd;                 /// D0 product of impact parameter
+  float fNormd0MeasMinusExp;         /// candidate topomatic variable
+  float fAngleD0dkpPisoft;           /// angle between D0 decay plane and soft pion
+  float fDeltaInvMassD0;             /// delta mass of D0
+
+  /// \cond CLASSIMP
+  ClassDef(AliHFTreeHandlerApplyDstartoKpipi,1); ///
+  /// \endcond
+};
+#endif

--- a/PWGHF/vertexingHF/vHFML/AliParticleTreeHandlerApply.cxx
+++ b/PWGHF/vertexingHF/vHFML/AliParticleTreeHandlerApply.cxx
@@ -1,0 +1,221 @@
+/* Copyright(c) 1998-2008, ALICE Experiment at CERN, All rights reserved. *
+ * See cxx source for full Copyright notice                               */
+
+/* $Id$ */
+
+//*************************************************************************
+// \class AliParticleTreeHandlerApply
+// \brief helper class to handle a tree for tracks with pion/kaon/proton hypotheses
+// \authors:
+// L. Vermunt, luuk.vermunt@cern.ch
+/////////////////////////////////////////////////////////////
+
+#include <TString.h>
+#include <TDatabasePDG.h>
+#include "AliPIDResponse.h"
+#include "AliParticleTreeHandlerApply.h"
+
+/// \cond CLASSIMP
+ClassImp(AliParticleTreeHandlerApply);
+/// \endcond
+
+//________________________________________________________________
+AliParticleTreeHandlerApply::AliParticleTreeHandlerApply():
+  TObject(),
+  fTreeVar(nullptr),
+  fTrackSel(0),
+  fPt(-9999.),
+  fY(-9999.),
+  fEta(-9999.),
+  fPhi(-9999.),
+  fPtGen(-9999.),
+  fYGen(-9999.),
+  fEtaGen(-9999.),
+  fPhiGen(-9999.),
+  fCharge(-9999),
+  fID(-9999),
+  fPDG(-9999),
+  fMCLabel(-9999),
+  fEvID(-9999),
+  fEvIDExt(-9999),
+  fEvIDLong(-9999),
+  fRunNumber(-9999),
+  fOnlyDedicatedBranches(false),
+  fIsMC(false),
+  fDebugMode(false),
+  fTPCCls(-9999),
+  fDCAXY(-9999),
+  fDCAZ(-9999),
+  fDCAXYProp(-9999),
+  fDCAZProp(-9999),
+  fTPCCrRows(-9999),
+  fTPCClsToFnd(-9999),
+  fChi2(-9999),
+  fPTPC(-9999),
+  fNSigTPC(-9999),
+  fNSigTOF(-9999),
+  fNSigCombTPCTOF(-9999)
+{
+  //
+  // Default constructor
+  //
+
+}
+
+//________________________________________________________________
+AliParticleTreeHandlerApply::~AliParticleTreeHandlerApply()
+{
+  //
+  // Destructor
+  //
+
+  delete fTreeVar;
+}
+
+//________________________________________________________________
+TTree* AliParticleTreeHandlerApply::BuildTree(TString name, TString title)
+{
+  if(fTreeVar) {
+    delete fTreeVar;
+    fTreeVar=nullptr;
+  }
+  fTreeVar = new TTree(name.Data(),title.Data());
+
+  fTreeVar->Branch("run_number", &fRunNumber);
+  fTreeVar->Branch("ev_id",&fEvID);
+  fTreeVar->Branch("ev_id_ext",&fEvIDExt);
+  if(!fOnlyDedicatedBranches) fTreeVar->Branch("ev_id_long",&fEvIDLong);
+  fTreeVar->Branch("track_sel",&fTrackSel);
+  fTreeVar->Branch("pt",&fPt);
+  fTreeVar->Branch("y",&fY);
+  fTreeVar->Branch("eta",&fEta);
+  fTreeVar->Branch("phi",&fPhi);
+  fTreeVar->Branch("charge",&fCharge);
+  fTreeVar->Branch("id",&fID);
+
+  if(fIsMC){
+    fTreeVar->Branch("pt_gen",&fPtGen);
+    fTreeVar->Branch("y_gen",&fYGen);
+    fTreeVar->Branch("eta_gen",&fEtaGen);
+    fTreeVar->Branch("phi_gen",&fPhiGen);
+    fTreeVar->Branch("pdg",&fPDG);
+    fTreeVar->Branch("mc_label",&fMCLabel);
+  }
+  
+  if(fDebugMode){
+    fTreeVar->Branch("tpc_cls",&fTPCCls);
+    fTreeVar->Branch("dca_xy",&fDCAXY);
+    fTreeVar->Branch("dca_z",&fDCAZ);
+    fTreeVar->Branch("dca_xy_prop",&fDCAXYProp);
+    fTreeVar->Branch("dca_z_prop",&fDCAZProp);
+    fTreeVar->Branch("tpc_cr_rows",&fTPCCrRows);
+    fTreeVar->Branch("tpc_cls_to_fnd",&fTPCClsToFnd);
+    fTreeVar->Branch("chi2",&fChi2);
+    fTreeVar->Branch("p_tpc",&fPTPC);
+    fTreeVar->Branch("nsig_TPC",&fNSigTPC);
+    fTreeVar->Branch("nsig_TOF",&fNSigTOF);
+    fTreeVar->Branch("nsig_comb_TPCTOF",&fNSigCombTPCTOF);
+  }
+
+  return fTreeVar;
+}
+
+//________________________________________________________________
+bool AliParticleTreeHandlerApply::SetVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, AliAODTrack* tr, AliAODTrack* trGlobal)
+{
+  if(!tr) return false;
+  
+  fRunNumber=runnumber;
+  fEvID=eventID;
+  fEvIDExt=eventID_Ext;
+  fEvIDLong=eventID_Long;
+
+  fPt=tr->Pt();
+  fY=tr->Y();
+  fEta=tr->Eta();
+  fPhi=tr->Phi();
+  fCharge=tr->Charge();
+  fID=tr->GetID();
+
+  fTPCCls=tr->GetTPCNcls();
+  Float_t trDCAXYProp, trDCAZProp;
+  trGlobal->GetImpactParameters(trDCAXYProp,trDCAZProp);
+  fDCAXYProp=trDCAXYProp;
+  fDCAZProp=trDCAZProp;
+  fDCAXY=tr->DCA();
+  fDCAZ=tr->ZAtDCA();
+  fTPCCrRows=tr->GetTPCClusterInfo(2, 1);
+  if (!(tr->GetTPCNclsF() > 0)) {
+    fTPCClsToFnd = 0.;
+  } else {
+    fTPCClsToFnd = tr->GetTPCClusterInfo(2, 1) / float(tr->GetTPCNclsF());
+  }
+  fChi2=tr->Chi2perNDF();
+  fPTPC=trGlobal->GetTPCmomentum();
+    
+  return true;
+}
+
+//________________________________________________________________
+void AliParticleTreeHandlerApply::SetSelectionType(int part, bool isstd, bool ispidloose, bool ispidtight) {
+
+  if(part == 0){
+    if(isstd) fTrackSel |= kSelectedProton;
+    else      fTrackSel &= ~kSelectedProton;
+    if(ispidloose) fTrackSel |= kSelectedProtonPIDLoose;
+    else           fTrackSel &= ~kSelectedProtonPIDLoose;
+    if(ispidtight) fTrackSel |= kSelectedProtonPIDTight;
+    else           fTrackSel &= ~kSelectedProtonPIDTight;
+  } else if(part == 1){
+    if(isstd) fTrackSel |= kSelectedKaon;
+    else      fTrackSel &= ~kSelectedKaon;
+    if(ispidloose) fTrackSel |= kSelectedKaonPIDLoose;
+    else           fTrackSel &= ~kSelectedKaonPIDLoose;
+    if(ispidtight) fTrackSel |= kSelectedKaonPIDTight;
+    else           fTrackSel &= ~kSelectedKaonPIDTight;
+  } else if(part == 2){
+    if(isstd) fTrackSel |= kSelectedPion;
+    else      fTrackSel &= ~kSelectedPion;
+    if(ispidloose) fTrackSel |= kSelectedPionPIDLoose;
+    else           fTrackSel &= ~kSelectedPionPIDLoose;
+    if(ispidtight) fTrackSel |= kSelectedPionPIDTight;
+    else           fTrackSel &= ~kSelectedPionPIDTight;
+  } else if(part == 3){
+    if(isstd) fTrackSel |= kSelectedNClsTPCStd;
+    else      fTrackSel &= ~kSelectedNClsTPCStd;
+    if(ispidtight) fTrackSel |= kSelectedNClsTPCTight;
+    else           fTrackSel &= ~kSelectedNClsTPCTight;
+  }
+}
+
+//________________________________________________________________
+bool AliParticleTreeHandlerApply::SetMCGenVariables(AliAODMCParticle* mcpart, int mc_label) {
+
+  fPtGen = -9999.;
+  fYGen = -9999.;
+  fEtaGen = -9999.;
+  fPhiGen = -9999.;
+  fPDG = -9999;
+  fMCLabel = -9999;
+
+  if(!mcpart) return false;
+  
+  fPtGen = mcpart->Pt();
+  fYGen = mcpart->Y();
+  fEtaGen = mcpart->Eta();
+  fPhiGen = mcpart->Phi();
+  fPDG = mcpart->GetPdgCode();
+  fMCLabel = mc_label;
+
+  return true;
+}
+
+//________________________________________________________________
+bool AliParticleTreeHandlerApply::SetPIDVariables(float nsig_TPC, float nsig_TOF, float nsig_comb_TPCTOF) {
+
+  fNSigTPC = nsig_TPC;
+  fNSigTOF = nsig_TOF;
+  fNSigCombTPCTOF = nsig_comb_TPCTOF;
+
+  return true;
+}

--- a/PWGHF/vertexingHF/vHFML/AliParticleTreeHandlerApply.h
+++ b/PWGHF/vertexingHF/vHFML/AliParticleTreeHandlerApply.h
@@ -1,0 +1,103 @@
+#ifndef ALIPARTICLETREEHANDLERAPPLY_H
+#define ALIPARTICLETREEHANDLERAPPLY_H
+
+/* Copyright(c) 1998-2008, ALICE Experiment at CERN, All rights reserved. *
+ * See cxx source for full Copyright notice                               */
+
+/* $Id$ */
+
+//*************************************************************************
+// \class AliParticleTreeHandlerApply
+// \brief helper class to handle a tree for Dstar cut optimisation and MVA analyses
+// \authors:
+// L. Vermunt, luuk.vermunt@cern.ch
+/////////////////////////////////////////////////////////////
+
+#include <TTree.h>
+#include "AliAODTrack.h"
+#include "AliAODMCParticle.h"
+
+class AliParticleTreeHandlerApply : public TObject
+{
+public:
+
+  enum selection_type {
+    kSelectedProton         = BIT(0),
+    kSelectedKaon           = BIT(1),
+    kSelectedPion           = BIT(2),
+    kSelectedNClsTPCStd     = BIT(3),
+    kSelectedNClsTPCTight   = BIT(4),
+    kSelectedProtonPIDLoose = BIT(5),
+    kSelectedProtonPIDTight = BIT(6),
+    kSelectedKaonPIDLoose   = BIT(7),
+    kSelectedKaonPIDTight   = BIT(8),
+    kSelectedPionPIDLoose   = BIT(9),
+    kSelectedPionPIDTight   = BIT(10)
+  };
+
+  AliParticleTreeHandlerApply();
+  virtual ~AliParticleTreeHandlerApply();
+
+  AliParticleTreeHandlerApply(const AliParticleTreeHandlerApply &source) = delete;
+  AliParticleTreeHandlerApply& operator=(const AliParticleTreeHandlerApply &source) = delete;
+
+  TTree* BuildTree(TString name="tree", TString title="tree");
+  bool SetVariables(int runnumber, int eventID, int eventID_Ext, Long64_t eventID_Long, AliAODTrack* tr, AliAODTrack* trGlobal);
+  bool SetMCGenVariables(AliAODMCParticle* mcpart, int mc_label);
+  bool SetPIDVariables(float nsig_TPC, float nsig_TOF, float nsig_comb_TPCTOF);
+
+  //to be called for each candidate
+  void SetSelectionType(int part, bool isstd, bool ispidloose, bool ispidtight); //0=proton, 1=kaon, 2=pion, 3=NClsTPC
+  void FillTree() { //to be called for each candidate!
+    fTreeVar->Fill();
+    fTrackSel = 0;
+  }
+
+  void SetOnlyDedicatedBranches(bool b) { fOnlyDedicatedBranches = b; }
+  void SetIsMC(bool b) { fIsMC = b; }
+  void SetIsDebugMode(bool b) { fDebugMode = b; }
+
+private:
+
+  TTree* fTreeVar;                                                     //!<! tree with variables
+
+  int fTrackSel;                                                       /// flag for track type (bit map above)
+  float fPt;                                                           /// track pt
+  float fY;                                                            /// track rapidity
+  float fEta;                                                          /// track pseudorapidity
+  float fPhi;                                                          /// track azimuthal angle
+  float fPtGen;                                                        /// track generated pt
+  float fYGen;                                                         /// track generated rapidity
+  float fEtaGen;                                                       /// track generated pseudorapidity
+  float fPhiGen;                                                       /// track generated azimuthal angle
+  int fCharge;                                                         /// track charge
+  int fID;                                                             /// track ID
+  int fPDG;                                                            /// PDG code track
+  int fMCLabel;                                                        /// track MC label
+  int fEvID;                                                           /// event ID corresponding to the one set in fTreeEvChar, first 32 bit of fEvIDLong
+  int fEvIDExt;                                                        /// event ID corresponding to the one set in fTreeEvChar, second 32 bit of fEvIDLong
+  Long64_t fEvIDLong;                                                  /// event ID corresponding to the one set in fTreeEvChar, full fEvIDLong
+  int fRunNumber;                                                      /// run number
+
+  bool fOnlyDedicatedBranches;                                         /// variable to disable unnecessary branches
+  bool fIsMC;                                                          /// flag to include MC branches
+
+  bool fDebugMode;                                                     /// flag to enable debug mode (to validate selection new task wrt old one)
+  float fTPCCls;                                                       /// track number of TPC clusters
+  float fDCAXY;                                                        /// track DCA XY (without recalculation)
+  float fDCAZ;                                                         /// track DCA Z (without recalculation)
+  float fDCAXYProp;                                                    /// track DCA XY (with recalculation)
+  float fDCAZProp;                                                     /// track DCA Z (with recalculation)
+  float fTPCCrRows;                                                    /// track TPC crossed rows
+  float fTPCClsToFnd;                                                  /// track ratio TPC clusters over findable
+  float fChi2;                                                         /// track chi2
+  float fPTPC;                                                         /// track TPC momentum
+  float fNSigTPC;                                                      /// track PID N sigma TPC
+  float fNSigTOF;                                                      /// track PID N sigma TOF
+  float fNSigCombTPCTOF;                                               /// track combined N sigma TPC & TOF PID (sqrt[nsig^2 + nsig^2])
+
+  /// \cond CLASSIMP
+  ClassDef(AliParticleTreeHandlerApply,1); ///
+  /// \endcond
+};
+#endif

--- a/PWGHF/vertexingHF/vHFML/CMakeLists.txt
+++ b/PWGHF/vertexingHF/vHFML/CMakeLists.txt
@@ -65,6 +65,8 @@ set(SRCS
     AliHFTreeHandlerApply.cxx
     AliHFTreeHandlerApplyDstoKKpi.cxx
     AliHFTreeHandlerApplyLc2V0bachelor.cxx
+    AliHFTreeHandlerApplyDstartoKpipi.cxx
+    AliParticleTreeHandlerApply.cxx
 )
 
 # Headers from sources

--- a/PWGHF/vertexingHF/vHFML/PWGHFvertexingHFMLLinkDef.h
+++ b/PWGHF/vertexingHF/vHFML/PWGHFvertexingHFMLLinkDef.h
@@ -31,4 +31,6 @@
 #pragma link C++ class AliHFTreeHandlerApply+;
 #pragma link C++ class AliHFTreeHandlerApplyDstoKKpi+;
 #pragma link C++ class AliHFTreeHandlerApplyLc2V0bachelor+;
+#pragma link C++ class AliHFTreeHandlerApplyDstartoKpipi+;
+#pragma link C++ class AliParticleTreeHandlerApply+;
 #endif


### PR DESCRIPTION
Added Dstar and particle TTrees to TreeCreator to reproduce D*-[pi,K,p] femtoscopy analysis in FemtoDream.