### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/clean-test.yml
+++ b/.github/workflows/clean-test.yml
@@ -22,7 +22,7 @@ permissions: {}
 jobs:
   cleanup_pr_checks:
     permissions:
-      repository-projects: write # to add to projects (octokit/graphql-action)
+      pull-requests: read # to get last commit for pr (octokit/graphql-action)
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/clean-test.yml
+++ b/.github/workflows/clean-test.yml
@@ -18,8 +18,12 @@ on:
         required: true
         default: 'AliPhysics'
 
+permissions: {}
 jobs:
   cleanup_pr_checks:
+    permissions:
+      repository-projects: write # to add to projects (octokit/graphql-action)
+
     runs-on: ubuntu-latest
     steps:
       - name: Set up Python 3.7

--- a/.github/workflows/clean-test.yml
+++ b/.github/workflows/clean-test.yml
@@ -23,6 +23,7 @@ jobs:
   cleanup_pr_checks:
     permissions:
       pull-requests: read # to get last commit for pr (octokit/graphql-action)
+      statuses: write # for set-github-status
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,12 @@ on:
         description: 'Tag to prepare'
         required: true
         default: 'v5-09-XXy-01'
+permissions: {}
 jobs:
   build:
+    permissions:
+      contents: write   # for git push
+
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.