### PR TITLE
Use L1 timesums in the calulation of the L0 patch ADCs

### DIFF
--- a/PWG/EMCAL/EMCALtasks/AliAnalysisTaskEmcalTriggerSelection.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliAnalysisTaskEmcalTriggerSelection.cxx
@@ -352,7 +352,7 @@ void AliAnalysisTaskEmcalTriggerSelection::ConfigurePP7TeV2011(){
   emcl0cuts->SetPatchType(AliEmcalTriggerSelectionCuts::kL0Patch);
   emcl0cuts->SetSelectionMethod(AliEmcalTriggerSelectionCuts::kADC);
   emcl0cuts->SetUseRecalcPatches(true);
-  emcl0cuts->SetThreshold(292);
+  emcl0cuts->SetThreshold(73); // MF Using timesums, adapt 2-bitshift L0->L1 292->73
   this->AddTriggerSelection(new AliEmcalTriggerSelection("EMCL0", emcl0cuts));
 }
 
@@ -390,7 +390,7 @@ void AliAnalysisTaskEmcalTriggerSelection::ConfigurePP2012(){
   emc7cuts->SetPatchType(AliEmcalTriggerSelectionCuts::kL0Patch);
   emc7cuts->SetSelectionMethod(AliEmcalTriggerSelectionCuts::kADC);
   emc7cuts->SetUseRecalcPatches(true);
-  emc7cuts->SetThreshold(106);
+  emc7cuts->SetThreshold(26); // MF Using timesums, adapt 2-bitshift L0->L1 106->26
   this->AddTriggerSelection(new AliEmcalTriggerSelection("EMCL0", emc7cuts));
 }
 
@@ -428,7 +428,7 @@ void AliAnalysisTaskEmcalTriggerSelection::ConfigurePPB5TeV2013(){
   emcl0cuts->SetPatchType(AliEmcalTriggerSelectionCuts::kL0Patch);
   emcl0cuts->SetSelectionMethod(AliEmcalTriggerSelectionCuts::kADC);
   emcl0cuts->SetUseRecalcPatches(true);
-  emcl0cuts->SetThreshold(158);
+  emcl0cuts->SetThreshold(39); // MF Using timesums, adapt 2-bitshift L0->L1 158->39
   this->AddTriggerSelection(new AliEmcalTriggerSelection("EMCL0", emcl0cuts));
 
   AliEmcalTriggerSelectionCuts *eg1cuts = new AliEmcalTriggerSelectionCuts;
@@ -516,7 +516,7 @@ void AliAnalysisTaskEmcalTriggerSelection::ConfigurePP5TeV2015(){
   emcl0cuts->SetPatchType(AliEmcalTriggerSelectionCuts::kL0Patch);
   emcl0cuts->SetSelectionMethod(AliEmcalTriggerSelectionCuts::kADC);
   emcl0cuts->SetUseRecalcPatches(true);
-  emcl0cuts->SetThreshold(263);
+  emcl0cuts->SetThreshold(66); // MF Using timesums, adapt 2-bitshift L0->L1 263->66
   this->AddTriggerSelection(new AliEmcalTriggerSelection("EMCL0", emcl0cuts));
 
   AliEmcalTriggerSelectionCuts *dmcl0cuts = new AliEmcalTriggerSelectionCuts;
@@ -524,7 +524,7 @@ void AliAnalysisTaskEmcalTriggerSelection::ConfigurePP5TeV2015(){
   dmcl0cuts->SetPatchType(AliEmcalTriggerSelectionCuts::kL0Patch);
   dmcl0cuts->SetSelectionMethod(AliEmcalTriggerSelectionCuts::kADC);
   dmcl0cuts->SetUseRecalcPatches(true);
-  dmcl0cuts->SetThreshold(263);
+  dmcl0cuts->SetThreshold(66); // MF Using timesums, adapt 2-bitshift L0->L1 263->66
   this->AddTriggerSelection(new AliEmcalTriggerSelection("DMCL0", dmcl0cuts));
 
 }

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerKernel.cxx
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerKernel.cxx
@@ -652,7 +652,15 @@ void AliEmcalTriggerMakerKernel::CreateTriggerPatches(const AliVEvent *inputeven
 
   // Find Level0 patches
   std::vector<AliEMCALTriggerRawPatch> l0patches;
-  if (fLevel0PatchFinder) l0patches = fLevel0PatchFinder->FindPatches(*fPatchAmplitudes, *fPatchADCSimple);
+  // Markus: 
+  // Trigger patches also in case of Level0 are based on the timesum. The
+  // timesum is caluclated at L0 in the TRU and sent to the STU. Since we don't 
+  // store the time sum from the TRU the time sum from the STU is a good proxy.
+  // Users have to recall that the L0 uses a 10 bit ADC (ALTRO data), the STU
+  // uses a 12 bit ADC, leading to a bit shift when sending timesums from TRU to
+  // STU. Users must divide the threshold applied in the TRU by 4 when operating
+  // on the timesums from STU  
+  if (fLevel0PatchFinder) l0patches = fLevel0PatchFinder->FindPatches(*fPatchADC, *fPatchADCSimple);
   for(std::vector<AliEMCALTriggerRawPatch>::iterator patchit = l0patches.begin(); patchit != l0patches.end(); ++patchit){
     Int_t offlinebits = 0, onlinebits = 0;
     if(HasPHOSOverlap(*patchit)) continue;

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerKernel.h
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerKernel.h
@@ -612,7 +612,7 @@ protected:
   Bool_t                                    fDoBackgroundSubtraction;     ///< Swtich for background subtraction (only online ADC)
 
   const AliEMCALGeometry                    *fGeometry;                   //!<! Underlying EMCAL geometry
-  AliEMCALTriggerDataGrid<double>           *fPatchAmplitudes;            //!<! TRU Amplitudes (for L0)
+  AliEMCALTriggerDataGrid<double>           *fPatchAmplitudes;            //!<! TRU Amplitudes - pure monitoring information
   AliEMCALTriggerDataGrid<double>           *fPatchADCSimple;             //!<! patch map for simple offline trigger
   AliEMCALTriggerDataGrid<double>           *fPatchADC;                   //!<! ADC values map
   AliEMCALTriggerDataGrid<double>           *fPatchEnergySimpleSmeared;   //!<! Data grid for smeared energy values from cell energies


### PR DESCRIPTION
L0 patches also use the timesums for the calculation of
the ADC value. The timesums are calculated at in the
TRU and sent to the STU. Since the timesums at L0 are
not available in the analysis objects the timesums at L1
serve as proxy. The only issue the user has to keep in
mind is that when shipping the timesums from the TRU
to the STU a bit shift from 12 to 10 bits is performed in
order to fit the timesums into the ALTRO format (10 bits).
When working with L1 timesums users need to divide
the L0 threshold by 4.