### PR TITLE
Updated jet pt matching

### DIFF
--- a/PWGCF/Correlations/JCORRAN/Pro/AliJCDijetAna.cxx
+++ b/PWGCF/Correlations/JCORRAN/Pro/AliJCDijetAna.cxx
@@ -881,6 +881,7 @@ void AliJCDijetAna::CalculateResponse(AliJCDijetAna *anaDetMC, AliJCDijetHistos 
         fhistos->fh_deltaPtResponse[iJetSetPart]->Fill(ptTrue+fDeltaPt,ptTrue);
         fhistos->fh_deltaPtResponse_ALICE[iJetSetPart]->Fill(ptTrue+fDeltaPt,ptTrue);
         for (ujetDetMC = 0; ujetDetMC < NjetsDetMC; ujetDetMC++) { //Det MC jets
+            if(bDetJetMatch.at(ujetDetMC)) continue; //We want to match jets only once.
             deltaR = DeltaR(jets.at(iJetSetPart).at(ujet), jetsDetMC.at(iJetSetDet).at(ujetDetMC));
             if(deltaR<minR) minR=deltaR;
             if(deltaR < matchingR && jetsDetMC.at(iJetSetDet).at(ujetDetMC).pt() > maxpt) {
@@ -898,16 +899,16 @@ void AliJCDijetAna::CalculateResponse(AliJCDijetAna *anaDetMC, AliJCDijetHistos 
             fhistos->fh_jetResponse_ALICE[iJetSetPart][iJetSetDet]->Fill(ptDetMC, ptTrue);
             fhistos->fh_jetResponseDeltaR[iJetSetPart][iJetSetDet]->Fill(deltaRMatch);
             fhistos->fh_jetResponseDeltaPt[iJetSetPart][iJetSetDet]->Fill((ptTrue-ptDetMC)/ptTrue);
-            if(iJetSetPart==0 && iJetSetDet==0) fhistos->fh_responseInfo->Fill("True jet has pair",1.0);
+            fhistos->fh_responseInfo[iJetSetPart][iJetSetDet]->Fill("True jet has pair",1.0);
             bTrueJetMatch.at(ujet) = true;
             bDetJetMatch.at(maxptIndex) = true;
         } else {
-            if(iJetSetPart==0 && iJetSetDet==0) fhistos->fh_responseInfo->Fill("True jet has no pair",1.0);
+            fhistos->fh_responseInfo[iJetSetPart][iJetSetDet]->Fill("True jet has no pair",1.0);
         }
     }
     for (ujetDetMC = 0; ujetDetMC < NjetsDetMC; ujetDetMC++) { //Det MC jets
         if(!bDetJetMatch.at(ujetDetMC)) {
-            if(iJetSetPart==0 && iJetSetDet==0) fhistos->fh_responseInfo->Fill("Det jet has no pair",1.0);
+            fhistos->fh_responseInfo[iJetSetPart][iJetSetDet]->Fill("Det jet has no pair",1.0);
         }
     }
 
@@ -979,22 +980,23 @@ void AliJCDijetAna::CalculateResponse(AliJCDijetAna *anaDetMC, AliJCDijetHistos 
                     << dijetsDetMC.at(iJetSetDet).at(0).at(1).eta() << ")" << endl;
             }
             dijetDetMC = dijetsDetMC.at(iJetSetDet).at(0).at(0) + dijetsDetMC.at(iJetSetDet).at(0).at(1);
+            fhistos->fh_dijetResponseLinNoMatching[iJetSetPart][iJetSetDet]->Fill(dijetDetMC.m(), dijet.m());
             if(bLeadingMatch && bSubleadingMatch) {
                 fhistos->fh_dijetResponse[iJetSetPart][iJetSetDet]->Fill(dijetDetMC.m(), dijet.m());
                 fhistos->fh_dijetResponseLin[iJetSetPart][iJetSetDet]->Fill(dijetDetMC.m(), dijet.m());
                 fhistos->fh_dijetResponseTrunc[iJetSetPart][iJetSetDet]->Fill(dijetDetMC.m(), dijet.m());
                 fhistos->fh_dijetResponseTrunc2[iJetSetPart][iJetSetDet]->Fill(dijetDetMC.m(), dijet.m());
-                if(iJetSetPart==0 && iJetSetDet==0) fhistos->fh_responseInfo->Fill("Dijet match",1.0);
+                fhistos->fh_responseInfo[iJetSetPart][iJetSetDet]->Fill("Dijet match",1.0);
             } else {
-                if(iJetSetPart==0 && iJetSetDet==0) fhistos->fh_responseInfo->Fill("Dijet not match",1.0);
+                fhistos->fh_responseInfo[iJetSetPart][iJetSetDet]->Fill("Dijet not match",1.0);
             }
         } else {
-            if(iJetSetPart==0 && iJetSetDet==0) fhistos->fh_responseInfo->Fill("Dijet det not found",1.0);
+            fhistos->fh_responseInfo[iJetSetPart][iJetSetDet]->Fill("Dijet det not found",1.0);
         }
     } else {
         if(anaDetMC->HasDijet(iJetSetDet)) {
             //dijetDetMC = dijetsDetMC.at(iJetSetDet).at(0).at(0) + dijetsDetMC.at(iJetSetDet).at(0).at(1);
-            if(iJetSetPart==0 && iJetSetDet==0) fhistos->fh_responseInfo->Fill("Dijet true not found",1.0);
+            fhistos->fh_responseInfo[iJetSetPart][iJetSetDet]->Fill("Dijet true not found",1.0);
         }
     }
     if(fDebug>8) cout << ((anaDetMC->HasDijet(iJetSetDet) && bLeadingMatch && bSubleadingMatch) ? "Dijet match" : "Dijet no match") << endl;
@@ -1039,22 +1041,23 @@ void AliJCDijetAna::CalculateResponse(AliJCDijetAna *anaDetMC, AliJCDijetHistos 
             dijetDetMC = dijetsDetMC.at(iJetSetDet).at(1).at(0) + dijetsDetMC.at(iJetSetDet).at(1).at(1);
             // Check subleading jet match.
 
+            fhistos->fh_dijetResponseDeltaPhiCutLinNoMatching[iJetSetPart][iJetSetDet]->Fill(dijetDetMC.m(), dijet.m());
             if(bLeadingMatch && bSubleadingMatchDeltaPhi) {
                 fhistos->fh_dijetResponseDeltaPhiCut[iJetSetPart][iJetSetDet]->Fill(dijetDetMC.m(), dijet.m());
                 fhistos->fh_dijetResponseDeltaPhiCutLin[iJetSetPart][iJetSetDet]->Fill(dijetDetMC.m(), dijet.m());
                 fhistos->fh_dijetResponseDeltaPhiCutTrunc[iJetSetPart][iJetSetDet]->Fill(dijetDetMC.m(), dijet.m());
                 fhistos->fh_dijetResponseDeltaPhiCutTrunc2[iJetSetPart][iJetSetDet]->Fill(dijetDetMC.m(), dijet.m());
-                if(iJetSetPart==0 && iJetSetDet==0) fhistos->fh_responseInfo->Fill("Dijet DPhi match",1.0);
+                fhistos->fh_responseInfo[iJetSetPart][iJetSetDet]->Fill("Dijet DPhi match",1.0);
             } else {
-                if(iJetSetPart==0 && iJetSetDet==0) fhistos->fh_responseInfo->Fill("Dijet DPhi not match",1.0);
+                fhistos->fh_responseInfo[iJetSetPart][iJetSetDet]->Fill("Dijet DPhi not match",1.0);
             }
         } else {
-            if(iJetSetPart==0 && iJetSetDet==0) fhistos->fh_responseInfo->Fill("Dijet DPhi det not found",1.0);
+            fhistos->fh_responseInfo[iJetSetPart][iJetSetDet]->Fill("Dijet DPhi det not found",1.0);
         }
     } else {
         if(anaDetMC->HasDeltaPhiDijet(iJetSetDet)) {
             //dijetDetMC = dijetsDetMC.at(iJetSetDet).at(1).at(0) + dijetsDetMC.at(iJetSetDet).at(1).at(1);
-            if(iJetSetPart==0 && iJetSetDet==0) fhistos->fh_responseInfo->Fill("Dijet DPhi true not found",1.0);
+            fhistos->fh_responseInfo[iJetSetPart][iJetSetDet]->Fill("Dijet DPhi true not found",1.0);
         }
     }
     if(fDebug>8) cout << ((anaDetMC->HasDeltaPhiDijet(iJetSetDet) && bLeadingMatch && bSubleadingMatchDeltaPhi) ? "Delta Phi Dijet match" : "Delta Phi Dijet no match") << endl;
@@ -1112,7 +1115,7 @@ double AliJCDijetAna::GetDeltaPhi(fastjet::PseudoJet jet1, fastjet::PseudoJet je
 }
 
 // This should be done after SetSettings.
-void AliJCDijetAna::InitHistos(AliJCDijetHistos *histos, bool bIsMC, int nCentBins) {
+void AliJCDijetAna::InitHistos(AliJCDijetHistos *histos, bool bIsMC, int nCentBins, int iJetClassTrue, int iJetClassDet) {
     cout << "Initing histograms for AliJCDijetAna" << endl;
     histos->fh_info->Fill("Count", 1.0);
     histos->fh_info->Fill("MC", bIsMC);
@@ -1197,18 +1200,33 @@ void AliJCDijetAna::InitHistos(AliJCDijetHistos *histos, bool bIsMC, int nCentBi
         histos->fh_events[iBin]->Fill("localRho increased subleading jet",0.0);
         histos->fh_events[iBin]->Fill("cones overlap",0.0);
         histos->fh_events[iBin]->Fill("cones overlap alt",0.0);
-        if(bIsMC) {
-            histos->fh_responseInfo->Fill("True jet has pair",0.0);
-            histos->fh_responseInfo->Fill("True jet has no pair",0.0);
-            histos->fh_responseInfo->Fill("Det jet has no pair",0.0);
-            histos->fh_responseInfo->Fill("Dijet match",0.0);
-            histos->fh_responseInfo->Fill("Dijet not match",0.0);
-            histos->fh_responseInfo->Fill("Dijet det not found",0.0);
-            histos->fh_responseInfo->Fill("Dijet true not found",0.0);
-            histos->fh_responseInfo->Fill("Dijet DPhi match",0.0);
-            histos->fh_responseInfo->Fill("Dijet DPhi not match",0.0);
-            histos->fh_responseInfo->Fill("Dijet DPhi det not found",0.0);
-            histos->fh_responseInfo->Fill("Dijet DPhi true not found",0.0);
+    }
+    if(bIsMC) {
+        for(int iBin=0; iBin<jetClassesSize-1; iBin++) {
+            histos->fh_responseInfo[iBin][iBin]->Fill("True jet has pair",0.0);
+            histos->fh_responseInfo[iBin][iBin]->Fill("True jet has no pair",0.0);
+            histos->fh_responseInfo[iBin][iBin]->Fill("Det jet has no pair",0.0);
+            histos->fh_responseInfo[iBin][iBin]->Fill("Dijet match",0.0);
+            histos->fh_responseInfo[iBin][iBin]->Fill("Dijet not match",0.0);
+            histos->fh_responseInfo[iBin][iBin]->Fill("Dijet det not found",0.0);
+            histos->fh_responseInfo[iBin][iBin]->Fill("Dijet true not found",0.0);
+            histos->fh_responseInfo[iBin][iBin]->Fill("Dijet DPhi match",0.0);
+            histos->fh_responseInfo[iBin][iBin]->Fill("Dijet DPhi not match",0.0);
+            histos->fh_responseInfo[iBin][iBin]->Fill("Dijet DPhi det not found",0.0);
+            histos->fh_responseInfo[iBin][iBin]->Fill("Dijet DPhi true not found",0.0);
+        }
+        if(iJetClassDet!=iJetClassTrue) {
+            histos->fh_responseInfo[iJetClassTrue][iJetClassDet]->Fill("True jet has pair",0.0);
+            histos->fh_responseInfo[iJetClassTrue][iJetClassDet]->Fill("True jet has no pair",0.0);
+            histos->fh_responseInfo[iJetClassTrue][iJetClassDet]->Fill("Det jet has no pair",0.0);
+            histos->fh_responseInfo[iJetClassTrue][iJetClassDet]->Fill("Dijet match",0.0);
+            histos->fh_responseInfo[iJetClassTrue][iJetClassDet]->Fill("Dijet not match",0.0);
+            histos->fh_responseInfo[iJetClassTrue][iJetClassDet]->Fill("Dijet det not found",0.0);
+            histos->fh_responseInfo[iJetClassTrue][iJetClassDet]->Fill("Dijet true not found",0.0);
+            histos->fh_responseInfo[iJetClassTrue][iJetClassDet]->Fill("Dijet DPhi match",0.0);
+            histos->fh_responseInfo[iJetClassTrue][iJetClassDet]->Fill("Dijet DPhi not match",0.0);
+            histos->fh_responseInfo[iJetClassTrue][iJetClassDet]->Fill("Dijet DPhi det not found",0.0);
+            histos->fh_responseInfo[iJetClassTrue][iJetClassDet]->Fill("Dijet DPhi true not found",0.0);
         }
     }
     return;

--- a/PWGCF/Correlations/JCORRAN/Pro/AliJCDijetAna.h
+++ b/PWGCF/Correlations/JCORRAN/Pro/AliJCDijetAna.h
@@ -39,7 +39,7 @@ class AliJCDijetAna : public TObject
         vector<vector<vector<fastjet::PseudoJet>>> GetDijets() { return dijets; }
         bool HasDijet(int iSet) { return bHasDijet.at(iSet); }
         bool HasDeltaPhiDijet(int iSet) { return bHasDeltaPhiDijet.at(iSet); }
-        void InitHistos(AliJCDijetHistos *histos, bool bIsMC, int nCentBins);
+        void InitHistos(AliJCDijetHistos *histos, bool bIsMC, int nCentBins, int iJetClassTrue, int iJetClassDet);
 
         void SetSettings(int    lDebug,
                          double lParticleEtaCut,

--- a/PWGCF/Correlations/JCORRAN/Pro/AliJCDijetHistos.cxx
+++ b/PWGCF/Correlations/JCORRAN/Pro/AliJCDijetHistos.cxx
@@ -26,6 +26,7 @@
 vector<double> AliJCDijetHistos::CentBin;
 vector<double> AliJCDijetHistos::dijetMBin;
 int AliJCDijetHistos::fNCentBin;
+int AliJCDijetHistos::fNJetClasses;
 int AliJCDijetHistos::fnNewBinsDijet1;
 
 //______________________________________________________________________________
@@ -105,6 +106,7 @@ AliJCDijetHistos::AliJCDijetHistos() :
     fh_deltaPtResponseEvery_ALICE(),
     fh_dijetResponse(),
     fh_dijetResponseLin(),
+    fh_dijetResponseLinNoMatching(),
     fh_doubleConeM(),
     fh_doubleConeMAlt(),
     fh_jet2Cone1Dist(),
@@ -129,6 +131,7 @@ AliJCDijetHistos::AliJCDijetHistos() :
     fh_dijetResponseTrunc2(),
     fh_dijetResponseDeltaPhiCut(),
     fh_dijetResponseDeltaPhiCutLin(),
+    fh_dijetResponseDeltaPhiCutLinNoMatching(),
     fh_dijetResponseDeltaPhiCutTrunc(),
     fh_dijetResponseDeltaPhiCutTrunc2()
 {
@@ -211,6 +214,7 @@ AliJCDijetHistos::AliJCDijetHistos(const AliJCDijetHistos& obj) :
     fh_deltaPtResponseEvery_ALICE(obj.fh_deltaPtResponseEvery_ALICE),
     fh_dijetResponse(obj.fh_dijetResponse),
     fh_dijetResponseLin(obj.fh_dijetResponseLin),
+    fh_dijetResponseLinNoMatching(obj.fh_dijetResponseLinNoMatching),
     fh_doubleConeM(obj.fh_doubleConeM),
     fh_doubleConeMAlt(obj.fh_doubleConeMAlt),
     fh_jet2Cone1Dist(obj.fh_jet2Cone1Dist),
@@ -235,6 +239,7 @@ AliJCDijetHistos::AliJCDijetHistos(const AliJCDijetHistos& obj) :
     fh_dijetResponseTrunc2(obj.fh_dijetResponseTrunc2),
     fh_dijetResponseDeltaPhiCut(obj.fh_dijetResponseDeltaPhiCut),
     fh_dijetResponseDeltaPhiCutLin(obj.fh_dijetResponseDeltaPhiCutLin),
+    fh_dijetResponseDeltaPhiCutLinNoMatching(obj.fh_dijetResponseDeltaPhiCutLinNoMatching),
     fh_dijetResponseDeltaPhiCutTrunc(obj.fh_dijetResponseDeltaPhiCutTrunc),
     fh_dijetResponseDeltaPhiCutTrunc2(obj.fh_dijetResponseDeltaPhiCutTrunc2)
 {
@@ -260,7 +265,7 @@ void AliJCDijetHistos::CreateEventTrackHistos(){
     fHMG = new AliJHistManager(Form("AliJCDijetHistManager%s",sMngrName.Data()),sMngrName.Data());
     // set AliJBin here //
     fHistCentBin.Set("CentBin","CentBin","Cent:",AliJBin::kSingle).SetBin(fNCentBin);
-    fJetBin.Set("JetBin","JetBin","Jet bin:",AliJBin::kSingle).SetBin(7);
+    fJetBin.Set("JetBin","JetBin","Jet bin:",AliJBin::kSingle).SetBin(fNJetClasses);
     fMBin.Set("MBin","MBin","dijetM:%.0f-%.0f:").SetBin(fSMBins);
 
     // fh_events counts several things:
@@ -612,6 +617,7 @@ void AliJCDijetHistos::CreateEventTrackHistos(){
     // ============ Response histograms ===========
     fh_responseInfo
         << TH1D("h_responseInfo", "h_responseInfo", 40, 0.0, 40.0 )
+        << fJetBin << fJetBin
         << "END" ;
 
     fh_jetResponseDeltaR
@@ -666,6 +672,10 @@ void AliJCDijetHistos::CreateEventTrackHistos(){
 
     fh_dijetResponseLin
         << TH2D("h_dijetResponseLin", "h_dijetResponseLin", 500, 0, 500, 500, 0, 500 )
+        << fJetBin << fJetBin << "END" ;
+
+    fh_dijetResponseLinNoMatching
+        << TH2D("h_dijetResponseLinNoMatching", "h_dijetResponseLinNoMatching", 500, 0, 500, 500, 0, 500 )
         << fJetBin << fJetBin << "END" ;
 
     fh_doubleConeM
@@ -762,6 +772,10 @@ void AliJCDijetHistos::CreateEventTrackHistos(){
 
     fh_dijetResponseDeltaPhiCutLin
         << TH2D("h_dijetResponseDeltaPhiCutLin", "h_dijetResponseDeltaPhiCutLin", 500, 0, 500, 500, 0, 500 )
+        << fJetBin << fJetBin << "END" ;
+
+    fh_dijetResponseDeltaPhiCutLinNoMatching
+        << TH2D("h_dijetResponseDeltaPhiCutLinNoMatching", "h_dijetResponseDeltaPhiCutLinNoMatching", 500, 0, 500, 500, 0, 500 )
         << fJetBin << fJetBin << "END" ;
 
     fh_dijetResponseDeltaPhiCutTrunc

--- a/PWGCF/Correlations/JCORRAN/Pro/AliJCDijetHistos.h
+++ b/PWGCF/Correlations/JCORRAN/Pro/AliJCDijetHistos.h
@@ -54,9 +54,13 @@ class AliJCDijetHistos : public AliJHistogramInterface
                 dijetMBin.push_back(ar.at(i).Atof());
             }
         }
+        void SetNJetClasses( int ljetclasses ) {
+            fNJetClasses = ljetclasses;
+        }
         static int fNCentBin;
         static vector<double> CentBin;//[NCENT+1]; //8
         TString fSMBins;//
+        static int fNJetClasses;
         static int fnNewBinsDijet1;//
         static vector<double> dijetMBin;//
 
@@ -147,7 +151,8 @@ class AliJCDijetHistos : public AliJHistogramInterface
         AliJTH2D fh_deltaPtResponseEvery;          //! // delta-pt response matrix, filled for every true bin
         AliJTH2D fh_deltaPtResponseEvery_ALICE;    //! // delta-pt response matrix with ALICE bin, filled for every true bin
         AliJTH2D fh_dijetResponse;                 //! // Dijet response matrix
-        AliJTH2D fh_dijetResponseLin;                 //! // Dijet response matrix
+        AliJTH2D fh_dijetResponseLin;              //! // Dijet response matrix
+        AliJTH2D fh_dijetResponseLinNoMatching;    //! // Dijet response matrix
 
         AliJTH1D fh_doubleConeM;              //! // Double cone invariant mass
         AliJTH1D fh_doubleConeMAlt;              //! // Double cone invariant mass
@@ -173,6 +178,7 @@ class AliJCDijetHistos : public AliJHistogramInterface
         AliJTH2D fh_dijetResponseTrunc2;            //! // Dijet response matrix truncated from above and below
         AliJTH2D fh_dijetResponseDeltaPhiCut;      //! // Dijet response matrix with deltaPhi cut
         AliJTH2D fh_dijetResponseDeltaPhiCutLin;      //! // Dijet response matrix with deltaPhi cut
+        AliJTH2D fh_dijetResponseDeltaPhiCutLinNoMatching;      //! // Dijet response matrix with deltaPhi cut
         AliJTH2D fh_dijetResponseDeltaPhiCutTrunc; //! // Dijet response matrix with deltaPhi cut truncated from above and below
         AliJTH2D fh_dijetResponseDeltaPhiCutTrunc2; //! // Dijet response matrix with deltaPhi cut truncated from above and below
 };

--- a/PWGCF/Correlations/JCORRAN/Pro/AliJCDijetTask.cxx
+++ b/PWGCF/Correlations/JCORRAN/Pro/AliJCDijetTask.cxx
@@ -176,22 +176,24 @@ void AliJCDijetTask::UserCreateOutputObjects()
 
     fEventCuts.AddQAplotsToList(fJCatalystTask->GetCataList());
 
+    fana = new AliJCDijetAna();
     fhistos = new AliJCDijetHistos();
     fhistos->SetName("jcdijet");
     fhistos->SetCentralityBinsHistos(fcentralityBins);
     fhistos->SetDijetMBinsHistos(fsDijetMBins);
+    fhistos->SetNJetClasses(fana->jetClassesSize);
     fhistos->CreateEventTrackHistos();
     fhistos->fHMG->Print();
-    fana = new AliJCDijetAna();
 
     if(fIsMC) {
+        fanaMC = new AliJCDijetAna();
         fhistosDetMC = new AliJCDijetHistos();
         fhistosDetMC->SetName("jcdijetDetMC");
         fhistosDetMC->SetCentralityBinsHistos(fcentralityBins);
         fhistosDetMC->SetDijetMBinsHistos(fsDijetMBins);
+        fhistosDetMC->SetNJetClasses(fanaMC->jetClassesSize);
         fhistosDetMC->CreateEventTrackHistos();
         fhistosDetMC->fHMG->Print();
-        fanaMC = new AliJCDijetAna();
     }
 
     fUtils = new AliAnalysisUtils();
@@ -316,8 +318,8 @@ void AliJCDijetTask::UserCreateOutputObjects()
 
     // Save information about the settings used.
     // Done after SetSettings
-    fana->InitHistos(fhistos, fIsMC, fcentralityBins.size());
-    if(fIsMC) fanaMC->InitHistos(fhistosDetMC, fIsMC, fcentralityBins.size());
+    fana->InitHistos(fhistos, fIsMC, fcentralityBins.size(), iUnfJetClassTrue, iUnfJetClassDet);
+    if(fIsMC) fanaMC->InitHistos(fhistosDetMC, fIsMC, fcentralityBins.size(), iUnfJetClassTrue, iUnfJetClassDet);
 
 #endif
 
@@ -409,35 +411,6 @@ void AliJCDijetTask::UserExec(Option_t* /*option*/)
             fhistosDetMC->fh_zvtx->Fill(fJCatalystTask->GetZVertex());
 
             fInputListDetMC = (TClonesArray*)fJCatalystDetMCTask->GetInputList();
-
-            /* //In development:
-            if(mcEvent) {
-                for(int it = 0;it < mcEvent->GetNumberOfTracks();++it){
-
-                    //if ESD AliMCParticle* part = (AliMCParticle*)mcEvent->GetTrack(it);
-                    //if AOD AliVParticle* part=(AliVParticle*)mcEvent->GetTrack(it);
-
-                    TString genname;
-                    Bool_t yesno=mcEvent->GetCocktailGenerator(it,genname);
-                    //if(!yesno) Printf("no cocktail header list was found for this event");
-                    //if(yesno) {Printf("cocktail header name is %s", genname.Data());}
-                    //you may want to check wether it is Hijing, for example.
-                    if(yesno) {
-                        if(genname.Contains("EPOS")) {
-                            //fInputListDetMC->RemoveAt(it);
-                            fhistosDetMC->fh_events[fCBin]->Fill("EPOS particles",1.0);
-                        } else if(genname.Contains("jetjet")) {
-                            fhistosDetMC->fh_events[fCBin]->Fill("jetjet particles",1.0);
-                        } else {
-                            fhistosDetMC->fh_events[fCBin]->Fill("other particles",1.0);
-                        }
-                    } else {
-                        fhistosDetMC->fh_events[fCBin]->Fill("No coctail header",1.0);
-                    }
-                    //cout << "This particle comes from: " << genname.Data() << endl;
-                }
-            }
-            */
 
         }
 


### PR DESCRIPTION
Previously the same det MC jet could match to a true jet multiple times. This is a problem in the very low true jet range, under 5 GeV. Now there is a limit that det mc jet can be matched only once. Added a couple of histograms as well.