### PR TITLE
PWGGA/GammaConv: Add Neutral meson in-jet task

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskConvJet.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskConvJet.cxx
@@ -38,49 +38,49 @@
 ClassImp(AliAnalysisTaskConvJet);
 /// \endcond
 
-
-AliAnalysisTaskConvJet::AliAnalysisTaskConvJet() :
-  AliAnalysisTaskEmcalJet(),
-  fNJets(0),
-  fVectorJetPt(0),
-  fVectorJetPx(0),
-  fVectorJetPy(0),
-  fVectorJetPz(0),
-  fVectorJetEta(0),
-  fVectorJetPhi(0),
-  fVectorJetR(0),
-  fTrueNJets(0),
-  fTrueVectorJetPt(0),
-  fTrueVectorJetPx(0),
-  fTrueVectorJetPy(0),
-  fTrueVectorJetPz(0),
-  fTrueVectorJetEta(0),
-  fTrueVectorJetPhi(0),
-  fTrueVectorJetR(0)
+AliAnalysisTaskConvJet::AliAnalysisTaskConvJet() : AliAnalysisTaskEmcalJet(),
+                                                   fNJets(0),
+                                                   fVectorJetPt(0),
+                                                   fVectorJetPx(0),
+                                                   fVectorJetPy(0),
+                                                   fVectorJetPz(0),
+                                                   fVectorJetEta(0),
+                                                   fVectorJetPhi(0),
+                                                   fVectorJetR(0),
+                                                   fTrueNJets(0),
+                                                   fTrueVectorJetPt(0),
+                                                   fTrueVectorJetPx(0),
+                                                   fTrueVectorJetPy(0),
+                                                   fTrueVectorJetPz(0),
+                                                   fTrueVectorJetEta(0),
+                                                   fTrueVectorJetPhi(0),
+                                                   fTrueVectorJetR(0),
+                                                   fTrueVectorJetParton(0),
+                                                   fTrueVectorJetPartonPt(0)
 {
 }
 
-AliAnalysisTaskConvJet::AliAnalysisTaskConvJet(const char *name) :
-  AliAnalysisTaskEmcalJet(name, kTRUE),
-  fNJets(0),
-  fVectorJetPt(0),
-  fVectorJetPx(0),
-  fVectorJetPy(0),
-  fVectorJetPz(0),
-  fVectorJetEta(0),
-  fVectorJetPhi(0),
-  fVectorJetR(0),
-  fTrueVectorJetPt(0),
-  fTrueVectorJetPx(0),
-  fTrueVectorJetPy(0),
-  fTrueVectorJetPz(0),
-  fTrueVectorJetEta(0),
-  fTrueVectorJetPhi(0),
-  fTrueVectorJetR(0)
+AliAnalysisTaskConvJet::AliAnalysisTaskConvJet(const char* name) : AliAnalysisTaskEmcalJet(name, kTRUE),
+                                                                   fNJets(0),
+                                                                   fVectorJetPt(0),
+                                                                   fVectorJetPx(0),
+                                                                   fVectorJetPy(0),
+                                                                   fVectorJetPz(0),
+                                                                   fVectorJetEta(0),
+                                                                   fVectorJetPhi(0),
+                                                                   fVectorJetR(0),
+                                                                   fTrueVectorJetPt(0),
+                                                                   fTrueVectorJetPx(0),
+                                                                   fTrueVectorJetPy(0),
+                                                                   fTrueVectorJetPz(0),
+                                                                   fTrueVectorJetEta(0),
+                                                                   fTrueVectorJetPhi(0),
+                                                                   fTrueVectorJetR(0),
+                                                                   fTrueVectorJetParton(0),
+                                                                   fTrueVectorJetPartonPt(0)
 {
   SetMakeGeneralHistograms(kTRUE);
 }
-
 
 AliAnalysisTaskConvJet::~AliAnalysisTaskConvJet()
 {
@@ -92,7 +92,7 @@ AliAnalysisTaskConvJet::~AliAnalysisTaskConvJet()
  */
 void AliAnalysisTaskConvJet::UserCreateOutputObjects()
 {
-   AliAnalysisTaskEmcalJet::UserCreateOutputObjects();
+  AliAnalysisTaskEmcalJet::UserCreateOutputObjects();
 
   PostData(1, fOutput); // Post data for ALL output slots > 0 here.
 }
@@ -120,11 +120,11 @@ void AliAnalysisTaskConvJet::DoJetLoop()
   TIter next(&fJetCollArray);
   while ((jetCont = static_cast<AliJetContainer*>(next()))) {
     TString JetName = jetCont->GetTitle();
-    TObjArray *arr = JetName.Tokenize("__");
+    TObjArray* arr = JetName.Tokenize("__");
     TObjString* testObjString = (TObjString*)arr->At(2);
-    if(testObjString->GetString() != "mcparticles"){
+    if (testObjString->GetString() != "mcparticles") {
       UInt_t count = 0;
-      fNJets = 0 ;
+      fNJets = 0;
       fVectorJetPt.clear();
       fVectorJetPx.clear();
       fVectorJetPy.clear();
@@ -132,8 +132,9 @@ void AliAnalysisTaskConvJet::DoJetLoop()
       fVectorJetEta.clear();
       fVectorJetPhi.clear();
       fVectorJetR.clear();
-      for(auto const& jet : jetCont->accepted()) {
-        if (!jet) continue;
+      for (auto const& jet : jetCont->accepted()) {
+        if (!jet)
+          continue;
         count++;
         fVectorJetPt.push_back(jet->Pt());
         fVectorJetPx.push_back(jet->Px());
@@ -143,10 +144,10 @@ void AliAnalysisTaskConvJet::DoJetLoop()
         fVectorJetPhi.push_back(jet->Phi());
         fVectorJetR.push_back(jet->Area());
       }
-      fNJets = count ;
-    }else{
+      fNJets = count;
+    } else {
       UInt_t count = 0;
-      fTrueNJets = 0 ;
+      fTrueNJets = 0;
       fTrueVectorJetPt.clear();
       fTrueVectorJetPx.clear();
       fTrueVectorJetPy.clear();
@@ -154,8 +155,9 @@ void AliAnalysisTaskConvJet::DoJetLoop()
       fTrueVectorJetEta.clear();
       fTrueVectorJetPhi.clear();
       fTrueVectorJetR.clear();
-      for(auto const& jet : jetCont->accepted()) {
-        if (!jet) continue;
+      for (auto const& jet : jetCont->accepted()) {
+        if (!jet)
+          continue;
         count++;
         fTrueVectorJetPt.push_back(jet->Pt());
         fTrueVectorJetPx.push_back(jet->Px());
@@ -165,7 +167,57 @@ void AliAnalysisTaskConvJet::DoJetLoop()
         fTrueVectorJetPhi.push_back(jet->Phi());
         fTrueVectorJetR.push_back(jet->Area());
       }
-      fTrueNJets = count ;
+      fTrueNJets = count;
+    }
+  }
+}
+
+/**
+ * This function finds the leading /hardest parton in each jet
+ * The id of the mc particles is written to fTrueVectorJetParton
+ */
+void AliAnalysisTaskConvJet::FindPartonsJet(TClonesArray* arrMCPart)
+{
+  // Loop over all primary MC particle
+  fTrueVectorJetParton.resize(fTrueNJets);
+  fTrueVectorJetPartonPt.resize(fTrueNJets);
+  std::vector<double> partonEnergy(fTrueNJets, -1);
+  double JetR2 = Get_Jet_Radius() * Get_Jet_Radius();
+
+  for (Long_t i = 0; i < arrMCPart->GetEntriesFast(); i++) {
+    AliAODMCParticle* particle = static_cast<AliAODMCParticle*>(arrMCPart->At(i));
+    if (!particle)
+      continue;
+
+    // particle has to be quark or gluon
+    if (std::abs(particle->GetPdgCode()) == 21 || (std::abs(particle->GetPdgCode()) < 9 && std::abs(particle->GetPdgCode()) > 0)) {
+
+      int indexNearestJet = -1;
+      double deltaR2 = 100000;
+      // loop over all jets and find the closest jet to the parton inside the jet radius
+      for (int j = 0; j < fTrueNJets; ++j) {
+        // check if mc particle and jet coincide
+        double dEta = particle->Eta() - fTrueVectorJetEta[j];
+        double dPhi = particle->Phi() - fTrueVectorJetPhi[j];
+        double deltaR2tmp = dEta * dEta + dPhi * dPhi;
+        // std::cout << "deltaR2tmp " << deltaR2tmp << "   deltaR2 " << deltaR2 <<"   JetR2 " << JetR2 << std::endl;
+        if (deltaR2tmp < JetR2 && deltaR2tmp < deltaR2) {
+          indexNearestJet = j;
+          deltaR2 = deltaR2tmp;
+          // std::cout << "indexNearestJet " << indexNearestJet << std::endl;
+          // std::cout << "deltaR2tmp " << deltaR2tmp << "   deltaR2 " << deltaR2 <<"   JetR2 " << JetR2 << std::endl;
+        }
+      }
+      if (indexNearestJet == -1) {
+        continue;
+      }
+
+      // assign a parton to the jet if the parton has an energy thats larger than the previously assigned value
+      if (partonEnergy[indexNearestJet] < particle->Pt()) {
+        partonEnergy[indexNearestJet] = particle->Pt();
+        fTrueVectorJetParton[indexNearestJet] = i;
+        fTrueVectorJetPartonPt[indexNearestJet] = particle->Pt();
+      }
     }
   }
 }
@@ -194,7 +246,7 @@ Bool_t AliAnalysisTaskConvJet::Run()
 /**
  * This function is called once at the end of the analysis.
  */
-void AliAnalysisTaskConvJet::Terminate(Option_t *) 
+void AliAnalysisTaskConvJet::Terminate(Option_t*)
 {
 }
 
@@ -203,17 +255,16 @@ void AliAnalysisTaskConvJet::Terminate(Option_t *)
  * by an AddTask C macro. However, by compiling the code, it ensures that we do not
  * have to deal with difficulties caused by CINT.
  */
-AliAnalysisTaskConvJet * AliAnalysisTaskConvJet::AddTask_GammaConvJet(
-  const char *ntracks,
-  const char *nclusters,
+AliAnalysisTaskConvJet* AliAnalysisTaskConvJet::AddTask_GammaConvJet(
+  const char* ntracks,
+  const char* nclusters,
   const char* ncells,
-  const char *suffix)
+  const char* suffix)
 {
   // Get the pointer to the existing analysis manager via the static access method.
   //==============================================================================
-  AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
-  if (!mgr)
-  {
+  AliAnalysisManager* mgr = AliAnalysisManager::GetAnalysisManager();
+  if (!mgr) {
     ::Error("AddTask_GammaConvJet", "No analysis manager to connect to.");
     return 0;
   }
@@ -221,8 +272,7 @@ AliAnalysisTaskConvJet * AliAnalysisTaskConvJet::AddTask_GammaConvJet(
   // Check the analysis type using the event handlers connected to the analysis manager.
   //==============================================================================
   AliVEventHandler* handler = mgr->GetInputEventHandler();
-  if (!handler)
-  {
+  if (!handler) {
     ::Error("AddTask_GammaConvJet", "This task requires an input event handler");
     return 0;
   }
@@ -237,8 +287,7 @@ AliAnalysisTaskConvJet * AliAnalysisTaskConvJet::AddTask_GammaConvJet(
 
   if (handler->InheritsFrom("AliESDInputHandler")) {
     dataType = kESD;
-  }
-  else if (handler->InheritsFrom("AliAODInputHandler")) {
+  } else if (handler->InheritsFrom("AliAODInputHandler")) {
     dataType = kAOD;
   }
 
@@ -253,11 +302,9 @@ AliAnalysisTaskConvJet * AliAnalysisTaskConvJet::AddTask_GammaConvJet(
   if (trackName == "usedefault") {
     if (dataType == kESD) {
       trackName = "Tracks";
-    }
-    else if (dataType == kAOD) {
+    } else if (dataType == kAOD) {
       trackName = "tracks";
-    }
-    else {
+    } else {
       trackName = "";
     }
   }
@@ -265,11 +312,9 @@ AliAnalysisTaskConvJet * AliAnalysisTaskConvJet::AddTask_GammaConvJet(
   if (clusName == "usedefault") {
     if (dataType == kESD) {
       clusName = "CaloClusters";
-    }
-    else if (dataType == kAOD) {
+    } else if (dataType == kAOD) {
       clusName = "caloClusters";
-    }
-    else {
+    } else {
       clusName = "";
     }
   }
@@ -277,11 +322,9 @@ AliAnalysisTaskConvJet * AliAnalysisTaskConvJet::AddTask_GammaConvJet(
   if (cellName == "usedefault") {
     if (dataType == kESD) {
       cellName = "EMCALCells";
-    }
-    else if (dataType == kAOD) {
+    } else if (dataType == kAOD) {
       cellName = "emcalCells";
-    }
-    else {
+    } else {
       cellName = "";
     }
   }
@@ -290,48 +333,45 @@ AliAnalysisTaskConvJet * AliAnalysisTaskConvJet::AddTask_GammaConvJet(
 
   AliAnalysisTaskConvJet* sampleTask = new AliAnalysisTaskConvJet(name);
   sampleTask->SetCaloCellsName(cellName);
-  sampleTask->SetVzRange(-10,10);
+  sampleTask->SetVzRange(-10, 10);
 
   if (trackName == "mcparticles") {
     sampleTask->AddMCParticleContainer(trackName);
-  }
-  else if (trackName == "tracks" || trackName == "Tracks") {
+  } else if (trackName == "tracks" || trackName == "Tracks") {
     sampleTask->AddTrackContainer(trackName);
-  }
-  else if (!trackName.IsNull()) {
+  } else if (!trackName.IsNull()) {
     sampleTask->AddParticleContainer(trackName);
   }
   sampleTask->AddClusterContainer(clusName);
-  
+
   sampleTask->GetClusterContainer(0)->SetClusECut(0.);
   sampleTask->GetClusterContainer(0)->SetClusPtCut(0.);
   sampleTask->GetClusterContainer(0)->SetClusNonLinCorrEnergyCut(0.);
   sampleTask->GetClusterContainer(0)->SetClusHadCorrEnergyCut(0.30);
   sampleTask->GetClusterContainer(0)->SetDefaultClusterEnergy(AliVCluster::kHadCorr);
   sampleTask->GetParticleContainer(0)->SetParticlePtCut(0.15);
-  sampleTask->GetParticleContainer(0)->SetParticleEtaLimits(-0.8,0.8);
+  sampleTask->GetParticleContainer(0)->SetParticleEtaLimits(-0.8, 0.8);
 
-  if(trackName != "mcparticles"){
-      sampleTask->GetTrackContainer(0)->SetFilterHybridTracks(kTRUE);
-      sampleTask->GetTrackContainer(0)->SetParticlePtCut(0.15);
-      sampleTask->GetTrackContainer(0)->SetParticleEtaLimits(-0.8,0.8);
+  if (trackName != "mcparticles") {
+    sampleTask->GetTrackContainer(0)->SetFilterHybridTracks(kTRUE);
+    sampleTask->GetTrackContainer(0)->SetParticlePtCut(0.15);
+    sampleTask->GetTrackContainer(0)->SetParticleEtaLimits(-0.8, 0.8);
   }
 
   //-------------------------------------------------------
   // Final settings, pass to manager and set the containers
   //-------------------------------------------------------
-
   mgr->AddTask(sampleTask);
 
   // Create containers for input/output
-  AliAnalysisDataContainer *cinput1  = mgr->GetCommonInputContainer()  ;
+  AliAnalysisDataContainer* cinput1 = mgr->GetCommonInputContainer();
   TString contname(trackName);
   contname += "_histos";
-  AliAnalysisDataContainer *coutput1 = mgr->CreateContainer(contname.Data(),
-      TList::Class(),AliAnalysisManager::kOutputContainer,
-      Form("%s", AliAnalysisManager::GetCommonFileName()));
-  mgr->ConnectInput  (sampleTask, 0,  cinput1 );
-  mgr->ConnectOutput (sampleTask, 1, coutput1 );
+  AliAnalysisDataContainer* coutput1 = mgr->CreateContainer(contname.Data(),
+                                                            TList::Class(), AliAnalysisManager::kOutputContainer,
+                                                            Form("%s", AliAnalysisManager::GetCommonFileName()));
+  mgr->ConnectInput(sampleTask, 0, cinput1);
+  mgr->ConnectOutput(sampleTask, 1, coutput1);
 
   return sampleTask;
 }

--- a/PWGGA/GammaConv/AliAnalysisTaskConvJet.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskConvJet.h
@@ -22,81 +22,90 @@
  * It derives from AliAnalysisTaskEmcalJet.
  * It performs a simple analysis, producing jet spectra.
  */
-class AliAnalysisTaskConvJet : public AliAnalysisTaskEmcalJet {
+class AliAnalysisTaskConvJet : public AliAnalysisTaskEmcalJet
+{
  public:
+  AliAnalysisTaskConvJet();
+  AliAnalysisTaskConvJet(const char* name);
+  virtual ~AliAnalysisTaskConvJet();
 
-  AliAnalysisTaskConvJet()                                               ;
-  AliAnalysisTaskConvJet(const char *name)                               ;
-  virtual ~AliAnalysisTaskConvJet()                                      ;
-
-  void                        UserCreateOutputObjects()                         ;
-  void                        Terminate(Option_t *option)                       ;
+  void UserCreateOutputObjects();
+  void Terminate(Option_t* option);
 
   static AliAnalysisTaskConvJet* AddTask_GammaConvJet(
-      const char *ntracks            = "usedefault",
-      const char *nclusters          = "usedefault",
-      const char* ncells             = "usedefault",
-      const char *suffix             = "");
+    const char* ntracks = "usedefault",
+    const char* nclusters = "usedefault",
+    const char* ncells = "usedefault",
+    const char* suffix = "");
 
-  Double_t GetNJets() {return fNJets;}
-  std::vector<Double_t> GetVectorJetPt()  {return fVectorJetPt;}
-  std::vector<Double_t> GetVectorJetPx()  {return fVectorJetPx;}
-  std::vector<Double_t> GetVectorJetPy()  {return fVectorJetPy;}
-  std::vector<Double_t> GetVectorJetPz()  {return fVectorJetPz;}
-  std::vector<Double_t> GetVectorJetEta() {return fVectorJetEta;}
-  std::vector<Double_t> GetVectorJetPhi() {return fVectorJetPhi;}
-  std::vector<Double_t> GetVectorJetArea() {return fVectorJetR;}
+  Double_t GetNJets() { return fNJets; }
+  std::vector<Double_t> GetVectorJetPt() { return fVectorJetPt; }
+  std::vector<Double_t> GetVectorJetPx() { return fVectorJetPx; }
+  std::vector<Double_t> GetVectorJetPy() { return fVectorJetPy; }
+  std::vector<Double_t> GetVectorJetPz() { return fVectorJetPz; }
+  std::vector<Double_t> GetVectorJetEta() { return fVectorJetEta; }
+  std::vector<Double_t> GetVectorJetPhi() { return fVectorJetPhi; }
+  std::vector<Double_t> GetVectorJetArea() { return fVectorJetR; }
 
-  Double_t GetTrueNJets() {return fTrueNJets;}
-  std::vector<Double_t> GetTrueVectorJetPt()  {return fTrueVectorJetPt;}
-  std::vector<Double_t> GetTrueVectorJetPx()  {return fTrueVectorJetPx;}
-  std::vector<Double_t> GetTrueVectorJetPy()  {return fTrueVectorJetPy;}
-  std::vector<Double_t> GetTrueVectorJetPz()  {return fTrueVectorJetPz;}
-  std::vector<Double_t> GetTrueVectorJetEta() {return fTrueVectorJetEta;}
-  std::vector<Double_t> GetTrueVectorJetPhi() {return fTrueVectorJetPhi;}
-  std::vector<Double_t> GetTrueVectorJetArea()   {return fTrueVectorJetR;}
+  Double_t GetTrueNJets() { return fTrueNJets; }
+  std::vector<Double_t> GetTrueVectorJetPt() { return fTrueVectorJetPt; }
+  std::vector<Double_t> GetTrueVectorJetPx() { return fTrueVectorJetPx; }
+  std::vector<Double_t> GetTrueVectorJetPy() { return fTrueVectorJetPy; }
+  std::vector<Double_t> GetTrueVectorJetPz() { return fTrueVectorJetPz; }
+  std::vector<Double_t> GetTrueVectorJetEta() { return fTrueVectorJetEta; }
+  std::vector<Double_t> GetTrueVectorJetPhi() { return fTrueVectorJetPhi; }
+  std::vector<Double_t> GetTrueVectorJetArea() { return fTrueVectorJetR; }
 
-  Double_t Get_Jet_Radius(){
-      AliJetContainer* jetCont = 0;
-      TIter next(&fJetCollArray);
-      Double_t radius = -1;
-      while ((jetCont = static_cast<AliJetContainer*>(next()))) {
-         radius = jetCont->GetJetRadius();
-      }
-      return radius;
- }
+  std::vector<int> GetTrueVectorJetParton() { return fTrueVectorJetParton; }
+  std::vector<double> GetTrueVectorJetPartonPt() { return fTrueVectorJetPartonPt; }
+
+  Double_t Get_Jet_Radius()
+  {
+    AliJetContainer* jetCont = 0;
+    TIter next(&fJetCollArray);
+    Double_t radius = -1;
+    while ((jetCont = static_cast<AliJetContainer*>(next()))) {
+      radius = jetCont->GetJetRadius();
+    }
+    return radius;
+  }
+
+  void FindPartonsJet(TClonesArray* arrMCPart);
 
  protected:
-  void                        ExecOnce();
-  Bool_t                      FillHistograms();
-  Bool_t                      Run();
+  void ExecOnce();
+  Bool_t FillHistograms();
+  Bool_t Run();
 
-  void                        DoJetLoop();
+  void DoJetLoop();
 
-  Double_t                    fNJets;                          // Number of reconstructed jets
-  std::vector<Double_t>       fVectorJetPt;                    // Vector for the pt of the reconstructed jets
-  std::vector<Double_t>       fVectorJetPx;                    // Vector for the px of the reconstructed jets
-  std::vector<Double_t>       fVectorJetPy;                    // Vector for the py of the reconstructed jets
-  std::vector<Double_t>       fVectorJetPz;                    // Vector for the pz of the reconstructed jets
-  std::vector<Double_t>       fVectorJetEta;                   // Vector for the eta of the reconstructed jets
-  std::vector<Double_t>       fVectorJetPhi;                   // Vector for the phi of the reconstructed jets
-  std::vector<Double_t>       fVectorJetR;                     // Vector for the radius of the reconstructed jets
+  Double_t fNJets;                     // Number of reconstructed jets
+  std::vector<Double_t> fVectorJetPt;  // Vector for the pt of the reconstructed jets
+  std::vector<Double_t> fVectorJetPx;  // Vector for the px of the reconstructed jets
+  std::vector<Double_t> fVectorJetPy;  // Vector for the py of the reconstructed jets
+  std::vector<Double_t> fVectorJetPz;  // Vector for the pz of the reconstructed jets
+  std::vector<Double_t> fVectorJetEta; // Vector for the eta of the reconstructed jets
+  std::vector<Double_t> fVectorJetPhi; // Vector for the phi of the reconstructed jets
+  std::vector<Double_t> fVectorJetR;   // Vector for the radius of the reconstructed jets
 
-  Double_t                    fTrueNJets;                      // Number of true jets
-  std::vector<Double_t>       fTrueVectorJetPt;                // Vector for the pt of the true jets
-  std::vector<Double_t>       fTrueVectorJetPx;                // Vector for the px of the true jets
-  std::vector<Double_t>       fTrueVectorJetPy;                // Vector for the py of the true jets
-  std::vector<Double_t>       fTrueVectorJetPz;                // Vector for the pz of the true jets
-  std::vector<Double_t>       fTrueVectorJetEta;               // Vector for the eta of the true jets
-  std::vector<Double_t>       fTrueVectorJetPhi;               // Vector for the phi of the true jets
-  std::vector<Double_t>       fTrueVectorJetR;                 // Vector for the radius of the true jets
+  Double_t fTrueNJets;                     // Number of true jets
+  std::vector<Double_t> fTrueVectorJetPt;  // Vector for the pt of the true jets
+  std::vector<Double_t> fTrueVectorJetPx;  // Vector for the px of the true jets
+  std::vector<Double_t> fTrueVectorJetPy;  // Vector for the py of the true jets
+  std::vector<Double_t> fTrueVectorJetPz;  // Vector for the pz of the true jets
+  std::vector<Double_t> fTrueVectorJetEta; // Vector for the eta of the true jets
+  std::vector<Double_t> fTrueVectorJetPhi; // Vector for the phi of the true jets
+  std::vector<Double_t> fTrueVectorJetR;   // Vector for the radius of the true jets
+
+  std::vector<int> fTrueVectorJetParton;      // vector containing the mc stack id from the leading parton ("seed of the jet")
+  std::vector<double> fTrueVectorJetPartonPt; // vector containing the pt of the leading parton ("seed of the jet")
 
  private:
-  AliAnalysisTaskConvJet(const AliAnalysisTaskConvJet&)           ;
-  AliAnalysisTaskConvJet &operator=(const AliAnalysisTaskConvJet&);
+  AliAnalysisTaskConvJet(const AliAnalysisTaskConvJet&);
+  AliAnalysisTaskConvJet& operator=(const AliAnalysisTaskConvJet&);
 
   /// \cond CLASSIMP
-  ClassDef(AliAnalysisTaskConvJet, 11);
+  ClassDef(AliAnalysisTaskConvJet, 12);
   /// \endcond
 };
 #endif

--- a/PWGGA/GammaConv/AliAnalysisTaskMesonJetCorrelation.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskMesonJetCorrelation.cxx
@@ -1,0 +1,2895 @@
+/**************************************************************************
+ * Copyright(c) 1998-2020, ALICE Experiment at CERN, All rights reserved. *
+ *                                                                        *
+ * Author: Joshua Koenig <joshua.konig@cern.ch>                                        *
+ * Version 1.0                                                            *
+ *                                                                        *
+ *                                                                        *
+ * Permission to use, copy, modify and distribute this software and its   *
+ * documentation strictly for non-commercial purposes is hereby granted   *
+ * without fee, provided that the above copyright notice appears in all   *
+ * copies and that both the copyright notice and this permission notice   *
+ * appear in the supporting documentation. The authors make no claims     *
+ * about the suitability of this software for any purpose. It is          *
+ * provided "as is" without express or implied warranty.                  *
+ **************************************************************************/
+
+//////////////////////////////////////////////////////////////////
+//----------------------------------------------------------------
+// Class used to do analysis for light neutral mesons inside Jets
+//----------------------------------------------------------------
+//////////////////////////////////////////////////////////////////
+
+#include "AliAnalysisTaskMesonJetCorrelation.h"
+
+ClassImp(AliAnalysisTaskMesonJetCorrelation)
+
+  //________________________________________________________________________
+  AliAnalysisTaskMesonJetCorrelation::AliAnalysisTaskMesonJetCorrelation() : AliAnalysisTaskSE(),
+                                                                             fV0Reader(nullptr),
+                                                                             fV0ReaderName("V0ReaderV1"),
+                                                                             fReaderGammas(nullptr),
+                                                                             fCaloTriggerHelperName(""),
+                                                                             fCorrTaskSetting(""),
+                                                                             fInputEvent(nullptr),
+                                                                             fMCEvent(nullptr),
+                                                                             fAODMCTrackArray(nullptr),
+                                                                             // cut folders
+                                                                             fCutFolder(nullptr),
+                                                                             fESDList(nullptr),
+                                                                             fMCList(nullptr),
+                                                                             fTrueList(nullptr),
+                                                                             fJetList(nullptr),
+                                                                             fTrueJetList(nullptr),
+                                                                             fOutputContainer(nullptr),
+                                                                             fEventCutArray(nullptr),
+                                                                             fConvCutArray(nullptr),
+                                                                             fClusterCutArray(nullptr),
+                                                                             fMesonCutArray(nullptr),
+                                                                             // photon and cluster candidates
+                                                                             fGammaCandidates({}),
+                                                                             fClusterCandidates({}),
+                                                                             // Event mixing and background related
+                                                                             fEventMix(nullptr),
+                                                                             fRandom(),
+                                                                             fGenPhaseSpace(),
+                                                                             // Jet related
+                                                                             fConvJetReader(nullptr),
+                                                                             fHighestJetVector(),
+                                                                             fMaxPtJet(0),
+                                                                             fOutlierJetReader(nullptr),
+                                                                             // global settings
+                                                                             fMesonPDGCode(111),
+                                                                             fiCut(0),
+                                                                             fIsMC(0),
+                                                                             fnCuts(0),
+                                                                             fWeightJetJetMC(0),
+                                                                             fDoLightOutput(0),
+                                                                             fDoMesonQA(0),
+                                                                             fDoPhotonQA(0),
+                                                                             fDoClusterQA(0),
+                                                                             fDoJetQA(0),
+                                                                             fIsHeavyIon(0),
+                                                                             fIsCalo(false),
+                                                                             fIsConv(false),
+                                                                             fIsConvCalo(false),
+                                                                             fIsFromDesiredHeader(false),
+                                                                             fDoMaterialBudgetWeightingOfGammasForTrueMesons(false),
+                                                                             fEventPlaneAngle(0),
+                                                                             fTrackMatcherRunningMode(0),
+                                                                             fUseThNForResponse(true),
+                                                                             fEnableSortForClusMC(true),
+                                                                             // aod relabeling
+                                                                             fMCEventPos(nullptr),
+                                                                             fMCEventNeg(nullptr),
+                                                                             fESDArrayPos(nullptr),
+                                                                             fESDArrayNeg(nullptr),
+                                                                             // binnings
+                                                                             fVecBinsMesonInvMass({}),
+                                                                             fVecBinsPhotonPt({}),
+                                                                             fVecBinsMesonPt({}),
+                                                                             fVecBinsJetPt({}),
+                                                                             fVecBinsFragment({}),
+                                                                             vecEquidistFromMinus05({}),
+                                                                             // Jet vectors
+                                                                             fVectorJetPt({}),
+                                                                             fVectorJetPx({}),
+                                                                             fVectorJetPy({}),
+                                                                             fVectorJetPz({}),
+                                                                             fVectorJetEta({}),
+                                                                             fVectorJetPhi({}),
+                                                                             fVectorJetArea({}),
+                                                                             fTrueVectorJetPt({}),
+                                                                             fTrueVectorJetPx({}),
+                                                                             fTrueVectorJetPy({}),
+                                                                             fTrueVectorJetPz({}),
+                                                                             fTrueVectorJetEta({}),
+                                                                             fTrueVectorJetPhi({}),
+                                                                             fTrueVectorJetPartonID({}),
+                                                                             fTrueVectorJetPartonPt({}),
+                                                                             fVectorJetEtaPerp({}),
+                                                                             fVectorJetPhiPerp({}),
+                                                                             MapRecJetsTrueJets(),
+                                                                             //response matrix
+                                                                             fRespMatrixHandlerMesonPt({}),
+                                                                             fRespMatrixHandlerFrag({}),
+                                                                             fRespMatrixHandlerMesonInvMass({}),
+                                                                             fRespMatrixHandlerMesonInvMassVsZ({}),
+                                                                             fRespMatrixHandlerMesonBackInvMassVsZ({}),
+                                                                             fRespMatrixHandlerMesonInvMassPerpCone({}),
+                                                                             fRespMatrixHandlerMesonInvMassVsZPerpCone({}),
+                                                                             // basic Histograms
+                                                                             fHistoNEvents({}),
+                                                                             fHistoNEventsWOWeight({}),
+                                                                             fHistoNGoodESDTracks({}),
+                                                                             fHistoVertexZ({}),
+                                                                             // inv mass Histograms
+                                                                             fHistoInvMassVsPt({}),
+                                                                             fHistoInvMassVsPt_Incl({}),
+                                                                             fHistoJetPtVsFrag({}),
+                                                                             fHistoJetPtVsFrag_SB({}),
+                                                                             fHistoInvMassVsPtMassCut({}),
+                                                                             fHistoInvMassVsPtMassCutSB({}),
+                                                                             fHistoInvMassVsPtBack({}),
+                                                                             fHistoInvMassVsPtPerpCone({}),
+                                                                             fHistoJetPtVsFragPerpCone({}),
+                                                                             fHistoJetPtVsFragPerpCone_SB({}),
+                                                                             // conversion histograms
+                                                                             fHistoConvGammaPt({}),
+                                                                             // jet related Histograms
+                                                                             fHistoEventwJets({}),
+                                                                             fHistoNJets({}),
+                                                                             fHistoPtJet({}),
+                                                                             fHistoJetEta({}),
+                                                                             fHistoJetPhi({}),
+                                                                             fHistoJetArea({}),
+                                                                             fHistoTruevsRecJetPt({}),
+                                                                             fHistoTrueJetPtVsPartonPt({}),
+                                                                             // true meon histograms
+                                                                             fHistoTrueMesonInvMassVsPt({}),
+                                                                             fHistoTrueMesonInvMassVsTruePt({}),
+                                                                             fHistoTruePrimaryMesonInvMassPt({}),
+                                                                             fHistoTrueSecondaryMesonInvMassPt({}),
+                                                                             fHistoMesonResponse({}),
+                                                                             // true conv. photons
+                                                                             fHistoTrueConvGammaPt({}),
+                                                                             fHistoTruePrimaryConvGammaPt({}),
+                                                                             fHistoTruePrimaryConvGammaESDPtMCPt({}),
+                                                                             // true cluster histograms
+                                                                             fHistoTrueClusGammaPt({}),
+                                                                             // MC generated histograms
+                                                                             fHistoMCGammaPtNotTriggered({}),
+                                                                             fHistoMCGammaPtNoVertex({}),
+                                                                             fHistoMCAllGammaPt({}),
+                                                                             fHistoMCDecayGammaPi0Pt({}),
+                                                                             fHistoMCDecayGammaRhoPt({}),
+                                                                             fHistoMCDecayGammaEtaPt({}),
+                                                                             fHistoMCDecayGammaOmegaPt({}),
+                                                                             fHistoMCDecayGammaEtapPt({}),
+                                                                             fHistoMCDecayGammaPhiPt({}),
+                                                                             fHistoMCDecayGammaSigmaPt({}),
+                                                                             fHistoMCPrimaryPtvsSource({}),
+                                                                             fHistoMCMesonPtNotTriggered({}),
+                                                                             fHistoMCMesonPtNoVertex({}),
+                                                                             fHistoMCMesonPt({}),
+                                                                             fHistoMCMesonWOEvtWeightPt({}),
+                                                                             fHistoMCMesonInAccPt({}),
+                                                                             fHistoMCMesonInAccPtNotTriggered({}),
+                                                                             fHistoMCMesonWOWeightInAccPt({}),
+                                                                             fHistoMCMesonWOEvtWeightInAccPt({}),
+                                                                             fHistoMCSecMesonPtvsSource({}),
+                                                                             fHistoMCSecMesonSource({}),
+                                                                             fHistoMCSecMesonInAccPtvsSource({}),
+                                                                             // MC gen jet-meson corr
+                                                                             fHistoMCJetPtVsFrag({}),
+                                                                             fHistoMCJetPtVsFrag_Sec({}),
+                                                                             fHistoMCPartonPtVsFrag({}),
+                                                                             fHistoMCJetPtVsFragTrueParton({}),
+                                                                             fHistoMCPartonPtVsFragTrueParton({})
+{
+}
+
+//________________________________________________________________________
+AliAnalysisTaskMesonJetCorrelation::AliAnalysisTaskMesonJetCorrelation(const char* name) : AliAnalysisTaskSE(name),
+                                                                                           fV0Reader(nullptr),
+                                                                                           fV0ReaderName("V0ReaderV1"),
+                                                                                           fReaderGammas(nullptr),
+                                                                                           fCaloTriggerHelperName(""),
+                                                                                           fCorrTaskSetting(""),
+                                                                                           fInputEvent(nullptr),
+                                                                                           fMCEvent(nullptr),
+                                                                                           fAODMCTrackArray(nullptr),
+                                                                                           // cut folders
+                                                                                           fCutFolder(nullptr),
+                                                                                           fESDList(nullptr),
+                                                                                           fMCList(nullptr),
+                                                                                           fTrueList(nullptr),
+                                                                                           fJetList(nullptr),
+                                                                                           fTrueJetList(nullptr),
+                                                                                           fOutputContainer(nullptr),
+                                                                                           fEventCutArray(nullptr),
+                                                                                           fConvCutArray(nullptr),
+                                                                                           fClusterCutArray(nullptr),
+                                                                                           fMesonCutArray(nullptr),
+                                                                                           // photon and cluster candidates
+                                                                                           fGammaCandidates({}),
+                                                                                           fClusterCandidates({}),
+                                                                                           // Event mixing and background related
+                                                                                           fEventMix(nullptr),
+                                                                                           fRandom(),
+                                                                                           fGenPhaseSpace(),
+                                                                                           // Jet related
+                                                                                           fConvJetReader(nullptr),
+                                                                                           fHighestJetVector(),
+                                                                                           fMaxPtJet(0),
+                                                                                           fOutlierJetReader(nullptr),
+                                                                                           // global settings
+                                                                                           fMesonPDGCode(111),
+                                                                                           fiCut(0),
+                                                                                           fIsMC(0),
+                                                                                           fnCuts(0),
+                                                                                           fWeightJetJetMC(0),
+                                                                                           fDoLightOutput(0),
+                                                                                           fDoMesonQA(0),
+                                                                                           fDoPhotonQA(0),
+                                                                                           fDoClusterQA(0),
+                                                                                           fDoJetQA(0),
+                                                                                           fIsHeavyIon(0),
+                                                                                           fIsCalo(false),
+                                                                                           fIsConv(false),
+                                                                                           fIsConvCalo(false),
+                                                                                           fIsFromDesiredHeader(false),
+                                                                                           fDoMaterialBudgetWeightingOfGammasForTrueMesons(false),
+                                                                                           fEventPlaneAngle(0),
+                                                                                           fTrackMatcherRunningMode(0),
+                                                                                           fUseThNForResponse(true),
+                                                                                           fEnableSortForClusMC(true),
+                                                                                           // aod relabeling
+                                                                                           fMCEventPos(nullptr),
+                                                                                           fMCEventNeg(nullptr),
+                                                                                           fESDArrayPos(nullptr),
+                                                                                           fESDArrayNeg(nullptr),
+                                                                                           // binnings
+                                                                                           fVecBinsMesonInvMass({}),
+                                                                                           fVecBinsPhotonPt({}),
+                                                                                           fVecBinsMesonPt({}),
+                                                                                           fVecBinsJetPt({}),
+                                                                                           fVecBinsFragment({}),
+                                                                                           vecEquidistFromMinus05({}),
+                                                                                           // Jet vectors
+                                                                                           fVectorJetPt({}),
+                                                                                           fVectorJetPx({}),
+                                                                                           fVectorJetPy({}),
+                                                                                           fVectorJetPz({}),
+                                                                                           fVectorJetEta({}),
+                                                                                           fVectorJetPhi({}),
+                                                                                           fVectorJetArea({}),
+                                                                                           fTrueVectorJetPt({}),
+                                                                                           fTrueVectorJetPx({}),
+                                                                                           fTrueVectorJetPy({}),
+                                                                                           fTrueVectorJetPz({}),
+                                                                                           fTrueVectorJetEta({}),
+                                                                                           fTrueVectorJetPhi({}),
+                                                                                           fTrueVectorJetPartonID({}),
+                                                                                           fTrueVectorJetPartonPt({}),
+                                                                                           fVectorJetEtaPerp({}),
+                                                                                           fVectorJetPhiPerp({}),
+                                                                                           MapRecJetsTrueJets(),
+                                                                                           //response matrix
+                                                                                           fRespMatrixHandlerMesonPt({}),
+                                                                                           fRespMatrixHandlerFrag({}),
+                                                                                           fRespMatrixHandlerMesonInvMass({}),
+                                                                                           fRespMatrixHandlerMesonInvMassVsZ({}),
+                                                                                           fRespMatrixHandlerMesonBackInvMassVsZ({}),
+                                                                                           fRespMatrixHandlerMesonInvMassPerpCone({}),
+                                                                                           fRespMatrixHandlerMesonInvMassVsZPerpCone({}),
+                                                                                           // basic Histograms
+                                                                                           fHistoNEvents({}),
+                                                                                           fHistoNEventsWOWeight({}),
+                                                                                           fHistoNGoodESDTracks({}),
+                                                                                           fHistoVertexZ({}),
+                                                                                           // inv mass Histograms
+                                                                                           fHistoInvMassVsPt({}),
+                                                                                           fHistoInvMassVsPt_Incl({}),
+                                                                                           fHistoJetPtVsFrag({}),
+                                                                                           fHistoJetPtVsFrag_SB({}),
+                                                                                           fHistoInvMassVsPtMassCut({}),
+                                                                                           fHistoInvMassVsPtMassCutSB({}),
+                                                                                           fHistoInvMassVsPtBack({}),
+                                                                                           fHistoInvMassVsPtPerpCone({}),
+                                                                                           fHistoJetPtVsFragPerpCone({}),
+                                                                                           fHistoJetPtVsFragPerpCone_SB({}),
+                                                                                           // conversion histograms
+                                                                                           fHistoConvGammaPt({}),
+                                                                                           // jet related Histograms
+                                                                                           fHistoEventwJets({}),
+                                                                                           fHistoNJets({}),
+                                                                                           fHistoPtJet({}),
+                                                                                           fHistoJetEta({}),
+                                                                                           fHistoJetPhi({}),
+                                                                                           fHistoJetArea({}),
+                                                                                           fHistoTruevsRecJetPt({}),
+                                                                                           fHistoTrueJetPtVsPartonPt({}),
+                                                                                           // true meon histograms
+                                                                                           fHistoTrueMesonInvMassVsPt({}),
+                                                                                           fHistoTrueMesonInvMassVsTruePt({}),
+                                                                                           fHistoTruePrimaryMesonInvMassPt({}),
+                                                                                           fHistoTrueSecondaryMesonInvMassPt({}),
+                                                                                           fHistoMesonResponse({}),
+                                                                                           // true conv. photons
+                                                                                           fHistoTrueConvGammaPt({}),
+                                                                                           fHistoTruePrimaryConvGammaPt({}),
+                                                                                           fHistoTruePrimaryConvGammaESDPtMCPt({}),
+                                                                                           // true cluster histograms
+                                                                                           fHistoTrueClusGammaPt({}),
+                                                                                           // MC generated histograms
+                                                                                           fHistoMCGammaPtNotTriggered({}),
+                                                                                           fHistoMCGammaPtNoVertex({}),
+                                                                                           fHistoMCAllGammaPt({}),
+                                                                                           fHistoMCDecayGammaPi0Pt({}),
+                                                                                           fHistoMCDecayGammaRhoPt({}),
+                                                                                           fHistoMCDecayGammaEtaPt({}),
+                                                                                           fHistoMCDecayGammaOmegaPt({}),
+                                                                                           fHistoMCDecayGammaEtapPt({}),
+                                                                                           fHistoMCDecayGammaPhiPt({}),
+                                                                                           fHistoMCDecayGammaSigmaPt({}),
+                                                                                           fHistoMCPrimaryPtvsSource({}),
+                                                                                           fHistoMCMesonPtNotTriggered({}),
+                                                                                           fHistoMCMesonPtNoVertex({}),
+                                                                                           fHistoMCMesonPt({}),
+                                                                                           fHistoMCMesonWOEvtWeightPt({}),
+                                                                                           fHistoMCMesonInAccPt({}),
+                                                                                           fHistoMCMesonInAccPtNotTriggered({}),
+                                                                                           fHistoMCMesonWOWeightInAccPt({}),
+                                                                                           fHistoMCMesonWOEvtWeightInAccPt({}),
+                                                                                           fHistoMCSecMesonPtvsSource({}),
+                                                                                           fHistoMCSecMesonSource({}),
+                                                                                           fHistoMCSecMesonInAccPtvsSource({}),
+                                                                                           // MC gen jet-meson corr
+                                                                                           fHistoMCJetPtVsFrag({}),
+                                                                                           fHistoMCJetPtVsFrag_Sec({}),
+                                                                                           fHistoMCPartonPtVsFrag({}),
+                                                                                           fHistoMCJetPtVsFragTrueParton({}),
+                                                                                           fHistoMCPartonPtVsFragTrueParton({})
+{
+  // Define output slots here
+  DefineOutput(1, TList::Class());
+}
+
+//________________________________________________________________________
+AliAnalysisTaskMesonJetCorrelation::~AliAnalysisTaskMesonJetCorrelation()
+{
+}
+
+//________________________________________________________________________
+void AliAnalysisTaskMesonJetCorrelation::Terminate(const Option_t*)
+{
+}
+
+//_____________________________________________________________________________
+Bool_t AliAnalysisTaskMesonJetCorrelation::Notify()
+{
+  return true;
+}
+
+//________________________________________________________________________
+void AliAnalysisTaskMesonJetCorrelation::UserCreateOutputObjects()
+{
+  // cout << "in UserCreateOutputObjects" << endl;
+
+  MakeBinning();
+
+  // Create top level output list
+  if (fOutputContainer != NULL) {
+    delete fOutputContainer;
+    fOutputContainer = NULL;
+  }
+  if (fOutputContainer == NULL) {
+    fOutputContainer = new TList();
+    fOutputContainer->SetOwner(kTRUE);
+  }
+
+  // Initialize V0 reader
+  fV0Reader = (AliV0ReaderV1*)AliAnalysisManager::GetAnalysisManager()->GetTask(fV0ReaderName.Data());
+  if (!fV0Reader) {
+    printf("Error: No V0 Reader");
+    return;
+  } // GetV0Reader
+
+  fConvJetReader = (AliAnalysisTaskConvJet*)AliAnalysisManager::GetAnalysisManager()->GetTask("AliAnalysisTaskConvJet");
+  if (!fConvJetReader) {
+    printf("Error: No AliAnalysisTaskConvJet");
+    return;
+  } // GetV0Reader
+
+  fEventMix = new EventMixPoolMesonJets();
+
+  // initialize lists
+  fCutFolder = new TList*[fnCuts];
+  fESDList = new TList*[fnCuts];
+  fTrueList = new TList*[fnCuts];
+  fMCList = new TList*[fnCuts];
+  fJetList = new TList*[fnCuts];
+  fTrueJetList = new TList*[fnCuts];
+
+  // initialize lists of histograms
+  fHistoNEvents.resize(fnCuts);
+  if (fIsMC > 1) {
+    fHistoNEventsWOWeight.resize(fnCuts);
+  }
+
+  //----------------------
+  // MC gen histograms
+  //----------------------
+  if (fIsMC) {
+    fHistoMCGammaPtNotTriggered.resize(fnCuts);
+    fHistoMCGammaPtNoVertex.resize(fnCuts);
+    fHistoMCAllGammaPt.resize(fnCuts);
+    fHistoMCDecayGammaPi0Pt.resize(fnCuts);
+    fHistoMCDecayGammaRhoPt.resize(fnCuts);
+    fHistoMCDecayGammaEtaPt.resize(fnCuts);
+    fHistoMCDecayGammaOmegaPt.resize(fnCuts);
+    fHistoMCDecayGammaEtapPt.resize(fnCuts);
+    fHistoMCDecayGammaPhiPt.resize(fnCuts);
+    fHistoMCDecayGammaSigmaPt.resize(fnCuts);
+    fHistoMCPrimaryPtvsSource.resize(fnCuts);
+    fHistoMCMesonPtNotTriggered.resize(fnCuts);
+    fHistoMCMesonPtNoVertex.resize(fnCuts);
+    fHistoMCMesonPt.resize(fnCuts);
+    fHistoMCMesonWOEvtWeightPt.resize(fnCuts);
+    fHistoMCMesonInAccPt.resize(fnCuts);
+    fHistoMCMesonInAccPtNotTriggered.resize(fnCuts);
+    fHistoMCMesonWOEvtWeightInAccPt.resize(fnCuts);
+    fHistoMCSecMesonPtvsSource.resize(fnCuts);
+    fHistoMCSecMesonSource.resize(fnCuts);
+    fHistoMCSecMesonInAccPtvsSource.resize(fnCuts);
+
+    fHistoMCJetPtVsFrag.resize(fnCuts);
+    fHistoMCJetPtVsFrag_Sec.resize(fnCuts);
+    fHistoMCPartonPtVsFrag.resize(fnCuts);
+    fHistoMCJetPtVsFragTrueParton.resize(fnCuts);
+    fHistoMCPartonPtVsFragTrueParton.resize(fnCuts);
+  }
+
+  //----------------------
+  // true conversion photon histograms
+  //----------------------
+  if (fIsMC) {
+    fHistoTrueConvGammaPt.resize(fnCuts);
+    fHistoTruePrimaryConvGammaPt.resize(fnCuts);
+    fHistoTruePrimaryConvGammaESDPtMCPt.resize(fnCuts);
+  }
+
+  //----------------------
+  // true cluster histograms
+  //----------------------
+  if (fIsMC && !fIsConv) {
+    fHistoTrueClusGammaPt.resize(fnCuts);
+  }
+
+  //----------------------
+  // jet histogram
+  //----------------------
+  fHistoEventwJets.resize(fnCuts);
+  fHistoNJets.resize(fnCuts);
+  fHistoPtJet.resize(fnCuts);
+  fHistoJetEta.resize(fnCuts);
+  fHistoJetPhi.resize(fnCuts);
+  fHistoJetArea.resize(fnCuts);
+  if (fIsMC) {
+    fHistoTruevsRecJetPt.resize(fnCuts);
+    fHistoTrueJetPtVsPartonPt.resize(fnCuts);
+  }
+
+  //----------------------
+  // inv mass histograms
+  //----------------------
+  fHistoInvMassVsPt.resize(fnCuts);
+  fHistoInvMassVsPt_Incl.resize(fnCuts);
+
+  fHistoInvMassVsPtMassCut.resize(fnCuts);
+  fHistoInvMassVsPtMassCutSB.resize(fnCuts);
+
+  fHistoTrueMesonInvMassVsPt.resize(fnCuts);
+  fHistoTrueMesonInvMassVsTruePt.resize(fnCuts);
+  fHistoTruePrimaryMesonInvMassPt.resize(fnCuts);
+  fHistoTrueSecondaryMesonInvMassPt.resize(fnCuts);
+
+  // perpendicular cone
+  fHistoInvMassVsPtPerpCone.resize(fnCuts);
+
+  // inv mass background
+  fHistoInvMassVsPtBack.resize(fnCuts);
+
+  //----------------------
+  // fragmentation histos
+  //----------------------
+  fHistoJetPtVsFrag.resize(fnCuts);
+  fHistoJetPtVsFrag_SB.resize(fnCuts);
+
+  // perpendicular cone
+  fHistoJetPtVsFragPerpCone.resize(fnCuts);
+  fHistoJetPtVsFragPerpCone_SB.resize(fnCuts);
+
+  //----------------------
+  // response matrix
+  //----------------------
+  fRespMatrixHandlerMesonInvMassVsZ.resize(fnCuts);
+  fRespMatrixHandlerMesonInvMass.resize(fnCuts);
+  fRespMatrixHandlerMesonBackInvMassVsZ.resize(fnCuts);
+  //perpendicular cone
+  fRespMatrixHandlerMesonInvMassVsZPerpCone.resize(fnCuts);
+  fRespMatrixHandlerMesonInvMassPerpCone.resize(fnCuts);
+  if (fIsMC) {
+    fRespMatrixHandlerMesonPt.resize(fnCuts);
+    fRespMatrixHandlerFrag.resize(fnCuts);
+  }
+
+  for (int iCut = 0; iCut < fnCuts; ++iCut) {
+    TString cutstringEvent = ((AliConvEventCuts*)fEventCutArray->At(iCut))->GetCutNumber();
+    TString cutstringCalo = (fIsCalo == true || fIsConvCalo == true) ? ((AliCaloPhotonCuts*)fClusterCutArray->At(iCut))->GetCutNumber() : "";
+    TString cutstringMeson = ((AliConversionMesonCuts*)fMesonCutArray->At(iCut))->GetCutNumber();
+    TString cutstringConv = (fIsConv == true || fIsConvCalo == true) ? ((AliConversionPhotonCuts*)fConvCutArray->At(iCut))->GetCutNumber() : "";
+
+    TString cutString = "";
+    if (fIsConv)
+      cutString = Form("%s_%s_%s", cutstringEvent.Data(), cutstringConv.Data(), cutstringMeson.Data());
+    else if (fIsCalo)
+      cutString = Form("%s_%s_%s", cutstringEvent.Data(), cutstringCalo.Data(), cutstringMeson.Data());
+    else if (fIsConvCalo)
+      cutString = Form("%s_%s_%s_%s", cutstringEvent.Data(), cutstringConv.Data(), cutstringCalo.Data(), cutstringMeson.Data());
+
+    fCutFolder[iCut] = new TList();
+    fCutFolder[iCut]->SetName(Form("Cut Number %s", cutString.Data()));
+    fCutFolder[iCut]->SetOwner(kTRUE);
+    fOutputContainer->Add(fCutFolder[iCut]);
+
+    fESDList[iCut] = new TList();
+    fESDList[iCut]->SetName(Form("%s ESD histograms", cutString.Data()));
+    fESDList[iCut]->SetOwner(kTRUE);
+    fCutFolder[iCut]->Add(fESDList[iCut]);
+
+    fJetList[iCut] = new TList();
+    fJetList[iCut]->SetName(Form("%s Jet histograms", cutString.Data()));
+    fJetList[iCut]->SetOwner(kTRUE);
+    fCutFolder[iCut]->Add(fJetList[iCut]);
+
+    if (fIsMC) {
+      fTrueJetList[iCut] = new TList();
+      fTrueJetList[iCut]->SetName(Form("%s True Jet histograms", cutString.Data()));
+      fTrueJetList[iCut]->SetOwner(kTRUE);
+      fCutFolder[iCut]->Add(fTrueJetList[iCut]);
+
+      fTrueList[iCut] = new TList();
+      fTrueList[iCut]->SetName(Form("%s True histograms", cutString.Data()));
+      fTrueList[iCut]->SetOwner(kTRUE);
+      fCutFolder[iCut]->Add(fTrueList[iCut]);
+
+      fMCList[iCut] = new TList();
+      fMCList[iCut]->SetName(Form("%s MC histograms", cutString.Data()));
+      fMCList[iCut]->SetOwner(kTRUE);
+      fCutFolder[iCut]->Add(fMCList[iCut]);
+    }
+
+    fHistoNEvents[iCut] = new TH1F("NEvents", "NEvents", 15, -0.5, 14.5);
+    fHistoNEvents[iCut]->GetXaxis()->SetBinLabel(1, "Accepted");
+    fHistoNEvents[iCut]->GetXaxis()->SetBinLabel(2, "Centrality");
+    fHistoNEvents[iCut]->GetXaxis()->SetBinLabel(3, "Miss. MC or inc. ev.");
+    if (((AliConvEventCuts*)fEventCutArray->At(iCut))->IsSpecialTrigger() > 1) {
+      TString TriggerNames = "Not Trigger: ";
+      TriggerNames = TriggerNames + ((AliConvEventCuts*)fEventCutArray->At(iCut))->GetSpecialTriggerName();
+      fHistoNEvents[iCut]->GetXaxis()->SetBinLabel(4, TriggerNames.Data());
+    } else {
+      fHistoNEvents[iCut]->GetXaxis()->SetBinLabel(4, "Trigger");
+    }
+    fHistoNEvents[iCut]->GetXaxis()->SetBinLabel(5, "Vertex Z");
+    fHistoNEvents[iCut]->GetXaxis()->SetBinLabel(6, "Cont. Vertex");
+    fHistoNEvents[iCut]->GetXaxis()->SetBinLabel(7, "SPD Pile-Up");
+    fHistoNEvents[iCut]->GetXaxis()->SetBinLabel(8, "no SDD");
+    fHistoNEvents[iCut]->GetXaxis()->SetBinLabel(9, "no V0AND");
+    fHistoNEvents[iCut]->GetXaxis()->SetBinLabel(10, "EMCAL/TPC problems");
+    fHistoNEvents[iCut]->GetXaxis()->SetBinLabel(11, "rejectedForJetJetMC");
+    fHistoNEvents[iCut]->GetXaxis()->SetBinLabel(12, "SPD hits vs tracklet");
+    fHistoNEvents[iCut]->GetXaxis()->SetBinLabel(13, "Out-of-Bunch pileup Past-Future");
+    fHistoNEvents[iCut]->GetXaxis()->SetBinLabel(14, "Pileup V0M-TPCout Tracks");
+    fHistoNEvents[iCut]->GetXaxis()->SetBinLabel(15, "Sphericity");
+    fESDList[iCut]->Add(fHistoNEvents[iCut]);
+    if (fIsMC > 1) {
+      fHistoNEventsWOWeight[iCut] = new TH1F("NEventsWOWeight", "NEventsWOWeight", 15, -0.5, 14.5);
+      fHistoNEventsWOWeight[iCut]->GetXaxis()->SetBinLabel(1, "Accepted");
+      fHistoNEventsWOWeight[iCut]->GetXaxis()->SetBinLabel(2, "Centrality");
+      fHistoNEventsWOWeight[iCut]->GetXaxis()->SetBinLabel(3, "Miss. MC or inc. ev.");
+      if (((AliConvEventCuts*)fEventCutArray->At(iCut))->IsSpecialTrigger() > 1) {
+        TString TriggerNames = "Not Trigger: ";
+        TriggerNames = TriggerNames + ((AliConvEventCuts*)fEventCutArray->At(iCut))->GetSpecialTriggerName();
+        fHistoNEventsWOWeight[iCut]->GetXaxis()->SetBinLabel(4, TriggerNames.Data());
+      } else {
+        fHistoNEventsWOWeight[iCut]->GetXaxis()->SetBinLabel(4, "Trigger");
+      }
+      fHistoNEventsWOWeight[iCut]->GetXaxis()->SetBinLabel(5, "Vertex Z");
+      fHistoNEventsWOWeight[iCut]->GetXaxis()->SetBinLabel(6, "Cont. Vertex");
+      fHistoNEventsWOWeight[iCut]->GetXaxis()->SetBinLabel(7, "Pile-Up");
+      fHistoNEventsWOWeight[iCut]->GetXaxis()->SetBinLabel(8, "no SDD");
+      fHistoNEventsWOWeight[iCut]->GetXaxis()->SetBinLabel(9, "no V0AND");
+      fHistoNEventsWOWeight[iCut]->GetXaxis()->SetBinLabel(10, "EMCAL problem");
+      fHistoNEventsWOWeight[iCut]->GetXaxis()->SetBinLabel(11, "rejectedForJetJetMC");
+      fHistoNEventsWOWeight[iCut]->GetXaxis()->SetBinLabel(12, "SPD hits vs tracklet");
+      fHistoNEventsWOWeight[iCut]->GetXaxis()->SetBinLabel(13, "Out-of-Bunch pileup Past-Future");
+      fHistoNEventsWOWeight[iCut]->GetXaxis()->SetBinLabel(14, "Pileup V0M-TPCout Tracks");
+      fHistoNEventsWOWeight[iCut]->GetXaxis()->SetBinLabel(15, "Sphericity");
+      fESDList[iCut]->Add(fHistoNEventsWOWeight[iCut]);
+    }
+
+    // MC histograms
+    if (fIsMC) {
+      fHistoMCGammaPtNotTriggered[iCut] = new TH1F("MC_AllGammaNotTriggered_Pt", "MC_AllGammaNotTriggered_Pt", fVecBinsPhotonPt.size() - 1, fVecBinsPhotonPt.data());
+      fHistoMCGammaPtNotTriggered[iCut]->SetXTitle("p_{T} (GeV/c)");
+      fMCList[iCut]->Add(fHistoMCGammaPtNotTriggered[iCut]);
+      fHistoMCGammaPtNoVertex[iCut] = new TH1F("MC_AllGammaNoVertex_Pt", "MC_AllGammaNoVertex_Pt", fVecBinsPhotonPt.size() - 1, fVecBinsPhotonPt.data());
+      fHistoMCGammaPtNoVertex[iCut]->SetXTitle("p_{T} (GeV/c)");
+      fMCList[iCut]->Add(fHistoMCGammaPtNoVertex[iCut]);
+
+      fHistoMCAllGammaPt[iCut] = new TH1F("MC_AllGamma_Pt", "MC_AllGamma_Pt", fVecBinsPhotonPt.size() - 1, fVecBinsPhotonPt.data());
+      fHistoMCAllGammaPt[iCut]->SetXTitle("p_{T} (GeV/c)");
+      fMCList[iCut]->Add(fHistoMCAllGammaPt[iCut]);
+
+      fHistoMCDecayGammaPi0Pt[iCut] = new TH1F("MC_DecayGammaPi0_Pt", "MC_DecayGammaPi0_Pt", fVecBinsPhotonPt.size() - 1, fVecBinsPhotonPt.data());
+      fHistoMCDecayGammaPi0Pt[iCut]->SetXTitle("p_{T} (GeV/c)");
+      fMCList[iCut]->Add(fHistoMCDecayGammaPi0Pt[iCut]);
+      fHistoMCDecayGammaRhoPt[iCut] = new TH1F("MC_DecayGammaRho_Pt", "MC_DecayGammaRho_Pt", fVecBinsPhotonPt.size() - 1, fVecBinsPhotonPt.data());
+      fHistoMCDecayGammaRhoPt[iCut]->SetXTitle("p_{T} (GeV/c)");
+      fMCList[iCut]->Add(fHistoMCDecayGammaRhoPt[iCut]);
+      fHistoMCDecayGammaEtaPt[iCut] = new TH1F("MC_DecayGammaEta_Pt", "MC_DecayGammaEta_Pt", fVecBinsPhotonPt.size() - 1, fVecBinsPhotonPt.data());
+      fHistoMCDecayGammaEtaPt[iCut]->SetXTitle("p_{T} (GeV/c)");
+      fMCList[iCut]->Add(fHistoMCDecayGammaEtaPt[iCut]);
+      fHistoMCDecayGammaOmegaPt[iCut] = new TH1F("MC_DecayGammaOmega_Pt", "MC_DecayGammaOmmega_Pt", fVecBinsPhotonPt.size() - 1, fVecBinsPhotonPt.data());
+      fHistoMCDecayGammaOmegaPt[iCut]->SetXTitle("p_{T} (GeV/c)");
+      fMCList[iCut]->Add(fHistoMCDecayGammaOmegaPt[iCut]);
+      fHistoMCDecayGammaEtapPt[iCut] = new TH1F("MC_DecayGammaEtap_Pt", "MC_DecayGammaEtap_Pt", fVecBinsPhotonPt.size() - 1, fVecBinsPhotonPt.data());
+      fHistoMCDecayGammaEtapPt[iCut]->SetXTitle("p_{T} (GeV/c)");
+      fMCList[iCut]->Add(fHistoMCDecayGammaEtapPt[iCut]);
+      fHistoMCDecayGammaPhiPt[iCut] = new TH1F("MC_DecayGammaPhi_Pt", "MC_DecayGammaPhi_Pt", fVecBinsPhotonPt.size() - 1, fVecBinsPhotonPt.data());
+      fHistoMCDecayGammaPhiPt[iCut]->SetXTitle("p_{T} (GeV/c)");
+      fMCList[iCut]->Add(fHistoMCDecayGammaPhiPt[iCut]);
+      fHistoMCDecayGammaSigmaPt[iCut] = new TH1F("MC_DecayGammaSigma_Pt", "MC_DecayGammaSigma_Pt", fVecBinsPhotonPt.size() - 1, fVecBinsPhotonPt.data());
+      fHistoMCDecayGammaSigmaPt[iCut]->SetXTitle("p_{T} (GeV/c)");
+      fMCList[iCut]->Add(fHistoMCDecayGammaSigmaPt[iCut]);
+
+      fHistoMCPrimaryPtvsSource[iCut] = new TH2F("MC_Primary_Pt_Source", "MC_Primary_Pt_Source", fVecBinsPhotonPt.size() - 1, fVecBinsPhotonPt.data(), 7, vecEquidistFromMinus05.data());
+      fHistoMCPrimaryPtvsSource[iCut]->GetYaxis()->SetBinLabel(1, "Pi+");
+      fHistoMCPrimaryPtvsSource[iCut]->GetYaxis()->SetBinLabel(2, "Pi-");
+      fHistoMCPrimaryPtvsSource[iCut]->GetYaxis()->SetBinLabel(3, "K+");
+      fHistoMCPrimaryPtvsSource[iCut]->GetYaxis()->SetBinLabel(4, "K-");
+      fHistoMCPrimaryPtvsSource[iCut]->GetYaxis()->SetBinLabel(5, "K0s");
+      fHistoMCPrimaryPtvsSource[iCut]->GetYaxis()->SetBinLabel(6, "K0l");
+      fHistoMCPrimaryPtvsSource[iCut]->GetYaxis()->SetBinLabel(7, "Lambda");
+      fHistoMCPrimaryPtvsSource[iCut]->SetXTitle("p_{T} (GeV/c)");
+      fHistoMCPrimaryPtvsSource[iCut]->SetYTitle("particle");
+      fMCList[iCut]->Add(fHistoMCPrimaryPtvsSource[iCut]);
+
+      fHistoMCMesonPt[iCut] = new TH1F("MC_Pi0_Pt", "MC_Pi0_Pt", fVecBinsPhotonPt.size() - 1, fVecBinsPhotonPt.data());
+      fHistoMCMesonPt[iCut]->SetXTitle("p_{T} (GeV/c)");
+      fHistoMCMesonPt[iCut]->Sumw2();
+      fMCList[iCut]->Add(fHistoMCMesonPt[iCut]);
+      fHistoMCMesonPtNotTriggered[iCut] = new TH1F("MC_Pi0_Pt_NotTriggered", "MC_Pi0_Pt_NotTriggered", fVecBinsPhotonPt.size() - 1, fVecBinsPhotonPt.data());
+      fHistoMCMesonPtNotTriggered[iCut]->SetXTitle("p_{T} (GeV/c)");
+      fHistoMCMesonPtNotTriggered[iCut]->Sumw2();
+      fMCList[iCut]->Add(fHistoMCMesonPtNotTriggered[iCut]);
+      fHistoMCMesonPtNoVertex[iCut] = new TH1F("MC_Pi0_Pt_NoVertex", "MC_Pi0_Pt_NoVertex", fVecBinsPhotonPt.size() - 1, fVecBinsPhotonPt.data());
+      fHistoMCMesonPtNoVertex[iCut]->SetXTitle("p_{T} (GeV/c)");
+      fHistoMCMesonPtNoVertex[iCut]->Sumw2();
+      fMCList[iCut]->Add(fHistoMCMesonPtNoVertex[iCut]);
+
+      fHistoMCMesonWOEvtWeightPt[iCut] = new TH1F("MC_Pi0_WOEventWeights_Pt", "MC_Pi0_WOEventWeights_Pt", fVecBinsPhotonPt.size() - 1, fVecBinsPhotonPt.data());
+      fHistoMCMesonWOEvtWeightPt[iCut]->SetXTitle("p_{T} (GeV/c)");
+      fMCList[iCut]->Add(fHistoMCMesonWOEvtWeightPt[iCut]);
+
+      fHistoMCMesonInAccPt[iCut] = new TH1F("MC_Pi0InAcc_Pt", "MC_Pi0InAcc_Pt", fVecBinsPhotonPt.size() - 1, fVecBinsPhotonPt.data());
+      fHistoMCMesonInAccPt[iCut]->SetXTitle("p_{T} (GeV/c)");
+      fHistoMCMesonInAccPt[iCut]->Sumw2();
+      fMCList[iCut]->Add(fHistoMCMesonInAccPt[iCut]);
+      fHistoMCMesonInAccPtNotTriggered[iCut] = new TH1F("MC_Pi0InAcc_Pt_NotTriggered", "MC_Pi0InAcc_Pt_NotTriggered", fVecBinsPhotonPt.size() - 1, fVecBinsPhotonPt.data());
+      fHistoMCMesonInAccPtNotTriggered[iCut]->SetXTitle("p_{T} (GeV/c)");
+      fHistoMCMesonInAccPtNotTriggered[iCut]->Sumw2();
+      fMCList[iCut]->Add(fHistoMCMesonInAccPtNotTriggered[iCut]);
+
+      if (fIsMC > 1) {
+        fHistoMCMesonWOEvtWeightInAccPt[iCut] = new TH1F("MC_Pi0WOEvtWeightInAcc_Pt", "MC_Pi0WOEvtWeightInAcc_Pt", fVecBinsPhotonPt.size() - 1, fVecBinsPhotonPt.data());
+        fHistoMCMesonWOEvtWeightInAccPt[iCut]->SetXTitle("p_{T} (GeV/c)");
+        fMCList[iCut]->Add(fHistoMCMesonWOEvtWeightInAccPt[iCut]);
+      }
+
+      fHistoMCSecMesonPtvsSource[iCut] = new TH2F("MC_SecPi0_Pt_Source", "MC_SecPi0_Pt_Source", fVecBinsPhotonPt.size() - 1, fVecBinsPhotonPt.data(), 16, vecEquidistFromMinus05.data());
+      fHistoMCSecMesonPtvsSource[iCut]->SetXTitle("p_{T} (GeV/c)");
+      fHistoMCSecMesonPtvsSource[iCut]->SetYTitle("source");
+      fMCList[iCut]->Add(fHistoMCSecMesonPtvsSource[iCut]);
+
+      fHistoMCSecMesonSource[iCut] = new TH1F("MC_SecPi0_Source", "MC_SecPi0_Source", 5000, 0., 5000);
+      fHistoMCSecMesonSource[iCut]->SetYTitle("source PDG");
+      fMCList[iCut]->Add(fHistoMCSecMesonSource[iCut]);
+
+      fHistoMCSecMesonInAccPtvsSource[iCut] = new TH2F("MC_SecPi0InAcc_Pt_Source", "MC_SecPi0InAcc_Pt_Source", fVecBinsPhotonPt.size() - 1, fVecBinsPhotonPt.data(), 16, vecEquidistFromMinus05.data());
+      fHistoMCSecMesonInAccPtvsSource[iCut]->SetXTitle("p_{T} (GeV/c)");
+      fHistoMCSecMesonInAccPtvsSource[iCut]->SetYTitle("source");
+      fMCList[iCut]->Add(fHistoMCSecMesonInAccPtvsSource[iCut]);
+
+      // jet pt vs fragmentation z
+      fHistoMCJetPtVsFrag[iCut] = new TH2F("MC_Frag_JetPt", "MC_Frag_JetPt", fVecBinsFragment.size() - 1, fVecBinsFragment.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
+      fHistoMCJetPtVsFrag[iCut]->SetXTitle("z (true)");
+      fHistoMCJetPtVsFrag[iCut]->SetYTitle("p_{T, true, Jet} (GeV/c)");
+      fMCList[iCut]->Add(fHistoMCJetPtVsFrag[iCut]);
+
+      fHistoMCJetPtVsFrag_Sec[iCut] = new TH2F("MC_Sec_Frag_JetPt", "MC_Sec_Frag_JetPt", fVecBinsFragment.size() - 1, fVecBinsFragment.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
+      fHistoMCJetPtVsFrag_Sec[iCut]->SetXTitle("z (true)");
+      fHistoMCJetPtVsFrag_Sec[iCut]->SetYTitle("p_{T, true, Jet} (GeV/c)");
+      fMCList[iCut]->Add(fHistoMCJetPtVsFrag_Sec[iCut]);
+
+      fHistoMCPartonPtVsFrag[iCut] = new TH2F("MC_Frag_PartonPt", "MC_Frag_PartonPt", fVecBinsFragment.size() - 1, fVecBinsFragment.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
+      fHistoMCPartonPtVsFrag[iCut]->SetXTitle("z (true)");
+      fHistoMCPartonPtVsFrag[iCut]->SetYTitle("p_{T, parton, jet} (GeV/c)");
+      fMCList[iCut]->Add(fHistoMCPartonPtVsFrag[iCut]);
+
+      fHistoMCJetPtVsFragTrueParton[iCut] = new TH2F("MC_Frag_JetPt_TrueParton", "MC_Frag_JetPt_TrueParton", fVecBinsFragment.size() - 1, fVecBinsFragment.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
+      fHistoMCJetPtVsFragTrueParton[iCut]->SetXTitle("z (true)");
+      fHistoMCJetPtVsFragTrueParton[iCut]->SetYTitle("p_{T, true, Jet} (GeV/c)");
+      fMCList[iCut]->Add(fHistoMCJetPtVsFragTrueParton[iCut]);
+
+      fHistoMCPartonPtVsFragTrueParton[iCut] = new TH2F("MC_Frag_PartonPt_TrueParton", "MC_Frag_PartonPt_TrueParton", fVecBinsFragment.size() - 1, fVecBinsFragment.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
+      fHistoMCPartonPtVsFragTrueParton[iCut]->SetXTitle("z (true)");
+      fHistoMCPartonPtVsFragTrueParton[iCut]->SetYTitle("p_{T, parton, jet} (GeV/c)");
+      fMCList[iCut]->Add(fHistoMCPartonPtVsFragTrueParton[iCut]);
+    }
+
+    // conversion photons
+    if (fIsMC && !fIsCalo) {
+      fHistoTrueConvGammaPt[iCut] = new TH1F("ESD_TrueConvGamma_Pt", "ESD_TrueConvGamma_Pt", fVecBinsPhotonPt.size() - 1, fVecBinsPhotonPt.data());
+      fTrueList[iCut]->Add(fHistoTrueConvGammaPt[iCut]);
+      if (!fDoLightOutput) {
+        fHistoTruePrimaryConvGammaPt[iCut] = new TH1F("ESD_TruePrimaryConvGamma_Pt", "ESD_TruePrimaryConvGamma_Pt", fVecBinsPhotonPt.size() - 1, fVecBinsPhotonPt.data());
+        fTrueList[iCut]->Add(fHistoTruePrimaryConvGammaPt[iCut]);
+        fHistoTruePrimaryConvGammaESDPtMCPt[iCut] = new TH2F("ESD_TruePrimaryConvGammaESD_PtMCPt", "ESD_TruePrimaryConvGammaESD_PtMCPt",
+                                                             fVecBinsPhotonPt.size() - 1, fVecBinsPhotonPt.data(), fVecBinsPhotonPt.size() - 1, fVecBinsPhotonPt.data());
+        fTrueList[iCut]->Add(fHistoTruePrimaryConvGammaESDPtMCPt[iCut]);
+      }
+    }
+
+    if (fIsMC && !fIsConv) {
+      fHistoTrueClusGammaPt[iCut] = new TH1F("TrueClusGamma_Pt", "ESD_TrueClusGamma_Pt", fVecBinsPhotonPt.size() - 1, fVecBinsPhotonPt.data());
+      fHistoTrueClusGammaPt[iCut]->SetXTitle("p_{T} (GeV/c)");
+      fTrueList[iCut]->Add(fHistoTrueClusGammaPt[iCut]);
+    }
+
+    // jet histograms
+    fHistoEventwJets[iCut] = new TH1F("NEvents_with_Jets", "NEvents_with_Jets", 4, 0, 4);
+    fJetList[iCut]->Add(fHistoEventwJets[iCut]);
+
+    fHistoNJets[iCut] = new TH1F("NJets", "NJets", 10, 0, 10);
+    fJetList[iCut]->Add(fHistoNJets[iCut]);
+
+    fHistoPtJet[iCut] = new TH1F("JetPt", "JetPt", fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
+    fJetList[iCut]->Add(fHistoPtJet[iCut]);
+    fHistoJetEta[iCut] = new TH1F("JetEta", "JetEta", 100, -1, 1);
+    fJetList[iCut]->Add(fHistoJetEta[iCut]);
+    fHistoJetPhi[iCut] = new TH1F("JetPhi", "JetPhi", 70, 0, 7);
+    fJetList[iCut]->Add(fHistoJetPhi[iCut]);
+    fHistoJetArea[iCut] = new TH1F("JetArea", "JetArea", 50, 0, 1);
+    fJetList[iCut]->Add(fHistoJetArea[iCut]);
+
+    if (fIsMC) {
+      fHistoTruevsRecJetPt[iCut] = new TH2F("True_JetPt_vs_Rec_JetPt", "True_JetPt_vs_Rec_JetPt", fVecBinsJetPt.size() - 1, fVecBinsJetPt.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
+      fTrueJetList[iCut]->Add(fHistoTruevsRecJetPt[iCut]);
+      fHistoTrueJetPtVsPartonPt[iCut] = new TH2F("True_JetPt_vs_Parton_Pt", "True_JetPt_vs_Parton_Pt", fVecBinsJetPt.size() - 1, fVecBinsJetPt.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
+      fTrueJetList[iCut]->Add(fHistoTrueJetPtVsPartonPt[iCut]);
+    }
+
+    // inv mass histograms
+    fHistoInvMassVsPt[iCut] = new TH2F("ESD_Mother_InvMass_Pt", "ESD_Mother_InvMass_Pt", fVecBinsMesonInvMass.size() - 1, fVecBinsMesonInvMass.data(), fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data());
+    fHistoInvMassVsPt[iCut]->SetXTitle("M_{#gamma#gamma} (GeV/c^{2})");
+    fHistoInvMassVsPt[iCut]->SetYTitle("p_{T} (GeV/c)");
+    fESDList[iCut]->Add(fHistoInvMassVsPt[iCut]);
+
+    // in perpendicular cone
+
+    fHistoInvMassVsPtPerpCone[iCut] = new TH2F("ESD_Mother_InvMass_Pt_PerpCone", "ESD_Mother_InvMass_Pt_PerpCone", fVecBinsMesonInvMass.size() - 1, fVecBinsMesonInvMass.data(), fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data());
+    fHistoInvMassVsPtPerpCone[iCut]->SetXTitle("M_{#gamma#gamma} (GeV/c^{2})");
+    fHistoInvMassVsPtPerpCone[iCut]->SetYTitle("p_{T} (GeV/c)");
+    fESDList[iCut]->Add(fHistoInvMassVsPtPerpCone[iCut]);
+
+    if (fIsMC) {
+      // true mesons inv mass vs pT
+      fHistoTrueMesonInvMassVsPt[iCut] = new TH2F("ESD_TrueMother_InvMass_Pt", "ESD_TrueMother_InvMass_Pt", fVecBinsMesonInvMass.size() - 1, fVecBinsMesonInvMass.data(), fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data());
+      fHistoTrueMesonInvMassVsPt[iCut]->SetXTitle("M_{#gamma#gamma} (GeV/c^{2})");
+      fHistoTrueMesonInvMassVsPt[iCut]->SetYTitle("p_{T} (GeV/c)");
+      fTrueList[iCut]->Add(fHistoTrueMesonInvMassVsPt[iCut]);
+
+      fHistoTrueMesonInvMassVsTruePt[iCut] = new TH2F("ESD_TrueMother_InvMass_TruePt", "ESD_TrueMother_InvMass_TruePt", fVecBinsMesonInvMass.size() - 1, fVecBinsMesonInvMass.data(), fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data());
+      fHistoTrueMesonInvMassVsTruePt[iCut]->SetXTitle("M_{#gamma#gamma} (GeV/c^{2})");
+      fHistoTrueMesonInvMassVsTruePt[iCut]->SetYTitle("p_{T} (GeV/c)");
+      fTrueList[iCut]->Add(fHistoTrueMesonInvMassVsTruePt[iCut]);
+
+      fHistoTruePrimaryMesonInvMassPt[iCut] = new TH2F("ESD_TruePrimaryMother_InvMass_Pt", "ESD_TruePrimaryMother_InvMass_Pt", fVecBinsMesonInvMass.size() - 1, fVecBinsMesonInvMass.data(), fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data());
+      fHistoTruePrimaryMesonInvMassPt[iCut]->SetXTitle("M_{#gamma#gamma} (GeV/c^{2})");
+      fHistoTruePrimaryMesonInvMassPt[iCut]->SetYTitle("p_{T} (GeV/c)");
+      fTrueList[iCut]->Add(fHistoTruePrimaryMesonInvMassPt[iCut]);
+
+      fHistoTrueSecondaryMesonInvMassPt[iCut] = new TH2F("ESD_TrueSecondaryMother_InvMass_Pt", "ESD_TrueSecondaryMother_InvMass_Pt", fVecBinsMesonInvMass.size() - 1, fVecBinsMesonInvMass.data(), fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data());
+      fHistoTrueSecondaryMesonInvMassPt[iCut]->SetXTitle("M_{#gamma#gamma} (GeV/c^{2})");
+      fHistoTrueSecondaryMesonInvMassPt[iCut]->SetYTitle("p_{T} (GeV/c)");
+      fTrueList[iCut]->Add(fHistoTrueSecondaryMesonInvMassPt[iCut]);
+    }
+
+    if (fDoMesonQA > 0) {
+      fHistoInvMassVsPt_Incl[iCut] = new TH2F("ESD_Mother_InvMass_Pt_Incl", "ESD_Mother_InvMass_Pt_Incl", fVecBinsMesonInvMass.size() - 1, fVecBinsMesonInvMass.data(), fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data());
+      fHistoInvMassVsPt_Incl[iCut]->SetXTitle("M_{#gamma#gamma} (GeV/c^{2})");
+      fHistoInvMassVsPt_Incl[iCut]->SetYTitle("p_{T} (GeV/c)");
+      fESDList[iCut]->Add(fHistoInvMassVsPt_Incl[iCut]);
+
+      fHistoInvMassVsPtMassCut[iCut] = new TH2F("ESD_Mother_InvMass_Pt_MassCut", "ESD_Mother_InvMass_Pt_MassCut", fVecBinsMesonInvMass.size() - 1, fVecBinsMesonInvMass.data(), fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data());
+      fHistoInvMassVsPtMassCut[iCut]->SetXTitle("M_{#gamma#gamma} (GeV/c^{2})");
+      fHistoInvMassVsPtMassCut[iCut]->SetYTitle("p_{T} (GeV/c)");
+      fESDList[iCut]->Add(fHistoInvMassVsPtMassCut[iCut]);
+
+      fHistoInvMassVsPtMassCutSB[iCut] = new TH2F("ESD_Mother_InvMass_Pt_MassCutSB", "ESD_Mother_InvMass_Pt_MassCutSB", fVecBinsMesonInvMass.size() - 1, fVecBinsMesonInvMass.data(), fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data());
+      fHistoInvMassVsPtMassCutSB[iCut]->SetXTitle("M_{#gamma#gamma} (GeV/c^{2})");
+      fHistoInvMassVsPtMassCutSB[iCut]->SetYTitle("p_{T} (GeV/c)");
+      fESDList[iCut]->Add(fHistoInvMassVsPtMassCutSB[iCut]);
+    }
+
+    fHistoInvMassVsPtBack[iCut] = new TH2F("ESD_Back_InvMass_Pt", "ESD_Back_InvMass_Pt", fVecBinsMesonInvMass.size() - 1, fVecBinsMesonInvMass.data(), fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data());
+    fHistoInvMassVsPtBack[iCut]->SetXTitle("M_{#gamma#gamma} (GeV/c^{2})");
+    fHistoInvMassVsPtBack[iCut]->SetYTitle("p_{T} (GeV/c)");
+    fESDList[iCut]->Add(fHistoInvMassVsPtBack[iCut]);
+
+    fHistoJetPtVsFrag[iCut] = new TH2F("ESD_Frag_JetPt", "ESD_Frag_JetPt", fVecBinsFragment.size() - 1, fVecBinsFragment.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
+    fHistoJetPtVsFrag[iCut]->SetXTitle("z");
+    fHistoJetPtVsFrag[iCut]->SetYTitle("p_{T, Jet} (GeV/c)");
+    fESDList[iCut]->Add(fHistoJetPtVsFrag[iCut]);
+
+    fHistoJetPtVsFrag_SB[iCut] = new TH2F("ESD_Frag_JetPt_SB", "ESD_Frag_JetPt_SB", fVecBinsFragment.size() - 1, fVecBinsFragment.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
+    fHistoJetPtVsFrag_SB[iCut]->SetXTitle("z");
+    fHistoJetPtVsFrag_SB[iCut]->SetYTitle("p_{T, Jet} (GeV/c)");
+    fESDList[iCut]->Add(fHistoJetPtVsFrag_SB[iCut]);
+
+    // perpendicular cone
+    fHistoJetPtVsFragPerpCone[iCut] = new TH2F("ESD_Frag_JetPt_PerpCone", "ESD_Frag_JetPt_PerpCone", fVecBinsFragment.size() - 1, fVecBinsFragment.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
+    fHistoJetPtVsFragPerpCone[iCut]->SetXTitle("z");
+    fHistoJetPtVsFragPerpCone[iCut]->SetYTitle("p_{T, Jet} (GeV/c)");
+    fESDList[iCut]->Add(fHistoJetPtVsFragPerpCone[iCut]);
+
+    fHistoJetPtVsFragPerpCone_SB[iCut] = new TH2F("ESD_Frag_JetPt_PerpCone_SB", "ESD_Frag_JetPt_PerpCone_SB", fVecBinsFragment.size() - 1, fVecBinsFragment.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
+    fHistoJetPtVsFragPerpCone_SB[iCut]->SetXTitle("z");
+    fHistoJetPtVsFragPerpCone_SB[iCut]->SetYTitle("p_{T, Jet} (GeV/c)");
+    fESDList[iCut]->Add(fHistoJetPtVsFragPerpCone_SB[iCut]);
+
+    fRespMatrixHandlerMesonInvMass[iCut] = new MatrixHandler4D(fVecBinsMesonInvMass, fVecBinsMesonPt, fVecBinsJetPt, fVecBinsJetPt, fUseThNForResponse);
+    fESDList[iCut]->Add(fRespMatrixHandlerMesonInvMass[iCut]->GetTHnSparse("InvMassVsPt_JetPt"));
+    fRespMatrixHandlerMesonInvMassVsZ[iCut] = new MatrixHandler4D(fVecBinsMesonInvMass, fVecBinsFragment, fVecBinsJetPt, {0, 1}, fUseThNForResponse);
+    fESDList[iCut]->Add(fRespMatrixHandlerMesonInvMassVsZ[iCut]->GetTHnSparse("InvMassVsZ_JetPt"));
+    fRespMatrixHandlerMesonBackInvMassVsZ[iCut] = new MatrixHandler4D(fVecBinsMesonInvMass, fVecBinsFragment, fVecBinsJetPt, {0, 1}, fUseThNForResponse);
+    fESDList[iCut]->Add(fRespMatrixHandlerMesonBackInvMassVsZ[iCut]->GetTHnSparse("InvMassVsZ_Background_JetPt"));
+    // perpendicular cone
+    fRespMatrixHandlerMesonInvMassVsZPerpCone[iCut] = new MatrixHandler4D(fVecBinsMesonInvMass, fVecBinsFragment, fVecBinsJetPt, {0, 1}, fUseThNForResponse);
+    fESDList[iCut]->Add(fRespMatrixHandlerMesonInvMassVsZPerpCone[iCut]->GetTHnSparse("InvMassVsZ_JetPt_PerpCone"));
+    fRespMatrixHandlerMesonInvMassPerpCone[iCut] = new MatrixHandler4D(fVecBinsMesonInvMass, fVecBinsMesonPt, fVecBinsJetPt, {0, 1}, fUseThNForResponse);
+    fESDList[iCut]->Add(fRespMatrixHandlerMesonInvMassPerpCone[iCut]->GetTHnSparse("InvMassVsPt_JetPt_PerpCone"));
+
+    if (fIsMC) {
+      fRespMatrixHandlerMesonPt[iCut] = new MatrixHandler4D(fVecBinsMesonPt, fVecBinsMesonPt, fVecBinsJetPt, fVecBinsJetPt, fUseThNForResponse);
+      fTrueList[iCut]->Add(fRespMatrixHandlerMesonPt[iCut]->GetTHnSparse("MesonPt_JetPt_TrueVsRec"));
+      fRespMatrixHandlerFrag[iCut] = new MatrixHandler4D(fVecBinsFragment, fVecBinsFragment, fVecBinsJetPt, fVecBinsJetPt, fUseThNForResponse);
+      fTrueList[iCut]->Add(fRespMatrixHandlerFrag[iCut]->GetTHnSparse("Frag_JetPt_TrueVsRec"));
+    }
+
+    // Call Sumw2 forall histograms in list
+    if (fIsMC) {
+      CallSumw2ForLists(fESDList[iCut]);
+      CallSumw2ForLists(fTrueList[iCut]);
+      CallSumw2ForLists(fMCList[iCut]);
+      CallSumw2ForLists(fJetList[iCut]);
+      CallSumw2ForLists(fTrueJetList[iCut]);
+    }
+
+  } // end cut loop
+
+  if (fIsCalo || fIsConvCalo) {
+    // Add the track matcher (has to be initialized in the AddTask!)
+    for (int iMatcherTask = 0; iMatcherTask < 5; iMatcherTask++) {
+      AliCaloTrackMatcher* temp = 0x0;
+      if (!fCorrTaskSetting.CompareTo("")) {
+        temp = (AliCaloTrackMatcher*)(AliAnalysisManager::GetAnalysisManager()->GetTask(Form("CaloTrackMatcher_%i_%i", iMatcherTask, fTrackMatcherRunningMode)));
+      } else {
+        temp = (AliCaloTrackMatcher*)(AliAnalysisManager::GetAnalysisManager()->GetTask(Form("CaloTrackMatcher_%i_%i_%s", iMatcherTask, fTrackMatcherRunningMode, fCorrTaskSetting.Data())));
+      }
+      if (temp)
+        fOutputContainer->Add(temp->GetCaloTrackMatcherHistograms());
+    }
+  }
+
+  // now add all the cut lists if needed
+  for (int iCut = 0; iCut < fnCuts; iCut++) {
+    // if(!((AliConvEventCuts*)fEventCutArray->At(iCut))) continue;
+    if (((AliConvEventCuts*)fEventCutArray->At(iCut))->GetCutHistograms()) {
+      fCutFolder[iCut]->Add(((AliConvEventCuts*)fEventCutArray->At(iCut))->GetCutHistograms());
+    }
+    if (fIsCalo || fIsConvCalo) {
+      // if(!((AliCaloPhotonCuts*)fClusterCutArray->At(iCut))) continue;
+      if (((AliCaloPhotonCuts*)fClusterCutArray->At(iCut))->GetCutHistograms()) {
+        fCutFolder[iCut]->Add(((AliCaloPhotonCuts*)fClusterCutArray->At(iCut))->GetCutHistograms());
+      }
+    }
+
+    if (fIsConv || fIsConvCalo) {
+      // if(!((AliConversionPhotonCuts*)fConvCutArray->At(iCut))) continue;
+      if (((AliConversionPhotonCuts*)fConvCutArray->At(iCut))->GetCutHistograms()) {
+        fCutFolder[iCut]->Add(((AliConversionPhotonCuts*)fConvCutArray->At(iCut))->GetCutHistograms());
+      }
+    }
+    // if(fSetPlotHistsExtQA){
+    //   if(!((AliCaloPhotonCuts*)fClusterCutArray->At(iCut))) continue;
+    //   if(((AliCaloPhotonCuts*)fClusterCutArray->At(iCut))->GetExtQAHistograms()){
+    //     fCutFolder[iCut]->Add(((AliCaloPhotonCuts*)fClusterCutArray->At(iCut))->GetExtQAHistograms());
+    //   }
+    // }
+    // if(!((AliConversionMesonCuts*)fMesonCutArray->At(iCut))) continue;
+    if (((AliConversionMesonCuts*)fMesonCutArray->At(iCut))->GetCutHistograms()) {
+      fCutFolder[iCut]->Add(((AliConversionMesonCuts*)fMesonCutArray->At(iCut))->GetCutHistograms());
+    }
+  }
+
+  OpenFile(1);
+  PostData(1, fOutputContainer);
+}
+
+void AliAnalysisTaskMesonJetCorrelation::MakeBinning()
+{
+  // cout << " In Make Binning" << endl;
+
+  if (fMesonPDGCode == 111) { // pi0
+    double valInvMass = 0;
+    for (int i = 0; i <= 1000; ++i) {
+      fVecBinsMesonInvMass.push_back(valInvMass);
+      if (valInvMass < 0.3)
+        valInvMass += 0.002;
+      else
+        break;
+    }
+  } else if (fMesonPDGCode == 221) { // eta
+    double valInvMass = 0.3;
+    for (int i = 0; i <= 1000; ++i) {
+      fVecBinsMesonInvMass.push_back(valInvMass);
+      if (valInvMass >= 0.3 && valInvMass < 0.8)
+        valInvMass += 0.004;
+      else
+        break;
+    }
+  } else { // this should not really happen
+    double valInvMass = 0;
+    for (int i = 0; i <= 1000; ++i) {
+      fVecBinsMesonInvMass.push_back(valInvMass);
+      if (valInvMass < 0.3)
+        valInvMass += 0.002;
+      else
+        break;
+    }
+  }
+  //---------------------------
+  // Photon/single part pt Binning
+  //---------------------------
+  double valGammaPt = 0;
+  for (int i = 0; i < 1000; ++i) {
+    fVecBinsPhotonPt.push_back(valGammaPt);
+    if (valGammaPt < 1.0)
+      valGammaPt += 0.1;
+    else if (valGammaPt < 5)
+      valGammaPt += 0.2;
+    else if (valGammaPt < 10)
+      valGammaPt += 0.5;
+    else if (valGammaPt < 50)
+      valGammaPt += 1;
+    else if (valGammaPt < 100)
+      valGammaPt += 5;
+    else
+      break;
+  }
+  //---------------------------
+  // Meson pt Binning
+  //---------------------------
+  double valMesonPt = 0;
+  for (int i = 0; i < 1000; ++i) {
+    fVecBinsMesonPt.push_back(valMesonPt);
+    if (valMesonPt < 5)
+      valMesonPt += 0.2;
+    else if (valMesonPt < 10)
+      valMesonPt += 0.5;
+    else if (valMesonPt < 20)
+      valMesonPt += 1;
+    else if (valMesonPt < 50)
+      valMesonPt += 5;
+    else
+      break;
+  }
+  //---------------------------
+  // Jet pt Binning
+  //---------------------------
+  double valJetPt = 0;
+  for (int i = 0; i < 1000; ++i) {
+    fVecBinsJetPt.push_back(valJetPt);
+    if (valJetPt < 10)
+      valJetPt += 10;
+    else if (valJetPt < 50.0)
+      valJetPt += 5;
+    else if (valJetPt < 100)
+      valJetPt += 10;
+    else if (valJetPt < 200)
+      valJetPt += 20;
+    else if (valJetPt < 500)
+      valJetPt += 50;
+    else
+      break;
+  }
+  //---------------------------
+  // Fragmentation Binning
+  //---------------------------
+  double valZ = 0;
+  for (int i = 0; i < 1000; ++i) {
+    fVecBinsFragment.push_back(valZ);
+    if (valZ < 0.1)
+      valZ += 0.01;
+    else if (valZ < 0.2)
+      valZ += 0.02;
+    else if (valZ < 1)
+      valZ += 0.05;
+    else
+      break;
+  }
+
+  //---------------------------
+  // Equidistant binning starting at -0.5
+  //---------------------------
+  for (int i = 0; i < 1000; ++i) {
+    vecEquidistFromMinus05.push_back(i - 0.5);
+  }
+}
+
+//________________________________________________________________________
+void AliAnalysisTaskMesonJetCorrelation::CallSumw2ForLists(TList* l)
+{
+  if (fIsMC > 1) {
+    TIter iter(l->MakeIterator());
+    while (TObject* obj = iter()) {
+      TString className = obj->ClassName();
+      // cout << objectName.Data() << "\t" << className.Data() << endl;
+      if (className.Contains("TH1")) { // is if_constexpr already available in AliPhysics?
+        static_cast<TH1*>(obj)->Sumw2();
+      } else if (className.Contains("TH2")) {
+        static_cast<TH2*>(obj)->Sumw2();
+      } else if (className.Contains("THnSparse")) {
+        static_cast<THnSparse*>(obj)->Sumw2();
+      }
+    }
+  }
+}
+
+//________________________________________________________________________
+void AliAnalysisTaskMesonJetCorrelation::InitJets()
+{
+  fVectorJetPt = fConvJetReader->GetVectorJetPt();
+  fVectorJetPx = fConvJetReader->GetVectorJetPx();
+  fVectorJetPy = fConvJetReader->GetVectorJetPy();
+  fVectorJetPz = fConvJetReader->GetVectorJetPz();
+  fVectorJetEta = fConvJetReader->GetVectorJetEta();
+  fVectorJetPhi = fConvJetReader->GetVectorJetPhi();
+  fVectorJetArea = fConvJetReader->GetVectorJetArea();
+
+  fVectorJetEtaPerp = fConvJetReader->GetVectorJetEta();
+  for (auto& eta : fVectorJetEtaPerp) {
+    eta *= -1;
+  }
+  fVectorJetPhiPerp = fConvJetReader->GetVectorJetPhi();
+  for (auto& phi : fVectorJetPhiPerp) {
+    phi += 0.5 * TMath::Pi();
+    if (phi > 2 * TMath::Pi()) {
+      phi -= TMath::Pi();
+    }
+  }
+
+  if (fIsMC > 0) {
+    if (fIsMC) {
+      if (!fAODMCTrackArray)
+        fAODMCTrackArray = dynamic_cast<TClonesArray*>(fInputEvent->FindListObject(AliAODMCParticle::StdBranchName()));
+      fConvJetReader->FindPartonsJet(fAODMCTrackArray);
+    }
+    fTrueVectorJetPx = fConvJetReader->GetTrueVectorJetPx();
+    fTrueVectorJetPy = fConvJetReader->GetTrueVectorJetPy();
+    fTrueVectorJetPz = fConvJetReader->GetTrueVectorJetPz();
+    fTrueVectorJetPt = fConvJetReader->GetTrueVectorJetPt();
+    fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta();
+    fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi();
+    fTrueVectorJetPartonID = fConvJetReader->GetTrueVectorJetParton();
+    fTrueVectorJetPartonPt = fConvJetReader->GetTrueVectorJetPartonPt();
+  }
+}
+
+//________________________________________________________________________
+void AliAnalysisTaskMesonJetCorrelation::ProcessJets()
+{
+  // cout << "ProcessJets" << endl;
+  // clear map before next event
+  MapRecJetsTrueJets.clear();
+
+  fHistoNJets[fiCut]->Fill(fConvJetReader->GetNJets());
+
+  if (fConvJetReader->GetTrueNJets() > 0) {
+    fHistoEventwJets[fiCut]->Fill(1); // event has true jet
+    if (fConvJetReader->GetNJets() > 0) {
+      fHistoEventwJets[fiCut]->Fill(2); // event has true jet and rec. jet
+    }
+  }
+
+  if (fConvJetReader->GetNJets() > 0) {
+
+    fHistoEventwJets[fiCut]->Fill(0); // event has jet
+    fHighestJetVector.SetXYZ(0, 0, 0);
+    fMaxPtJet = 0.;
+
+    for (int i = 0; i < fConvJetReader->GetNJets(); i++) {
+      fHistoPtJet[fiCut]->Fill(fVectorJetPt.at(i));
+      fHistoJetEta[fiCut]->Fill(fVectorJetEta.at(i));
+      fHistoJetPhi[fiCut]->Fill(fVectorJetPhi.at(i));
+      fHistoJetArea[fiCut]->Fill(fVectorJetArea.at(i));
+
+      if (fIsMC > 0 && fConvJetReader->GetNJets() > 0 && fConvJetReader->GetTrueNJets() > 0) {
+        Double_t min = 100;
+        int match = 0;
+        for (int j = 0; j < fConvJetReader->GetTrueNJets(); j++) {
+          Double_t R_jetjet;
+          Double_t DeltaEta = fVectorJetEta.at(i) - fTrueVectorJetEta.at(j);
+          Double_t DeltaPhi = abs(fVectorJetPhi.at(i) - fTrueVectorJetPhi.at(j));
+          if (DeltaPhi > M_PI) {
+            DeltaPhi = 2 * M_PI - DeltaPhi;
+          }
+          R_jetjet = TMath::Sqrt(pow((DeltaEta), 2) + pow((DeltaPhi), 2));
+          if (R_jetjet < min) {
+            min = R_jetjet;
+            match = j;
+          }
+        }
+        MapRecJetsTrueJets[i] = match; // store matched jet indices in map
+        fHistoTruevsRecJetPt[fiCut]->Fill(fVectorJetPt.at(i), fTrueVectorJetPt.at(match));
+        fHistoTrueJetPtVsPartonPt[fiCut]->Fill(fTrueVectorJetPt.at(match), fTrueVectorJetPartonPt.at(match));
+      }
+      if (fVectorJetPt.at(i) > fMaxPtJet) {
+        fMaxPtJet = fVectorJetPt.at(i);
+        fHighestJetVector.SetXYZ(fVectorJetPx[i], fVectorJetPy[i], fVectorJetPz[i]);
+      }
+    }
+  }
+}
+
+//_____________________________________________________________________________
+void AliAnalysisTaskMesonJetCorrelation::UserExec(Option_t*)
+{
+  // cout << "in user exec" << endl;
+  //
+  // Called for each event
+  //
+  fInputEvent = InputEvent();
+
+  if (fIsMC > 0)
+    fMCEvent = MCEvent();
+
+  int eventQuality = ((AliConvEventCuts*)fV0Reader->GetEventCuts())->GetEventQuality();
+  if (fInputEvent->IsIncompleteDAQ() == kTRUE)
+    eventQuality = 2; // incomplete event
+  // Event Not Accepted due to MC event missing or wrong trigger for V0ReaderV1 or because it is incomplete => abort processing of this event/file
+  if (eventQuality == 2 || eventQuality == 3) {
+    for (int iCut = 0; iCut < fnCuts; iCut++) {
+      fHistoNEvents[iCut]->Fill(eventQuality);
+      if (fIsMC > 1)
+        fHistoNEventsWOWeight[iCut]->Fill(eventQuality);
+    }
+    return;
+  }
+
+  if (fIsConv || fIsConvCalo) {
+    fReaderGammas = fV0Reader->GetReconstructedGammas(); // Gammas from default Cut
+  }
+
+  if (fIsMC > 0 && fInputEvent->IsA() == AliAODEvent::Class() && !(fV0Reader->AreAODsRelabeled())) {
+    RelabelAODPhotonCandidates(kTRUE); // In case of AODMC relabeling MC
+    fV0Reader->RelabelAODs(kTRUE);
+  }
+
+  // Get Event Plane Angle
+  AliEventplane* EventPlane = fInputEvent->GetEventplane();
+  if (fIsHeavyIon == 1)
+    fEventPlaneAngle = EventPlane->GetEventplane("V0", fInputEvent, 2);
+  else
+    fEventPlaneAngle = 0.0;
+
+  for (int iCut = 0; iCut < fnCuts; iCut++) {
+    fiCut = iCut;
+    Bool_t isRunningEMCALrelAna = kFALSE;
+    if (fIsCalo || fIsConvCalo) {
+      if (((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetClusterType() == 1)
+        isRunningEMCALrelAna = kTRUE;
+    }
+
+    int eventNotAccepted = ((AliConvEventCuts*)fEventCutArray->At(iCut))->IsEventAcceptedByCut(fV0Reader->GetEventCuts(), fInputEvent, fMCEvent, fIsHeavyIon, isRunningEMCALrelAna);
+    if (fIsMC == 2) {
+      Float_t xsection = -1.;
+      Float_t ntrials = -1.;
+      ((AliConvEventCuts*)fEventCutArray->At(iCut))->GetXSectionAndNTrials(fMCEvent, xsection, ntrials, fInputEvent);
+      if ((xsection == -1.) || (ntrials == -1.))
+        AliFatal(Form("ERROR: GetXSectionAndNTrials returned invalid xsection/ntrials, periodName from V0Reader: '%s'", fV0Reader->GetPeriodName().Data()));
+      // fProfileJetJetXSection[iCut]->Fill(0.,xsection);
+      // fHistoJetJetNTrials[iCut]->Fill("#sum{NTrials}", ntrials);
+    }
+
+    fWeightJetJetMC = 1;
+    if (fIsMC > 0) {
+      Float_t maxjetpt = -1.;
+      Float_t pthard = -1;
+      if (((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetUseJetFinderForOutliers())
+        maxjetpt = fOutlierJetReader->GetMaxJetPt();
+      Bool_t isMCJet = ((AliConvEventCuts*)fEventCutArray->At(iCut))->IsJetJetMCEventAccepted(fMCEvent, fWeightJetJetMC, pthard, fInputEvent, maxjetpt);
+      // if(isMCJet && (fIsMC==2))           fHistoPtHardJJWeight[iCut]->Fill(pthard,fWeightJetJetMC);
+      if (fIsMC == 3) {
+        Double_t weightMult = ((AliConvEventCuts*)fEventCutArray->At(iCut))->GetWeightForMultiplicity(fV0Reader->GetNumberOfPrimaryTracks());
+        fWeightJetJetMC = fWeightJetJetMC * weightMult;
+      }
+
+      if (!isMCJet) {
+        fHistoNEvents[iCut]->Fill(10, fWeightJetJetMC);
+        if (fIsMC > 1)
+          fHistoNEventsWOWeight[iCut]->Fill(10);
+        continue;
+      }
+    }
+
+    // Jets need to be initialized before the ProcessMCParticles because they are needed in ProcessAODMCParticles
+    InitJets();
+
+    if (eventNotAccepted != 0) {
+      fHistoNEvents[iCut]->Fill(eventNotAccepted, fWeightJetJetMC); // Check Centrality, PileUp, SDD and V0AND --> Not Accepted => eventQuality = 1
+      if (fIsMC > 1)
+        fHistoNEventsWOWeight[iCut]->Fill(eventNotAccepted);
+
+      if (eventNotAccepted == 3 && fIsMC > 0) {
+        ProcessAODMCParticles(1);
+      }
+      if (eventNotAccepted == 5 && fIsMC > 0) {
+        ProcessAODMCParticles(2);
+      }
+      continue;
+    }
+
+    if (eventQuality != 0) { // Event Not Accepted
+      fHistoNEvents[iCut]->Fill(eventQuality, fWeightJetJetMC);
+      if (fIsMC > 1)
+        fHistoNEventsWOWeight[iCut]->Fill(eventQuality); // Should be 0 here
+      continue;
+    }
+
+    // from here on we accepted the event!
+    fHistoNEvents[iCut]->Fill(eventQuality, fWeightJetJetMC); // Should be 0 here
+    if (fIsMC > 1)
+      fHistoNEventsWOWeight[iCut]->Fill(eventQuality); // Should be 0 here
+    // fHistoNGoodESDTracks[iCut]->Fill(fV0Reader->GetNumberOfPrimaryTracks(), fWeightJetJetMC);
+    // fHistoVertexZ[iCut]->Fill(fInputEvent->GetPrimaryVertex()->GetZ(), fWeightJetJetMC);
+
+    if (fIsMC > 0) {
+      ProcessAODMCParticles(0);
+    }
+
+    ProcessJets();
+    if (fIsConvCalo || fIsCalo) {
+      ProcessClusters(); // process calo clusters
+    }
+    if (fIsConvCalo || fIsConv) {
+      ProcessPhotonCandidates(); // Process this cuts gammas
+    }
+
+    CalculateMesonCandidates();
+
+    CalculateBackground();
+
+    UpdateEventMixData();
+  }
+
+  if (fIsMC > 0 && fInputEvent->IsA() == AliAODEvent::Class() && !(fV0Reader->AreAODsRelabeled())) {
+    RelabelAODPhotonCandidates(kFALSE); // Back to ESDMC Label
+    fV0Reader->RelabelAODs(kFALSE);
+  }
+  PostData(1, fOutputContainer);
+
+} // end userExec
+
+//________________________________________________________________________
+void AliAnalysisTaskMesonJetCorrelation::ProcessClusters()
+{
+  // cout << "in Process clusters" << endl;
+
+  // clear cluster candidates
+  for (unsigned int i = 0; i < fClusterCandidates.size(); ++i) {
+    if (fClusterCandidates[i])
+      delete fClusterCandidates[i];
+    fClusterCandidates[i] = nullptr;
+  }
+  fClusterCandidates.clear();
+
+  int nclus = 0;
+  TClonesArray* arrClustersProcess = NULL;
+  // fNCurrentClusterBasic             = 0;
+  if (!fCorrTaskSetting.CompareTo("")) {
+    nclus = fInputEvent->GetNumberOfCaloClusters();
+  } else {
+    arrClustersProcess = dynamic_cast<TClonesArray*>(fInputEvent->FindListObject(Form("%sClustersBranch", fCorrTaskSetting.Data())));
+    if (!arrClustersProcess) {
+      AliFatal(Form("%sClustersBranch was not found in AliAnalysisTaskGammaCalo! Check the correction framework settings!", fCorrTaskSetting.Data()));
+    }
+    nclus = arrClustersProcess->GetEntries();
+  }
+
+  if (nclus == 0)
+    return;
+  int NClusinJets = 0;
+
+  // match tracks to clusters
+  ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->MatchTracksToClusters(fInputEvent, fWeightJetJetMC, kTRUE, fMCEvent);
+
+  for (Long_t i = 0; i < nclus; i++) {
+    Double_t tempClusterWeight = fWeightJetJetMC;
+    // Double_t tempPhotonWeight = fWeightJetJetMC;
+    AliVCluster* clus = NULL;
+    if (fInputEvent->IsA() == AliESDEvent::Class()) {
+      if (arrClustersProcess)
+        clus = new AliESDCaloCluster(*(AliESDCaloCluster*)arrClustersProcess->At(i));
+      else
+        clus = new AliESDCaloCluster(*(AliESDCaloCluster*)fInputEvent->GetCaloCluster(i));
+    } else if (fInputEvent->IsA() == AliAODEvent::Class()) {
+      if (arrClustersProcess)
+        clus = new AliAODCaloCluster(*(AliAODCaloCluster*)arrClustersProcess->At(i));
+      else
+        clus = new AliAODCaloCluster(*(AliAODCaloCluster*)fInputEvent->GetCaloCluster(i));
+    }
+    if (!clus)
+      continue;
+
+    // Set the jetjet weight to 1 in case the cluster orignated from the minimum bias header
+    if (fIsMC > 0 && ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetSignalRejection() == 4) {
+      if (((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsParticleFromBGEvent(clus->GetLabelAt(0), fMCEvent, fInputEvent) == 2) {
+        tempClusterWeight = 1;
+      }
+    }
+
+    // apply cluster cuts
+    if (!((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->ClusterIsSelected(clus, fInputEvent, fMCEvent, fIsMC, tempClusterWeight, i)) {
+      // if (((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetIsAcceptedForBasicCounting())fNCurrentClusterBasic++;
+      delete clus;
+      continue;
+    }
+
+    // vertex
+    Double_t vertex[3] = {0};
+    InputEvent()->GetPrimaryVertex()->GetXYZ(vertex);
+
+    // TLorentzvector with cluster
+    TLorentzVector clusterVector;
+    clus->GetMomentum(clusterVector, vertex);
+
+    TLorentzVector* tmpvec = new TLorentzVector();
+    tmpvec->SetPxPyPzE(clusterVector.Px(), clusterVector.Py(), clusterVector.Pz(), clusterVector.E());
+
+    // convert to AODConversionPhoton
+    AliAODConversionPhoton* PhotonCandidate = new AliAODConversionPhoton(tmpvec);
+    if (!PhotonCandidate) {
+      delete clus;
+      delete tmpvec;
+      continue;
+    }
+
+    // Flag Photon as CaloPhoton
+    PhotonCandidate->SetIsCaloPhoton(((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetClusterType());
+    PhotonCandidate->SetCaloClusterRef(i);
+    PhotonCandidate->SetLeadingCellID(((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->FindLargestCellInCluster(clus, fInputEvent));
+    // get MC label
+    if (fIsMC > 0) {
+      int* mclabelsCluster = clus->GetLabels();
+      PhotonCandidate->SetNCaloPhotonMCLabels(clus->GetNLabels());
+      if (clus->GetNLabels() > 0) {
+        for (int k = 0; k < (int)clus->GetNLabels(); k++) {
+          PhotonCandidate->SetCaloPhotonMCLabel(k, mclabelsCluster[k]);
+        } // end of label loop
+      }
+    }
+
+    // Bool_t InsideJet = kFALSE;
+    // fNumberOfClusters[fiCut]->Fill(nclus);
+    Float_t clusPos[3] = {0, 0, 0};
+    clus->GetPosition(clusPos);
+    TVector3 clusterVectorJets(clusPos[0], clusPos[1], clusPos[2]);
+    Double_t etaCluster = clusterVectorJets.Eta();
+    Double_t phiCluster = clusterVectorJets.Phi();
+
+    if (fConvJetReader->GetNJets() > 0) {
+      Double_t RJetPi0Cand;
+      int matchedJet = -1;
+      if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->IsParticleInJet(fVectorJetEta, fVectorJetPhi, fConvJetReader->Get_Jet_Radius(), etaCluster, phiCluster, matchedJet, RJetPi0Cand)) {
+        // InsideJet = kTRUE;
+        NClusinJets++;
+        // fClusterEtaPhiJets[fiCut]->Fill(phiCluster, etaCluster);
+      }
+    }
+
+    fIsFromDesiredHeader = kTRUE;
+    // bool fIsOverlappingWithOtherHeader = kFALSE;
+    // bool fAllowOverlapHeaders = true;
+    // test whether largest contribution to cluster orginates in added signals
+    if (fIsMC > 0 && ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetSignalRejection() > 0) {
+      // Set the jetjet weight to 1 in case the photon candidate orignated from the minimum bias header
+      // if (((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsParticleFromBGEvent(PhotonCandidate->GetCaloPhotonMCLabel(0), fMCEvent, fInputEvent) == 2 && ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetSignalRejection() == 4)
+      //   tempPhotonWeight = 1;
+      // if (((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsParticleFromBGEvent(PhotonCandidate->GetCaloPhotonMCLabel(0), fMCEvent, fInputEvent) == 0)
+      // fIsFromDesiredHeader = kFALSE;
+      // if (clus->GetNLabels() > 1) {
+      // int* mclabelsCluster = clus->GetLabels();
+      // for (int l = 1; l < (int)clus->GetNLabels(); l++) {
+      //   if (((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsParticleFromBGEvent(mclabelsCluster[l], fMCEvent, fInputEvent, false) == 0)
+      //     fIsOverlappingWithOtherHeader = kTRUE;
+      // }
+      // }
+    }
+
+    if (fIsMC > 0) {
+      ProcessTrueClusterCandidatesAOD(PhotonCandidate);
+    }
+    // if ( (fIsFromDesiredHeader && !fIsOverlappingWithOtherHeader && !fAllowOverlapHeaders) || (fIsFromDesiredHeader && fAllowOverlapHeaders) ){
+    fClusterCandidates.push_back(PhotonCandidate);
+    // }
+  } // end cluster loop
+}
+
+//________________________________________________________________________
+void AliAnalysisTaskMesonJetCorrelation::ProcessPhotonCandidates()
+{
+  // cout << "ProcessPhotonCandidates" << endl;
+
+  fGammaCandidates.clear();
+
+  Double_t magField = fInputEvent->GetMagneticField();
+  int nV0 = 0;
+  TList* GammaCandidatesStepOne = new TList();
+  TList* GammaCandidatesStepTwo = new TList();
+  // Loop over Photon Candidates allocated by ReaderV1
+  for (int i = 0; i < fReaderGammas->GetEntriesFast(); i++) {
+    AliAODConversionPhoton* PhotonCandidate = (AliAODConversionPhoton*)fReaderGammas->At(i);
+    if (!PhotonCandidate)
+      continue;
+    fIsFromDesiredHeader = kTRUE;
+
+    Double_t weightMatBudgetGamma = 1.;
+    if (fDoMaterialBudgetWeightingOfGammasForTrueMesons && ((AliConversionPhotonCuts*)fConvCutArray->At(fiCut))->GetMaterialBudgetWeightsInitialized()) {
+      weightMatBudgetGamma = ((AliConversionPhotonCuts*)fConvCutArray->At(fiCut))->GetMaterialBudgetCorrectingWeightForTrueGamma(PhotonCandidate, magField);
+    }
+
+    // if(fIsMC>0 && ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetSignalRejection() != 0){
+    //   int isPosFromMBHeader = ((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsParticleFromBGEvent(PhotonCandidate->GetMCLabelPositive(), fMCEvent, fInputEvent);
+    //   if(isPosFromMBHeader == 0 && ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetSignalRejection() != 3) continue;
+    //   int isNegFromMBHeader = ((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsParticleFromBGEvent(PhotonCandidate->GetMCLabelNegative(), fMCEvent, fInputEvent);
+    //   if(isNegFromMBHeader == 0 && ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetSignalRejection() != 3) continue;
+    //   if( (isNegFromMBHeader+isPosFromMBHeader) != 4) fIsFromDesiredHeader = kFALSE;
+    // }
+
+    if (!((AliConversionPhotonCuts*)fConvCutArray->At(fiCut))->PhotonIsSelected(PhotonCandidate, fInputEvent))
+      continue;
+    if (!((AliConversionPhotonCuts*)fConvCutArray->At(fiCut))->InPlaneOutOfPlaneCut(PhotonCandidate->GetPhotonPhi(), fEventPlaneAngle))
+      continue;
+    if (!((AliConversionPhotonCuts*)fConvCutArray->At(fiCut))->UseElecSharingCut() &&
+        !((AliConversionPhotonCuts*)fConvCutArray->At(fiCut))->UseToCloseV0sCut()) {
+      fGammaCandidates.push_back(PhotonCandidate); // if no second loop is required add to events good gammas
+
+      if (fIsFromDesiredHeader) {
+        if (!fDoLightOutput)
+          fHistoConvGammaPt[fiCut]->Fill(PhotonCandidate->Pt(), fWeightJetJetMC * weightMatBudgetGamma);
+      }
+      if (fIsMC > 0) {
+        ProcessTruePhotonCandidatesAOD(PhotonCandidate);
+      }
+
+    } else if (((AliConversionPhotonCuts*)fConvCutArray->At(fiCut))->UseElecSharingCut()) { // if Shared Electron cut is enabled, Fill array, add to step one
+      ((AliConversionPhotonCuts*)fConvCutArray->At(fiCut))->FillElectonLabelArray(PhotonCandidate, nV0);
+      nV0++;
+      GammaCandidatesStepOne->Add(PhotonCandidate);
+    } else if (!((AliConversionPhotonCuts*)fConvCutArray->At(fiCut))->UseElecSharingCut() &&
+               ((AliConversionPhotonCuts*)fConvCutArray->At(fiCut))->UseToCloseV0sCut()) { // shared electron is disabled, step one not needed -> step two
+      GammaCandidatesStepTwo->Add(PhotonCandidate);
+    }
+  }
+  if (((AliConversionPhotonCuts*)fConvCutArray->At(fiCut))->UseElecSharingCut()) {
+
+    for (int i = 0; i < GammaCandidatesStepOne->GetEntries(); i++) {
+
+      AliAODConversionPhoton* PhotonCandidate = (AliAODConversionPhoton*)GammaCandidatesStepOne->At(i);
+      if (!PhotonCandidate)
+        continue;
+      fIsFromDesiredHeader = kTRUE;
+
+      // Double_t weightMatBudgetGamma = 1.;
+      // if (fDoMaterialBudgetWeightingOfGammasForTrueMesons && ((AliConversionPhotonCuts*)fConvCutArray->At(fiCut))->GetMaterialBudgetWeightsInitialized()) {
+      //   weightMatBudgetGamma = ((AliConversionPhotonCuts*)fConvCutArray->At(fiCut))->GetMaterialBudgetCorrectingWeightForTrueGamma(PhotonCandidate, magField);
+      // }
+
+      if (fMCEvent && ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetSignalRejection() != 0) {
+        int isPosFromMBHeader = ((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsParticleFromBGEvent(PhotonCandidate->GetMCLabelPositive(), fMCEvent, fInputEvent);
+        int isNegFromMBHeader = ((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsParticleFromBGEvent(PhotonCandidate->GetMCLabelNegative(), fMCEvent, fInputEvent);
+        if ((isNegFromMBHeader + isPosFromMBHeader) != 4)
+          fIsFromDesiredHeader = kFALSE;
+      }
+
+      if (!((AliConversionPhotonCuts*)fConvCutArray->At(fiCut))->RejectSharedElectronV0s(PhotonCandidate, i, GammaCandidatesStepOne->GetEntries()))
+        continue;
+      if (!((AliConversionPhotonCuts*)fConvCutArray->At(fiCut))->UseToCloseV0sCut()) { // To Colse v0s cut diabled, step two not needed
+        fGammaCandidates.push_back(PhotonCandidate);
+        // if(fIsFromDesiredHeader){
+        // if(!fDoLightOutput) fHistoConvGammaPt[fiCut]->Fill(PhotonCandidate->Pt(),fWeightJetJetMC*weightMatBudgetGamma);
+        // }
+        if (fIsMC > 0) {
+          ProcessTruePhotonCandidatesAOD(PhotonCandidate);
+        }
+      } else
+        GammaCandidatesStepTwo->Add(PhotonCandidate); // Close v0s cut enabled -> add to list two
+    }
+  }
+  if (((AliConversionPhotonCuts*)fConvCutArray->At(fiCut))->UseToCloseV0sCut()) {
+    for (int i = 0; i < GammaCandidatesStepTwo->GetEntries(); i++) {
+
+      AliAODConversionPhoton* PhotonCandidate = (AliAODConversionPhoton*)GammaCandidatesStepTwo->At(i);
+
+      if (!PhotonCandidate)
+        continue;
+      fIsFromDesiredHeader = kTRUE;
+
+      //     Double_t weightMatBudgetGamma = 1.;
+      //     if (fDoMaterialBudgetWeightingOfGammasForTrueMesons && ((AliConversionPhotonCuts*)fConvCutArray->At(fiCut))->GetMaterialBudgetWeightsInitialized()) {
+      // weightMatBudgetGamma = ((AliConversionPhotonCuts*)fConvCutArray->At(fiCut))->GetMaterialBudgetCorrectingWeightForTrueGamma(PhotonCandidate, magField);
+      //     }
+
+      if (fMCEvent && ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetSignalRejection() != 0) {
+        int isPosFromMBHeader = ((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsParticleFromBGEvent(PhotonCandidate->GetMCLabelPositive(), fMCEvent, fInputEvent);
+        int isNegFromMBHeader = ((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsParticleFromBGEvent(PhotonCandidate->GetMCLabelNegative(), fMCEvent, fInputEvent);
+        if ((isNegFromMBHeader + isPosFromMBHeader) != 4)
+          fIsFromDesiredHeader = kFALSE;
+      }
+      if (!((AliConversionPhotonCuts*)fConvCutArray->At(fiCut))->RejectToCloseV0s(PhotonCandidate, GammaCandidatesStepTwo, i))
+        continue;
+      fGammaCandidates.push_back(PhotonCandidate); // Add gamma to current cut TList
+      // if(fIsFromDesiredHeader){
+      // if(!fDoLightOutput) fHistoConvGammaPt[fiCut]->Fill(PhotonCandidate->Pt(),fWeightJetJetMC*weightMatBudgetGamma);
+      // }
+      if (fIsMC > 0) {
+        ProcessTruePhotonCandidatesAOD(PhotonCandidate);
+      }
+    }
+  }
+
+  delete GammaCandidatesStepOne;
+  GammaCandidatesStepOne = 0x0;
+  delete GammaCandidatesStepTwo;
+  GammaCandidatesStepTwo = 0x0;
+}
+
+//________________________________________________________________________
+void AliAnalysisTaskMesonJetCorrelation::CalculateMesonCandidates()
+{
+  // PCM-Calo case
+  if (fIsConvCalo) {
+    if (fGammaCandidates.size() > 0) {
+
+      TClonesArray* arrClustersMesonCand = NULL;
+      if (fCorrTaskSetting.CompareTo(""))
+        arrClustersMesonCand = dynamic_cast<TClonesArray*>(fInputEvent->FindListObject(Form("%sClustersBranch", fCorrTaskSetting.Data())));
+
+      for (unsigned int firstGammaIndex = 0; firstGammaIndex < fGammaCandidates.size(); firstGammaIndex++) {
+        AliAODConversionPhoton* gamma0 = dynamic_cast<AliAODConversionPhoton*>(fGammaCandidates[firstGammaIndex]);
+        if (gamma0 == NULL)
+          continue;
+
+        for (unsigned int secondGammaIndex = 0; secondGammaIndex < fClusterCandidates.size(); secondGammaIndex++) {
+          AliAODConversionPhoton* gamma1 = dynamic_cast<AliAODConversionPhoton*>(fClusterCandidates[secondGammaIndex]);
+          if (gamma1 == NULL)
+            continue;
+
+          // match conv to clusters
+          if (gamma1->GetIsCaloPhoton() > 0) {
+            AliVCluster* cluster = NULL;
+            if (arrClustersMesonCand) {
+              cluster = new AliAODCaloCluster(*(AliAODCaloCluster*)arrClustersMesonCand->At(gamma1->GetCaloClusterRef()));
+            } else {
+              cluster = fInputEvent->GetCaloCluster(gamma1->GetCaloClusterRef());
+            }
+
+            bool matched = ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->MatchConvPhotonToCluster(gamma0, cluster, fInputEvent, fWeightJetJetMC);
+
+            if (!matched) {
+              FillMesonHistograms(gamma0, gamma1, firstGammaIndex, secondGammaIndex);
+            }
+          }
+        }
+      }
+    }
+
+    // Pure Calo case
+  } else if (fIsCalo) {
+    for (unsigned int firstGammaIndex = 0; firstGammaIndex < fClusterCandidates.size(); firstGammaIndex++) {
+      AliAODConversionPhoton* gamma0 = dynamic_cast<AliAODConversionPhoton*>(fClusterCandidates[firstGammaIndex]);
+      if (gamma0 == NULL)
+        continue;
+
+      for (unsigned int secondGammaIndex = firstGammaIndex + 1; secondGammaIndex < fClusterCandidates.size(); secondGammaIndex++) {
+        AliAODConversionPhoton* gamma1 = dynamic_cast<AliAODConversionPhoton*>(fClusterCandidates[secondGammaIndex]);
+        if (gamma1 == NULL)
+          continue;
+
+        FillMesonHistograms(gamma0, gamma1, firstGammaIndex, secondGammaIndex);
+      }
+    }
+
+    // Pure Conv case
+  } else if (fIsConv) {
+    for (unsigned int firstGammaIndex = 0; firstGammaIndex < fGammaCandidates.size(); firstGammaIndex++) {
+      AliAODConversionPhoton* gamma0 = dynamic_cast<AliAODConversionPhoton*>(fGammaCandidates[firstGammaIndex]);
+      if (gamma0 == NULL)
+        continue;
+
+      for (unsigned int secondGammaIndex = firstGammaIndex + 1; secondGammaIndex < fGammaCandidates.size(); secondGammaIndex++) {
+        AliAODConversionPhoton* gamma1 = dynamic_cast<AliAODConversionPhoton*>(fGammaCandidates[secondGammaIndex]);
+        if (gamma1 == NULL)
+          continue;
+
+        FillMesonHistograms(gamma0, gamma1, firstGammaIndex, secondGammaIndex);
+      }
+    }
+  }
+}
+
+void AliAnalysisTaskMesonJetCorrelation::FillMesonHistograms(AliAODConversionPhoton* gamma0, AliAODConversionPhoton* gamma1, int firstGammaIndex, int secondGammaIndex)
+{
+  AliAODConversionMother* pi0cand = new AliAODConversionMother(gamma0, gamma1);
+  pi0cand->SetLabels(firstGammaIndex, secondGammaIndex);
+
+  if ((((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelected(pi0cand, kTRUE, ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift(), gamma0->GetLeadingCellID(), gamma1->GetLeadingCellID(), gamma0->GetIsCaloPhoton(), gamma1->GetIsCaloPhoton()))) {
+
+    if (fDoMesonQA > 0) {
+      fHistoInvMassVsPt_Incl[fiCut]->Fill(pi0cand->M(), pi0cand->Pt(), fWeightJetJetMC);
+    }
+    double RJetPi0Cand = 0;
+    int matchedJet = -1;
+    float ptJet = 0;
+    if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->IsParticleInJet(fVectorJetEta, fVectorJetPhi, fConvJetReader->Get_Jet_Radius(), pi0cand->Eta(), pi0cand->Phi(), matchedJet, RJetPi0Cand)) {
+      if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->DoJetAnalysis()) {
+        ptJet = fVectorJetPt[matchedJet];
+      }
+
+      // Fill Inv Mass Histograms
+      fHistoInvMassVsPt[fiCut]->Fill(pi0cand->M(), pi0cand->Pt(), fWeightJetJetMC);
+
+      // Fill the inv. mass histograms for all jet pTs
+      fRespMatrixHandlerMesonInvMass[fiCut]->Fill(pi0cand->M(), pi0cand->Pt(), ptJet, 0.5, fWeightJetJetMC);
+
+      // Fill Z histograms
+      float z = GetFrag(pi0cand, matchedJet, false);
+
+      fRespMatrixHandlerMesonInvMassVsZ[fiCut]->Fill(ptJet, 0.5, pi0cand->M(), z);                      // Inv Mass vs. Z in Jet Pt_rec bins. Needed to subtract background in the Z-distribution
+      if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelectedByMassCut(pi0cand, 0)) { // nominal mass range
+        fHistoJetPtVsFrag[fiCut]->Fill(z, ptJet, fWeightJetJetMC);
+        if (fDoMesonQA > 0) {
+          fHistoInvMassVsPtMassCut[fiCut]->Fill(pi0cand->M(), pi0cand->Pt(), fWeightJetJetMC);
+        }
+      } else if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelectedByMassCut(pi0cand, 1)) { // sideband
+        fHistoJetPtVsFrag_SB[fiCut]->Fill(z, ptJet, fWeightJetJetMC);
+        if (fDoMesonQA > 0) {
+          fHistoInvMassVsPtMassCutSB[fiCut]->Fill(pi0cand->M(), pi0cand->Pt(), fWeightJetJetMC);
+        }
+      }
+
+      if (fIsMC > 0) {
+        ProcessTrueMesonCandidatesAOD(pi0cand, gamma0, gamma1, matchedJet, RJetPi0Cand);
+      }
+
+    } // end IsParticleInJet
+    // check if particle is in jet transverse to original jet.
+    // Needed for underlying event study
+    double RJetPi0CandPerp = 0;
+    int matchedJetPerp = -1;
+    if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->IsParticleInJet(fVectorJetEtaPerp, fVectorJetPhiPerp, fConvJetReader->Get_Jet_Radius(), pi0cand->Eta(), pi0cand->Phi(), matchedJetPerp, RJetPi0CandPerp)) {
+
+      fHistoInvMassVsPtPerpCone[fiCut]->Fill(pi0cand->M(), pi0cand->Pt(), fWeightJetJetMC);
+
+      // Fill the inv. mass histograms for all jet pTs
+      fRespMatrixHandlerMesonInvMassPerpCone[fiCut]->Fill(pi0cand->M(), pi0cand->Pt(), ptJet, 0.5, fWeightJetJetMC);
+
+      // Fill Z histograms
+      float z = GetFrag(pi0cand, matchedJet, false);
+
+      fRespMatrixHandlerMesonInvMassVsZPerpCone[fiCut]->Fill(ptJet, 0.5, pi0cand->M(), z);              // Inv Mass vs. Z in Jet Pt_rec bins. Needed to subtract background in the Z-distribution
+      if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelectedByMassCut(pi0cand, 0)) { // nominal mass range
+        fHistoJetPtVsFragPerpCone[fiCut]->Fill(z, ptJet, fWeightJetJetMC);
+      } else if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelectedByMassCut(pi0cand, 1)) { // sideband
+        fHistoJetPtVsFragPerpCone_SB[fiCut]->Fill(z, ptJet, fWeightJetJetMC);
+      }
+
+    } // end isInJet in perpendicular direction
+  }   // end mesonIsSelected
+}
+
+//________________________________________________________________________
+float AliAnalysisTaskMesonJetCorrelation::GetFrag(AliAODConversionMother* Pi0Candidate, const int matchedJet, int isTrueJet)
+{
+  if (!((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->DoJetAnalysis()) {
+    return 0;
+  }
+  if (matchedJet < 0) {
+    return 0;
+  }
+  float z = 0;
+  if (isTrueJet == 1) {
+    z = Pi0Candidate->Pt() / fTrueVectorJetPt[matchedJet];
+  } else if (isTrueJet == 2) {
+    z = Pi0Candidate->Pt() / fTrueVectorJetPartonPt[matchedJet];
+  } else {
+    z = Pi0Candidate->Pt() / fVectorJetPt[matchedJet];
+  }
+  return z;
+}
+
+//________________________________________________________________________
+float AliAnalysisTaskMesonJetCorrelation::GetFrag(AliAODMCParticle* Pi0Candidate, const int matchedJet, int isTrueJet)
+{
+  if (!((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->DoJetAnalysis()) {
+    return 0;
+  }
+  if (matchedJet < 0) {
+    return 0;
+  }
+  float z = 0;
+  if (isTrueJet) {
+    z = Pi0Candidate->Pt() / fTrueVectorJetPt[matchedJet];
+  } else if (isTrueJet == 2) {
+    z = Pi0Candidate->Pt() / fTrueVectorJetPartonPt[matchedJet];
+  } else {
+    z = Pi0Candidate->Pt() / fVectorJetPt[matchedJet];
+  }
+  return z;
+}
+
+//________________________________________________________________________
+/// \brief function to steer the background calculation. Either mixed events or rotation is called
+void AliAnalysisTaskMesonJetCorrelation::CalculateBackground()
+{
+  // cout << "CalculateBackground" << endl;
+  if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->DoGammaSwappForBg()) {
+    CalculateBackgroundSwapp();
+  } else {
+    CalculateBackgroundMix();
+  }
+}
+
+//________________________________________________________________________
+/// \brief Calculate Mixed event distribution. This depends on the mixing class EventMixPoolMesonJets. This new mixing technique shifts the events such that the axis of the leading Jet overlaps and as such, the mixing should be more realistic
+void AliAnalysisTaskMesonJetCorrelation::CalculateBackgroundMix()
+{
+  // cout << "CalculateBackgroundMix" << endl;
+  // Mix just within jets or shift event such that jet axes match
+  if (fIsCalo) {
+    for (unsigned int iCurrent = 0; iCurrent < fClusterCandidates.size(); iCurrent++) {
+      AliAODConversionPhoton* currentEventGamma = (AliAODConversionPhoton*)(fClusterCandidates.at(iCurrent));
+
+      for (unsigned int iMix = 0; iMix < fEventMix->GetNBGEvents(fMaxPtJet); iMix++) {
+
+        std::vector<std::unique_ptr<AliAODConversionPhoton>> vecGammaMix = fEventMix->getPhotonsRotated(iMix, fMaxPtJet, fHighestJetVector, true);
+        for (const auto& gammaMix : vecGammaMix) {
+          int cellID = ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetCaloCellIdFromEtaPhi(gammaMix->GetPhotonEta(), static_cast<double>((gammaMix->GetPhotonPhi() < 0) ? gammaMix->GetPhotonPhi() + TMath::Pi() * 2. : gammaMix->GetPhotonPhi()));
+          if (!(((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->CheckDistanceToBadChannelSwapping(cellID, fInputEvent, ((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->GetDistanceToBorderForBg()))) {
+            std::unique_ptr<AliAODConversionMother> backgroundCandidate(new AliAODConversionMother(gammaMix.get(), ((AliAODConversionPhoton*)currentEventGamma)));
+
+            if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelected(backgroundCandidate.get(), kFALSE, ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift(), cellID, ((AliAODConversionPhoton*)currentEventGamma)->GetLeadingCellID())) {
+              // Fill histograms here
+              FillInvMassBackHistograms(backgroundCandidate.get());
+            }
+          }
+        }
+      }
+    }
+  } else if (fIsConvCalo) { // for now take the rotated clusters
+    for (unsigned int iCurrent = 0; iCurrent < fGammaCandidates.size(); iCurrent++) {
+      AliAODConversionPhoton* currentEventGamma = (AliAODConversionPhoton*)(fGammaCandidates.at(iCurrent));
+
+      for (unsigned int iMix = 0; iMix < fEventMix->GetNBGEvents(fMaxPtJet); iMix++) {
+
+        std::vector<std::unique_ptr<AliAODConversionPhoton>> vecGammaMix = fEventMix->getPhotonsRotated(iMix, fMaxPtJet, fHighestJetVector, true);
+        for (const auto& gammaMix : vecGammaMix) {
+          int cellID = ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetCaloCellIdFromEtaPhi(gammaMix->GetPhotonEta(), static_cast<double>((gammaMix->GetPhotonPhi() < 0) ? gammaMix->GetPhotonPhi() + TMath::Pi() * 2. : gammaMix->GetPhotonPhi()));
+          if (!(((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->CheckDistanceToBadChannelSwapping(cellID, fInputEvent, ((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->GetDistanceToBorderForBg()))) {
+
+            std::unique_ptr<AliAODConversionMother> backgroundCandidate(new AliAODConversionMother(gammaMix.get(), ((AliAODConversionPhoton*)currentEventGamma)));
+
+            if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelected(backgroundCandidate.get(), kFALSE, ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift(), cellID, -1)) {
+              // Fill histograms here
+              FillInvMassBackHistograms(backgroundCandidate.get());
+            }
+          }
+        }
+      }
+    }
+  } else if (fIsConv) {
+    for (unsigned int iCurrent = 0; iCurrent < fGammaCandidates.size(); iCurrent++) {
+      AliAODConversionPhoton* currentEventGamma = (AliAODConversionPhoton*)(fGammaCandidates.at(iCurrent));
+
+      for (unsigned int iMix = 0; iMix < fEventMix->GetNBGEvents(fMaxPtJet); iMix++) {
+
+        std::vector<std::unique_ptr<AliAODConversionPhoton>> vecGammaMix = fEventMix->getPhotonsRotated(iMix, fMaxPtJet, fHighestJetVector, false);
+        for (const auto& gammaMix : vecGammaMix) {
+
+          if (fabs(gammaMix->Eta()) > ((AliConversionPhotonCuts*)fConvCutArray->At(fiCut))->GetEtaCut()) {
+            std::unique_ptr<AliAODConversionMother> backgroundCandidate(new AliAODConversionMother(gammaMix.get(), ((AliAODConversionPhoton*)currentEventGamma)));
+
+            if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelected(backgroundCandidate.get(), kFALSE, ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift(), -1, -1)) {
+              // Fill histograms here
+              FillInvMassBackHistograms(backgroundCandidate.get());
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+//________________________________________________________________________
+/// \brief Calculate the rotation background and fill background histograms (Inv mass vs. pT) (Details of steering implemented in AliConversionMesonCuts)
+void AliAnalysisTaskMesonJetCorrelation::CalculateBackgroundSwapp()
+{
+  // cout << "CalculateBackgroundSwapp" << endl;
+
+  std::vector<std::array<Double_t, 2>> vSwappingInvMassPT;
+  std::vector<std::array<Double_t, 2>> vSwappingInvMassPTAlphaCut;
+  vSwappingInvMassPT.clear();
+  vSwappingInvMassPTAlphaCut.clear();
+  vSwappingInvMassPT.resize(0);
+  vSwappingInvMassPTAlphaCut.resize(0);
+
+  // curcial requirement is that the event has at least 3 cluster candidates
+  if (fIsCalo) {
+    // needs at least three clusters
+    if (fClusterCandidates.size() <= 2)
+      return;
+    for (unsigned int iCurrent1 = 0; iCurrent1 < fClusterCandidates.size(); iCurrent1++) {
+
+      AliAODConversionPhoton* currentEventGoodV0Temp1 = (AliAODConversionPhoton*)(fClusterCandidates.at(iCurrent1));
+
+      for (unsigned int iCurrent2 = iCurrent1 + 1; iCurrent2 < fClusterCandidates.size(); iCurrent2++) {
+        AliAODConversionPhoton* currentEventGoodV0Temp2 = (AliAODConversionPhoton*)(fClusterCandidates.at(iCurrent2));
+
+        std::array<std::unique_ptr<AliAODConversionPhoton>, 2> swappedGammas = GetGammasSwapped(currentEventGoodV0Temp1, currentEventGoodV0Temp2);
+        if (!swappedGammas[0].get())
+          continue;
+
+        std::array<int, 2> cellIDRotatedPhoton{
+          ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetCaloCellIdFromEtaPhi(swappedGammas[0]->GetPhotonEta(), static_cast<double>((swappedGammas[0]->GetPhotonPhi() < 0) ? swappedGammas[0]->GetPhotonPhi() + TMath::Pi() * 2. : swappedGammas[0]->GetPhotonPhi())),
+          ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetCaloCellIdFromEtaPhi(swappedGammas[1]->GetPhotonEta(), static_cast<double>((swappedGammas[1]->GetPhotonPhi() < 0) ? swappedGammas[1]->GetPhotonPhi() + TMath::Pi() * 2. : swappedGammas[1]->GetPhotonPhi()))};
+
+        for (auto const& kCurrentClusterCandidates : fClusterCandidates) {
+          for (unsigned int iSwapped = 0; iSwapped < swappedGammas.size(); ++iSwapped) {
+            if (swappedGammas[iSwapped].get() == ((AliAODConversionPhoton*)kCurrentClusterCandidates)) {
+              continue;
+            }
+            std::unique_ptr<AliAODConversionMother> backgroundCandidate(new AliAODConversionMother(swappedGammas[iSwapped].get(), ((AliAODConversionPhoton*)kCurrentClusterCandidates)));
+            if (!(((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->CheckDistanceToBadChannelSwapping(cellIDRotatedPhoton[iSwapped], fInputEvent, ((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->GetDistanceToBorderForBg())) && swappedGammas[iSwapped]->P() > ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetMinClusterEnergy()) {
+              if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelected(backgroundCandidate.get(), kFALSE, ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift(), cellIDRotatedPhoton[iSwapped], ((AliAODConversionPhoton*)kCurrentClusterCandidates)->GetLeadingCellID())) {
+                // Fill histograms here
+                FillInvMassBackHistograms(backgroundCandidate.get());
+              }
+            }
+          }
+        }
+      }
+    }
+  } else if (fIsConvCalo) {
+    // gamma1 is cluster, gamma2 is V0
+    for (unsigned int iCurrent1 = 0; iCurrent1 < fClusterCandidates.size(); iCurrent1++) {
+      AliAODConversionPhoton* currentEventGoodV0Temp1 = (AliAODConversionPhoton*)(fClusterCandidates.at(iCurrent1));
+
+      for (unsigned int iCurrent2 = iCurrent1 + 1; iCurrent2 < fGammaCandidates.size(); iCurrent2++) {
+        AliAODConversionPhoton* currentEventGoodV0Temp2 = (AliAODConversionPhoton*)(fGammaCandidates.at(iCurrent2));
+
+        std::array<std::unique_ptr<AliAODConversionPhoton>, 2> swappedGammas = GetGammasSwapped(currentEventGoodV0Temp1, currentEventGoodV0Temp2);
+        if (!swappedGammas[0].get())
+          continue;
+
+        int cellIDRotatedPhoton = ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetCaloCellIdFromEtaPhi(swappedGammas[0]->GetPhotonEta(), static_cast<double>((swappedGammas[0]->GetPhotonPhi() < 0) ? swappedGammas[0]->GetPhotonPhi() + TMath::Pi() * 2. : swappedGammas[0]->GetPhotonPhi()));
+
+        for (auto const& kCurrentClusterCandidates : fClusterCandidates) {
+          if (swappedGammas[1].get() == ((AliAODConversionPhoton*)kCurrentClusterCandidates)) {
+            continue;
+          }
+
+          if (swappedGammas[1]->Eta() < ((AliConversionPhotonCuts*)fConvCutArray->At(fiCut))->GetEtaCut()) {
+            std::unique_ptr<AliAODConversionMother> backgroundCandidate(new AliAODConversionMother(swappedGammas[1].get(), ((AliAODConversionPhoton*)kCurrentClusterCandidates)));
+
+            if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelected(backgroundCandidate.get(), kFALSE, ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift(), -1, ((AliAODConversionPhoton*)kCurrentClusterCandidates)->GetLeadingCellID())) {
+              // Fill histograms here
+              FillInvMassBackHistograms(backgroundCandidate.get());
+            }
+          }
+        }
+        for (auto const& kCurrentPhotonCandidates : fGammaCandidates) {
+          if (swappedGammas[0].get() == ((AliAODConversionPhoton*)kCurrentPhotonCandidates)) {
+            continue;
+          }
+
+          std::unique_ptr<AliAODConversionMother> backgroundCandidate(new AliAODConversionMother(swappedGammas[0].get(), ((AliAODConversionPhoton*)kCurrentPhotonCandidates)));
+
+          if (!(((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->CheckDistanceToBadChannelSwapping(cellIDRotatedPhoton, fInputEvent, ((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->GetDistanceToBorderForBg())) && swappedGammas[0]->P() > ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetMinClusterEnergy()) {
+            if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelected(backgroundCandidate.get(), kFALSE, ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift(), cellIDRotatedPhoton, -1)) {
+              // Fill histograms here
+              FillInvMassBackHistograms(backgroundCandidate.get());
+            }
+          }
+        }
+      }
+    }
+  } else if (fIsConv) {
+    // needs at least three photons
+    if (fGammaCandidates.size() <= 2)
+      return;
+    for (unsigned int iCurrent1 = 0; iCurrent1 < fGammaCandidates.size(); iCurrent1++) {
+      AliAODConversionPhoton* currentEventGoodV0Temp1 = (AliAODConversionPhoton*)(fGammaCandidates.at(iCurrent1));
+
+      for (unsigned int iCurrent2 = iCurrent1 + 1; iCurrent2 < fGammaCandidates.size(); iCurrent2++) {
+        AliAODConversionPhoton* currentEventGoodV0Temp2 = (AliAODConversionPhoton*)(fGammaCandidates.at(iCurrent2));
+
+        std::array<std::unique_ptr<AliAODConversionPhoton>, 2> swappedGammas = GetGammasSwapped(currentEventGoodV0Temp1, currentEventGoodV0Temp2);
+
+        if (!swappedGammas[0].get())
+          continue;
+
+        for (auto const& kCurrentClusterCandidates : fGammaCandidates) {
+
+          for (unsigned int iSwapped = 0; iSwapped < swappedGammas.size(); ++iSwapped) {
+
+            if (swappedGammas[iSwapped].get() == ((AliAODConversionPhoton*)kCurrentClusterCandidates)) {
+              continue;
+            }
+
+            std::unique_ptr<AliAODConversionMother> backgroundCandidate(new AliAODConversionMother(swappedGammas[iSwapped].get(), ((AliAODConversionPhoton*)kCurrentClusterCandidates)));
+            if (swappedGammas[iSwapped]->Eta() < ((AliConversionPhotonCuts*)fConvCutArray->At(fiCut))->GetEtaCut()) {
+              if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelected(backgroundCandidate.get(), kFALSE, ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift(), -1, -1)) {
+                // Fill histograms here
+                FillInvMassBackHistograms(backgroundCandidate.get());
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+//__________________________________________________________________________
+/// \brief function to fill all histograms related to the meson background (estimated with rotation, mixed evt etc.)
+/// \param backgroundCandidate particle reconstructed from two photons containing the mass, pT etc.
+void AliAnalysisTaskMesonJetCorrelation::FillInvMassBackHistograms(AliAODConversionMother* backgroundCandidate)
+{
+
+  int matchedJet = -1;
+  double RJetPi0Cand = 0;
+  if (!((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->IsParticleInJet(fVectorJetEta, fVectorJetPhi, fConvJetReader->Get_Jet_Radius(), backgroundCandidate->Eta(), backgroundCandidate->Phi(), matchedJet, RJetPi0Cand)) {
+    return;
+  }
+
+  //_______ Standard Inv Mass vs. pT background histo _______________
+  fHistoInvMassVsPtBack[fiCut]->Fill(backgroundCandidate->M(), backgroundCandidate->Pt(), fWeightJetJetMC);
+
+  //_______ Fill Inv Mass vs. Z for purity correction _______________
+  float ptJet = (matchedJet < 0) ? 0 : fVectorJetPt[matchedJet];
+  float z = GetFrag(backgroundCandidate, matchedJet, false);
+  fRespMatrixHandlerMesonBackInvMassVsZ[fiCut]->Fill(ptJet, 0.5, backgroundCandidate->M(), z); // Inv Mass vs. Z in Jet Pt_rec bins. Needed to subtract background in the Z-distribution
+}
+
+//__________________________________________________________________________
+/// \brief Function to rotate two photons around their combined 4-momentum axis. Main function for the rotation background. Details of the swapping are steered via AliConversionMesonCuts
+/// \param currentEventGoodV0Temp1 original photon 1 (not rotated)
+/// \param currentEventGoodV0Temp2 original photon 2 (not rotated)
+std::array<std::unique_ptr<AliAODConversionPhoton>, 2> AliAnalysisTaskMesonJetCorrelation::GetGammasSwapped(AliAODConversionPhoton* currentEventGoodV0Temp1, AliAODConversionPhoton* currentEventGoodV0Temp2)
+{
+
+  Double_t rotationAngle = TMath::Pi() / 2.0; //0.78539816339; // rotaion angle 90°
+
+  // Needed for TGenPhaseSpace
+  TVector3 tvEtaPhigamma1, tvEtaPhigamma2, tvEtaPhigamma1Decay, tvEtaPhigamma2Decay, tvNormBeforeDecay, tvNormAfterDecay;
+  Float_t asymBeforeDecay = 0.;
+  Float_t asymAfterDecay = 0.;
+  Double_t massGamma[2] = {0, 0};
+
+  TLorentzVector lvRotationPhoton1; // photon candidates which get rotated
+  TLorentzVector lvRotationPhoton2; // photon candidates which get rotated
+  TVector3 lvRotationPion;          // reconstructed mother particle from the two photons
+
+  lvRotationPhoton1.SetX(currentEventGoodV0Temp1->Px());
+  lvRotationPhoton1.SetY(currentEventGoodV0Temp1->Py());
+  lvRotationPhoton1.SetZ(currentEventGoodV0Temp1->Pz());
+  lvRotationPhoton1.SetE(currentEventGoodV0Temp1->E());
+
+  lvRotationPhoton2.SetX(currentEventGoodV0Temp2->Px());
+  lvRotationPhoton2.SetY(currentEventGoodV0Temp2->Py());
+  lvRotationPhoton2.SetZ(currentEventGoodV0Temp2->Pz());
+  lvRotationPhoton2.SetE(currentEventGoodV0Temp2->E());
+
+  lvRotationPion = (lvRotationPhoton1 + lvRotationPhoton2).Vect();
+
+  // rotate both photons around the momentum vector of their hypothetical mother particle
+  if ((((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->GammaSwappMethodBg() == 0 || ((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->GammaSwappMethodBg() == 1)) {
+    if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->GammaSwappMethodBg() == 0)
+      rotationAngle = TMath::Pi() / 2.0;                                                        // rotate by 90 degree
+    else if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->GammaSwappMethodBg() == 1) { // rotate by random angle between
+      Double_t temp = (fRandom.Rndm() < 0.5) ? 0 : TMath::Pi();
+      rotationAngle = temp + TMath::Pi() / 3.0 + fRandom.Rndm() * TMath::Pi() / 3.0;
+    }
+    lvRotationPhoton1.Rotate(rotationAngle, lvRotationPion);
+    lvRotationPhoton2.Rotate(rotationAngle, lvRotationPion);
+  } else if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->GammaSwappMethodBg() >= 10) { // generate new decay with TGenPhaseSpace
+    if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->GammaSwappMethodBg() == 11) {
+      tvEtaPhigamma1 = lvRotationPhoton1.Vect();
+      tvEtaPhigamma2 = lvRotationPhoton2.Vect();
+      tvNormBeforeDecay = tvEtaPhigamma1.Cross(tvEtaPhigamma2);
+      asymBeforeDecay = fabs((lvRotationPhoton1.E() - lvRotationPhoton2.E()) / (lvRotationPhoton1.E() + lvRotationPhoton2.E()));
+    }
+
+    TLorentzVector lvRotationMother = lvRotationPhoton1 + lvRotationPhoton2;
+    fGenPhaseSpace.SetDecay(lvRotationMother, 2, massGamma);
+    fGenPhaseSpace.Generate();
+    lvRotationPhoton1 = *fGenPhaseSpace.GetDecay(0);
+    lvRotationPhoton2 = *fGenPhaseSpace.GetDecay(1);
+
+    if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->GammaSwappMethodBg() == 11) {
+      tvEtaPhigamma1Decay = lvRotationPhoton1.Vect();
+      tvEtaPhigamma2Decay = lvRotationPhoton2.Vect();
+      tvNormAfterDecay = tvEtaPhigamma1Decay.Cross(tvEtaPhigamma2Decay); // norm vector to decay plane
+      asymAfterDecay = fabs((lvRotationPhoton1.E() - lvRotationPhoton2.E()) / (lvRotationPhoton1.E() + lvRotationPhoton2.E()));
+      // check if decay is nearly the same as original decay: if yes continue with next decay
+      if ((tvNormAfterDecay.Angle(tvNormBeforeDecay) < 20 * TMath::Pi() / 180. || tvNormAfterDecay.Angle(tvNormBeforeDecay) > 340 * TMath::Pi() / 180.) && (fabs(asymBeforeDecay - asymAfterDecay) < 0.05)) {
+        std::array<std::unique_ptr<AliAODConversionPhoton>, 2> gammasNULL{nullptr, nullptr};
+        return gammasNULL;
+      }
+    }
+  }
+  std::array<std::unique_ptr<AliAODConversionPhoton>, 2> gammas{std::make_unique<AliAODConversionPhoton>(new AliAODConversionPhoton(&lvRotationPhoton1)), std::make_unique<AliAODConversionPhoton>(new AliAODConversionPhoton(&lvRotationPhoton2))};
+  return gammas;
+}
+
+bool AliAnalysisTaskMesonJetCorrelation::MCParticleIsSelected(AliAODMCParticle* particle1, AliAODMCParticle* particle2, bool checkConversion)
+{
+  if (fIsCalo) {
+    if (MCParticleIsSelected(particle1, false, false) && MCParticleIsSelected(particle2, false, false)) {
+      return true;
+    }
+  } else if (fIsConv) {
+    if (MCParticleIsSelected(particle1, true, checkConversion) && MCParticleIsSelected(particle2, true, checkConversion)) {
+      return true;
+    }
+  } else if (fIsConvCalo) {
+    if (MCParticleIsSelected(particle1, false, false) && MCParticleIsSelected(particle2, true, checkConversion)) {
+      return true;
+    } else if (MCParticleIsSelected(particle2, false, false) && MCParticleIsSelected(particle1, true, checkConversion)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool AliAnalysisTaskMesonJetCorrelation::MCParticleIsSelected(AliAODMCParticle* particle, bool isConv, bool checkConversion)
+{
+  if (isConv) {
+    return ((AliConversionPhotonCuts*)fConvCutArray->At(fiCut))->PhotonIsSelectedAODMC(particle, fAODMCTrackArray, checkConversion);
+  } else {
+    return ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->ClusterIsSelectedAODMC(particle, fAODMCTrackArray);
+  }
+}
+
+// bool AliAnalysisTaskMesonJetCorrelation::IsParticleFromPartonFrag(AliAODMCParticle* particle, int idParton){
+//   if (((AliAODMCParticle*)fAODMCTrackArray->At(tmpGammaMotherlabel))->GetPdgCode() != 111 && ((AliAODMCParticle*)fAODMCTrackArray->At(tmpGammaMotherlabel))->GetPdgCode() != 221) {
+//         tmpGammaMotherlabel = ((AliAODMCParticle*)fAODMCTrackArray->At(tmpGammaMotherlabel))->GetMother();
+//       } else
+// }
+
+// ToDo: Fill histograms for jet stuff
+//________________________________________________________________________
+void AliAnalysisTaskMesonJetCorrelation::ProcessAODMCParticles(int isCurrentEventSelected)
+{
+
+  const AliVVertex* primVtxMC = fMCEvent->GetPrimaryVertex();
+  Double_t mcProdVtxX = primVtxMC->GetX();
+  Double_t mcProdVtxY = primVtxMC->GetY();
+  Double_t mcProdVtxZ = primVtxMC->GetZ();
+
+  if (!fAODMCTrackArray)
+    fAODMCTrackArray = dynamic_cast<TClonesArray*>(fInputEvent->FindListObject(AliAODMCParticle::StdBranchName()));
+  if (fAODMCTrackArray == NULL)
+    return;
+
+  // Check if MC generated particles should be filled for this event using the selected trigger
+  if (!((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsMCTriggerSelected(fInputEvent, fMCEvent)) {
+    return;
+  }
+
+  // Loop over all primary MC particle
+  for (Long_t i = 0; i < fAODMCTrackArray->GetEntriesFast(); i++) {
+
+    AliAODMCParticle* particle = static_cast<AliAODMCParticle*>(fAODMCTrackArray->At(i));
+    if (!particle)
+      continue;
+    int matchedJet = -1;
+    double RJetPi0Cand = 0;
+    if (!((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->IsParticleInJet(fTrueVectorJetEta, fTrueVectorJetPhi, fConvJetReader->Get_Jet_Radius(), particle->Eta(), particle->Phi(), matchedJet, RJetPi0Cand)) {
+      continue;
+    }
+
+    Bool_t isPrimary = ((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsConversionPrimaryAOD(fInputEvent, particle, mcProdVtxX, mcProdVtxY, mcProdVtxZ);
+    if (isPrimary) {
+
+      int isMCFromMBHeader = -1;
+      if (((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetSignalRejection() != 0) {
+        isMCFromMBHeader = ((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsParticleFromBGEvent(i, fMCEvent, fInputEvent, true);
+        if (isMCFromMBHeader == 0 && ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetSignalRejection() != 3)
+          continue;
+      }
+      // if(!((AliConversionPhotonCuts*)fConvCutArray->At(fiCut))->InPlaneOutOfPlaneCut(particle->Phi(),fEventPlaneAngle,kFALSE)) continue;
+
+      // check photons
+      if (MCParticleIsSelected(particle, fIsConv, false)) { // here we state that this is a conversion, however this also works for calo photons on generator level!
+        if (isCurrentEventSelected == 1) {
+          fHistoMCGammaPtNotTriggered[fiCut]->Fill(particle->Pt(), fWeightJetJetMC); // All MC Gamma
+        } else if (isCurrentEventSelected == 2) {
+          fHistoMCGammaPtNoVertex[fiCut]->Fill(particle->Pt(), fWeightJetJetMC); // All MC Gamma
+        }
+        fHistoMCAllGammaPt[fiCut]->Fill(particle->Pt(), fWeightJetJetMC); // All MC Gamma
+
+        if (!fDoLightOutput) {
+          if (particle->GetMother() > -1) { // Meson Decay Gamma
+            switch ((static_cast<AliAODMCParticle*>(fAODMCTrackArray->At(particle->GetMother())))->GetPdgCode()) {
+              case 111: // Pi0
+                fHistoMCDecayGammaPi0Pt[fiCut]->Fill(particle->Pt(), fWeightJetJetMC);
+                break;
+              case 113: // Rho0
+                fHistoMCDecayGammaRhoPt[fiCut]->Fill(particle->Pt(), fWeightJetJetMC);
+                break;
+              case 221: // Eta
+                fHistoMCDecayGammaEtaPt[fiCut]->Fill(particle->Pt(), fWeightJetJetMC);
+                break;
+              case 223: // Omega
+                fHistoMCDecayGammaOmegaPt[fiCut]->Fill(particle->Pt(), fWeightJetJetMC);
+                break;
+              case 331: // Eta'
+                fHistoMCDecayGammaEtapPt[fiCut]->Fill(particle->Pt(), fWeightJetJetMC);
+                break;
+              case 333: // Phi
+                fHistoMCDecayGammaPhiPt[fiCut]->Fill(particle->Pt(), fWeightJetJetMC);
+                break;
+              case 3212: // Sigma
+                fHistoMCDecayGammaSigmaPt[fiCut]->Fill(particle->Pt(), fWeightJetJetMC);
+                break;
+            }
+          }
+        }
+      } // end if photons
+      // check for photon conversions
+      // if(((AliConversionPhotonCuts*)fConvCutArray->At(fiCut))->PhotonIsSelectedAODMC(particle,fAODMCTrackArray,kTRUE)){
+      // for(int daughterIndex=particle->GetDaughterLabel(0);daughterIndex<=particle->GetDaughterLabel(1);daughterIndex++){
+      //   AliAODMCParticle *tmpDaughter = static_cast<AliAODMCParticle*>(fAODMCTrackArray->At(daughterIndex));
+      //   if(!tmpDaughter) continue;
+      // }
+      // if(!fDoLightOutput) fHistoMCConvGammaPt[fiCut]->Fill(particle->Pt(),fWeightJetJetMC);
+      // }
+
+      Double_t mesonY = 1.e30;
+      Double_t ratio = 0;
+      if (particle->E() != TMath::Abs(particle->Pz())) {
+        ratio = (particle->E() + particle->Pz()) / (particle->E() - particle->Pz());
+      }
+      if (!(ratio <= 0)) {
+        mesonY = particle->Y() - ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift();
+      }
+
+      if (!fDoLightOutput) {
+        if ((mesonY > ((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->GetRapidityCutValueMin()) && (mesonY < ((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->GetRapidityCutValueMax())) {
+          if (particle->GetPdgCode() == 211) { // positve pions
+            fHistoMCPrimaryPtvsSource[fiCut]->Fill(particle->Pt(), 0., fWeightJetJetMC);
+          } else if (particle->GetPdgCode() == -211) { // negative pions
+            fHistoMCPrimaryPtvsSource[fiCut]->Fill(particle->Pt(), 1., fWeightJetJetMC);
+          } else if (particle->GetPdgCode() == 321) { // positve kaons
+            fHistoMCPrimaryPtvsSource[fiCut]->Fill(particle->Pt(), 2., fWeightJetJetMC);
+          } else if (particle->GetPdgCode() == -321) { // negative kaons
+            fHistoMCPrimaryPtvsSource[fiCut]->Fill(particle->Pt(), 3., fWeightJetJetMC);
+          } else if (TMath::Abs(particle->GetPdgCode()) == 310) { // K0s
+            fHistoMCPrimaryPtvsSource[fiCut]->Fill(particle->Pt(), 4., fWeightJetJetMC);
+          } else if (TMath::Abs(particle->GetPdgCode()) == 130) { // K0l
+            fHistoMCPrimaryPtvsSource[fiCut]->Fill(particle->Pt(), 5., fWeightJetJetMC);
+          } else if (TMath::Abs(particle->GetPdgCode()) == 3122) { // Lambda/ AntiLambda
+            fHistoMCPrimaryPtvsSource[fiCut]->Fill(particle->Pt(), 6., fWeightJetJetMC);
+          }
+        }
+      }
+      // check neutral mesons
+      if (particle->GetPdgCode() == fMesonPDGCode) {
+
+        if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))
+              ->MesonIsSelectedAODMC(particle, fAODMCTrackArray, ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift())) {
+
+          AliAODMCParticle* daughter0 = static_cast<AliAODMCParticle*>(fAODMCTrackArray->At(particle->GetDaughterLabel(0)));
+          AliAODMCParticle* daughter1 = static_cast<AliAODMCParticle*>(fAODMCTrackArray->At(particle->GetDaughterLabel(1)));
+          Float_t weighted = 1;
+          if (((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsParticleFromBGEvent(i, fMCEvent, fInputEvent)) {
+            if (particle->Pt() > 0.005) {
+              weighted = ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetWeightForMeson(i, 0x0, fInputEvent);
+            }
+          }
+
+          // Double_t mesonY = 1.e30;
+          // Double_t ratio = 0;
+          if (particle->E() != TMath::Abs(particle->Pz())) {
+            ratio = (particle->E() + particle->Pz()) / (particle->E() - particle->Pz());
+          }
+          // if (!(ratio <= 0)) {
+          //   mesonY = particle->Y() - ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift();
+          // }
+
+          if (isCurrentEventSelected == 1)
+            fHistoMCMesonPtNotTriggered[fiCut]->Fill(particle->Pt(), weighted * fWeightJetJetMC); // All MC Pi0 in not triggered collisions
+          else if (isCurrentEventSelected == 2)
+            fHistoMCMesonPtNoVertex[fiCut]->Fill(particle->Pt(), weighted * fWeightJetJetMC); // All MC Pi0 in not triggered collisions
+          fHistoMCMesonPt[fiCut]->Fill(particle->Pt(), weighted * fWeightJetJetMC);
+          if (fIsMC > 1)
+            fHistoMCMesonWOEvtWeightPt[fiCut]->Fill(particle->Pt());
+
+          //------------------------
+          // Fill histograms for meson fragmentation
+          //------------------------
+          if (matchedJet >= 0) {
+            float z_jet = GetFrag(particle, matchedJet, 1);
+            fHistoMCJetPtVsFrag[fiCut]->Fill(z_jet, fTrueVectorJetPt[matchedJet], weighted * fWeightJetJetMC);
+            float z_parton = GetFrag(particle, matchedJet, 2);
+            fHistoMCPartonPtVsFrag[fiCut]->Fill(z_parton, fTrueVectorJetPartonPt[matchedJet], weighted * fWeightJetJetMC);
+
+            if (IsParticleFromPartonFrag(particle, fTrueVectorJetPartonID[matchedJet])) {
+              fHistoMCJetPtVsFragTrueParton[fiCut]->Fill(z_jet, fTrueVectorJetPt[matchedJet], weighted * fWeightJetJetMC);
+              fHistoMCPartonPtVsFragTrueParton[fiCut]->Fill(z_parton, fTrueVectorJetPartonPt[matchedJet], weighted * fWeightJetJetMC);
+            }
+          }
+          // Check the acceptance for both gammas
+          if (MCParticleIsSelected(daughter0, daughter1, false)) {
+            // if(((AliConversionPhotonCuts*)fConvCutArray->At(fiCut))->PhotonIsSelectedAODMC(daughter0,fAODMCTrackArray,kFALSE) &&
+            // ((AliConversionPhotonCuts*)fConvCutArray->At(fiCut))->PhotonIsSelectedAODMC(daughter1,fAODMCTrackArray,kFALSE)  &&
+            // ((AliConversionPhotonCuts*)fConvCutArray->At(fiCut))->InPlaneOutOfPlaneCut(daughter0->Phi(),fEventPlaneAngle,kFALSE) &&
+            // ((AliConversionPhotonCuts*)fConvCutArray->At(fiCut))->InPlaneOutOfPlaneCut(daughter1->Phi(),fEventPlaneAngle,kFALSE)){
+            // check acceptance of gammas
+            if (CheckAcceptance(daughter0, daughter1)) {
+              fHistoMCMesonInAccPt[fiCut]->Fill(particle->Pt(), weighted * fWeightJetJetMC); // MC Pi0 with gamma in acc
+              if (isCurrentEventSelected == 1)
+                fHistoMCMesonInAccPtNotTriggered[fiCut]->Fill(particle->Pt(), weighted * fWeightJetJetMC); // MC Pi0 with gamma in acc for not triggered events
+              if (fIsMC > 1)
+                fHistoMCMesonWOEvtWeightInAccPt[fiCut]->Fill(particle->Pt()); // MC Pi0 with gamma in acc wo any weight
+            }
+          }
+        }
+      }
+    } else {
+      // fill secondary histograms
+      int isMCFromMBHeader = -1;
+      if (((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetSignalRejection() != 0) {
+        isMCFromMBHeader = ((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsParticleFromBGEvent(i, fMCEvent, fInputEvent);
+        if (isMCFromMBHeader == 0 && ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetSignalRejection() != 3)
+          continue;
+      }
+      if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelectedAODMC(particle, fAODMCTrackArray, ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift())) {
+        AliAODMCParticle* daughter0 = static_cast<AliAODMCParticle*>(fAODMCTrackArray->At(particle->GetDaughterLabel(0)));
+        AliAODMCParticle* daughter1 = static_cast<AliAODMCParticle*>(fAODMCTrackArray->At(particle->GetDaughterLabel(1)));
+        AliAODMCParticle* mother = static_cast<AliAODMCParticle*>(fAODMCTrackArray->At(particle->GetMother()));
+        int pdgCode = mother->GetPdgCode();
+        int source = -1;
+        if (particle->GetPdgCode() == fMesonPDGCode) {
+          source = ((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->GetSourceClassification(fMesonPDGCode, pdgCode);
+          fHistoMCSecMesonPtvsSource[fiCut]->Fill(particle->Pt(), source, fWeightJetJetMC); // All MC Pi0
+          fHistoMCSecMesonSource[fiCut]->Fill(pdgCode);
+
+          //------------------------
+          // Fill histograms for meson fragmentation
+          //------------------------
+          if (matchedJet >= 0) {
+            float z_jet = GetFrag(particle, matchedJet, 1);
+            fHistoMCJetPtVsFrag_Sec[fiCut]->Fill(z_jet, fTrueVectorJetPt[matchedJet], fWeightJetJetMC);
+          }
+
+          // check if mesons where within acceptance
+          // if( ((AliConversionPhotonCuts*)fConvCutArray->At(fiCut))->PhotonIsSelectedAODMC(daughter0,fAODMCTrackArray,kFALSE) &&
+          //     ((AliConversionPhotonCuts*)fConvCutArray->At(fiCut))->PhotonIsSelectedAODMC(daughter1,fAODMCTrackArray,kFALSE)  &&
+          //     ((AliConversionPhotonCuts*)fConvCutArray->At(fiCut))->InPlaneOutOfPlaneCut(daughter0->Phi(),fEventPlaneAngle,kFALSE) &&
+          //     ((AliConversionPhotonCuts*)fConvCutArray->At(fiCut))->InPlaneOutOfPlaneCut(daughter1->Phi(),fEventPlaneAngle,kFALSE)){
+          if (MCParticleIsSelected(daughter0, daughter1, false)) {
+            if (CheckAcceptance(daughter0, daughter1)) {
+              fHistoMCSecMesonInAccPtvsSource[fiCut]->Fill(particle->Pt(), source, fWeightJetJetMC); // All MC Pi0
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+//__________________________________________________________________________________________________________
+bool AliAnalysisTaskMesonJetCorrelation::IsParticleFromPartonFrag(AliAODMCParticle* particle, int idParton)
+{
+  int motherLabel = particle->GetMother();
+
+  for (int i = 0; i < 50; ++i) {
+    if (motherLabel == idParton) {
+      return true;
+    }
+    auto tmpPart = static_cast<AliAODMCParticle*>(fAODMCTrackArray->At(motherLabel));
+    if (!tmpPart) {
+      return false;
+    }
+    if (tmpPart->GetPdgCode() == 90) {
+      return false;
+    }
+    motherLabel = tmpPart->GetMother();
+    if (motherLabel < 0) {
+      return false;
+    }
+  }
+  return false;
+}
+
+//__________________________________________________________________________________________________________
+bool AliAnalysisTaskMesonJetCorrelation::CheckAcceptance(AliAODMCParticle* gamma0, AliAODMCParticle* gamma1)
+{
+  if (fIsCalo) {
+    if (((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->ClusterIsSelectedAODMC(gamma0, fAODMCTrackArray) &&
+        ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->ClusterIsSelectedAODMC(gamma1, fAODMCTrackArray)) {
+      return true;
+    } else {
+      return false;
+    }
+  } else if (fIsConvCalo) {
+    if (((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->ClusterIsSelectedAODMC(gamma0, fAODMCTrackArray) ||
+        ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->ClusterIsSelectedAODMC(gamma1, fAODMCTrackArray)) {
+      return true;
+    } else {
+      return false;
+    }
+  } else if (fIsConv) {
+    return true;
+  }
+  return false;
+}
+
+//________________________________________________________________________
+int AliAnalysisTaskMesonJetCorrelation::GetPhotonMotherLabel(AliAODConversionPhoton* gammaCand, int& convertedPhotonLabel, bool isCaloPhoton)
+{
+
+  int gammaMotherLabel = -1;
+
+  if (isCaloPhoton) {
+    int gammaMCLabel = gammaCand->GetCaloPhotonMCLabel(0); // get most probable MC label
+    int tmpGammaMotherlabel = -1;
+    convertedPhotonLabel = -1; // default is -1
+
+    // check if gamma0 originates from pi0 decay
+    AliAODMCParticle* gammaMC = 0x0;
+    if (gammaMCLabel != -1) { // Gamma is Combinatorial; MC Particles don't belong to the same Mother
+      // Daughters Gamma 0
+      gammaMC = static_cast<AliAODMCParticle*>(fAODMCTrackArray->At(gammaMCLabel));
+
+      if (gammaCand->IsLargestComponentPhoton() || gammaCand->IsLargestComponentElectron()) { // largest component is electro magnetic
+
+        tmpGammaMotherlabel = gammaMC->GetMother();
+        // get mother of interest (pi0 or eta)
+        if (gammaCand->IsLargestComponentPhoton()) { // for photons its the direct mother
+          gammaMotherLabel = gammaMC->GetMother();
+        } else if (gammaCand->IsLargestComponentElectron()) { // for electrons its either the direct mother or for conversions the grandmother
+          if (gammaCand->IsConversion()) {
+            convertedPhotonLabel = gammaMC->GetMother();
+            AliAODMCParticle* gammaGrandMotherMC = static_cast<AliAODMCParticle*>(fAODMCTrackArray->At(gammaMC->GetMother()));
+            gammaMotherLabel = gammaGrandMotherMC->GetMother();
+          } else
+            gammaMotherLabel = gammaMC->GetMother();
+        }
+      }
+    }
+
+    int SaftyLoopCounter = 0;
+    while (tmpGammaMotherlabel > 0 && SaftyLoopCounter < 100) {
+      SaftyLoopCounter++;
+      if (((AliAODMCParticle*)fAODMCTrackArray->At(tmpGammaMotherlabel))->GetPdgCode() != 111 && ((AliAODMCParticle*)fAODMCTrackArray->At(tmpGammaMotherlabel))->GetPdgCode() != 221) {
+        tmpGammaMotherlabel = ((AliAODMCParticle*)fAODMCTrackArray->At(tmpGammaMotherlabel))->GetMother();
+      } else {
+        gammaMotherLabel = tmpGammaMotherlabel;
+        break;
+      }
+    }
+  } else {
+    AliAODMCParticle* positiveMC = static_cast<AliAODMCParticle*>(fAODMCTrackArray->At(gammaCand->GetMCLabelPositive()));
+    AliAODMCParticle* negativeMC = static_cast<AliAODMCParticle*>(fAODMCTrackArray->At(gammaCand->GetMCLabelNegative()));
+
+    Int_t gamma0MCLabel = -1;
+    if (!positiveMC || !negativeMC) {
+      return -1;
+    }
+
+    if (gammaCand->IsTrueConvertedPhoton()) {
+      gamma0MCLabel = positiveMC->GetMother();
+      AliAODMCParticle* gammaMC0 = static_cast<AliAODMCParticle*>(fAODMCTrackArray->At(gamma0MCLabel));
+      gammaMotherLabel = gammaMC0->GetMother();
+    }
+
+    Int_t tmpGammaMotherlabel = gammaMotherLabel;
+    Int_t SaftyLoopCounter = 0;
+    while (tmpGammaMotherlabel > 0 && SaftyLoopCounter < 100) {
+      SaftyLoopCounter++;
+      if (((AliAODMCParticle*)fAODMCTrackArray->At(tmpGammaMotherlabel))->GetPdgCode() != 111 && ((AliAODMCParticle*)fAODMCTrackArray->At(tmpGammaMotherlabel))->GetPdgCode() != 221) {
+        tmpGammaMotherlabel = ((AliAODMCParticle*)fAODMCTrackArray->At(tmpGammaMotherlabel))->GetMother();
+      } else {
+        gammaMotherLabel = tmpGammaMotherlabel;
+        break;
+      }
+    }
+  }
+  return gammaMotherLabel;
+}
+
+//________________________________________________________________________
+void AliAnalysisTaskMesonJetCorrelation::ProcessTrueClusterCandidatesAOD(AliAODConversionPhoton* TruePhotonCandidate)
+{
+  // const AliVVertex* primVtxMC = fMCEvent->GetPrimaryVertex();
+  // Double_t mcProdVtxX = primVtxMC->GetX();
+  // Double_t mcProdVtxY = primVtxMC->GetY();
+  // Double_t mcProdVtxZ = primVtxMC->GetZ();
+
+  Double_t tempPhotonWeight = fWeightJetJetMC;
+  AliAODMCParticle* Photon = NULL;
+  if (!fAODMCTrackArray)
+    fAODMCTrackArray = dynamic_cast<TClonesArray*>(fInputEvent->FindListObject(AliAODMCParticle::StdBranchName()));
+  if (fAODMCTrackArray) {
+    if (TruePhotonCandidate->GetIsCaloPhoton() == 0)
+      AliFatal("CaloPhotonFlag has not been set task will abort");
+    if (TruePhotonCandidate->GetNCaloPhotonMCLabels() > 0)
+      Photon = (AliAODMCParticle*)fAODMCTrackArray->At(TruePhotonCandidate->GetCaloPhotonMCLabel(0));
+    else
+      return;
+  } else {
+    AliInfo("AODMCTrackArray could not be loaded");
+    return;
+  }
+
+  if (Photon == NULL) {
+    return;
+  }
+  // int pdgCodeParticle = Photon->GetPdgCode();
+  TruePhotonCandidate->SetCaloPhotonMCFlagsAOD(fAODMCTrackArray, fEnableSortForClusMC);
+
+  // Set the jetjet weight to 1 in case the cluster orignated from the minimum bias header
+  // if (fIsMC>0 && ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetSignalRejection() == 4){
+  //   if ( ((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsParticleFromBGEvent(TruePhotonCandidate->GetCaloPhotonMCLabel(0), fMCEvent, fInputEvent) == 2) tempPhotonWeight = 1;
+  // }
+
+  // True Photon
+  if (TruePhotonCandidate->IsLargestComponentPhoton() || (TruePhotonCandidate->IsLargestComponentElectron() && TruePhotonCandidate->IsConversion())) {
+    fHistoTrueClusGammaPt[fiCut]->Fill(TruePhotonCandidate->Pt(), tempPhotonWeight);
+  }
+}
+
+// TODO!! Make the pi0 and eta selections setable by the task to just analyze eta or pi0s or both
+/// \brief check if particle is true meson
+/// \param Pi0Candidate meson candidate to be checked
+/// \param TrueGammaCandidate0 cluster in case of calo and convCalo, conversion photon in case of conv
+/// \param TrueGammaCandidate1 cluster in case of calo, conversion photon in case of conv-calo and conv
+/// \param matchedJet index of matched Jet
+/// \param RJetPi0Cand distance of Jet axis to meson
+//________________________________________________________________________
+void AliAnalysisTaskMesonJetCorrelation::ProcessTrueMesonCandidatesAOD(AliAODConversionMother* Pi0Candidate, AliAODConversionPhoton* TrueGammaCandidate0, AliAODConversionPhoton* TrueGammaCandidate1, const int matchedJet, const float RJetPi0Cand)
+{
+
+  const AliVVertex* primVtxMC = fMCEvent->GetPrimaryVertex();
+  Double_t mcProdVtxX = primVtxMC->GetX();
+  Double_t mcProdVtxY = primVtxMC->GetY();
+  Double_t mcProdVtxZ = primVtxMC->GetZ();
+
+  // Double_t tempTruePi0CandWeight = fWeightJetJetMC;
+
+  // Process True Mesons
+  if (!fAODMCTrackArray)
+    fAODMCTrackArray = dynamic_cast<TClonesArray*>(fInputEvent->FindListObject(AliAODMCParticle::StdBranchName()));
+  if (fAODMCTrackArray == NULL)
+    return;
+
+  Bool_t isTrueParticle = false;
+
+  // check if meson originates from the same meson
+  int convertedPhotonLabel0, convertedPhotonLabel1;                                                                            // to check if two conversion clusters come from the same mother
+  int gamma0MotherLabel = GetPhotonMotherLabel(TrueGammaCandidate0, convertedPhotonLabel0, (fIsCalo == false) ? false : true); // calo photon for calo
+  int gamma1MotherLabel = GetPhotonMotherLabel(TrueGammaCandidate1, convertedPhotonLabel1, (fIsConv == true) ? false : true);  // calo photon for calo and convcalo
+
+  AliAODMCParticle* trueMesonCand = nullptr;
+  if (gamma0MotherLabel >= 0 && gamma0MotherLabel == gamma1MotherLabel) {
+    trueMesonCand = static_cast<AliAODMCParticle*>(fAODMCTrackArray->At(gamma1MotherLabel));
+    if (trueMesonCand->GetPdgCode() == fMesonPDGCode) {
+      isTrueParticle = true;
+    }
+  }
+
+  if (!isTrueParticle)
+    return; // I guess we can just return in that case
+
+  // Define most important variables here
+  float mesonPtRec = Pi0Candidate->Pt();
+  float mesonPtTrue = trueMesonCand->Pt();
+  float mesonMassRec = Pi0Candidate->M();
+  float jetPtRec = (matchedJet < 0) ? 0 : fVectorJetPt[matchedJet];
+  int indexTrueJet = (matchedJet < 0 || MapRecJetsTrueJets.count(matchedJet) == 0) ? -1 : MapRecJetsTrueJets[matchedJet];
+  float jetPtTrue = (indexTrueJet < 0) ? 0 : fTrueVectorJetPt[indexTrueJet];
+
+  // fill all true mesons (primary + secondaries)
+  fHistoTrueMesonInvMassVsPt[fiCut]->Fill(Pi0Candidate->M(), Pi0Candidate->Pt(), fWeightJetJetMC);
+  fHistoTrueMesonInvMassVsTruePt[fiCut]->Fill(Pi0Candidate->M(), trueMesonCand->Pt(), fWeightJetJetMC);
+
+  // fill all primary true mesons
+  Bool_t isPrimary = ((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsConversionPrimaryAOD(fInputEvent, static_cast<AliAODMCParticle*>(fAODMCTrackArray->At(gamma0MotherLabel)), mcProdVtxX, mcProdVtxY, mcProdVtxZ);
+
+  if (isPrimary) {
+    fHistoTruePrimaryMesonInvMassPt[fiCut]->Fill(mesonMassRec, mesonPtRec, fWeightJetJetMC);
+    // meson response matrix (no Jet included here)
+    // fHistoMesonResponse[fiCut]->Fill(mesonPtRec, mesonPtTrue, fWeightJetJetMC);
+    float z_rec = GetFrag(Pi0Candidate, matchedJet, false);
+    float z_true = GetFrag(trueMesonCand, indexTrueJet, true);
+
+    if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelectedByMassCut(Pi0Candidate, 0)) { // nominal mass range
+      fRespMatrixHandlerFrag[fiCut]->Fill(jetPtRec, jetPtTrue, z_rec, z_true);
+    }
+    fRespMatrixHandlerMesonInvMass[fiCut]->Fill(jetPtRec, jetPtTrue, Pi0Candidate->M(), Pi0Candidate->Pt());
+
+    // fill 4d response matrix
+    fRespMatrixHandlerMesonPt[fiCut]->Fill(jetPtRec, jetPtTrue, mesonPtRec, mesonPtTrue, fWeightJetJetMC);
+  } else { // fill all secondary mesons
+    fHistoTrueSecondaryMesonInvMassPt[fiCut]->Fill(mesonPtRec, mesonPtRec, fWeightJetJetMC);
+  }
+}
+
+//_____________________________________________________________________________________________________________________
+void AliAnalysisTaskMesonJetCorrelation::ProcessTruePhotonCandidatesAOD(AliAODConversionPhoton* TruePhotonCandidate)
+{
+
+  const AliVVertex* primVtxMC = fMCEvent->GetPrimaryVertex();
+  Double_t mcProdVtxX = primVtxMC->GetX();
+  Double_t mcProdVtxY = primVtxMC->GetY();
+  Double_t mcProdVtxZ = primVtxMC->GetZ();
+
+  Double_t magField = fInputEvent->GetMagneticField();
+
+  if (!fAODMCTrackArray)
+    fAODMCTrackArray = dynamic_cast<TClonesArray*>(fInputEvent->FindListObject(AliAODMCParticle::StdBranchName()));
+  if (fAODMCTrackArray == NULL)
+    return;
+  AliAODMCParticle* posDaughter = (AliAODMCParticle*)fAODMCTrackArray->At(TruePhotonCandidate->GetMCLabelPositive());
+  AliAODMCParticle* negDaughter = (AliAODMCParticle*)fAODMCTrackArray->At(TruePhotonCandidate->GetMCLabelNegative());
+
+  if (posDaughter == NULL || negDaughter == NULL)
+    return; // cant find electon/positron
+  int pdgCode[2] = {TMath::Abs(posDaughter->GetPdgCode()), TMath::Abs(negDaughter->GetPdgCode())};
+
+  if (pdgCode[0] != 11 || pdgCode[1] != 11) {
+    return; //One Particle is not a electron
+  }
+
+  if (posDaughter->GetPdgCode() == negDaughter->GetPdgCode()) {
+    return; // Same Charge
+  }
+
+  AliAODMCParticle* Photon = (AliAODMCParticle*)fAODMCTrackArray->At(posDaughter->GetMother());
+  if (Photon->GetPdgCode() != 22) {
+    return; // Mother is no Photon
+  }
+
+  if (((posDaughter->GetMCProcessCode())) != 5 || ((negDaughter->GetMCProcessCode())) != 5) {
+    return; // check if the daughters come from a conversion
+  }
+
+  if (!fIsFromDesiredHeader) {
+    return;
+  }
+
+  // True Photon
+  Double_t weightMatBudgetGamma = 1.;
+  if (fDoMaterialBudgetWeightingOfGammasForTrueMesons && ((AliConversionPhotonCuts*)fConvCutArray->At(fiCut))->GetMaterialBudgetWeightsInitialized()) {
+    weightMatBudgetGamma = ((AliConversionPhotonCuts*)fConvCutArray->At(fiCut))->GetMaterialBudgetCorrectingWeightForTrueGamma(TruePhotonCandidate, magField);
+  }
+
+  fHistoTrueConvGammaPt[fiCut]->Fill(TruePhotonCandidate->Pt(), fWeightJetJetMC * weightMatBudgetGamma);
+
+  Bool_t isPrimary = ((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsConversionPrimaryAOD(fInputEvent, Photon, mcProdVtxX, mcProdVtxY, mcProdVtxZ);
+  if (isPrimary) {
+    // Count just primary MC Gammas as true --> For Ratio esdtruegamma / mcconvgamma
+    if (!fDoLightOutput) {
+      fHistoTruePrimaryConvGammaPt[fiCut]->Fill(TruePhotonCandidate->Pt(), fWeightJetJetMC * weightMatBudgetGamma);
+      fHistoTruePrimaryConvGammaESDPtMCPt[fiCut]->Fill(TruePhotonCandidate->Pt(), Photon->Pt(), fWeightJetJetMC * weightMatBudgetGamma); // Allways Filled
+    }
+  }
+  TruePhotonCandidate->SetIsTrueConvertedPhoton();
+}
+
+//________________________________________________________________________
+// void AliAnalysisTaskMesonJetCorrelation::IsTrueParticle(AliAODConversionMother* Pi0Candidate, AliAODConversionPhoton* TrueGammaCandidate0, AliAODConversionPhoton* TrueGammaCandidate1, Bool_t matched)
+// {
+
+//   // Double_t magField = fInputEvent->GetMagneticField();
+//   // const AliVVertex* primVtxMC = fMCEvent->GetPrimaryVertex();
+//   // Double_t mcProdVtxX = primVtxMC->GetX();
+//   // Double_t mcProdVtxY = primVtxMC->GetY();
+//   // Double_t mcProdVtxZ = primVtxMC->GetZ();
+
+//   // Process True Mesons
+//   if (!fAODMCTrackArray)
+//     fAODMCTrackArray = dynamic_cast<TClonesArray*>(fInputEvent->FindListObject(AliAODMCParticle::StdBranchName()));
+//   if (fAODMCTrackArray == NULL)
+//     return;
+
+//   // PCM-Calo case
+//   if (fIsConvCalo) {
+//     AliAODMCParticle* positiveMC = static_cast<AliAODMCParticle*>(fAODMCTrackArray->At(TrueGammaCandidate0->GetMCLabelPositive()));
+//     AliAODMCParticle* negativeMC = static_cast<AliAODMCParticle*>(fAODMCTrackArray->At(TrueGammaCandidate0->GetMCLabelNegative()));
+
+//     int gamma0MCLabel = -1;
+//     int gamma0MotherLabel = -1;
+//     if (!positiveMC || !negativeMC)
+//       return;
+
+//     if (TrueGammaCandidate0->IsTrueConvertedPhoton()) {
+//       gamma0MCLabel = positiveMC->GetMother();
+//       AliAODMCParticle* gammaMC0 = static_cast<AliAODMCParticle*>(fAODMCTrackArray->At(gamma0MCLabel));
+//       gamma0MotherLabel = gammaMC0->GetMother();
+//     }
+
+//     int tmpGammaMotherlabel = gamma0MotherLabel;
+//     int SaftyLoopCounter = 0;
+//     while (tmpGammaMotherlabel > 0 && SaftyLoopCounter < 100) {
+//       SaftyLoopCounter++;
+//       if (((AliAODMCParticle*)fAODMCTrackArray->At(tmpGammaMotherlabel))->GetPdgCode() != fMesonPDGCode) {
+//         tmpGammaMotherlabel = ((AliAODMCParticle*)fAODMCTrackArray->At(tmpGammaMotherlabel))->GetMother();
+//       } else {
+//         gamma0MotherLabel = tmpGammaMotherlabel;
+//         break;
+//       }
+//     }
+
+//     if (TrueGammaCandidate1->GetIsCaloPhoton() == 0)
+//       AliFatal("CaloPhotonFlag has not been set. Aborting");
+//     int gamma1MCLabel = TrueGammaCandidate1->GetCaloPhotonMCLabel(0); // get most probable MC label
+//     int gamma1MotherLabel = -1;
+//     tmpGammaMotherlabel = -1;
+//     // check if
+
+//     AliAODMCParticle* gammaMC1 = 0x0;
+//     if (gamma1MCLabel != -1) { // Gamma is Combinatorial; MC Particles don't belong to the same Mother
+//       // Daughters Gamma 1
+//       gammaMC1 = static_cast<AliAODMCParticle*>(fAODMCTrackArray->At(gamma1MCLabel));
+//       if (TrueGammaCandidate1->IsLargestComponentPhoton() || TrueGammaCandidate1->IsLargestComponentElectron()) { // largest component is electro magnetic
+//         tmpGammaMotherlabel = gammaMC1->GetMother();
+//         // get mother of interest (pi0 or eta)
+//         if (TrueGammaCandidate1->IsLargestComponentPhoton()) { // for photons its the direct mother
+//           gamma1MotherLabel = gammaMC1->GetMother();
+//         } else if (TrueGammaCandidate1->IsLargestComponentElectron()) { // for electrons its either the direct mother or for conversions the grandmother
+//           if (TrueGammaCandidate1->IsConversion()) {
+//             AliAODMCParticle* gammaGrandMotherMC1 = static_cast<AliAODMCParticle*>(fAODMCTrackArray->At(gammaMC1->GetMother()));
+//             gamma1MotherLabel = gammaGrandMotherMC1->GetMother();
+//           } else
+//             gamma1MotherLabel = gammaMC1->GetMother();
+//         }
+//       } else {
+//         // if (fDoMesonQA > 0 && fIsMC < 2) fHistoTrueMotherCaloEMNonLeadingInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt());
+//       }
+//     }
+
+//     SaftyLoopCounter = 0;
+//     while (tmpGammaMotherlabel > 0 && SaftyLoopCounter < 100) {
+//       SaftyLoopCounter++;
+//       if (((AliAODMCParticle*)fAODMCTrackArray->At(tmpGammaMotherlabel))->GetPdgCode() != 111 && ((AliAODMCParticle*)fAODMCTrackArray->At(tmpGammaMotherlabel))->GetPdgCode() != 221) {
+//         tmpGammaMotherlabel = ((AliAODMCParticle*)fAODMCTrackArray->At(tmpGammaMotherlabel))->GetMother();
+//       } else {
+//         gamma1MotherLabel = tmpGammaMotherlabel;
+//         break;
+//       }
+//     }
+
+//     if (gamma0MotherLabel >= 0 && gamma0MotherLabel == gamma1MotherLabel) {
+//       if (((AliAODMCParticle*)fAODMCTrackArray->At(gamma1MotherLabel))->GetPdgCode() == 111) {
+//         isTruePi0 = kTRUE;
+//       }
+//       if (((AliAODMCParticle*)fAODMCTrackArray->At(gamma1MotherLabel))->GetPdgCode() == 221) {
+//         isTrueEta = kTRUE;
+//       }
+//     }
+
+//     // Double_t weightMatBudgetGamma = 1.;
+//     // if (fDoMaterialBudgetWeightingOfGammasForTrueMesons && ((AliConversionPhotonCuts*)fConvCutArray->At(fiCut))->GetMaterialBudgetWeightsInitialized()) {
+//     //   weightMatBudgetGamma = ((AliConversionPhotonCuts*)fConvCutArray->At(fiCut))->GetMaterialBudgetCorrectingWeightForTrueGamma(TrueGammaCandidate0, magField);
+//     // }
+//   } // end PCM-Calo case
+//   else if (fIsCalo) {
+//     int gamma0MCLabel = TrueGammaCandidate0->GetCaloPhotonMCLabel(0); // get most probable MC label
+//     int gamma0MotherLabel = -1;
+//     int tmpGammaMotherlabel = -1;
+
+//     // check if
+//     AliAODMCParticle* gammaMC0 = 0x0;
+//     if (gamma0MCLabel != -1) { // Gamma is Combinatorial; MC Particles don't belong to the same Mother
+//       // Daughters Gamma 0
+//       gammaMC0 = static_cast<AliAODMCParticle*>(fAODMCTrackArray->At(gamma0MCLabel));
+//       if (TrueGammaCandidate0->IsLargestComponentPhoton() || TrueGammaCandidate0->IsLargestComponentElectron()) { // largest component is electromagnetic
+//         tmpGammaMotherlabel = gammaMC0->GetMother();
+//         // get mother of interest (pi0 or eta)
+//         if (TrueGammaCandidate0->IsLargestComponentPhoton()) { // for photons its the direct mother
+//           gamma0MotherLabel = gammaMC0->GetMother();
+//         } else if (TrueGammaCandidate0->IsLargestComponentElectron()) { // for electrons its either the direct mother or for conversions the grandmother
+//           if (TrueGammaCandidate0->IsConversion()) {
+//             AliAODMCParticle* gammaGrandMotherMC0 = static_cast<AliAODMCParticle*>(fAODMCTrackArray->At(gammaMC0->GetMother()));
+//             gamma0MotherLabel = gammaGrandMotherMC0->GetMother();
+//           } else
+//             gamma0MotherLabel = gammaMC0->GetMother();
+//         }
+//       }
+//     }
+//     int SaftyLoopCounter = 0;
+//     while (tmpGammaMotherlabel > 0 && SaftyLoopCounter < 100) {
+//       SaftyLoopCounter++;
+//       if (((AliAODMCParticle*)fAODMCTrackArray->At(tmpGammaMotherlabel))->GetPdgCode() != 111 && ((AliAODMCParticle*)fAODMCTrackArray->At(tmpGammaMotherlabel))->GetPdgCode() != 221) {
+//         tmpGammaMotherlabel = ((AliAODMCParticle*)fAODMCTrackArray->At(tmpGammaMotherlabel))->GetMother();
+//       } else {
+//         gamma0MotherLabel = tmpGammaMotherlabel;
+//         break;
+//       }
+//     }
+
+//     int gamma1MCLabel = TrueGammaCandidate1->GetCaloPhotonMCLabel(0); // get most probable MC label
+//     int gamma1MotherLabel = -1;
+//     tmpGammaMotherlabel = -1;
+
+//     // check if
+//     AliAODMCParticle* gammaMC1 = 0x0;
+//     if (gamma1MCLabel != -1) { // Gamma is Combinatorial; MC Particles don't belong to the same Mother
+//       // Daughters Gamma 1
+//       gammaMC1 = static_cast<AliAODMCParticle*>(fAODMCTrackArray->At(gamma1MCLabel));
+//       if (TrueGammaCandidate1->IsLargestComponentPhoton() || TrueGammaCandidate1->IsLargestComponentElectron()) { // largest component is electro magnetic
+//         tmpGammaMotherlabel = gammaMC1->GetMother();
+//         // get mother of interest (pi0 or eta)
+//         if (TrueGammaCandidate1->IsLargestComponentPhoton()) { // for photons its the direct mother
+//           gamma1MotherLabel = gammaMC1->GetMother();
+//         } else if (TrueGammaCandidate1->IsLargestComponentElectron()) { // for electrons its either the direct mother or for conversions the grandmother
+//           if (TrueGammaCandidate1->IsConversion()) {
+//             AliAODMCParticle* gammaGrandMotherMC1 = static_cast<AliAODMCParticle*>(fAODMCTrackArray->At(gammaMC1->GetMother()));
+//             gamma1MotherLabel = gammaGrandMotherMC1->GetMother();
+//           } else
+//             gamma1MotherLabel = gammaMC1->GetMother();
+//         }
+//       }
+//     }
+
+//     SaftyLoopCounter = 0;
+//     while (tmpGammaMotherlabel > 0 && SaftyLoopCounter < 100) {
+//       SaftyLoopCounter++;
+//       if (((AliAODMCParticle*)fAODMCTrackArray->At(tmpGammaMotherlabel))->GetPdgCode() != 111 && ((AliAODMCParticle*)fAODMCTrackArray->At(tmpGammaMotherlabel))->GetPdgCode() != 221) {
+//         tmpGammaMotherlabel = ((AliAODMCParticle*)fAODMCTrackArray->At(tmpGammaMotherlabel))->GetMother();
+//       } else {
+//         gamma1MotherLabel = tmpGammaMotherlabel;
+//         break;
+//       }
+//     }
+
+//     if (gamma0MotherLabel >= 0 && gamma0MotherLabel == gamma1MotherLabel) {
+//       if (((AliAODMCParticle*)fAODMCTrackArray->At(gamma1MotherLabel))->GetPdgCode() == 111) {
+//         isTruePi0 = kTRUE;
+//       }
+//       if (((AliAODMCParticle*)fAODMCTrackArray->At(gamma1MotherLabel))->GetPdgCode() == 221) {
+//         isTrueEta = kTRUE;
+//       }
+//     }
+//   }
+// }
+
+void AliAnalysisTaskMesonJetCorrelation::UpdateEventMixData()
+{
+  if (fIsCalo) {
+    EventWithJetAxis* tmpEvt = new EventWithJetAxis(fClusterCandidates, true, fHighestJetVector);
+    fEventMix->AddEvent(tmpEvt, fMaxPtJet);
+  }
+  if (fIsConvCalo) {
+    EventWithJetAxis* tmpEvt = new EventWithJetAxis(fClusterCandidates, fGammaCandidates, fHighestJetVector);
+    fEventMix->AddEvent(tmpEvt, fMaxPtJet);
+  }
+  if (fIsConv) {
+    EventWithJetAxis* tmpEvt = new EventWithJetAxis(fGammaCandidates, false, fHighestJetVector);
+    fEventMix->AddEvent(tmpEvt, fMaxPtJet);
+  }
+}
+
+//________________________________________________________________________
+void AliAnalysisTaskMesonJetCorrelation::RelabelAODPhotonCandidates(Bool_t mode)
+{
+
+  // Relabeling For AOD Event
+  // ESDiD -> AODiD
+  // MCLabel -> AODMCLabel
+
+  if (mode) {
+    fMCEventPos = new int[fReaderGammas->GetEntries()];
+    fMCEventNeg = new int[fReaderGammas->GetEntries()];
+    fESDArrayPos = new int[fReaderGammas->GetEntries()];
+    fESDArrayNeg = new int[fReaderGammas->GetEntries()];
+  }
+
+  for (int iGamma = 0; iGamma < fReaderGammas->GetEntries(); iGamma++) {
+    AliAODConversionPhoton* PhotonCandidate = (AliAODConversionPhoton*)fReaderGammas->At(iGamma);
+    if (!PhotonCandidate)
+      continue;
+    if (!mode) { // Back to ESD Labels
+      PhotonCandidate->SetMCLabelPositive(fMCEventPos[iGamma]);
+      PhotonCandidate->SetMCLabelNegative(fMCEventNeg[iGamma]);
+      PhotonCandidate->SetLabelPositive(fESDArrayPos[iGamma]);
+      PhotonCandidate->SetLabelNegative(fESDArrayNeg[iGamma]);
+      continue;
+    }
+    fMCEventPos[iGamma] = PhotonCandidate->GetMCLabelPositive();
+    fMCEventNeg[iGamma] = PhotonCandidate->GetMCLabelNegative();
+    fESDArrayPos[iGamma] = PhotonCandidate->GetTrackLabelPositive();
+    fESDArrayNeg[iGamma] = PhotonCandidate->GetTrackLabelNegative();
+
+    Bool_t AODLabelPos = kFALSE;
+    Bool_t AODLabelNeg = kFALSE;
+
+    for (int i = 0; i < fInputEvent->GetNumberOfTracks(); i++) {
+      AliAODTrack* tempDaughter = static_cast<AliAODTrack*>(fInputEvent->GetTrack(i));
+      if (!AODLabelPos) {
+        if (tempDaughter->GetID() == PhotonCandidate->GetTrackLabelPositive()) {
+          PhotonCandidate->SetMCLabelPositive(TMath::Abs(tempDaughter->GetLabel()));
+          PhotonCandidate->SetLabelPositive(i);
+          AODLabelPos = kTRUE;
+        }
+      }
+      if (!AODLabelNeg) {
+        if (tempDaughter->GetID() == PhotonCandidate->GetTrackLabelNegative()) {
+          PhotonCandidate->SetMCLabelNegative(TMath::Abs(tempDaughter->GetLabel()));
+          PhotonCandidate->SetLabelNegative(i);
+          AODLabelNeg = kTRUE;
+        }
+      }
+      if (AODLabelNeg && AODLabelPos) {
+        break;
+      }
+    }
+    if (!AODLabelPos || !AODLabelNeg) {
+      cout << "WARNING!!! AOD TRACKS NOT FOUND FOR" << endl;
+      if (!AODLabelNeg) {
+        PhotonCandidate->SetMCLabelNegative(-999999);
+        PhotonCandidate->SetLabelNegative(-999999);
+      }
+      if (!AODLabelPos) {
+        PhotonCandidate->SetMCLabelPositive(-999999);
+        PhotonCandidate->SetLabelPositive(-999999);
+      }
+    }
+  }
+
+  if (!mode) {
+    delete[] fMCEventPos;
+    delete[] fMCEventNeg;
+    delete[] fESDArrayPos;
+    delete[] fESDArrayNeg;
+  }
+}

--- a/PWGGA/GammaConv/AliAnalysisTaskMesonJetCorrelation.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskMesonJetCorrelation.h
@@ -1,0 +1,373 @@
+/**************************************************************************
+ * Copyright(c) 1998-2020, ALICE Experiment at CERN, All rights reserved. *
+ *                                                                        *
+ * Author: Joshua Koenig <joshua.konig@cern.ch>                                        *
+ * Version 1.0                                                            *
+ *                                                                        *
+ *                                                                        *
+ * Permission to use, copy, modify and distribute this software and its   *
+ * documentation strictly for non-commercial purposes is hereby granted   *
+ * without fee, provided that the above copyright notice appears in all   *
+ * copies and that both the copyright notice and this permission notice   *
+ * appear in the supporting documentation. The authors make no claims     *
+ * about the suitability of this software for any purpose. It is          *
+ * provided "as is" without express or implied warranty.                  *
+ **************************************************************************/
+
+//////////////////////////////////////////////////////////////////
+//----------------------------------------------------------------
+// Class used to do analysis for light neutral mesons inside Jets
+//----------------------------------------------------------------
+//////////////////////////////////////////////////////////////////
+
+#ifndef ALIANLYSISTASKMesonJetCorrelation_cxx
+#define ALIANLYSISTASKMesonJetCorrelation_cxx
+
+#include "AliAnalysisManager.h"
+#include "AliAnalysisTaskConvJet.h"
+#include "AliAnalysisTaskJetOutlierRemoval.h"
+#include "AliAnalysisTaskSE.h"
+#include "AliCaloPhotonCuts.h"
+#include "AliConvEventCuts.h"
+#include "AliConversionAODBGHandlerRP.h"
+#include "AliConversionMesonCuts.h"
+#include "AliConversionPhotonCuts.h"
+#include "AliESDtrack.h"
+#include "AliGammaConversionAODBGHandler.h"
+#include "AliKFConversionPhoton.h"
+#include "AliV0ReaderV1.h"
+#include "TH3.h"
+#include "TH3F.h"
+#include "THnSparse.h"
+#include "TGenPhaseSpace.h"
+#include "TProfile2D.h"
+#include <map>
+#include <vector>
+#include "AliResponseMatrixHelper.h"
+#include "AliGammaConvEventMixing.h"
+
+class AliAnalysisTaskMesonJetCorrelation : public AliAnalysisTaskSE
+{
+ public:
+  AliAnalysisTaskMesonJetCorrelation();
+  AliAnalysisTaskMesonJetCorrelation(const char* name);
+  virtual ~AliAnalysisTaskMesonJetCorrelation();
+
+  virtual void UserCreateOutputObjects();
+  virtual Bool_t Notify();
+  virtual void UserExec(Option_t*);
+  virtual void Terminate(const Option_t*);
+
+  // base functions for selecting photon and meson candidates
+  void ProcessClusters();
+  void ProcessPhotonCandidates();
+  void CalculateMesonCandidates();
+  void CalculateBackground();
+  void CalculateBackgroundSwapp();
+  void CalculateBackgroundMix();
+  void UpdateEventMixData();
+  void FillInvMassBackHistograms(AliAODConversionMother* backgroundCandidate);
+  std::array<std::unique_ptr<AliAODConversionPhoton>, 2> GetGammasSwapped(AliAODConversionPhoton* currentEventGoodV0Temp1, AliAODConversionPhoton* currentEventGoodV0Temp2);
+  void FillMesonHistograms(AliAODConversionPhoton* gamma0, AliAODConversionPhoton* gamma1, int firstGammaIndex, int secondGammaIndex);
+  void ProcessTrueBackgroundCandidatesAOD(AliAODConversionMother* Pi0Candidate, AliAODConversionPhoton* TrueGammaCandidate0, AliAODConversionPhoton* TrueGammaCandidate1, const int matchedJet, const float RJetPi0Cand);
+  float GetFrag(AliAODConversionMother* Pi0Candidate, const int matchedJet, int isTrueJet);
+  float GetFrag(AliAODMCParticle* Pi0Candidate, const int matchedJet, int isTrueJet);
+
+  // MC functions
+  void ProcessAODMCParticles(Int_t isCurrentEventSelected = 0);
+  void ProcessTrueClusterCandidatesAOD(AliAODConversionPhoton* TruePhotonCandidate);
+  void ProcessTruePhotonCandidatesAOD(AliAODConversionPhoton* TruePhotonCandidate);
+  bool MCParticleIsSelected(AliAODMCParticle* particle1, AliAODMCParticle* particle2, bool checkConversion);
+  bool MCParticleIsSelected(AliAODMCParticle* particle, bool isConv, bool checkConversion);
+  int GetPhotonMotherLabel(AliAODConversionPhoton* gammaCand, int& convertedPhotonLabel, bool isCaloPhoton);
+  void RelabelAODPhotonCandidates(Bool_t mode);
+  void ProcessTrueMesonCandidatesAOD(AliAODConversionMother* Pi0Candidate, AliAODConversionPhoton* TrueGammaCandidate0, AliAODConversionPhoton* TrueGammaCandidate1, const int matchedJet, const float RJetPi0Cand = 0);
+  // void IsTrueParticle(AliAODConversionMother* Pi0Candidate, AliAODConversionPhoton* TrueGammaCandidate0, AliAODConversionPhoton* TrueGammaCandidate1, Bool_t matched);
+  bool CheckAcceptance(AliAODMCParticle* gamma0, AliAODMCParticle* gamma1);
+  bool IsParticleFromPartonFrag(AliAODMCParticle* particle, int idParton);
+
+  // Jet functions
+  void ProcessJets();
+  void InitJets();
+
+  // Helper functions
+  void MakeBinning();
+  void CallSumw2ForLists(TList* l);
+
+  // Setters
+  void SetIsMC(Int_t isMC) { fIsMC = isMC; }
+  void SetLightOutput(Int_t flag) { fDoLightOutput = flag; }
+  void SetDoMesonQA(Int_t flag) { fDoMesonQA = flag; }
+  void SetDoPhotonQA(Int_t flag) { fDoPhotonQA = flag; }
+  void SetDoClusterQA(Int_t flag) { fDoClusterQA = flag; }
+  // Function to set correction task setting
+  void SetCorrectionTaskSetting(TString setting) { fCorrTaskSetting = setting; }
+  void SetDoMaterialBudgetWeightingOfGammasForTrueMesons(Bool_t flag) { fDoMaterialBudgetWeightingOfGammasForTrueMesons = flag; }
+  void SetIsCalo(bool isCalo) { fIsCalo = isCalo; }
+  void SetIsConv(bool isConv) { fIsConv = isConv; }
+  void SetIsConvCalo(bool isConvCalo) { fIsConvCalo = isConvCalo; }
+  void SetIsHeavyIon(int flag) { fIsHeavyIon = flag; }
+  void SetV0ReaderName(TString name) { fV0ReaderName = name; }
+  void SetTrackMatcherRunningMode(Int_t mode) { fTrackMatcherRunningMode = mode; }
+  void SetUseTHnSparseForResponse(bool tmp) { fUseThNForResponse = tmp; }
+  void SetMesonKind(int meson) { (meson == 0) ? fMesonPDGCode = 111 : fMesonPDGCode = 221; }
+
+  void SetEventCutList(Int_t nCuts,
+                       TList* CutArray)
+  {
+    fnCuts = nCuts;
+    fEventCutArray = CutArray;
+  }
+
+  // Setting the cut lists for the conversion photons
+  void SetConversionCutList(Int_t nCuts,
+                            TList* CutArray)
+  {
+    fnCuts = nCuts;
+    fConvCutArray = CutArray;
+  }
+
+  // Setting the cut lists for the calo photons
+  void SetCaloCutList(Int_t nCuts,
+                      TList* CutArray)
+  {
+    fnCuts = nCuts;
+    fClusterCutArray = CutArray;
+  }
+
+  // Setting the cut lists for the meson
+  void SetMesonCutList(Int_t nCuts,
+                       TList* CutArray)
+  {
+    fnCuts = nCuts;
+    fMesonCutArray = CutArray;
+  }
+
+ protected:
+  //-------------------------------
+  // GLobal settings
+  //-------------------------------
+  AliV0ReaderV1* fV0Reader;       //! basic photon Selection Task
+  TString fV0ReaderName;          // name of V0Reader
+  TClonesArray* fReaderGammas;    // Array with conversion photons selected by V0Reader Cut
+  TString fCaloTriggerHelperName; // name of trigger helper for PHOS
+  TString fCorrTaskSetting;       // Correction Task Special Name
+  AliVEvent* fInputEvent;         //! current event
+  AliMCEvent* fMCEvent;           //! corresponding MC event
+  TClonesArray* fAODMCTrackArray; //! pointer to track array
+
+  //-------------------------------
+  // Lists for cut folders and output containers
+  //-------------------------------
+  TList** fCutFolder;      //! Top level cut folder in which all folders belonging to this cut are stored
+  TList** fESDList;        //! List for standard histograms for data+MC (Inv mass vs pt etc.)
+  TList** fMCList;         //! List for MC generated histograms
+  TList** fTrueList;       //! List for true meson quantities
+  TList** fJetList;        //! List for jet related observables
+  TList** fTrueJetList;    //! List of true jet quantities (response matrix)
+  TList* fOutputContainer; //! Top level output container
+  TList* fEventCutArray;   //! Event cut output container
+  TList* fConvCutArray;    //! Conversion cut output container
+  TList* fClusterCutArray; //! Cluster cut output container
+  TList* fMesonCutArray;   //! Meson cut output container
+
+  std::vector<AliAODConversionPhoton*> fGammaCandidates;   //! current list of photon candidates
+  std::vector<AliAODConversionPhoton*> fClusterCandidates; //! current list of cluster candidates
+
+  EventMixPoolMesonJets* fEventMix; //! Eventmixing class used for events with a jet axis (also works with no jet axis but has no z-vertex bins etc.)
+
+  TRandom3 fRandom;              //! random generator needed for the rotation background
+  TGenPhaseSpace fGenPhaseSpace; //! For generation of decays into two gammas
+
+  //-------------------------------
+  // Jet related variables
+  //-------------------------------
+  AliAnalysisTaskConvJet* fConvJetReader; // JetReader
+  TVector3 fHighestJetVector;             // vector px,py,pz of jet with highest momentum in the event. Needed for jet event mixing
+  float fMaxPtJet;                        // pt of jet with highest pt in the event. Needed for jet ecvent mixing
+
+  AliAnalysisTaskJetOutlierRemoval* fOutlierJetReader; // Jet outlier Reader
+
+  //-------------------------------
+  // global settings and variables
+  //-------------------------------
+  int fMesonPDGCode;                                    // PDG code of current meson (111 for pi0 etc.)
+  int fiCut;                                            //! index of the current cut
+  int fIsMC;                                            //! flag for data or MC (JJ MC > 1)
+  int fnCuts;                                           //! number of cuts
+  double fWeightJetJetMC;                               //! weights if jet-jet MC is used
+  int fDoLightOutput;                                   // flag if light output should be used
+  int fDoMesonQA;                                       // flag if meson QA should be switched on
+  int fDoPhotonQA;                                      // flag if photon QA should be switched on
+  int fDoClusterQA;                                     // flag if cluster QA should be switched on
+  int fDoJetQA;                                         // flag if Jet QA should be switched on
+  int fIsHeavyIon;                                      // lag for heavy ion
+  bool fIsCalo;                                         // flag if current analysis is calo only
+  bool fIsConv;                                         // flag if current analysis is using conversions only
+  bool fIsConvCalo;                                     // flag if current analysis is
+  bool fIsFromDesiredHeader;                            // flag if particle is from desired header
+  bool fDoMaterialBudgetWeightingOfGammasForTrueMesons; // flag if material budget weights should be applied
+  double fEventPlaneAngle;                              // event plane angle
+  int fTrackMatcherRunningMode;                         // track matcher mode
+  bool fUseThNForResponse;                              // flag if THnSparse or TH2 should be used for the 4d response matrices
+  bool fEnableSortForClusMC;                            // flag if cluster mc labels should be sorted
+
+  //-------------------------------
+  // conversions
+  //-------------------------------
+  Int_t* fMCEventPos;  //!
+  Int_t* fMCEventNeg;  //!
+  Int_t* fESDArrayPos; //!
+  Int_t* fESDArrayNeg; //!
+
+  //-------------------------------
+  // binning settings
+  //-------------------------------
+  std::vector<float> fVecBinsMesonInvMass;   //! meson inv. mass binning
+  std::vector<float> fVecBinsPhotonPt;       //! photon/cluster pt binning
+  std::vector<float> fVecBinsMesonPt;        //! meson pt binning
+  std::vector<float> fVecBinsJetPt;          //! jet pt binning
+  std::vector<float> fVecBinsFragment;       //! z (fragmentation function) binning
+  std::vector<float> vecEquidistFromMinus05; //! aequdistant binning starting from -0.5
+
+  //-------------------------------
+  // Jet related vectors
+  //-------------------------------
+  vector<double> fVectorJetPt;           //! Vector of JetPt
+  vector<double> fVectorJetPx;           //! Vector of JetPx
+  vector<double> fVectorJetPy;           //! Vector of JetPy
+  vector<double> fVectorJetPz;           //! Vector of JetPz
+  vector<double> fVectorJetEta;          //! Vector of JetEta
+  vector<double> fVectorJetPhi;          //! Vector of JetPhi
+  vector<double> fVectorJetArea;         //! Vector of JetArea
+  vector<double> fTrueVectorJetPt;       //! Vector of True JetPt
+  vector<double> fTrueVectorJetPx;       //! Vector of True JetPx
+  vector<double> fTrueVectorJetPy;       //! Vector of True JetPy
+  vector<double> fTrueVectorJetPz;       //! Vector of True JetPz
+  vector<double> fTrueVectorJetEta;      //! Vector of True JetEta
+  vector<double> fTrueVectorJetPhi;      //! Vector of True JetPhi
+  vector<int> fTrueVectorJetPartonID;    //! Vector of parton id matched to true jet
+  vector<double> fTrueVectorJetPartonPt; //! Vector of parton pt matched to true jet
+
+  vector<double> fVectorJetEtaPerp; //! vector of jet -eta (opposite eta to original jet)
+  vector<double> fVectorJetPhiPerp; //! vector of jet phi + 90 degree (perpendicular to original jet)
+
+  std::map<int, int> MapRecJetsTrueJets; //! Map containing the reconstructed jet index in vector and mapping it to true Jet index
+
+  //-------------------------------
+  // Response Matrix handlers
+  //-------------------------------
+  std::vector<MatrixHandler4D*> fRespMatrixHandlerMesonPt;                 //! Response matrix for true vs. rec pt for each jet pt true vs. rec. bin
+  std::vector<MatrixHandler4D*> fRespMatrixHandlerFrag;                    //! Response matrix for meson z_rec vs z_true for each jet pt true vs. rec. bin
+  std::vector<MatrixHandler4D*> fRespMatrixHandlerMesonInvMass;            //! Response matrix for meson inv. mass and meson pt for each jet pt true vs. rec. bin
+  std::vector<MatrixHandler4D*> fRespMatrixHandlerMesonInvMassVsZ;         //! Response matrix for meson inv. mass and meson z for each jet pt true vs. rec. bin
+  std::vector<MatrixHandler4D*> fRespMatrixHandlerMesonBackInvMassVsZ;     //! Response matrix for meson inv. mass and meson z for background candidates (mixed evt/rotation) for each jet pt true vs. rec. bin
+  std::vector<MatrixHandler4D*> fRespMatrixHandlerMesonInvMassPerpCone;    //! Same as fRespMatrixHandlerMesonInvMass but in perpendicular cone
+  std::vector<MatrixHandler4D*> fRespMatrixHandlerMesonInvMassVsZPerpCone; //! Same as fRespMatrixHandlerMesonInvMassVsZ but in perpendicular cone
+
+  //-------------------------------
+  // basic histograms
+  //-------------------------------
+  std::vector<TH1F*> fHistoNEvents;         //! vector of histos with event information
+  std::vector<TH1F*> fHistoNEventsWOWeight; //! vector of histos with event information without event weights in case of JJ MC
+
+  std::vector<TH1F*> fHistoNGoodESDTracks; //! vector of histos for number of events
+  std::vector<TH1F*> fHistoVertexZ;        //! vector of histos for number of events without weights
+
+  //-------------------------------
+  // Inv. Mass histograms
+  //-------------------------------
+  std::vector<TH2F*> fHistoInvMassVsPt;          //! vector of histos with inv. mass vs pt
+  std::vector<TH2F*> fHistoInvMassVsPt_Incl;     //! vector of histos with inv. mass vs pt for all mesons (no in-jet criterium)
+  std::vector<TH2F*> fHistoJetPtVsFrag;          //! vector of histos for jet pt vs meson-z
+  std::vector<TH2F*> fHistoJetPtVsFrag_SB;       //! vector of histos for jet pt vs meson-z in the sideband region
+  std::vector<TH2F*> fHistoInvMassVsPtMassCut;   //! vector of histos with inv. mass vs. pT after cut
+  std::vector<TH2F*> fHistoInvMassVsPtMassCutSB; //! vector of histos with inv. mass vs. pT after cut in Sideband
+
+  std::vector<TH2F*> fHistoInvMassVsPtBack; //! vector of histos  with inv. mass vs pt for background distribution
+
+  std::vector<TH2F*> fHistoInvMassVsPtPerpCone;    //! same as fHistoInvMassVsPt but in perpendicular cone
+  std::vector<TH2F*> fHistoJetPtVsFragPerpCone;    //! same as fHistoJetPtVsFrag but in perp cone
+  std::vector<TH2F*> fHistoJetPtVsFragPerpCone_SB; //! same as fHistoJetPtVsFrag_SB but in perp cone
+
+  //-------------------------------
+  // conversion histograms
+  //-------------------------------
+  std::vector<TH1F*> fHistoConvGammaPt; //! vector of histos conversion photons vs. pt
+
+  //-------------------------------
+  // Jet related histograms
+  //-------------------------------
+  std::vector<TH1F*> fHistoEventwJets;          //! vector of histos for events with jets
+  std::vector<TH1F*> fHistoNJets;               //! vector of histos with number of jets per event
+  std::vector<TH1F*> fHistoPtJet;               //! vector of histos with pt of jets
+  std::vector<TH1F*> fHistoJetEta;              //! vector of histos with eta of jets
+  std::vector<TH1F*> fHistoJetPhi;              //! vector of histos with phi of jets
+  std::vector<TH1F*> fHistoJetArea;             //! vector of histos with jet area
+  std::vector<TH2F*> fHistoTruevsRecJetPt;      //! vector of histos response matrix for jets
+  std::vector<TH2F*> fHistoTrueJetPtVsPartonPt; //! vector of histos true jet pt vs. parton pt
+
+  //-------------------------------
+  // True meson histograms
+  //-------------------------------
+  std::vector<TH2F*> fHistoTrueMesonInvMassVsPt;        //! vector of histos inv. mass vs. pT for true mesons
+  std::vector<TH2F*> fHistoTrueMesonInvMassVsTruePt;    //! vector of histos inv. mass vs. true pT for true mesons
+  std::vector<TH2F*> fHistoTruePrimaryMesonInvMassPt;   //! vector of histos inv. mass vs. pT for true primary mesons
+  std::vector<TH2F*> fHistoTrueSecondaryMesonInvMassPt; //! vector of histos inv. mass vs. pT for true secondary mesons
+  std::vector<TH2F*> fHistoMesonResponse;               //! vector of histos with meson response matrix
+
+  //-------------------------------
+  // True conversion photon histograms
+  //-------------------------------
+  std::vector<TH1F*> fHistoTrueConvGammaPt;               //! vector of histos true conversion pt
+  std::vector<TH1F*> fHistoTruePrimaryConvGammaPt;        //! vector of histos true primary conversion pt
+  std::vector<TH2F*> fHistoTruePrimaryConvGammaESDPtMCPt; //! vector of histos true vs. rec. for conversions
+
+  //-------------------------------
+  // True cluster histograms
+  //-------------------------------
+  std::vector<TH1F*> fHistoTrueClusGammaPt; //! vector of histos true EM clusters
+
+  //-------------------------------
+  // mc generated histograms
+  //-------------------------------
+  std::vector<TH1F*> fHistoMCGammaPtNotTriggered;      //! vector of histos with photons in events which are not triggered vs pT
+  std::vector<TH1F*> fHistoMCGammaPtNoVertex;          //! vector of histos with photons in events which have no vertex vs pT
+  std::vector<TH1F*> fHistoMCAllGammaPt;               //! vector of histos with all photons vs pT
+  std::vector<TH1F*> fHistoMCDecayGammaPi0Pt;          //! vector of histos gammas pt from pi0s
+  std::vector<TH1F*> fHistoMCDecayGammaRhoPt;          //! vector of histos gammas pt from rho
+  std::vector<TH1F*> fHistoMCDecayGammaEtaPt;          //! vector of histos gammas pt from eta
+  std::vector<TH1F*> fHistoMCDecayGammaOmegaPt;        //! vector of histos  gammas pt from omega
+  std::vector<TH1F*> fHistoMCDecayGammaEtapPt;         //! vector of histos gammas pt from eta prime
+  std::vector<TH1F*> fHistoMCDecayGammaPhiPt;          //! vector of histos gammas pt from phi
+  std::vector<TH1F*> fHistoMCDecayGammaSigmaPt;        //! vector of histos  gammas pt from sigma
+  std::vector<TH2F*> fHistoMCPrimaryPtvsSource;        //! vector of histos primary gammas for different particles
+  std::vector<TH1F*> fHistoMCMesonPtNotTriggered;      //! vector of histos mesons which are in events that are not triggered
+  std::vector<TH1F*> fHistoMCMesonPtNoVertex;          //! vector of histos mesons which are in events that have no vertex
+  std::vector<TH1F*> fHistoMCMesonPt;                  //! vector of histos meson pt
+  std::vector<TH1F*> fHistoMCMesonWOEvtWeightPt;       //! vector of histos meson pt without event weights
+  std::vector<TH1F*> fHistoMCMesonInAccPt;             //! vector of histos mesons in acceptance
+  std::vector<TH1F*> fHistoMCMesonInAccPtNotTriggered; //! vector of histos mesons in acceptance which are in events that are not triggered
+  std::vector<TH1F*> fHistoMCMesonWOWeightInAccPt;     //! vector of histos mesons in acceptance without event weight
+  std::vector<TH1F*> fHistoMCMesonWOEvtWeightInAccPt;  //! vector of histos mesons in acceptance without event weight
+  std::vector<TH2F*> fHistoMCSecMesonPtvsSource;       //! vector of histos secondary mesons from different sources vs. pt
+  std::vector<TH1F*> fHistoMCSecMesonSource;           //! vector of histos secondary mesons from different sources
+  std::vector<TH2F*> fHistoMCSecMesonInAccPtvsSource;  //! vector of histos accepted secondary mesons from different sources vs. pt
+
+  //-------------------------------
+  // mc generated histograms jet-meson corr
+  //-------------------------------
+  std::vector<TH2F*> fHistoMCJetPtVsFrag;              //! vector of histos True Jet pT vs. true Frag (mc particle based distribution)
+  std::vector<TH2F*> fHistoMCJetPtVsFrag_Sec;          //! vector of histos True Jet pT vs. true Frag (mc particle based distribution for secondaries)
+  std::vector<TH2F*> fHistoMCPartonPtVsFrag;           //! vector of histos True parton pT vs. true Frag (mc particle based distribution)
+  std::vector<TH2F*> fHistoMCJetPtVsFragTrueParton;    //! vector of histos True Jet pT vs. true Frag (mc particle based distribution) for particles originating from hard parton from Jet
+  std::vector<TH2F*> fHistoMCPartonPtVsFragTrueParton; //! vector of histos True parton pT vs. true Frag (mc particle based distribution) for particles originating from hard parton from Jet
+
+ private:
+  AliAnalysisTaskMesonJetCorrelation(const AliAnalysisTaskMesonJetCorrelation&);            // Prevent copy-construction
+  AliAnalysisTaskMesonJetCorrelation& operator=(const AliAnalysisTaskMesonJetCorrelation&); // Prevent assignment
+
+  ClassDef(AliAnalysisTaskMesonJetCorrelation, 1);
+};
+
+#endif

--- a/PWGGA/GammaConv/CMakeLists.txt
+++ b/PWGGA/GammaConv/CMakeLists.txt
@@ -93,7 +93,9 @@ set(SRCS
     AliAnalysisTaskSigmaPlToProtonPiZero.cxx
     AliAnalysisTaskSigmaPlToProtonPiZeroAOD.cxx
     AliAnalysisTaskEtaToPiPlPiMiGamma.cxx
-    AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson.cxx    
+    AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson.cxx 
+    # meson jet correlation
+    AliAnalysisTaskMesonJetCorrelation.cxx   
 #     AliAnalysisTaskGCPartToPWG4Part.cxx
 #     AliAnaConvCorrBase.cxx
 #     AliAnaConvCorrPhoton.cxx

--- a/PWGGA/GammaConv/PWGGAGammaConvLinkDef.h
+++ b/PWGGA/GammaConv/PWGGAGammaConvLinkDef.h
@@ -63,6 +63,9 @@
 #pragma link C++ class AliAnalysisTaskEtaToPiPlPiMiGamma+;
 #pragma link C++ class AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson+;
 
+// mesons-jet correlation
+#pragma link C++ class AliAnalysisTaskMesonJetCorrelation+;
+
 // Old tasks
 // #pragma link C++ class AliAnaConvIsolation+;
 // #pragma link C++ class AliAnaConvCorrBase+;

--- a/PWGGA/GammaConv/macros/AddTask_MesonJetCorr_Calo.C
+++ b/PWGGA/GammaConv/macros/AddTask_MesonJetCorr_Calo.C
@@ -1,0 +1,321 @@
+/**************************************************************************
+ * Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights reserved. *
+ *                                                                        *
+ * Author: Joshua Koenig                                                  *
+ * Version 1.0                                                            *
+ *                                                                        *
+ *                                                                        *
+ * Permission to use, copy, modify and distribute this software and its   *
+ * documentation strictly for non-commercial purposes is hereby granted   *
+ * without fee, provided that the above copyright notice appears in all   *
+ * copies and that both the copyright notice and this permission notice   *
+ * appear in the supporting documentation. The authors make no claims     *
+ * about the suitability of this software for any purpose. It is          *
+ * provided "as is" without express or implied warranty.                  *
+ **************************************************************************/
+
+//***************************************************************************************
+// This AddTask is supposed to set up the main task
+//($ALIPHYSICS/PWGGA/GammaConv/AliAnalysisTaskMesonJetCorrelation.cxx) for
+// pp together with all supporting classes
+//***************************************************************************************
+
+//***************************************************************************************
+// main function
+//***************************************************************************************
+
+void AddTask_MesonJetCorr_Calo(
+  Int_t trainConfig = 1,                // change different set of cuts
+  Int_t isMC = 0,                       // run MC
+  int meson = 0,                        // meson: 0=pi0, 1 = eta
+  TString photonCutNumberV0Reader = "", // 00000008400000000100000000 nom. B, 00000088400000000100000000 low B
+  TString periodNameV0Reader = "",
+  // general setting for task
+  Int_t enableQAMesonTask = 0,             // enable QA in AliAnalysisTaskGammaConvV1
+  Int_t enableQAClusterTask = 0,           // enable additional QA task
+  Int_t enableExtMatchAndQA = 0,           // disabled (0), extMatch (1), extQA_noCellQA (2), extMatch+extQA_noCellQA (3), extQA+cellQA (4), extMatch+extQA+cellQA (5)
+  Int_t enableLightOutput = kFALSE,        // switch to run light output (only essential histograms for afterburner) (pi0 only mode: lighOutput + 10)
+  Bool_t enableTHnSparse = kFALSE,         // switch on THNsparse
+  Int_t enableTriggerMimicking = 0,        // enable trigger mimicking
+  Bool_t enableTriggerOverlapRej = kFALSE, // enable trigger overlap rejection
+  TString settingMaxFacPtHard = "3.",      // maximum factor between hardest jet and ptHard generated
+  Int_t debugLevel = 0,                    // introducing debug levels for grid running
+  // settings for weights
+  // FPTW:fileNamePtWeights, FMUW:fileNameMultWeights, separate with ;
+  TString fileNameExternalInputs = "",
+  Int_t doWeightingPart = 0,                   // enable Weighting
+  TString generatorName = "DPMJET",            // generator Name
+  Bool_t enableMultiplicityWeighting = kFALSE, //
+  TString periodNameAnchor = "",               //
+  // special settings
+  Bool_t enableSortingMCLabels = kTRUE, // enable sorting for MC cluster labels
+  // subwagon config
+  TString additionalTrainConfig = "0" // additional counter for trainconfig
+
+)
+{
+  AliCutHandlerPCM cuts(13);
+
+  TString addTaskName = "AddTask_MesonJetCorr_Calo";
+  TString sAdditionalTrainConfig = cuts.GetSpecialSettingFromAddConfig(additionalTrainConfig, "", "", addTaskName);
+  if (sAdditionalTrainConfig.Atoi() > 0) {
+    trainConfig = trainConfig + sAdditionalTrainConfig.Atoi();
+    cout << "INFO: " << addTaskName.Data() << " running additionalTrainConfig '" << sAdditionalTrainConfig.Atoi() << "', train config: '" << trainConfig << "'" << endl;
+  }
+
+  TString fileNamePtWeights = cuts.GetSpecialFileNameFromString(fileNameExternalInputs, "FPTW:");
+  TString fileNameMultWeights = cuts.GetSpecialFileNameFromString(fileNameExternalInputs, "FMUW:");
+  TString fileNameCustomTriggerMimicOADB = cuts.GetSpecialFileNameFromString(fileNameExternalInputs, "FTRM:");
+
+  TString corrTaskSetting = cuts.GetSpecialSettingFromAddConfig(additionalTrainConfig, "CF", "", addTaskName);
+  if (corrTaskSetting.CompareTo(""))
+    cout << "corrTaskSetting: " << corrTaskSetting.Data() << endl;
+
+  Int_t trackMatcherRunningMode = 0; // CaloTrackMatcher running mode
+  TString strTrackMatcherRunningMode = cuts.GetSpecialSettingFromAddConfig(additionalTrainConfig, "TM", "", addTaskName);
+  if (additionalTrainConfig.Contains("TM"))
+    trackMatcherRunningMode = strTrackMatcherRunningMode.Atoi();
+
+  TObjArray* rmaxFacPtHardSetting = settingMaxFacPtHard.Tokenize("_");
+  if (rmaxFacPtHardSetting->GetEntries() < 1) {
+    cout << "ERROR: AddTask_MesonJetCorr_pp during parsing of settingMaxFacPtHard String '" << settingMaxFacPtHard.Data() << "'" << endl;
+    return;
+  }
+  Bool_t fMinPtHardSet = kFALSE;
+  Double_t minFacPtHard = -1;
+  Bool_t fMaxPtHardSet = kFALSE;
+  Double_t maxFacPtHard = 100;
+  Bool_t fSingleMaxPtHardSet = kFALSE;
+  Double_t maxFacPtHardSingle = 100;
+  Bool_t fJetFinderUsage = kFALSE;
+  Bool_t fUsePtHardFromFile = kFALSE;
+  Bool_t fUseAddOutlierRej = kFALSE;
+  for (Int_t i = 0; i < rmaxFacPtHardSetting->GetEntries(); i++) {
+    TObjString* tempObjStrPtHardSetting = (TObjString*)rmaxFacPtHardSetting->At(i);
+    TString strTempSetting = tempObjStrPtHardSetting->GetString();
+    if (strTempSetting.BeginsWith("MINPTHFAC:")) {
+      strTempSetting.Replace(0, 10, "");
+      minFacPtHard = strTempSetting.Atof();
+      cout << "running with min pT hard jet fraction of: " << minFacPtHard << endl;
+      fMinPtHardSet = kTRUE;
+    } else if (strTempSetting.BeginsWith("MAXPTHFAC:")) {
+      strTempSetting.Replace(0, 10, "");
+      maxFacPtHard = strTempSetting.Atof();
+      cout << "running with max pT hard jet fraction of: " << maxFacPtHard << endl;
+      fMaxPtHardSet = kTRUE;
+    } else if (strTempSetting.BeginsWith("MAXPTHFACSINGLE:")) {
+      strTempSetting.Replace(0, 16, "");
+      maxFacPtHardSingle = strTempSetting.Atof();
+      cout << "running with max single particle pT hard fraction of: " << maxFacPtHardSingle << endl;
+      fSingleMaxPtHardSet = kTRUE;
+    } else if (strTempSetting.BeginsWith("USEJETFINDER:")) {
+      strTempSetting.Replace(0, 13, "");
+      if (strTempSetting.Atoi() == 1) {
+        cout << "using MC jet finder for outlier removal" << endl;
+        fJetFinderUsage = kTRUE;
+      }
+    } else if (strTempSetting.BeginsWith("PTHFROMFILE:")) {
+      strTempSetting.Replace(0, 12, "");
+      if (strTempSetting.Atoi() == 1) {
+        cout << "using MC jet finder for outlier removal" << endl;
+        fUsePtHardFromFile = kTRUE;
+      }
+    } else if (strTempSetting.BeginsWith("ADDOUTLIERREJ:")) {
+      strTempSetting.Replace(0, 14, "");
+      if (strTempSetting.Atoi() == 1) {
+        cout << "using path based outlier removal" << endl;
+        fUseAddOutlierRej = kTRUE;
+      }
+    } else if (rmaxFacPtHardSetting->GetEntries() == 1 && strTempSetting.Atof() > 0) {
+      maxFacPtHard = strTempSetting.Atof();
+      cout << "running with max pT hard jet fraction of: " << maxFacPtHard << endl;
+      fMaxPtHardSet = kTRUE;
+    }
+  }
+
+  Int_t isHeavyIon = 0;
+
+  // ================== GetAnalysisManager ===============================
+  AliAnalysisManager* mgr = AliAnalysisManager::GetAnalysisManager();
+  if (!mgr) {
+    Error(Form("%s_%i", addTaskName.Data(), trainConfig), "No analysis manager found.");
+    return;
+  }
+
+  // ================== GetInputEventHandler =============================
+  AliVEventHandler* inputHandler = mgr->GetInputEventHandler();
+
+  //=========  Set Cutnumber for V0Reader ================================
+  TString cutnumberPhoton = photonCutNumberV0Reader.Data();
+  TString cutnumberEvent = "00000003";
+  AliAnalysisDataContainer* cinput = mgr->GetCommonInputContainer();
+
+  //========= Add V0 Reader to  ANALYSIS manager if not yet existent =====
+  TString V0ReaderName = Form("V0ReaderV1_%s_%s", cutnumberEvent.Data(), cutnumberPhoton.Data());
+  AliV0ReaderV1* fV0ReaderV1 = NULL;
+  if (!(AliV0ReaderV1*)mgr->GetTask(V0ReaderName.Data())) {
+    cout << "V0Reader: " << V0ReaderName.Data() << " not found!!" << endl;
+    return;
+  } else {
+    cout << "V0Reader: " << V0ReaderName.Data() << " found!!" << endl;
+  }
+
+  //================================================
+  //========= Add task to the ANALYSIS manager =====
+  //================================================
+  AliAnalysisTaskMesonJetCorrelation* task = NULL;
+  task = new AliAnalysisTaskMesonJetCorrelation(Form("MesonJetCorrelation_Calo_%i", trainConfig));
+  task->SetIsHeavyIon(isHeavyIon);
+  task->SetIsMC(isMC);
+  task->SetV0ReaderName(V0ReaderName);
+  task->SetCorrectionTaskSetting(corrTaskSetting);
+  task->SetTrackMatcherRunningMode(trackMatcherRunningMode); // have to do this!
+
+  //---------------------------------------
+  // configs for pi0 meson pp 13 TeV
+  //---------------------------------------
+  if (trainConfig == 1) {
+    cuts.AddCutCalo("00010103", "411790109fe30230000", "0s631031000000d0"); // test config without in-jet selection
+  } else if (trainConfig == 2) {
+    cuts.AddCutCalo("00010103", "411790109fe30230000", "2s631034000000d0"); // in-jet, pi0 mass: 0.1-0.15, rotation back
+  } else if (trainConfig == 3) {
+    cuts.AddCutCalo("00010103", "411790109fe30230000", "21631034000000d0"); // in-jet, pi0 mass: 0.1-0.15, mixed jet back
+  } else if (trainConfig == 4) {
+    cuts.AddCutCalo("0008e103", "411790109fe30230000", "2s631034000000d0"); // EG2 in-jet, pi0 mass: 0.1-0.15, rotation back
+    cuts.AddCutCalo("0008e103", "411790109fe30230000", "2s631034000000d0"); // EG2 in-jet, pi0 mass: 0.1-0.15, rotation back
+  } else if (trainConfig == 5) {
+    cuts.AddCutCalo("0008d103", "411790109fe30230000", "21631034000000d0"); // EG1 in-jet, pi0 mass: 0.1-0.15, mixed jet back
+    cuts.AddCutCalo("0008d103", "411790109fe30230000", "21631034000000d0"); // EG1 in-jet, pi0 mass: 0.1-0.15, mixed jet back
+
+    //---------------------------------------
+    // configs for eta meson pp 13 TeV
+    //---------------------------------------
+  } else if (trainConfig == 1002) {
+    cuts.AddCutCalo("00010103", "411790109fe30230000", "2s631034000000d0"); // in-jet, pi0 mass: 0.1-0.15, rotation back
+  } else if (trainConfig == 1003) {
+    cuts.AddCutCalo("00010103", "411790109fe30230000", "21631034000000d0"); // in-jet, pi0 mass: 0.1-0.15, mixed jet back
+  } else {
+    Error(Form("MesonJetCorrelation_Calo_%i", trainConfig), "wrong trainConfig variable no cuts have been specified for the configuration");
+    return;
+  }
+
+  if (!cuts.AreValid()) {
+    cout << "\n\n****************************************************" << endl;
+    cout << "ERROR: No valid cuts stored in CutHandlerCalo! Returning..." << endl;
+    cout << "****************************************************\n\n"
+         << endl;
+    return;
+  }
+
+  Int_t numberOfCuts = cuts.GetNCuts();
+
+  TList* EventCutList = new TList();
+  TList* ClusterCutList = new TList();
+  TList* MesonCutList = new TList();
+
+  EventCutList->SetOwner(kTRUE);
+  AliConvEventCuts** analysisEventCuts = new AliConvEventCuts*[numberOfCuts];
+  ClusterCutList->SetOwner(kTRUE);
+  AliCaloPhotonCuts** analysisClusterCuts = new AliCaloPhotonCuts*[numberOfCuts];
+  MesonCutList->SetOwner(kTRUE);
+  AliConversionMesonCuts** analysisMesonCuts = new AliConversionMesonCuts*[numberOfCuts];
+
+  for (Int_t i = 0; i < numberOfCuts; i++) {
+    //create AliCaloTrackMatcher instance, if there is none present
+    TString caloCutPos = cuts.GetClusterCut(i);
+    caloCutPos.Resize(1);
+    TString TrackMatcherName = Form("CaloTrackMatcher_%s_%i", caloCutPos.Data(), trackMatcherRunningMode);
+    if (corrTaskSetting.CompareTo("")) {
+      TrackMatcherName = TrackMatcherName + "_" + corrTaskSetting.Data();
+      cout << "Using separate track matcher for correction framework setting: " << TrackMatcherName.Data() << endl;
+    }
+    if (!(AliCaloTrackMatcher*)mgr->GetTask(TrackMatcherName.Data())) {
+      AliCaloTrackMatcher* fTrackMatcher = new AliCaloTrackMatcher(TrackMatcherName.Data(), caloCutPos.Atoi(), trackMatcherRunningMode);
+      fTrackMatcher->SetV0ReaderName(V0ReaderName);
+      fTrackMatcher->SetCorrectionTaskSetting(corrTaskSetting);
+      mgr->AddTask(fTrackMatcher);
+      mgr->ConnectInput(fTrackMatcher, 0, cinput);
+    }
+
+    //---------------------------------------------------------//
+    //------------------------ Event Cuts ---------------------//
+    //---------------------------------------------------------//
+    analysisEventCuts[i] = new AliConvEventCuts();
+    // analysisEventCuts[i]->SetCaloTriggerHelperName(TriggerHelperName.Data());
+    analysisEventCuts[i]->SetTriggerMimicking(enableTriggerMimicking);
+    analysisEventCuts[i]->SetTriggerOverlapRejecion(enableTriggerOverlapRej);
+    analysisEventCuts[i]->SetV0ReaderName(V0ReaderName);
+    analysisEventCuts[i]->SetCorrectionTaskSetting(corrTaskSetting);
+    if (enableLightOutput > 0)
+      analysisEventCuts[i]->SetLightOutput(kTRUE);
+    if (fMinPtHardSet)
+      analysisEventCuts[i]->SetMinFacPtHard(minFacPtHard);
+    if (fMaxPtHardSet)
+      analysisEventCuts[i]->SetMaxFacPtHard(maxFacPtHard);
+    if (fSingleMaxPtHardSet)
+      analysisEventCuts[i]->SetMaxFacPtHardSingleParticle(maxFacPtHardSingle);
+    if (fJetFinderUsage)
+      analysisEventCuts[i]->SetUseJetFinderForOutliers(kTRUE);
+    if (fUsePtHardFromFile)
+      analysisEventCuts[i]->SetUsePtHardBinFromFile(kTRUE);
+    if (fUseAddOutlierRej)
+      analysisEventCuts[i]->SetUseAdditionalOutlierRejection(kTRUE);
+    if (periodNameV0Reader.CompareTo("") != 0)
+      analysisEventCuts[i]->SetPeriodEnum(periodNameV0Reader);
+    analysisEventCuts[i]->InitializeCutsFromCutString((cuts.GetEventCut(i)).Data());
+    analysisEventCuts[i]->SetFillCutHistograms("", kFALSE);
+    EventCutList->Add(analysisEventCuts[i]);
+
+    //---------------------------------------------------------//
+    //------------------- Calo Photon Cuts --------------------//
+    //---------------------------------------------------------//
+    analysisClusterCuts[i] = new AliCaloPhotonCuts(isMC);
+    // analysisClusterCuts[i]->SetHistoToModifyAcceptance(histoAcc);
+    analysisClusterCuts[i]->SetV0ReaderName(V0ReaderName);
+    analysisClusterCuts[i]->SetCorrectionTaskSetting(corrTaskSetting);
+    analysisClusterCuts[i]->SetCaloTrackMatcherName(TrackMatcherName);
+    if (enableLightOutput > 0)
+      analysisClusterCuts[i]->SetLightOutput(kTRUE);
+    analysisClusterCuts[i]->InitializeCutsFromCutString((cuts.GetClusterCut(i)).Data());
+    analysisClusterCuts[i]->SetExtendedMatchAndQA(enableExtMatchAndQA);
+    ClusterCutList->Add(analysisClusterCuts[i]);
+
+    //---------------------------------------------------------//
+    //------------------------ Meson Cuts ---------------------//
+    //---------------------------------------------------------//
+    analysisMesonCuts[i] = new AliConversionMesonCuts();
+    analysisMesonCuts[i]->InitializeCutsFromCutString((cuts.GetMesonCut(i)).Data());
+    analysisMesonCuts[i]->SetIsMergedClusterCut(2);
+    analysisMesonCuts[i]->SetCaloMesonCutsObject(analysisClusterCuts[i]);
+    analysisMesonCuts[i]->SetFillCutHistograms("");
+    // analysisEventCuts[i]->SetAcceptedHeader(HeaderList);
+    analysisClusterCuts[i]->SetFillCutHistograms("");
+    if (enableLightOutput > 0)
+      analysisMesonCuts[i]->SetLightOutput(kTRUE);
+    if (analysisMesonCuts[i]->DoGammaSwappForBg())
+      analysisClusterCuts[i]->SetUseEtaPhiMapForBackCand(kTRUE); // needed in case of rotation background QA histos
+    MesonCutList->Add(analysisMesonCuts[i]);
+  }
+
+  task->SetMesonKind(meson);
+  task->SetIsCalo(true);
+  task->SetEventCutList(numberOfCuts, EventCutList);
+  task->SetCaloCutList(numberOfCuts, ClusterCutList);
+  task->SetMesonCutList(numberOfCuts, MesonCutList);
+  //   task->SetDoMesonAnalysis(kTRUE); // I think we dont need that!
+  task->SetCorrectionTaskSetting(corrTaskSetting);
+  task->SetDoMesonQA(enableQAMesonTask); //Attention new switch for Pi0 QA
+                                         //   task->SetDoClusterQA(enableQAClusterTask);  //Attention new switch small for Cluster QA
+                                         //   task->SetDoTHnSparse(enableTHnSparse);
+
+  //connect containers
+  AliAnalysisDataContainer* coutput =
+    mgr->CreateContainer(!(corrTaskSetting.CompareTo("")) ? Form("MesonJetCorrelation_Calo_%i_%i", meson, trainConfig) : Form("MesonJetCorrelation_Calo_%i_%i_%s", meson, trainConfig, corrTaskSetting.Data()), TList::Class(),
+                         AliAnalysisManager::kOutputContainer, Form("MesonJetCorrelation_Calo_%i_%i.root", meson, trainConfig));
+
+  mgr->AddTask(task);
+  mgr->ConnectInput(task, 0, cinput);
+  mgr->ConnectOutput(task, 1, coutput);
+
+  return;
+}

--- a/PWGGA/GammaConv/macros/AddTask_MesonJetCorr_Conv.C
+++ b/PWGGA/GammaConv/macros/AddTask_MesonJetCorr_Conv.C
@@ -1,0 +1,323 @@
+/**************************************************************************
+ * Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights reserved. *
+ *                                                                        *
+ * Author: Joshua Koenig                                                  *
+ * Version 1.0                                                            *
+ *                                                                        *
+ *                                                                        *
+ * Permission to use, copy, modify and distribute this software and its   *
+ * documentation strictly for non-commercial purposes is hereby granted   *
+ * without fee, provided that the above copyright notice appears in all   *
+ * copies and that both the copyright notice and this permission notice   *
+ * appear in the supporting documentation. The authors make no claims     *
+ * about the suitability of this software for any purpose. It is          *
+ * provided "as is" without express or implied warranty.                  *
+ **************************************************************************/
+
+//***************************************************************************************
+// This AddTask is supposed to set up the main task
+//($ALIPHYSICS/PWGGA/GammaConv/AliAnalysisTaskMesonJetCorrelation.cxx) for
+// pp together with all supporting classes
+//***************************************************************************************
+
+//***************************************************************************************
+// main function
+//***************************************************************************************
+
+void AddTask_MesonJetCorr_Conv(
+  Int_t trainConfig = 1,                // change different set of cuts
+  Int_t isMC = 0,                       // run MC
+  int meson = 0,                        // meson: 0=pi0, 1 = eta
+  TString photonCutNumberV0Reader = "", // 00000008400000000100000000 nom. B, 00000088400000000100000000 low B
+  TString periodNameV0Reader = "",
+  // general setting for task
+  Int_t enableQAMesonTask = 0,             // enable QA in AliAnalysisTaskGammaConvV1
+  Int_t enableQAPhotonTask = 0,            // enable additional QA task
+  int enableLightOutput = kFALSE,          // switch to run light output (only essential histograms for afterburner)
+  Bool_t enableTHnSparse = kFALSE,         // switch on THNsparse
+  Int_t enableTriggerMimicking = 0,        // enable trigger mimicking
+  Bool_t enableTriggerOverlapRej = kFALSE, // enable trigger overlap rejection
+  TString settingMaxFacPtHard = "3.",      // maximum factor between hardest jet and ptHard generated
+  Int_t debugLevel = 0,                    // introducing debug levels for grid running
+  // settings for weights
+  // FPTW:fileNamePtWeights, FMUW:fileNameMultWeights, FMAW:fileNameMatBudWeights, FEPC:fileNamedEdxPostCalib, separate with ;
+  TString fileNameExternalInputs = "",
+  Int_t doWeightingPart = 0,                   // enable Weighting
+  TString generatorName = "DPMJET",            // generator Name
+  Bool_t enableMultiplicityWeighting = kFALSE, //
+  TString periodNameAnchor = "",               //
+  Int_t enableMatBudWeightsPi0 = 0,            // 1 = three radial bins, 2 = 10 radial bins
+  Bool_t enableElecDeDxPostCalibration = kFALSE,
+  // special settings
+  Bool_t enableChargedPrimary = kFALSE,
+  Bool_t doSmear = kFALSE, // switches to run user defined smearing
+  Double_t bremSmear = 1.,
+  Double_t smearPar = 0.,      // conv photon smearing params
+  Double_t smearParConst = 0., // conv photon smearing params
+  // subwagon config
+  TString additionalTrainConfig = "0" // additional counter for trainconfig + special settings
+)
+{
+
+  AliCutHandlerPCM cuts(13);
+
+  TString addTaskName = "AddTask_MesonJetCorr_ConvCalo";
+  TString sAdditionalTrainConfig = cuts.GetSpecialSettingFromAddConfig(additionalTrainConfig, "", "", addTaskName);
+  if (sAdditionalTrainConfig.Atoi() > 0) {
+    trainConfig = trainConfig + sAdditionalTrainConfig.Atoi();
+    cout << "INFO: " << addTaskName.Data() << " running additionalTrainConfig '" << sAdditionalTrainConfig.Atoi() << "', train config: '" << trainConfig << "'" << endl;
+  }
+
+  TString fileNamePtWeights = cuts.GetSpecialFileNameFromString(fileNameExternalInputs, "FPTW:");
+  TString fileNameMultWeights = cuts.GetSpecialFileNameFromString(fileNameExternalInputs, "FMUW:");
+  TString fileNamedEdxPostCalib = cuts.GetSpecialFileNameFromString(fileNameExternalInputs, "FEPC:");
+  TString fileNameCustomTriggerMimicOADB = cuts.GetSpecialFileNameFromString(fileNameExternalInputs, "FTRM:");
+
+  Int_t trackMatcherRunningMode = 0; // CaloTrackMatcher running mode
+  TString strTrackMatcherRunningMode = cuts.GetSpecialSettingFromAddConfig(additionalTrainConfig, "TM", "", addTaskName);
+  if (additionalTrainConfig.Contains("TM"))
+    trackMatcherRunningMode = strTrackMatcherRunningMode.Atoi();
+
+  TObjArray* rmaxFacPtHardSetting = settingMaxFacPtHard.Tokenize("_");
+  if (rmaxFacPtHardSetting->GetEntries() < 1) {
+    cout << "ERROR: AddTask_MesonJetCorr_pp during parsing of settingMaxFacPtHard String '" << settingMaxFacPtHard.Data() << "'" << endl;
+    return;
+  }
+  Bool_t fMinPtHardSet = kFALSE;
+  Double_t minFacPtHard = -1;
+  Bool_t fMaxPtHardSet = kFALSE;
+  Double_t maxFacPtHard = 100;
+  Bool_t fSingleMaxPtHardSet = kFALSE;
+  Double_t maxFacPtHardSingle = 100;
+  Bool_t fJetFinderUsage = kFALSE;
+  Bool_t fUsePtHardFromFile = kFALSE;
+  Bool_t fUseAddOutlierRej = kFALSE;
+  for (Int_t i = 0; i < rmaxFacPtHardSetting->GetEntries(); i++) {
+    TObjString* tempObjStrPtHardSetting = (TObjString*)rmaxFacPtHardSetting->At(i);
+    TString strTempSetting = tempObjStrPtHardSetting->GetString();
+    if (strTempSetting.BeginsWith("MINPTHFAC:")) {
+      strTempSetting.Replace(0, 10, "");
+      minFacPtHard = strTempSetting.Atof();
+      cout << "running with min pT hard jet fraction of: " << minFacPtHard << endl;
+      fMinPtHardSet = kTRUE;
+    } else if (strTempSetting.BeginsWith("MAXPTHFAC:")) {
+      strTempSetting.Replace(0, 10, "");
+      maxFacPtHard = strTempSetting.Atof();
+      cout << "running with max pT hard jet fraction of: " << maxFacPtHard << endl;
+      fMaxPtHardSet = kTRUE;
+    } else if (strTempSetting.BeginsWith("MAXPTHFACSINGLE:")) {
+      strTempSetting.Replace(0, 16, "");
+      maxFacPtHardSingle = strTempSetting.Atof();
+      cout << "running with max single particle pT hard fraction of: " << maxFacPtHardSingle << endl;
+      fSingleMaxPtHardSet = kTRUE;
+    } else if (strTempSetting.BeginsWith("USEJETFINDER:")) {
+      strTempSetting.Replace(0, 13, "");
+      if (strTempSetting.Atoi() == 1) {
+        cout << "using MC jet finder for outlier removal" << endl;
+        fJetFinderUsage = kTRUE;
+      }
+    } else if (strTempSetting.BeginsWith("PTHFROMFILE:")) {
+      strTempSetting.Replace(0, 12, "");
+      if (strTempSetting.Atoi() == 1) {
+        cout << "using MC jet finder for outlier removal" << endl;
+        fUsePtHardFromFile = kTRUE;
+      }
+    } else if (strTempSetting.BeginsWith("ADDOUTLIERREJ:")) {
+      strTempSetting.Replace(0, 14, "");
+      if (strTempSetting.Atoi() == 1) {
+        cout << "using path based outlier removal" << endl;
+        fUseAddOutlierRej = kTRUE;
+      }
+    } else if (rmaxFacPtHardSetting->GetEntries() == 1 && strTempSetting.Atof() > 0) {
+      maxFacPtHard = strTempSetting.Atof();
+      cout << "running with max pT hard jet fraction of: " << maxFacPtHard << endl;
+      fMaxPtHardSet = kTRUE;
+    }
+  }
+
+  Int_t isHeavyIon = 0;
+
+  // ================== GetAnalysisManager ===============================
+  AliAnalysisManager* mgr = AliAnalysisManager::GetAnalysisManager();
+  if (!mgr) {
+    Error(Form("%s_%i", addTaskName.Data(), trainConfig), "No analysis manager found.");
+    return;
+  }
+
+  // ================== GetInputEventHandler =============================
+  AliVEventHandler* inputHandler = mgr->GetInputEventHandler();
+
+  //=========  Set Cutnumber for V0Reader ================================
+  TString cutnumberPhoton = photonCutNumberV0Reader.Data();
+  TString cutnumberEvent = "00000003";
+  AliAnalysisDataContainer* cinput = mgr->GetCommonInputContainer();
+
+  //========= Add V0 Reader to  ANALYSIS manager if not yet existent =====
+  TString V0ReaderName = Form("V0ReaderV1_%s_%s", cutnumberEvent.Data(), cutnumberPhoton.Data());
+  AliV0ReaderV1* fV0ReaderV1 = NULL;
+  if (!(AliV0ReaderV1*)mgr->GetTask(V0ReaderName.Data())) {
+    cout << "V0Reader: " << V0ReaderName.Data() << " not found!!" << endl;
+    return;
+  } else {
+    cout << "V0Reader: " << V0ReaderName.Data() << " found!!" << endl;
+  }
+
+  //================================================
+  //========= Add task to the ANALYSIS manager =====
+  //================================================
+  AliAnalysisTaskMesonJetCorrelation* task = NULL;
+  task = new AliAnalysisTaskMesonJetCorrelation(Form("MesonJetCorrelation_%i", trainConfig));
+  task->SetIsHeavyIon(isHeavyIon);
+  task->SetIsMC(isMC);
+  task->SetV0ReaderName(V0ReaderName);
+  task->SetTrackMatcherRunningMode(trackMatcherRunningMode); // have to do this!
+
+  //---------------------------------------
+  // configs for pi0 meson pp 13 TeV
+  //---------------------------------------
+  if (trainConfig == 1) {
+    cuts.AddCutPCM("00010103", "0dm00009f9730000dge0474000", "0152103500000000"); // config without jet requirement
+  } else if (trainConfig == 2) {
+    cuts.AddCutPCM("00010103", "0dm00009f9730000dge0474000", "2r52103500000000"); // in-Jet mass cut around pi0: 0.1-0.15, rotation back
+  } else if (trainConfig == 3) {
+    cuts.AddCutPCM("00010103", "0dm00009f9730000dge0474000", "2152103500000000"); // in-Jet mass cut around pi0: 0.1-0.15, mixed jet back
+
+    //---------------------------------------
+    // configs for eta meson pp 13 TeV
+    //---------------------------------------
+
+  } else if (trainConfig == 1002) {
+    cuts.AddCutPCM("00010103", "0dm00009f9730000dge0474000", "2r52103l00000000"); // in-Jet mass cut around eta: 0.5-0.6, rotation back
+  } else if (trainConfig == 1003) {
+    cuts.AddCutPCM("00010103", "0dm00009f9730000dge0474000", "2152103l00000000"); // in-Jet mass cut around pi0: 0.5-0.6, mixed jet back
+
+  } else {
+    Error(Form("MesonJetCorrelation_%i", trainConfig), "wrong trainConfig variable no cuts have been specified for the configuration");
+    return;
+  }
+
+  if (!cuts.AreValid()) {
+    cout << "\n\n****************************************************" << endl;
+    cout << "ERROR: No valid cuts stored in CutHandlerCalo! Returning..." << endl;
+    cout << "****************************************************\n\n"
+         << endl;
+    return;
+  }
+
+  Int_t numberOfCuts = cuts.GetNCuts();
+
+  TList* EventCutList = new TList();
+  TList* ConvCutList = new TList();
+  TList* MesonCutList = new TList();
+
+  EventCutList->SetOwner(kTRUE);
+  AliConvEventCuts** analysisEventCuts = new AliConvEventCuts*[numberOfCuts];
+  ConvCutList->SetOwner(kTRUE);
+  AliConversionPhotonCuts** analysisConvCuts = new AliConversionPhotonCuts*[numberOfCuts];
+  MesonCutList->SetOwner(kTRUE);
+  AliConversionMesonCuts** analysisMesonCuts = new AliConversionMesonCuts*[numberOfCuts];
+
+  for (Int_t i = 0; i < numberOfCuts; i++) {
+
+    //---------------------------------------------------------//
+    //------------------------ Event Cuts ---------------------//
+    //---------------------------------------------------------//
+    analysisEventCuts[i] = new AliConvEventCuts();
+    // analysisEventCuts[i]->SetCaloTriggerHelperName(TriggerHelperName.Data());
+    analysisEventCuts[i]->SetTriggerMimicking(enableTriggerMimicking);
+    analysisEventCuts[i]->SetTriggerOverlapRejecion(enableTriggerOverlapRej);
+    analysisEventCuts[i]->SetV0ReaderName(V0ReaderName);
+    if (enableLightOutput > 0)
+      analysisEventCuts[i]->SetLightOutput(kTRUE);
+    if (fMinPtHardSet)
+      analysisEventCuts[i]->SetMinFacPtHard(minFacPtHard);
+    if (fMaxPtHardSet)
+      analysisEventCuts[i]->SetMaxFacPtHard(maxFacPtHard);
+    if (fSingleMaxPtHardSet)
+      analysisEventCuts[i]->SetMaxFacPtHardSingleParticle(maxFacPtHardSingle);
+    if (fJetFinderUsage)
+      analysisEventCuts[i]->SetUseJetFinderForOutliers(kTRUE);
+    if (fUsePtHardFromFile)
+      analysisEventCuts[i]->SetUsePtHardBinFromFile(kTRUE);
+    if (fUseAddOutlierRej)
+      analysisEventCuts[i]->SetUseAdditionalOutlierRejection(kTRUE);
+    if (periodNameV0Reader.CompareTo("") != 0)
+      analysisEventCuts[i]->SetPeriodEnum(periodNameV0Reader);
+    analysisEventCuts[i]->InitializeCutsFromCutString((cuts.GetEventCut(i)).Data());
+    analysisEventCuts[i]->SetFillCutHistograms("", kFALSE);
+    EventCutList->Add(analysisEventCuts[i]);
+
+    //---------------------------------------------------------//
+    //------------------- Conv Photon Cuts --------------------//
+    //---------------------------------------------------------//
+    analysisConvCuts[i] = new AliConversionPhotonCuts();
+
+    // if (enableMatBudWeightsPi0 > 0){
+    //   if (isMC > 0){
+    // if (analysisConvCuts[i]->InitializeMaterialBudgetWeights(enableMatBudWeightsPi0,fileNameMatBudWeights)){
+    //   initializedMatBudWeigths_existing = kTRUE;}
+    // else {cout << "ERROR The initialization of the materialBudgetWeights did not work out." << endl;}
+    //   }
+    //   else {cout << "ERROR 'enableMatBudWeightsPi0'-flag was set > 0 even though this is not a MC task. It was automatically reset to 0." << endl;}
+    // }
+
+    analysisConvCuts[i]->SetV0ReaderName(V0ReaderName);
+    if (enableElecDeDxPostCalibration) {
+      if (isMC == 0) {
+        if (fileNamedEdxPostCalib.CompareTo("") != 0) {
+          analysisConvCuts[i]->SetElecDeDxPostCalibrationCustomFile(fileNamedEdxPostCalib);
+          cout << "Setting custom dEdx recalibration file: " << fileNamedEdxPostCalib.Data() << endl;
+        }
+        analysisConvCuts[i]->SetDoElecDeDxPostCalibration(enableElecDeDxPostCalibration);
+        cout << "Enabled TPC dEdx recalibration." << endl;
+      } else {
+        cout << "ERROR enableElecDeDxPostCalibration set to True even if MC file. Automatically reset to 0" << endl;
+        enableElecDeDxPostCalibration = kFALSE;
+        analysisConvCuts[i]->SetDoElecDeDxPostCalibration(kFALSE);
+      }
+    }
+    if (enableLightOutput == 1 || enableLightOutput == 2 || enableLightOutput == 5)
+      analysisConvCuts[i]->SetLightOutput(1);
+    if (enableLightOutput == 4)
+      analysisConvCuts[i]->SetLightOutput(2);
+    if (enableLightOutput == 0)
+      analysisConvCuts[i]->SetPlotTrackPID(kTRUE);
+    analysisConvCuts[i]->InitializeCutsFromCutString((cuts.GetPhotonCut(i)).Data());
+    analysisConvCuts[i]->SetIsHeavyIon(isHeavyIon);
+    analysisConvCuts[i]->SetFillCutHistograms("", kFALSE);
+    ConvCutList->Add(analysisConvCuts[i]);
+
+    //---------------------------------------------------------//
+    //------------------------ Meson Cuts ---------------------//
+    //---------------------------------------------------------//
+    analysisMesonCuts[i] = new AliConversionMesonCuts();
+    analysisMesonCuts[i]->InitializeCutsFromCutString((cuts.GetMesonCut(i)).Data());
+    analysisMesonCuts[i]->SetFillCutHistograms("");
+    // analysisEventCuts[i]->SetAcceptedHeader(HeaderList);
+    if (enableLightOutput > 0)
+      analysisMesonCuts[i]->SetLightOutput(kTRUE);
+    MesonCutList->Add(analysisMesonCuts[i]);
+  }
+
+  task->SetMesonKind(meson);
+  task->SetIsConv(true);
+  task->SetEventCutList(numberOfCuts, EventCutList);
+  task->SetMesonCutList(numberOfCuts, MesonCutList);
+  task->SetConversionCutList(numberOfCuts, ConvCutList);
+  //   task->SetDoMesonAnalysis(kTRUE); // I think we dont need that!
+  task->SetDoMesonQA(enableQAMesonTask); //Attention new switch for Pi0 QA
+                                         //   task->SetDoTHnSparse(enableTHnSparse);
+
+  //connect containers
+  AliAnalysisDataContainer* coutput =
+    mgr->CreateContainer(Form("MesonJetCorrelation_Conv_%i_%i", meson, trainConfig), TList::Class(),
+                         AliAnalysisManager::kOutputContainer, Form("MesonJetCorrelation_Conv_%i_%i.root", meson, trainConfig));
+
+  mgr->AddTask(task);
+  cout << "before connect input\n";
+  mgr->ConnectInput(task, 0, cinput);
+  cout << "before ConnectOutput\n";
+  mgr->ConnectOutput(task, 1, coutput);
+
+  return;
+}

--- a/PWGGA/GammaConv/macros/AddTask_MesonJetCorr_ConvCalo.C
+++ b/PWGGA/GammaConv/macros/AddTask_MesonJetCorr_ConvCalo.C
@@ -1,0 +1,378 @@
+/**************************************************************************
+ * Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights reserved. *
+ *                                                                        *
+ * Author: Joshua Koenig                                                  *
+ * Version 1.0                                                            *
+ *                                                                        *
+ *                                                                        *
+ * Permission to use, copy, modify and distribute this software and its   *
+ * documentation strictly for non-commercial purposes is hereby granted   *
+ * without fee, provided that the above copyright notice appears in all   *
+ * copies and that both the copyright notice and this permission notice   *
+ * appear in the supporting documentation. The authors make no claims     *
+ * about the suitability of this software for any purpose. It is          *
+ * provided "as is" without express or implied warranty.                  *
+ **************************************************************************/
+
+//***************************************************************************************
+// This AddTask is supposed to set up the main task
+//($ALIPHYSICS/PWGGA/GammaConv/AliAnalysisTaskMesonJetCorrelation.cxx) for
+// pp together with all supporting classes
+//***************************************************************************************
+
+//***************************************************************************************
+// main function
+//***************************************************************************************
+
+void AddTask_MesonJetCorr_ConvCalo(
+  Int_t trainConfig = 1,                // change different set of cuts
+  Int_t isMC = 0,                       // run MC
+  int meson = 0,                        // meson: 0=pi0, 1 = eta
+  TString photonCutNumberV0Reader = "", // 00000008400000000100000000 nom. B, 00000088400000000100000000 low B
+  TString periodNameV0Reader = "",
+  // general setting for task
+  Int_t enableQAMesonTask = 0,             // enable QA in AliAnalysisTaskGammaConvV1
+  Int_t enableQAPhotonTask = 0,            // enable additional QA task
+  Int_t enableExtMatchAndQA = 0,           // disabled (0), extMatch (1), extQA_noCellQA (2), extMatch+extQA_noCellQA (3), extQA+cellQA (4), extMatch+extQA+cellQA (5)
+  Int_t enableLightOutput = 0,             // switch to run light output (only essential histograms for afterburner)
+  Bool_t enableTHnSparse = kFALSE,         // switch on THNsparse
+  Int_t enableTriggerMimicking = 0,        // enable trigger mimicking
+  Bool_t enableTriggerOverlapRej = kFALSE, // enable trigger overlap rejection
+  TString settingMaxFacPtHard = "3.",      // maximum factor between hardest jet and ptHard generated
+  Int_t debugLevel = 0,                    // introducing debug levels for grid running
+  // settings for weights
+  // FPTW:fileNamePtWeights, FMUW:fileNameMultWeights,  FMAW:fileNameMatBudWeights,  separate with ;
+  // Material Budget Weights file for Run 2
+  // FMAW:alien:///alice/cern.ch/user/a/amarin//MBW/MCInputFileMaterialBudgetWeightsLHC16_Pythia_00010103_0d000009266300008850404000_date181214.root
+  TString fileNameExternalInputs = "",
+  Int_t doWeightingPart = 0,                   // enable Weighting
+  TString generatorName = "DPMJET",            // generator Name
+  Bool_t enableMultiplicityWeighting = kFALSE, //
+  Int_t enableMatBudWeightsPi0 = 0,            // 1 = three radial bins, 2 = 10 radial bins (2 is the default when using weights)
+  Bool_t enableElecDeDxPostCalibration = kFALSE,
+  TString periodNameAnchor = "", //
+  // special settings
+  Bool_t enableSortingMCLabels = kTRUE,     // enable sorting for MC cluster labels
+  Bool_t enableTreeConvGammaShape = kFALSE, // enable additional tree for conversion properties for clusters
+  Bool_t doSmear = kFALSE,                  // switches to run user defined smearing
+  Double_t bremSmear = 1.,
+  Double_t smearPar = 0.,                // conv photon smearing params
+  Double_t smearParConst = 0.,           // conv photon smearing params
+  Bool_t doPrimaryTrackMatching = kTRUE, // enable basic track matching for all primary tracks to cluster
+  // subwagon config
+  TString additionalTrainConfig = "0" // additional counter for trainconfig
+)
+{
+
+  AliCutHandlerPCM cuts(13);
+
+  TString addTaskName = "AddTask_MesonJetCorr_ConvCalo";
+  TString sAdditionalTrainConfig = cuts.GetSpecialSettingFromAddConfig(additionalTrainConfig, "", "", addTaskName);
+  if (sAdditionalTrainConfig.Atoi() > 0) {
+    trainConfig = trainConfig + sAdditionalTrainConfig.Atoi();
+    cout << "INFO: " << addTaskName.Data() << " running additionalTrainConfig '" << sAdditionalTrainConfig.Atoi() << "', train config: '" << trainConfig << "'" << endl;
+  }
+
+  TString fileNamePtWeights = cuts.GetSpecialFileNameFromString(fileNameExternalInputs, "FPTW:");
+  TString fileNameMultWeights = cuts.GetSpecialFileNameFromString(fileNameExternalInputs, "FMUW:");
+  TString fileNamedEdxPostCalib = cuts.GetSpecialFileNameFromString(fileNameExternalInputs, "FEPC:");
+  TString fileNameCustomTriggerMimicOADB = cuts.GetSpecialFileNameFromString(fileNameExternalInputs, "FTRM:");
+
+  TString corrTaskSetting = cuts.GetSpecialSettingFromAddConfig(additionalTrainConfig, "CF", "", addTaskName);
+  if (corrTaskSetting.CompareTo(""))
+    cout << "corrTaskSetting: " << corrTaskSetting.Data() << endl;
+
+  Int_t trackMatcherRunningMode = 0; // CaloTrackMatcher running mode
+  TString strTrackMatcherRunningMode = cuts.GetSpecialSettingFromAddConfig(additionalTrainConfig, "TM", "", addTaskName);
+  if (additionalTrainConfig.Contains("TM"))
+    trackMatcherRunningMode = strTrackMatcherRunningMode.Atoi();
+
+  TObjArray* rmaxFacPtHardSetting = settingMaxFacPtHard.Tokenize("_");
+  if (rmaxFacPtHardSetting->GetEntries() < 1) {
+    cout << "ERROR: AddTask_MesonJetCorr_pp during parsing of settingMaxFacPtHard String '" << settingMaxFacPtHard.Data() << "'" << endl;
+    return;
+  }
+  Bool_t fMinPtHardSet = kFALSE;
+  Double_t minFacPtHard = -1;
+  Bool_t fMaxPtHardSet = kFALSE;
+  Double_t maxFacPtHard = 100;
+  Bool_t fSingleMaxPtHardSet = kFALSE;
+  Double_t maxFacPtHardSingle = 100;
+  Bool_t fJetFinderUsage = kFALSE;
+  Bool_t fUsePtHardFromFile = kFALSE;
+  Bool_t fUseAddOutlierRej = kFALSE;
+  for (Int_t i = 0; i < rmaxFacPtHardSetting->GetEntries(); i++) {
+    TObjString* tempObjStrPtHardSetting = (TObjString*)rmaxFacPtHardSetting->At(i);
+    TString strTempSetting = tempObjStrPtHardSetting->GetString();
+    if (strTempSetting.BeginsWith("MINPTHFAC:")) {
+      strTempSetting.Replace(0, 10, "");
+      minFacPtHard = strTempSetting.Atof();
+      cout << "running with min pT hard jet fraction of: " << minFacPtHard << endl;
+      fMinPtHardSet = kTRUE;
+    } else if (strTempSetting.BeginsWith("MAXPTHFAC:")) {
+      strTempSetting.Replace(0, 10, "");
+      maxFacPtHard = strTempSetting.Atof();
+      cout << "running with max pT hard jet fraction of: " << maxFacPtHard << endl;
+      fMaxPtHardSet = kTRUE;
+    } else if (strTempSetting.BeginsWith("MAXPTHFACSINGLE:")) {
+      strTempSetting.Replace(0, 16, "");
+      maxFacPtHardSingle = strTempSetting.Atof();
+      cout << "running with max single particle pT hard fraction of: " << maxFacPtHardSingle << endl;
+      fSingleMaxPtHardSet = kTRUE;
+    } else if (strTempSetting.BeginsWith("USEJETFINDER:")) {
+      strTempSetting.Replace(0, 13, "");
+      if (strTempSetting.Atoi() == 1) {
+        cout << "using MC jet finder for outlier removal" << endl;
+        fJetFinderUsage = kTRUE;
+      }
+    } else if (strTempSetting.BeginsWith("PTHFROMFILE:")) {
+      strTempSetting.Replace(0, 12, "");
+      if (strTempSetting.Atoi() == 1) {
+        cout << "using MC jet finder for outlier removal" << endl;
+        fUsePtHardFromFile = kTRUE;
+      }
+    } else if (strTempSetting.BeginsWith("ADDOUTLIERREJ:")) {
+      strTempSetting.Replace(0, 14, "");
+      if (strTempSetting.Atoi() == 1) {
+        cout << "using path based outlier removal" << endl;
+        fUseAddOutlierRej = kTRUE;
+      }
+    } else if (rmaxFacPtHardSetting->GetEntries() == 1 && strTempSetting.Atof() > 0) {
+      maxFacPtHard = strTempSetting.Atof();
+      cout << "running with max pT hard jet fraction of: " << maxFacPtHard << endl;
+      fMaxPtHardSet = kTRUE;
+    }
+  }
+
+  Int_t isHeavyIon = 0;
+
+  // ================== GetAnalysisManager ===============================
+  AliAnalysisManager* mgr = AliAnalysisManager::GetAnalysisManager();
+  if (!mgr) {
+    Error(Form("%s_%i", addTaskName.Data(), trainConfig), "No analysis manager found.");
+    return;
+  }
+
+  // ================== GetInputEventHandler =============================
+  AliVEventHandler* inputHandler = mgr->GetInputEventHandler();
+
+  //=========  Set Cutnumber for V0Reader ================================
+  TString cutnumberPhoton = photonCutNumberV0Reader.Data();
+  TString cutnumberEvent = "00000003";
+  AliAnalysisDataContainer* cinput = mgr->GetCommonInputContainer();
+
+  //========= Add V0 Reader to  ANALYSIS manager if not yet existent =====
+  TString V0ReaderName = Form("V0ReaderV1_%s_%s", cutnumberEvent.Data(), cutnumberPhoton.Data());
+  AliV0ReaderV1* fV0ReaderV1 = NULL;
+  if (!(AliV0ReaderV1*)mgr->GetTask(V0ReaderName.Data())) {
+    cout << "V0Reader: " << V0ReaderName.Data() << " not found!!" << endl;
+    return;
+  } else {
+    cout << "V0Reader: " << V0ReaderName.Data() << " found!!" << endl;
+  }
+
+  //================================================
+  //========= Add task to the ANALYSIS manager =====
+  //================================================
+  AliAnalysisTaskMesonJetCorrelation* task = NULL;
+  task = new AliAnalysisTaskMesonJetCorrelation(Form("MesonJetCorrelation_ConvCalo_%i", trainConfig));
+  task->SetIsHeavyIon(isHeavyIon);
+  task->SetIsMC(isMC);
+  task->SetV0ReaderName(V0ReaderName);
+  task->SetCorrectionTaskSetting(corrTaskSetting);
+  task->SetTrackMatcherRunningMode(trackMatcherRunningMode); // have to do this!
+
+  //---------------------------------------
+  // configs for pi0 meson pp 13 TeV
+  //---------------------------------------
+  if (trainConfig == 1) {
+    cuts.AddCutPCMCalo("00010103", "0dm00009f9730000dge0404000", "411790109fe30230000", "0r63103100000010"); // test config
+  } else if (trainConfig == 2) {
+    cuts.AddCutPCMCalo("00010103", "0dm00009f9730000dge0404000", "411790109fe30230000", "2r63103400000010"); // in-Jet, mass cut pi0: 0.1-0.15, rotation back
+  } else if (trainConfig == 3) {
+    cuts.AddCutPCMCalo("00010103", "0dm00009f9730000dge0404000", "411790109fe30230000", "2163103400000010"); // in-Jet, mass cut pi0: 0.1-0.15, mixed jet back
+  } else if (trainConfig == 4) {
+    cuts.AddCutPCMCalo("0008e103", "0dm00009f9730000dge0404000", "411790109fe30230000", "2r63103400000010"); // EG2 in-Jet, mass cut pi0: 0.1-0.15, rotation back
+    cuts.AddCutPCMCalo("0008e103", "0dm00009f9730000dge0404000", "411790109fe30230000", "2r63103400000010"); // EG2 in-Jet, mass cut pi0: 0.1-0.15, rotation back
+  } else if (trainConfig == 5) {
+    cuts.AddCutPCMCalo("0008d103", "0dm00009f9730000dge0404000", "411790109fe30230000", "2163103400000010"); // EG1 in-Jet, mass cut pi0: 0.1-0.15, mixed jet back
+    cuts.AddCutPCMCalo("0008d103", "0dm00009f9730000dge0404000", "411790109fe30230000", "2163103400000010"); // EG1 in-Jet, mass cut pi0: 0.1-0.15, mixed jet back
+
+    //---------------------------------------
+    // configs for eta meson pp 13 TeV
+    //---------------------------------------
+  } else if (trainConfig == 1002) {
+    cuts.AddCutPCMCalo("00010103", "0dm00009f9730000dge0404000", "411790109fe30230000", "2r63103l00000010"); // in-Jet, mass cut eta: 0.5-0.6, rotation back
+  } else if (trainConfig == 1003) {
+    cuts.AddCutPCMCalo("00010103", "0dm00009f9730000dge0404000", "411790109fe30230000", "2163103l00000010"); // in-Jet, mass cut eta: 0.5-0.6, mixed jet back
+  } else {
+    Error(Form("MesonJetCorrelation_ConvCalo_%i", trainConfig), "wrong trainConfig variable no cuts have been specified for the configuration");
+    return;
+  }
+
+  if (!cuts.AreValid()) {
+    cout << "\n\n****************************************************" << endl;
+    cout << "ERROR: No valid cuts stored in CutHandlerCalo! Returning..." << endl;
+    cout << "****************************************************\n\n"
+         << endl;
+    return;
+  }
+
+  Int_t numberOfCuts = cuts.GetNCuts();
+
+  TList* EventCutList = new TList();
+  TList* ConvCutList = new TList();
+  TList* ClusterCutList = new TList();
+  TList* MesonCutList = new TList();
+
+  EventCutList->SetOwner(kTRUE);
+  AliConvEventCuts** analysisEventCuts = new AliConvEventCuts*[numberOfCuts];
+  ConvCutList->SetOwner(kTRUE);
+  AliConversionPhotonCuts** analysisConvCuts = new AliConversionPhotonCuts*[numberOfCuts];
+  ClusterCutList->SetOwner(kTRUE);
+  AliCaloPhotonCuts** analysisClusterCuts = new AliCaloPhotonCuts*[numberOfCuts];
+  MesonCutList->SetOwner(kTRUE);
+  AliConversionMesonCuts** analysisMesonCuts = new AliConversionMesonCuts*[numberOfCuts];
+
+  for (Int_t i = 0; i < numberOfCuts; i++) {
+    //create AliCaloTrackMatcher instance, if there is none present
+    TString caloCutPos = cuts.GetClusterCut(i);
+    caloCutPos.Resize(1);
+    TString TrackMatcherName = Form("CaloTrackMatcher_%s_%i", caloCutPos.Data(), trackMatcherRunningMode);
+    if (corrTaskSetting.CompareTo("")) {
+      TrackMatcherName = TrackMatcherName + "_" + corrTaskSetting.Data();
+      cout << "Using separate track matcher for correction framework setting: " << TrackMatcherName.Data() << endl;
+    }
+    if (!(AliCaloTrackMatcher*)mgr->GetTask(TrackMatcherName.Data())) {
+      AliCaloTrackMatcher* fTrackMatcher = new AliCaloTrackMatcher(TrackMatcherName.Data(), caloCutPos.Atoi(), trackMatcherRunningMode);
+      fTrackMatcher->SetV0ReaderName(V0ReaderName);
+      fTrackMatcher->SetCorrectionTaskSetting(corrTaskSetting);
+      mgr->AddTask(fTrackMatcher);
+      mgr->ConnectInput(fTrackMatcher, 0, cinput);
+    }
+
+    //---------------------------------------------------------//
+    //------------------------ Event Cuts ---------------------//
+    //---------------------------------------------------------//
+    analysisEventCuts[i] = new AliConvEventCuts();
+    // analysisEventCuts[i]->SetCaloTriggerHelperName(TriggerHelperName.Data());
+    analysisEventCuts[i]->SetTriggerMimicking(enableTriggerMimicking);
+    analysisEventCuts[i]->SetTriggerOverlapRejecion(enableTriggerOverlapRej);
+    analysisEventCuts[i]->SetV0ReaderName(V0ReaderName);
+    analysisEventCuts[i]->SetCorrectionTaskSetting(corrTaskSetting);
+    if (enableLightOutput > 0)
+      analysisEventCuts[i]->SetLightOutput(kTRUE);
+    if (fMinPtHardSet)
+      analysisEventCuts[i]->SetMinFacPtHard(minFacPtHard);
+    if (fMaxPtHardSet)
+      analysisEventCuts[i]->SetMaxFacPtHard(maxFacPtHard);
+    if (fSingleMaxPtHardSet)
+      analysisEventCuts[i]->SetMaxFacPtHardSingleParticle(maxFacPtHardSingle);
+    if (fJetFinderUsage)
+      analysisEventCuts[i]->SetUseJetFinderForOutliers(kTRUE);
+    if (fUsePtHardFromFile)
+      analysisEventCuts[i]->SetUsePtHardBinFromFile(kTRUE);
+    if (fUseAddOutlierRej)
+      analysisEventCuts[i]->SetUseAdditionalOutlierRejection(kTRUE);
+    if (periodNameV0Reader.CompareTo("") != 0)
+      analysisEventCuts[i]->SetPeriodEnum(periodNameV0Reader);
+    analysisEventCuts[i]->InitializeCutsFromCutString((cuts.GetEventCut(i)).Data());
+    analysisEventCuts[i]->SetFillCutHistograms("", kFALSE);
+    EventCutList->Add(analysisEventCuts[i]);
+
+    //---------------------------------------------------------//
+    //------------------- Calo Photon Cuts --------------------//
+    //---------------------------------------------------------//
+    analysisClusterCuts[i] = new AliCaloPhotonCuts(isMC);
+    // analysisClusterCuts[i]->SetHistoToModifyAcceptance(histoAcc);
+    analysisClusterCuts[i]->SetV0ReaderName(V0ReaderName);
+    analysisClusterCuts[i]->SetCorrectionTaskSetting(corrTaskSetting);
+    analysisClusterCuts[i]->SetCaloTrackMatcherName(TrackMatcherName);
+    if (enableLightOutput > 0)
+      analysisClusterCuts[i]->SetLightOutput(kTRUE);
+    analysisClusterCuts[i]->InitializeCutsFromCutString((cuts.GetClusterCut(i)).Data());
+    analysisClusterCuts[i]->SetExtendedMatchAndQA(enableExtMatchAndQA);
+    ClusterCutList->Add(analysisClusterCuts[i]);
+
+    //---------------------------------------------------------//
+    //------------------- Conv Photon Cuts --------------------//
+    //---------------------------------------------------------//
+    analysisConvCuts[i] = new AliConversionPhotonCuts();
+
+    // if (enableMatBudWeightsPi0 > 0){
+    //   if (isMC > 0){
+    // if (analysisConvCuts[i]->InitializeMaterialBudgetWeights(enableMatBudWeightsPi0,fileNameMatBudWeights)){
+    //   initializedMatBudWeigths_existing = kTRUE;}
+    // else {cout << "ERROR The initialization of the materialBudgetWeights did not work out." << endl;}
+    //   }
+    //   else {cout << "ERROR 'enableMatBudWeightsPi0'-flag was set > 0 even though this is not a MC task. It was automatically reset to 0." << endl;}
+    // }
+
+    analysisConvCuts[i]->SetV0ReaderName(V0ReaderName);
+    if (enableElecDeDxPostCalibration) {
+      if (isMC == 0) {
+        if (fileNamedEdxPostCalib.CompareTo("") != 0) {
+          analysisConvCuts[i]->SetElecDeDxPostCalibrationCustomFile(fileNamedEdxPostCalib);
+          cout << "Setting custom dEdx recalibration file: " << fileNamedEdxPostCalib.Data() << endl;
+        }
+        analysisConvCuts[i]->SetDoElecDeDxPostCalibration(enableElecDeDxPostCalibration);
+        cout << "Enabled TPC dEdx recalibration." << endl;
+      } else {
+        cout << "ERROR enableElecDeDxPostCalibration set to True even if MC file. Automatically reset to 0" << endl;
+        enableElecDeDxPostCalibration = kFALSE;
+        analysisConvCuts[i]->SetDoElecDeDxPostCalibration(kFALSE);
+      }
+    }
+    if (enableLightOutput == 1 || enableLightOutput == 2 || enableLightOutput == 5)
+      analysisConvCuts[i]->SetLightOutput(1);
+    if (enableLightOutput == 4)
+      analysisConvCuts[i]->SetLightOutput(2);
+    if (enableLightOutput == 0)
+      analysisConvCuts[i]->SetPlotTrackPID(kTRUE);
+    analysisConvCuts[i]->InitializeCutsFromCutString((cuts.GetPhotonCut(i)).Data());
+    analysisConvCuts[i]->SetIsHeavyIon(isHeavyIon);
+    analysisConvCuts[i]->SetFillCutHistograms("", kFALSE);
+    ConvCutList->Add(analysisConvCuts[i]);
+
+    //---------------------------------------------------------//
+    //------------------------ Meson Cuts ---------------------//
+    //---------------------------------------------------------//
+    analysisMesonCuts[i] = new AliConversionMesonCuts();
+    analysisMesonCuts[i]->InitializeCutsFromCutString((cuts.GetMesonCut(i)).Data());
+    analysisMesonCuts[i]->SetIsMergedClusterCut(2);
+    analysisMesonCuts[i]->SetCaloMesonCutsObject(analysisClusterCuts[i]);
+    analysisMesonCuts[i]->SetFillCutHistograms("");
+    // analysisEventCuts[i]->SetAcceptedHeader(HeaderList);
+    analysisClusterCuts[i]->SetFillCutHistograms("");
+    if (enableLightOutput > 0)
+      analysisMesonCuts[i]->SetLightOutput(kTRUE);
+    if (analysisMesonCuts[i]->DoGammaSwappForBg())
+      analysisClusterCuts[i]->SetUseEtaPhiMapForBackCand(kTRUE); // needed in case of rotation background QA histos
+    MesonCutList->Add(analysisMesonCuts[i]);
+  }
+
+  task->SetMesonKind(meson);
+  task->SetIsConvCalo(true);
+  task->SetEventCutList(numberOfCuts, EventCutList);
+  task->SetCaloCutList(numberOfCuts, ClusterCutList);
+  task->SetMesonCutList(numberOfCuts, MesonCutList);
+  task->SetConversionCutList(numberOfCuts, ConvCutList);
+  //   task->SetDoMesonAnalysis(kTRUE); // I think we dont need that!
+  task->SetCorrectionTaskSetting(corrTaskSetting);
+  task->SetDoMesonQA(enableQAMesonTask); //Attention new switch for Pi0 QA
+                                         //   task->SetDoClusterQA(enableQAClusterTask);  //Attention new switch small for Cluster QA
+                                         //   task->SetDoTHnSparse(enableTHnSparse);
+
+  //connect containers
+  AliAnalysisDataContainer* coutput =
+    mgr->CreateContainer(!(corrTaskSetting.CompareTo("")) ? Form("MesonJetCorrelation_ConvCalo_%i_%i", meson, trainConfig) : Form("MesonJetCorrelation_ConvCalo_%i_%i_%s", meson, trainConfig, corrTaskSetting.Data()), TList::Class(),
+                         AliAnalysisManager::kOutputContainer, Form("MesonJetCorrelation_ConvCalo_%i_%i.root", meson, trainConfig));
+
+  mgr->AddTask(task);
+  cout << "before connect input\n";
+  mgr->ConnectInput(task, 0, cinput);
+  cout << "before ConnectOutput\n";
+  mgr->ConnectOutput(task, 1, coutput);
+
+  return;
+}

--- a/PWGGA/GammaConvBase/AliConversionMesonCuts.cxx
+++ b/PWGGA/GammaConvBase/AliConversionMesonCuts.cxx
@@ -5003,6 +5003,8 @@ Bool_t AliConversionMesonCuts::ArmenterosLikeQtCut(Double_t alpha, Double_t qT){
 /// Function to check if particle fullfills the required inJet criterium (inJet, out of Jet etc.)
 Bool_t AliConversionMesonCuts::IsParticleInJet(std::vector<Double_t> vectorJetEta, std::vector<Double_t> vectorJetPhi, Double_t JetRadius, Double_t partEta, Double_t partPhi, Int_t &matchedJet, Double_t &RJetPi0Cand){
 
+  if(!fDoJetAnalysis) return kTRUE;
+  
   // set up important variables
   matchedJet = 0;
   RJetPi0Cand = 100; // set to a random high value such that the first jet will overwrite this value
@@ -5101,6 +5103,7 @@ Bool_t AliConversionMesonCuts::MesonLeadTrackSelectionMC(AliVEvent* curEvent, Al
   return MesonLeadTrackSelectionBase((AliVEvent*) curEvent, vmeson);
 }
 
+///_____________________________________________________________________________
 Bool_t AliConversionMesonCuts::MesonLeadTrackSelectionAODMC(AliVEvent* curEvent, AliAODMCParticle* curmeson)
 {
   if(!curmeson) {
@@ -5111,6 +5114,7 @@ Bool_t AliConversionMesonCuts::MesonLeadTrackSelectionAODMC(AliVEvent* curEvent,
   return MesonLeadTrackSelectionBase((AliVEvent*) curEvent, vmeson);
 }
 
+///_____________________________________________________________________________
 Bool_t AliConversionMesonCuts::MesonLeadTrackSelection(AliVEvent* curEvent, AliAODConversionMother* curmeson)
 {
   if(!curmeson) {
@@ -5121,6 +5125,7 @@ Bool_t AliConversionMesonCuts::MesonLeadTrackSelection(AliVEvent* curEvent, AliA
   return MesonLeadTrackSelectionBase((AliVEvent*) curEvent, vmeson);
 }
 
+///_____________________________________________________________________________
 Bool_t AliConversionMesonCuts::MesonLeadTrackSelectionBase(AliVEvent* curEvent, TVector3 curmeson)
 {
   if (fInLeadTrackDir == 0) return kTRUE;
@@ -5189,6 +5194,25 @@ Bool_t AliConversionMesonCuts::MesonLeadTrackSelectionBase(AliVEvent* curEvent, 
       }
     }
   }
-
   return kFALSE;
+}
+
+//________________________________________________________________________
+int AliConversionMesonCuts::GetSourceClassification(int daughter, int pdgCode){
+
+  if (daughter == 111) {
+    if (TMath::Abs(pdgCode) == 310) return 1; // k0s
+    else if (TMath::Abs(pdgCode) == 3122) return 2; // Lambda
+    else if (TMath::Abs(pdgCode) == 130) return 3; // K0L
+    else if (TMath::Abs(pdgCode) == 2212) return 4; // proton
+    else if (TMath::Abs(pdgCode) == 2112) return 5; // neutron
+    else if (TMath::Abs(pdgCode) == 211) return 6; // pion
+    else if (TMath::Abs(pdgCode) == 321) return 7; // kaon
+    else if (TMath::Abs(pdgCode) == 113 || TMath::Abs(pdgCode) == 213 ) return 8; // rho 0,+,-
+    else if (TMath::Abs(pdgCode) == 3222 || TMath::Abs(pdgCode) == 3212 || TMath::Abs(pdgCode) == 3112  ) return 9; // Sigma
+    else if (TMath::Abs(pdgCode) == 2224 || TMath::Abs(pdgCode) == 2214 || TMath::Abs(pdgCode) == 2114 || TMath::Abs(pdgCode) == 1114  ) return 10; // Delta
+    else if (TMath::Abs(pdgCode) == 313 || TMath::Abs(pdgCode) == 323   ) return 11; // K*
+    else return 15;
+  }
+  return 15;
 }

--- a/PWGGA/GammaConvBase/AliConversionMesonCuts.h
+++ b/PWGGA/GammaConvBase/AliConversionMesonCuts.h
@@ -244,7 +244,10 @@ class AliConversionMesonCuts : public AliAnalysisCuts {
 
     // Jet specific function
     Bool_t  IsParticleInJet(std::vector<Double_t> vectorJetEta, std::vector<Double_t> vectorJetPhi, Double_t JetRadius, Double_t partEta, Double_t partPhi, Int_t &matchedJet, Double_t &RJetPi0Cand);
-
+    
+    // get source from pdg code
+    int GetSourceClassification(int daughter, int pdgCode);
+    
   protected:
     TRandom3    fRandom;                        ///<
     AliCaloPhotonCuts* fCaloPhotonCuts;         ///< CaloPhotonCutObject belonging to same main task

--- a/PWGGA/GammaConvBase/AliGammaConvEventMixing.cxx
+++ b/PWGGA/GammaConvBase/AliGammaConvEventMixing.cxx
@@ -1,0 +1,124 @@
+#include "AliGammaConvEventMixing.h"
+
+//________________________________________________________________________________
+EventMixPoolMesonJets::EventMixPoolMesonJets()
+{
+  mixingPool.resize(vecJetPClasses.size() - 1);
+  for (auto& i : mixingPool) {
+    i.clear();
+    i.resize(0);
+  }
+}
+
+//________________________________________________________________________________
+EventMixPoolMesonJets::EventMixPoolMesonJets(std::vector<float> vec)
+{
+  vecJetPClasses = vec;
+  mixingPool.resize(vec.size() - 1);
+  for (auto& i : mixingPool) {
+    i.clear();
+    i.resize(0);
+  }
+}
+
+//________________________________________________________________________________
+void EventMixPoolMesonJets::SetJetPtClasses(std::vector<float> vec)
+{
+  vecJetPClasses = vec;
+  mixingPool.resize(vec.size() - 1);
+}
+
+//________________________________________________________________________________
+int EventMixPoolMesonJets::getJetPIndex(float jetP)
+{
+  int index = -1;
+  for (unsigned int i = 0; i < vecJetPClasses.size() - 1; ++i) {
+    if (vecJetPClasses[i] < jetP && jetP < vecJetPClasses[i + 1]) {
+      index = i;
+      break;
+    }
+  }
+  return index;
+}
+
+//________________________________________________________________________________
+void EventMixPoolMesonJets::AddEvent(EventWithJetAxis* ev, float jetP)
+{
+  int index = getJetPIndex(jetP);
+  if (index < 0) {
+    printf("ERROR: index out of range\n");
+    return;
+  }
+  if (mixingPool[index].size() >= poolDepth) {
+    if (mixingPool[index][0])
+      delete mixingPool[index][0];
+    mixingPool[index].erase(mixingPool[index].begin());
+  }
+  mixingPool.at(index).push_back(ev);
+}
+
+//________________________________________________________________________________
+unsigned int EventMixPoolMesonJets::GetNBGEvents(float jetP)
+{
+  int index = getJetPIndex(jetP);
+  return mixingPool[index].size();
+}
+
+//________________________________________________________________________________
+unsigned int EventMixPoolMesonJets::GetNGammasInEvt(float jetP, int evt, bool isCaloPhoton)
+{
+  int index = getJetPIndex(jetP);
+  if (isCaloPhoton)
+    return mixingPool[index][evt]->caloPhotons.size();
+  return mixingPool[index][evt]->convPhotons.size();
+}
+
+//________________________________________________________________________________
+std::vector<std::unique_ptr<AliAODConversionPhoton>> EventMixPoolMesonJets::getPhotonsRotated(int nEvt, float jetP, TVector3 jetAxis, bool isCaloPhoton)
+{
+  int index = getJetPIndex(jetP);
+  if (index < 0) {
+    printf("ERROR: index out of range\n");
+    std::vector<std::unique_ptr<AliAODConversionPhoton>> tmpVec(1);
+    tmpVec[0] = nullptr;
+    return tmpVec;
+  }
+
+  if (nEvt >= mixingPool[index].size()) {
+    printf("index for mixing pool out of range");
+    std::vector<std::unique_ptr<AliAODConversionPhoton>> tmpVec(1);
+    tmpVec[0] = nullptr;
+    return tmpVec;
+  }
+  // calculate the shift
+  double jetThetaCurEv = jetAxis.Theta();
+  double jetPhiCurEv = jetAxis.Phi();
+  double jetEnergyCurEv = jetAxis.Mag();
+
+  double jetThetaMixEv = mixingPool[index][nEvt]->jetAxis.Theta();
+  double jetPhiMixEv = mixingPool[index][nEvt]->jetAxis.Phi();
+  double jetEnergyMixEv = mixingPool[index][nEvt]->jetAxis.Mag();
+
+  double diffTheta = jetThetaCurEv - jetThetaMixEv;
+  double diffPhi = jetPhiCurEv - jetPhiMixEv;
+
+  unsigned int nGammas = mixingPool[index][nEvt]->getNPhotons(isCaloPhoton);
+  std::vector<std::unique_ptr<AliAODConversionPhoton>> vecRotatedGammas(nGammas);
+  TLorentzVector LVGammaRot;
+  TVector3 tmpVec;
+  for (unsigned int i = 0; i < nGammas; ++i) {
+    // E has to stay the same
+
+    double energy = mixingPool[index][nEvt]->getPhoton(i, isCaloPhoton)->E();
+    double theta = mixingPool[index][nEvt]->getPhoton(i, isCaloPhoton)->Theta();
+    double phi = mixingPool[index][nEvt]->getPhoton(i, isCaloPhoton)->Phi();
+
+    theta += diffTheta;
+    phi += diffPhi;
+
+    tmpVec.SetMagThetaPhi(energy, theta, phi);
+    LVGammaRot.SetPtEtaPhiM(tmpVec.Pt(), tmpVec.Eta(), tmpVec.Phi(), 0.);
+    vecRotatedGammas[i] = std::move(std::make_unique<AliAODConversionPhoton>(new AliAODConversionPhoton(&LVGammaRot)));
+  }
+  return vecRotatedGammas;
+}

--- a/PWGGA/GammaConvBase/AliGammaConvEventMixing.h
+++ b/PWGGA/GammaConvBase/AliGammaConvEventMixing.h
@@ -1,0 +1,131 @@
+/**************************************************************************
+ * Copyright(c) 1998-2020, ALICE Experiment at CERN, All rights reserved. *
+ *                                                                        *
+ * Author: Joshua Koenig <joshua.konig@cern.ch>                                        *
+ * Version 1.0                                                            *
+ *                                                                        *
+ *                                                                        *
+ * Permission to use, copy, modify and distribute this software and its   *
+ * documentation strictly for non-commercial purposes is hereby granted   *
+ * without fee, provided that the above copyright notice appears in all   *
+ * copies and that both the copyright notice and this permission notice   *
+ * appear in the supporting documentation. The authors make no claims     *
+ * about the suitability of this software for any purpose. It is          *
+ * provided "as is" without express or implied warranty.                  *
+ **************************************************************************/
+
+//////////////////////////////////////////////////////////////////
+//----------------------------------------------------------------
+// Class used to do event mixing for events with Jet axis
+//----------------------------------------------------------------
+//////////////////////////////////////////////////////////////////
+
+#ifndef ALIGAMMACONVEVENTMIXING_H
+#define ALIGAMMACONVEVENTMIXING_H
+
+#include "AliAnalysisManager.h"
+#include "AliAnalysisTaskSE.h"
+#include "TLorentzVector.h"
+#include "TVector3.h"
+#include <map>
+#include <vector>
+#include "AliAODConversionPhoton.h"
+
+
+struct EventWithJetAxis{
+  EventWithJetAxis(std::vector<AliAODConversionPhoton*> vecPhotons, bool isCalo, TVector3 jet) : caloPhotons({}), convPhotons({}), jetAxis() {
+    if(isCalo){
+      for(const auto & i : vecPhotons){
+        caloPhotons.push_back(new AliAODConversionPhoton(*i));
+      }
+    } else {
+      for(const auto & i : vecPhotons){
+        convPhotons.push_back(new AliAODConversionPhoton(*i));
+      }
+    }
+    jetAxis = jet;
+  }
+  EventWithJetAxis(std::vector<AliAODConversionPhoton*> vecCaloPhotons, std::vector<AliAODConversionPhoton*> vecConvPhotons, TVector3 jet) : caloPhotons({}), convPhotons({}), jetAxis(){
+    for(const auto & i : vecCaloPhotons){
+      caloPhotons.push_back(new AliAODConversionPhoton(*i));
+    }
+    for(const auto & i : vecConvPhotons){
+      convPhotons.push_back(new AliAODConversionPhoton(*i));
+    }
+    jetAxis = jet;
+  }
+  ~EventWithJetAxis(){
+    for(unsigned int i = 0; i < caloPhotons.size(); ++i){
+      if(caloPhotons[i] != nullptr) delete caloPhotons[i];
+    }
+    for(unsigned int i = 0; i < convPhotons.size(); ++i){
+      if(convPhotons[i] != nullptr) delete convPhotons[i];
+    }
+  }
+  AliAODConversionPhoton* getPhoton(int index, bool isCaloPhoton){
+    if(isCaloPhoton) return caloPhotons[index];
+    return convPhotons[index];
+  }
+  unsigned int getNPhotons(bool isCaloPhoton){
+    if(isCaloPhoton) return caloPhotons.size();
+    return convPhotons.size();
+  }
+  std::vector<AliAODConversionPhoton*> caloPhotons;
+  std::vector<AliAODConversionPhoton*> convPhotons;
+  TVector3 jetAxis;
+};
+
+class EventMixPoolMesonJets{
+  public:
+  EventMixPoolMesonJets();
+  EventMixPoolMesonJets(std::vector<float> vec);
+  EventMixPoolMesonJets(const EventMixPoolMesonJets&) = delete;
+  EventMixPoolMesonJets(EventMixPoolMesonJets&&) = default;
+  ~EventMixPoolMesonJets();
+
+  ///\brief Set new jet momentum classes for mixing pool
+  ///\param vec vector with jet momenta
+  void SetJetPtClasses(std::vector<float> vec);
+
+  ///\brief Set mixing pool depth
+  ///\param n new pool depth
+  void SetPoolDepth(unsigned int n)             { poolDepth = n;}
+
+  ///\brief get index of jet momentum for mixing pool
+  ///\param jetP momentum of the jet
+  ///\return index
+  int getJetPIndex(float jetP);
+
+  ///\brief Add new event to the mixing pool. If mixing pool is full, delete first element and then add event
+  ///\param ev event that should be added
+  ///\param jetP highest jet momentum of this event
+  void AddEvent(EventWithJetAxis *ev, float jetP);
+
+  ///\brief get number of events in mixing pool for specified jet momentum
+  ///\param jetP momentum of the jet
+  ///\return number of events in mixing pool for specified jet momentum
+  unsigned int GetNBGEvents(float jetP);
+  
+  ///\brief get number of photons in the specified event in the mixing pool
+  ///\param jetP momentum of the jet in the current event
+  ///\param nEvt index of the event in the mixing pool 
+  ///\param isCaloPhoton switch if calo photons or conversion photons should be returned
+  ///\return number of photons in the specified mixing pool class
+  unsigned int GetNGammasInEvt(float jetP, int evt, bool isCaloPhoton);
+
+  ///\brief rotate events such that the jet axes with the highest momentum match.
+  ///\param nEvt index of the event in the mixing pool 
+  ///\param jetP momentum of the jet in the current event
+  ///\param jetAxis Jet axis of the current event
+  ///\param isCaloPhoton switch if calo photons or conversion photons should be returned
+  ///\return vector of rotated photons that can be used for mixing with th current event
+  std::vector<std::unique_ptr<AliAODConversionPhoton>> getPhotonsRotated(int nEvt, float jetP, TVector3 jetAxis, bool isCaloPhoton);
+  
+  private:
+  std::vector<float> vecJetPClasses = {-1, 20, 40, 60, 100, 100000};
+  std::vector<std::vector<EventWithJetAxis*>> mixingPool;
+  unsigned int poolDepth = 20;
+
+};
+
+#endif

--- a/PWGGA/GammaConvBase/AliResponseMatrixHelper.cxx
+++ b/PWGGA/GammaConvBase/AliResponseMatrixHelper.cxx
@@ -1,0 +1,103 @@
+
+/**************************************************************************
+ * Copyright(c) 1998-2020, ALICE Experiment at CERN, All rights reserved. *
+ *                                                                        *
+ * Author: Joshua Koenig <joshua.konig@cern.ch>                                        *
+ * Version 1.0                                                            *
+ *                                                                        *
+ *                                                                        *
+ * Permission to use, copy, modify and distribute this software and its   *
+ * documentation strictly for non-commercial purposes is hereby granted   *
+ * without fee, provided that the above copyright notice appears in all   *
+ * copies and that both the copyright notice and this permission notice   *
+ * appear in the supporting documentation. The authors make no claims     *
+ * about the suitability of this software for any purpose. It is          *
+ * provided "as is" without express or implied warranty.                  *
+ **************************************************************************/
+
+//////////////////////////////////////////////////////////////////
+//----------------------------------------------------------------
+// Class to hanlde 2d and 4d response matrix
+//----------------------------------------------------------------
+//////////////////////////////////////////////////////////////////
+
+#include "AliResponseMatrixHelper.h"
+
+//____________________________________________________________________________________________________________________________
+MatrixHandler4D::MatrixHandler4D(std::vector<float> arrMesonX, std::vector<float> arrMesonY, std::vector<float> arrJetX, std::vector<float> arrJetY, bool useTHN){
+    vecBinsMesonX = arrMesonX;
+    vecBinsMesonY = arrMesonY;
+    vecBinsJetX = arrJetX;
+    vecBinsJetY = arrJetY;
+    useTHNSparese = useTHN;
+    const int nBinsX = (arrMesonX.size() - 1) * (arrJetX.size() - 1); // + 1;
+    const int nBinsY = (arrMesonY.size() - 1) * (arrJetY.size() - 1); // + 1;
+    if(useTHNSparese){
+        // in case of thnsparse, just use equidistant binning
+        std::array<int, 2> arrNBins = {nBinsX, nBinsY};
+        std::array<double, 2> arrXBins = {0, 0};
+        std::array<double, 2> arrYBins = {static_cast<double>(nBinsX), static_cast<double>(nBinsY)}; 
+
+        hSparseResponse = new THnSparseF("ResponseMatrix_dyn", "ResponseMatrix_dyn", arrNBins.size(), arrNBins.data(), arrXBins.data(), arrYBins.data());
+
+    } else {
+        std::vector<double> vecXBins;
+        std::vector<double> vecYBins;
+        GetAxisBinning(vecXBins, vecYBins);
+        if(h2d){
+                delete h2d;
+            }
+        h2d = new TH2F("ResponseMatrix_stat", "ResponseMatrix_stat", vecXBins.size() - 1, vecXBins.data(), vecYBins.size() - 1, vecYBins.data() );
+        
+    }
+}
+
+//____________________________________________________________________________________________________________________________
+MatrixHandler4D::~MatrixHandler4D(){
+//  if(h2d){
+//      delete h2d;
+//  }
+//  if(hSparseResponse){
+//      delete hSparseResponse;
+//  }
+}
+
+//____________________________________________________________________________________________________________________________
+int MatrixHandler4D::getBinIndexMesonX(const float val) const{
+    for(unsigned int i = 0; i < vecBinsMesonX.size() - 1; ++i){
+        if(vecBinsMesonX[i] < val && vecBinsMesonX[i+1] > val){
+            return i;
+        }
+    }
+    return -1;
+}
+
+//____________________________________________________________________________________________________________________________
+int MatrixHandler4D::getBinIndexMesonY(const float val) const{
+    for(unsigned int i = 0; i < vecBinsMesonY.size() - 1; ++i){
+        if(vecBinsMesonY[i] < val && vecBinsMesonY[i+1] > val){
+            return i;
+        }
+    }
+    return -1;
+}
+
+//____________________________________________________________________________________________________________________________
+int MatrixHandler4D::getBinIndexJetX(const float val) const{
+    for(unsigned int i = 0; i < vecBinsJetX.size() - 1; ++i){
+        if(vecBinsJetX[i] < val && vecBinsJetX[i+1] > val){
+            return i;
+        }
+    }
+    return -1;
+}
+
+//____________________________________________________________________________________________________________________________
+int MatrixHandler4D::getBinIndexJetY(const float val) const{
+    for(unsigned int i = 0; i < vecBinsJetY.size() - 1; ++i){
+        if(vecBinsJetY[i] < val && vecBinsJetY[i+1] > val){
+            return i;
+        }
+    }
+    return -1;
+}

--- a/PWGGA/GammaConvBase/AliResponseMatrixHelper.h
+++ b/PWGGA/GammaConvBase/AliResponseMatrixHelper.h
@@ -1,0 +1,186 @@
+/**************************************************************************
+ * Copyright(c) 1998-2020, ALICE Experiment at CERN, All rights reserved. *
+ *                                                                        *
+ * Author: Joshua Koenig <joshua.konig@cern.ch>                                        *
+ * Version 1.0                                                            *
+ *                                                                        *
+ *                                                                        *
+ * Permission to use, copy, modify and distribute this software and its   *
+ * documentation strictly for non-commercial purposes is hereby granted   *
+ * without fee, provided that the above copyright notice appears in all   *
+ * copies and that both the copyright notice and this permission notice   *
+ * appear in the supporting documentation. The authors make no claims     *
+ * about the suitability of this software for any purpose. It is          *
+ * provided "as is" without express or implied warranty.                  *
+ **************************************************************************/
+
+//////////////////////////////////////////////////////////////////
+//----------------------------------------------------------------
+// Class to hanlde 2d and 4d response matrix
+//----------------------------------------------------------------
+//////////////////////////////////////////////////////////////////
+
+#ifndef ALIRESPONSEMATRIXHELPER_h
+#define ALIRESPONSEMATRIXHELPER_h
+
+#include <array>
+#include <vector>
+#include "TH1.h"
+#include "TH2.h"
+#include "THnSparse.h"
+
+class MatrixHandler4D
+{
+
+ public:
+  MatrixHandler4D() = default;
+  MatrixHandler4D(std::vector<float> arrMesonX, std::vector<float> arrMesonY, std::vector<float> arrJetX, std::vector<float> arrJetY, bool useTHN = false);
+  MatrixHandler4D(const MatrixHandler4D&) = delete;            // copy ctor
+  MatrixHandler4D(MatrixHandler4D&&) = delete;                 // move ctor
+  MatrixHandler4D& operator=(const MatrixHandler4D&) = delete; // copy assignment
+  MatrixHandler4D& operator=(MatrixHandler4D&&) = delete;      // move assignment
+  virtual ~MatrixHandler4D();
+
+  int getBinIndexMesonX(const float val) const;
+  int getBinIndexMesonY(const float val) const;
+  int getBinIndexJetX(const float val) const;
+  int getBinIndexJetY(const float val) const;
+
+  void Fill(double valJetX, double valJetY, double valMesonX, double valMesonY, double val = 1)
+  {
+    int binJetX = getBinIndexJetX(valJetX);
+    if (binJetX < 0)
+      return;
+    int binJetY = getBinIndexJetY(valJetY);
+    if (binJetY < 0)
+      return;
+    int binMesonX = getBinIndexMesonX(valMesonX);
+    if (binMesonX < 0)
+      return;
+    int binMesonY = getBinIndexMesonY(valMesonY);
+    if (binMesonY < 0)
+      return;
+
+    std::array<int, 2> arrFill;
+    arrFill[0] = binJetX * (vecBinsMesonX.size() - 1) + binMesonX + 1; // + 1 due to underflow bin?
+    arrFill[1] = binJetY * (vecBinsMesonY.size() - 1) + binMesonY + 1;
+
+    if (useTHNSparese) {
+      hSparseResponse->AddBinContent(arrFill.data(), val); // what happens to the errors?
+    } else {
+      h2d->Fill(h2d->GetXaxis()->GetBinCenter(arrFill[0]), h2d->GetYaxis()->GetBinCenter(arrFill[1]), val);
+    }
+  }
+  void GetAxisBinning(std::vector<double>& vecXBins, std::vector<double>& vecYBins)
+  {
+    const int sizeX = (vecBinsJetX.size() - 1) * (vecBinsMesonX.size() - 1) + 1;
+    const int sizeY = (vecBinsJetY.size() - 1) * (vecBinsMesonY.size() - 1) + 1;
+    vecXBins.resize(sizeX);
+    vecYBins.resize(sizeY);
+    float rangeXBinsMesons = std::abs(vecBinsMesonX[0] - vecBinsMesonX.back());
+    float rangeYBinsMesons = std::abs(vecBinsMesonY[0] - vecBinsMesonY.back());
+    int counter = 0;
+    for (unsigned int jx = 0; jx < vecBinsJetX.size() - 1; ++jx) {
+      float rangeXBinsJet = std::abs(vecBinsJetX[jx] - vecBinsJetX[jx + 1]);
+      float downscalingfacX = rangeXBinsJet / rangeXBinsMesons;
+      for (unsigned int mx = 0; mx < vecBinsMesonX.size() - 1; ++mx) {
+        vecXBins[counter] = vecBinsJetX[jx] + vecBinsMesonX[mx] * downscalingfacX;
+        counter++;
+      }
+    }
+    vecXBins[counter] = vecBinsJetX.back();
+    for (unsigned int i = 0; i < vecXBins.size() - 1; ++i) {
+      if (vecXBins[i] >= vecXBins[i + 1])
+        printf("Binning is not in ascending order! FIX THIS!!\n");
+    }
+    counter = 0;
+    for (unsigned int jy = 0; jy < vecBinsJetY.size() - 1; ++jy) {
+      float rangeYBinsJet = std::abs(vecBinsJetY[jy] - vecBinsJetY[jy + 1]);
+      float downscalingfacY = rangeYBinsJet / rangeYBinsMesons;
+      for (unsigned int my = 0; my < vecBinsMesonY.size() - 1; ++my) {
+        vecYBins[counter] = vecBinsJetY[jy] + vecBinsMesonY[my] * downscalingfacY;
+        counter++;
+      }
+    }
+    vecYBins[counter] = vecBinsJetY.back();
+  }
+
+  THnSparseF* GetTHnSparseClone(const char* name = "hSparseResponse_Clone")
+  {
+    return (THnSparseF*)hSparseResponse->Clone(name);
+  }
+  THnSparseF* GetTHnSparse(const char* name = "")
+  {
+    hSparseResponse->SetName(name);
+    return hSparseResponse;
+  }
+  TH2F* GetTH2(const char* name = "hSparseResponse_Clone")
+  {
+    if (useTHNSparese) {
+      if (!hSparseResponse) {
+        printf("Attention! hSparseResponse does not exist yet!\n");
+        return nullptr;
+      }
+      std::vector<double> vecXBins;
+      std::vector<double> vecYBins;
+      GetAxisBinning(vecXBins, vecYBins);
+
+      if (h2d) {
+        delete h2d;
+      }
+      h2d = new TH2F(name, name, vecXBins.size() - 1, vecXBins.data(), vecYBins.size() - 1, vecYBins.data());
+
+      // transfer the values
+      for (int x = 0; x < h2d->GetXaxis()->GetNbins(); ++x) {
+        for (int y = 0; y < h2d->GetYaxis()->GetNbins(); ++y) {
+          std::array<int, 2> arrBins = {x, y};
+          double binCont = hSparseResponse->GetBinContent(arrBins.data());
+          h2d->SetBinContent(x, y, binCont);
+        }
+      }
+      return h2d;
+
+    } else {
+      if (!h2d) {
+        printf("Attention! 2d histogram does not exist yet!\n");
+        return nullptr;
+      }
+      return h2d;
+    }
+  }
+
+  TH2F* GetResponseMatrix(int binX, int binY, const char* name = "dummy")
+  {
+    TString nameHist = Form("%s_%i_%i", name, binX, binY);
+    TH2F* hMesonResp = new TH2F(nameHist, nameHist, vecBinsMesonX.size() - 1, vecBinsMesonX.data(), vecBinsMesonY.size() - 1, vecBinsMesonY.data());
+    for (unsigned int x = 0; x < vecBinsMesonX.size(); ++x) {
+      for (unsigned int y = 0; y < vecBinsMesonY.size(); ++y) {
+        float binCont = 0;
+        std::array<int, 2> arrBins = {static_cast<int>(x + (binX * (vecBinsMesonX.size() - 1)) + 1), static_cast<int>(y + (binY * (vecBinsMesonY.size() - 1)) + 1)};
+        if (useTHNSparese) {
+          binCont = hSparseResponse->GetBinContent(arrBins.data());
+        } else {
+          binCont = h2d->GetBinContent(arrBins[0], arrBins[1]);
+        }
+        hMesonResp->SetBinContent(x + 1, y + 1, binCont);
+      }
+    }
+    return hMesonResp;
+  }
+
+ private:
+  bool useTHNSparese = false;
+  int nBinsJet = 0;
+  std::vector<float> vecBinsMesonX = {};
+  std::vector<float> vecBinsMesonY = {};
+  std::vector<float> vecBinsJetX = {};
+  std::vector<float> vecBinsJetY = {};
+  TH2F* h2d = nullptr;
+  TH1F* h1dJet = nullptr;
+  TH1F* h1dMeson = nullptr;
+  THnSparseF* hSparseResponse = nullptr;
+
+  ClassDef(MatrixHandler4D, 1)
+};
+
+#endif

--- a/PWGGA/GammaConvBase/CMakeLists.txt
+++ b/PWGGA/GammaConvBase/CMakeLists.txt
@@ -73,6 +73,8 @@ set(SRCS
     AliDalitzData.cxx
     AliGAKFParticle.cxx
     AliGAKFVertex.cxx
+    AliResponseMatrixHelper.cxx
+    AliGammaConvEventMixing.cxx
    )
 
 # Headers from sources

--- a/PWGGA/GammaConvBase/PWGGAGammaConvBaseLinkDef.h
+++ b/PWGGA/GammaConvBase/PWGGAGammaConvBaseLinkDef.h
@@ -28,6 +28,7 @@
 #pragma link C++ class AliDalitzElectronSelector+;
 #pragma link C++ class AliCaloTrackMatcher+;
 #pragma link C++ class AliPhotonIsolation+;
+#pragma link C++ class MatrixHandler4D+;
 
 
 // User tasks


### PR DESCRIPTION
- task to get neutral meson in corellation with a particle jet
- Aim to produce the meson pt spectra (differentiatet for different jet pt) (using full 2d unfolding)
- Aim to get the fragmentation function for neutral mesons using full 2d unfolding
- Helper task for response matrix can be used for response matrix as well as for storing 2d histograms vs jet pT
- New mixing class for rotating events such that two events have one overlapping jet momentum vector. Should improve the mixed event distribution compared to classical mixed events in mixing classes