### PR TITLE
PWGGA/GammaConv: Add cluster and conv. histograms to MesonJet task

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskMesonJetCorrelation.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskMesonJetCorrelation.h
@@ -225,6 +225,7 @@ class AliAnalysisTaskMesonJetCorrelation : public AliAnalysisTaskSE
   //-------------------------------
   std::vector<float> fVecBinsMesonInvMass;   //! meson inv. mass binning
   std::vector<float> fVecBinsPhotonPt;       //! photon/cluster pt binning
+  std::vector<float> fVecBinsClusterPt;      //! cluster binning until high pT
   std::vector<float> fVecBinsMesonPt;        //! meson pt binning
   std::vector<float> fVecBinsJetPt;          //! jet pt binning
   std::vector<float> fVecBinsFragment;       //! z (fragmentation function) binning
@@ -271,8 +272,24 @@ class AliAnalysisTaskMesonJetCorrelation : public AliAnalysisTaskSE
   std::vector<TH1F*> fHistoNEvents;         //! vector of histos with event information
   std::vector<TH1F*> fHistoNEventsWOWeight; //! vector of histos with event information without event weights in case of JJ MC
 
-  std::vector<TH1F*> fHistoNGoodESDTracks; //! vector of histos for number of events
-  std::vector<TH1F*> fHistoVertexZ;        //! vector of histos for number of events without weights
+  std::vector<TH1F*> fHistoNGoodESDTracks;            //! vector of histos for number of tracks
+  std::vector<TH1F*> fHistoNGoodESDTracksEvtWithJets; //! vector of histos for number of tracks in events with jets
+  std::vector<TH1F*> fHistoVertexZ;                   //! vector of histos for number of events without weights
+
+  //-------------------------------
+  // cluster related histograms
+  //-------------------------------
+  std::vector<TH1F*> fHistoClusterPt; //! vector of histos with number of clusters as function of pt
+  std::vector<TH1F*> fHistoClusterE;  //! vector of histos with number of clusters as function of E
+
+  std::vector<TH1F*> fHistoClusterPtInJet; //! vector of histos with number of clusters as function of pt inside of jets
+  std::vector<TH1F*> fHistoClusterEInJet;  //! vector of histos with number of clusters as function of E inside of jets
+
+  //-------------------------------
+  // conversion photon histograms
+  //-------------------------------
+  std::vector<TH1F*> fHistoConvGammaPt;      //! vector of histos conversion photons vs. pt
+  std::vector<TH1F*> fHistoConvGammaPtInJet; //! vector of histos conversion photons vs. pt inside of jet
 
   //-------------------------------
   // Inv. Mass histograms
@@ -289,11 +306,6 @@ class AliAnalysisTaskMesonJetCorrelation : public AliAnalysisTaskSE
   std::vector<TH2F*> fHistoInvMassVsPtPerpCone;    //! same as fHistoInvMassVsPt but in perpendicular cone
   std::vector<TH2F*> fHistoJetPtVsFragPerpCone;    //! same as fHistoJetPtVsFrag but in perp cone
   std::vector<TH2F*> fHistoJetPtVsFragPerpCone_SB; //! same as fHistoJetPtVsFrag_SB but in perp cone
-
-  //-------------------------------
-  // conversion histograms
-  //-------------------------------
-  std::vector<TH1F*> fHistoConvGammaPt; //! vector of histos conversion photons vs. pt
 
   //-------------------------------
   // Jet related histograms
@@ -370,7 +382,7 @@ class AliAnalysisTaskMesonJetCorrelation : public AliAnalysisTaskSE
   AliAnalysisTaskMesonJetCorrelation(const AliAnalysisTaskMesonJetCorrelation&);            // Prevent copy-construction
   AliAnalysisTaskMesonJetCorrelation& operator=(const AliAnalysisTaskMesonJetCorrelation&); // Prevent assignment
 
-  ClassDef(AliAnalysisTaskMesonJetCorrelation, 3);
+  ClassDef(AliAnalysisTaskMesonJetCorrelation, 4);
 };
 
 #endif

--- a/PWGGA/GammaConvBase/AliGammaConvEventMixing.cxx
+++ b/PWGGA/GammaConvBase/AliGammaConvEventMixing.cxx
@@ -74,36 +74,34 @@ unsigned int EventMixPoolMesonJets::GetNGammasInEvt(float jetP, int evt, bool is
 }
 
 //________________________________________________________________________________
-std::vector<std::unique_ptr<AliAODConversionPhoton>> EventMixPoolMesonJets::getPhotonsRotated(int nEvt, float jetP, TVector3 jetAxis, bool isCaloPhoton)
+std::vector<std::shared_ptr<AliAODConversionPhoton>> EventMixPoolMesonJets::getPhotonsRotated(unsigned int nEvt, float jetP, TVector3 jetAxis, bool isCaloPhoton)
 {
   int index = getJetPIndex(jetP);
   if (index < 0) {
     printf("ERROR: index out of range\n");
-    std::vector<std::unique_ptr<AliAODConversionPhoton>> tmpVec(1);
+    std::vector<std::shared_ptr<AliAODConversionPhoton>> tmpVec(1);
     tmpVec[0] = nullptr;
     return tmpVec;
   }
 
   if (nEvt >= mixingPool[index].size()) {
     printf("index for mixing pool out of range");
-    std::vector<std::unique_ptr<AliAODConversionPhoton>> tmpVec(1);
+    std::vector<std::shared_ptr<AliAODConversionPhoton>> tmpVec(1);
     tmpVec[0] = nullptr;
     return tmpVec;
   }
   // calculate the shift
   double jetThetaCurEv = jetAxis.Theta();
   double jetPhiCurEv = jetAxis.Phi();
-  double jetEnergyCurEv = jetAxis.Mag();
 
   double jetThetaMixEv = mixingPool[index][nEvt]->jetAxis.Theta();
   double jetPhiMixEv = mixingPool[index][nEvt]->jetAxis.Phi();
-  double jetEnergyMixEv = mixingPool[index][nEvt]->jetAxis.Mag();
 
   double diffTheta = jetThetaCurEv - jetThetaMixEv;
   double diffPhi = jetPhiCurEv - jetPhiMixEv;
 
   unsigned int nGammas = mixingPool[index][nEvt]->getNPhotons(isCaloPhoton);
-  std::vector<std::unique_ptr<AliAODConversionPhoton>> vecRotatedGammas(nGammas);
+  std::vector<std::shared_ptr<AliAODConversionPhoton>> vecRotatedGammas(nGammas);
   TLorentzVector LVGammaRot;
   TVector3 tmpVec;
   for (unsigned int i = 0; i < nGammas; ++i) {
@@ -118,7 +116,7 @@ std::vector<std::unique_ptr<AliAODConversionPhoton>> EventMixPoolMesonJets::getP
 
     tmpVec.SetMagThetaPhi(energy, theta, phi);
     LVGammaRot.SetPtEtaPhiM(tmpVec.Pt(), tmpVec.Eta(), tmpVec.Phi(), 0.);
-    vecRotatedGammas[i] = std::move(std::make_unique<AliAODConversionPhoton>(new AliAODConversionPhoton(&LVGammaRot)));
+    vecRotatedGammas[i] = std::make_shared<AliAODConversionPhoton>(&LVGammaRot);
   }
   return vecRotatedGammas;
 }

--- a/PWGGA/GammaConvBase/AliGammaConvEventMixing.h
+++ b/PWGGA/GammaConvBase/AliGammaConvEventMixing.h
@@ -155,12 +155,13 @@ class EventMixPoolMesonJets
   ///\param jetAxis Jet axis of the current event
   ///\param isCaloPhoton switch if calo photons or conversion photons should be returned
   ///\return vector of rotated photons that can be used for mixing with th current event
-  std::vector<std::unique_ptr<AliAODConversionPhoton>> getPhotonsRotated(int nEvt, float jetP, TVector3 jetAxis, bool isCaloPhoton);
+  std::vector<std::shared_ptr<AliAODConversionPhoton>> getPhotonsRotated(unsigned int nEvt, float jetP, TVector3 jetAxis, bool isCaloPhoton);
 
  private:
   std::vector<float> vecJetPClasses = {-1, 20, 40, 60, 100, 100000};
-  std::vector<std::vector<std::shared_ptr<EventWithJetAxis>>> mixingPool;
+  std::vector<std::vector<std::shared_ptr<EventWithJetAxis>>> mixingPool = {};
   unsigned int poolDepth = 20;
+
 };
 
 #endif


### PR DESCRIPTION
- Switch to shared_ptr in mixed background calculation struct
- Fix rotation background that both rotated photons are checked and not only one (Which led to a peak in the background distribution)