### PR TITLE
Update of the jet energy flow task to handle the analysis of embedded Pythia events

### DIFF
--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetEnergyFlow.h
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetEnergyFlow.h
@@ -26,6 +26,12 @@
 
 class AliAnalysisTaskEmcalJetEnergyFlow: public AliAnalysisTaskEmcalJet {
 	public:
+        enum AnalysisType{
+                kppData         = 0,
+                kppMC           = 1,
+                kPbPbData       = 2,
+                kEmbeded        = 3, 
+                };
 	
 	AliAnalysisTaskEmcalJetEnergyFlow()			;
 	AliAnalysisTaskEmcalJetEnergyFlow(const char* name)	;
@@ -39,7 +45,7 @@ class AliAnalysisTaskEmcalJetEnergyFlow: public AliAnalysisTaskEmcalJet {
 		const char *nclusters		= "usedefault",
 		const char *ncells		= "usedefault",
 		Double_t Rstep_EF               = 0.1,              
-		Bool_t SetMCprod                 = kTRUE,
+                AnalysisType fAnType            =kppData,
                 const char *suffix              = "" );
 	
 	protected:
@@ -52,7 +58,8 @@ class AliAnalysisTaskEmcalJetEnergyFlow: public AliAnalysisTaskEmcalJet {
 	void			ExecOnce()				;
 	Bool_t			FillHistograms()			;
 	Bool_t			Run()					;
-
+        void                    SetAnalysisType(AnalysisType a){fAnalysisType = a;}
+        AnalysisType            GetAnalysisType(){return fAnalysisType;}
 	void			AllocateJetHistograms()			;
 	void			AllocateTrackHistograms()		; ///<Same as Sample task
 	void                    AllocateClusterHistograms()             ; ///<May remove later
@@ -66,15 +73,14 @@ class AliAnalysisTaskEmcalJetEnergyFlow: public AliAnalysisTaskEmcalJet {
 	void                    DoCellLoop()                            ; ///<May remove later
 
 	Double_t                R_jet_step				;///<Radial step for the dpt calculation
-        Bool_t                  IsMCprod                                ;///<Flag for MC productions
 	THistManager            fHistManager                            ;///<Hist manager
 //	TList*			fOutput					;///!<! Output list
  	private:
+        AnalysisType            fAnalysisType                           ;///<Flag for type of analysis
  	 AliAnalysisTaskEmcalJetEnergyFlow(const AliAnalysisTaskEmcalJetEnergyFlow&); // not implemented
   	 AliAnalysisTaskEmcalJetEnergyFlow &operator=(const AliAnalysisTaskEmcalJetEnergyFlow&); // not implemented
 
-  	/// \cond CLASSIMP
-  	  ClassDef(AliAnalysisTaskEmcalJetEnergyFlow,14);
+  	  ClassDef(AliAnalysisTaskEmcalJetEnergyFlow,15);
 	/// \endcond
 };
 #endif

--- a/PWGJE/EMCALJetTasks/macros/AddTaskEmcalJetEnergyFlow.C
+++ b/PWGJE/EMCALJetTasks/macros/AddTaskEmcalJetEnergyFlow.C
@@ -1,9 +1,13 @@
+#if !defined(__CINT__) && !defined(__CLING__)
+#include "AliAnalysisTaskEmcalJetEnergyFlow.h"
+#endif
+
   AliAnalysisTaskEmcalJetEnergyFlow* AddTaskEmcalJetEnergyFlow(
        const char *ntracks            = "usedefault",
        const char *nclusters          = "usedefault",
        const char* ncells             = "usedefault",
-       Double_t Rstep_EF               = 0.1,
-       Bool_t      IsMCprod           = kTRUE,
+       Double_t Rstep_EF              = 0.1,
+       AnalysisType fAnType           = AliAnalysisTaskEmcalJetEnergyFlow::kppData,
        const char *suffix             = ""
      )
      {
@@ -11,7 +15,7 @@
           nclusters,
           ncells,
           Rstep_EF,                                                                 
-          IsMCprod,
+          fAnType,
           suffix);
     }
  


### PR DESCRIPTION
Update of the jet energy flow task to handle the analysis of embedded Pythia events. The main difference is the introduction of an enum object to describe the type of analysis which replaces the previous MC flag. This affects the switch of scaling the output AliEmcalList.