### PR TITLE
PWGGA/GammaConv: Added omega-asymmetry cut and changed lambda function

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson.cxx
@@ -117,9 +117,9 @@ AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::AliAnalysisTaskNeutralMesonTo
   fPDGCodeAnalyzedMeson(-1),
   fEnableNoCorrOutput(kTRUE),
   fEnableSubNDMOutput(kTRUE),
-  fLambda(nullptr),
   fEnableFixedpzOutput(kTRUE),
   fEnableSubLambdaOutput(kFALSE),
+  fLambda(nullptr),
   fEnableNDMEfficiency(kFALSE),
   fEnableNDMInputSpectrum(kFALSE),
   fEnableTreeTrueNDMFromHNM(kFALSE),
@@ -451,9 +451,9 @@ AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::AliAnalysisTaskNeutralMesonTo
   fPDGCodeAnalyzedMeson(-1),
   fEnableNoCorrOutput(kTRUE),
   fEnableSubNDMOutput(kTRUE),
-  fLambda(nullptr),
   fEnableFixedpzOutput(kTRUE),
   fEnableSubLambdaOutput(kFALSE),
+  fLambda(nullptr),
   fEnableNDMEfficiency(kFALSE),
   fEnableNDMInputSpectrum(kFALSE),
   fEnableTreeTrueNDMFromHNM(kFALSE),
@@ -1674,8 +1674,8 @@ void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::UserCreateOutputObjects(
     }
 
     if(fEnableSubLambdaOutput){
-      fLambda[iCut]                                            = new TF1("fLambda","pol4",0.,20);
-      fLambda[iCut]->SetParameters(1.88393,-0.329409,0.0855903,-0.00712377,0.000184257);
+      fLambda[iCut]                                            = new TF1("fLambda","pol2",0.,20);
+      fLambda[iCut]->SetParameters(0.0637,0.483,-0.031074);
       fHistoMotherInvMassSubLambda[iCut]                       = new TH2F("ESD_InvMass_Mother_Sub_Lambda_InvMass_Neutral_Pt","ESD_InvMass_Mother_Sub_InvMass_Neutral_Pt",HistoNMassBinsSub,HistoMassRangeSub[0],HistoMassRangeSub[1], HistoNPtBins, arrPtBinning);
       fHistoMotherInvMassSubLambda[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{+} #pi^{-} %s} - #lambda#times(M_{%s}-M_{%s},PDG}) (GeV/c^{2})",NameNDMLatex.Data(),NameNDMLatex.Data(),NameNDMLatex.Data()));
       fHistoMotherInvMassSubLambda[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
@@ -8491,6 +8491,14 @@ Bool_t AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::MesonIsSelectedByAlpha
                 ((6.30231e-01)-(-3.77337e+00))/(TMath::Exp(((5.60553e-05)-xx)/(1.35591e+00))+(9.99175e-01))+(-3.77337e+00);
         useConst_LowerLimit                 = kTRUE;
         const_LowerLimit                    = -0.8;
+        useConst_UpperLimit                 = kTRUE;
+        const_UpperLimit                    = 0.8;
+        break;
+    case 3:
+        useFunction_UpperLimit              = kTRUE;
+        FunctionValue_UpperLimit            = ((6.30231e-01)-(-3.77337e+00))/(TMath::Exp(((5.60553e-05)-xx)/(1.35591e+00))+(9.99175e-01))+(-3.77337e+00);
+        useConst_LowerLimit                 = kTRUE;
+        const_LowerLimit                    = -0.6;
         useConst_UpperLimit                 = kTRUE;
         const_UpperLimit                    = 0.8;
         break;

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_CaloMode_pPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_CaloMode_pPb.C
@@ -285,6 +285,8 @@ void AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_CaloMode_pPb(
   }else if (trainConfig == 1023){ // Cutvariation for pi0 pT
     cuts.AddCutHeavyMesonCalo("80010113","411790105fe30220000","32c51070a","0103663o00000000","0453503000000000"); // pi0 pT > 1.5
     cuts.AddCutHeavyMesonCalo("80010113","411790105fe30220000","32c51070a","01036z3o00000000","0453503000000000"); // pi0 pT > 2
+  }else if (trainConfig == 1024){ // Asymmetry cut on omega
+    cuts.AddCutHeavyMesonCalo("80010113","411790105fe30220000","32c51070a","0103603o00000000","045350l000000000");
 
  //************************************************ PCM- PHOS analysis 5 TeV pPb ********************************************
   } else if (trainConfig == 1501){ // PHOS  INT7 run1

--- a/PWGGA/GammaConvBase/AliConversionMesonCuts.cxx
+++ b/PWGGA/GammaConvBase/AliConversionMesonCuts.cxx
@@ -3236,6 +3236,11 @@ Bool_t AliConversionMesonCuts::SetAlphaMesonCut(Int_t alphaMesonCut)
     fAlphaCutMeson      = 1.;
     fAlphaInTaskMode = 2;
     break;
+  case 21:   // l (Alpha Cut is handled in Task)
+    fAlphaMinCutMeson   = 0.0;
+    fAlphaCutMeson      = 1.;
+    fAlphaInTaskMode = 3;
+    break;
   default:
     cout<<"Warning: AlphaMesonCut not defined "<<alphaMesonCut<<endl;
     return kFALSE;


### PR DESCRIPTION
- Added cut on asymmetry (l) with -0.6 < alpha < CustomFuction
- Added cutstring using the new cut
- Changed lambda function from pol4 to pol2 following previous DPMJet train data