### PR TITLE
Propagate updates from O2vertexer in O2 into AliPhysics

### DIFF
--- a/PWGLF/NUCLEX/Utils/O2vertexer/HelixHelper.h
+++ b/PWGLF/NUCLEX/Utils/O2vertexer/HelixHelper.h
@@ -15,8 +15,8 @@
 #ifndef _ALICEO2_HELIX_HELPER_
 #define _ALICEO2_HELIX_HELPER_
 
+#include "MathUtils.h"
 #include "Primitive2D.h"
-#include "Track.h"
 
 namespace o2
 {
@@ -26,15 +26,19 @@ namespace track
 ///__________________________________________________________________________
 //< precalculated track radius, center, alpha sin,cos and their combinations
 struct TrackAuxPar : public o2::utils::CircleXY {
-  using Track = o2::track::TrackParCov;
 
   float c, s, cc, ss, cs; // cos ans sin of track alpha and their products
 
   TrackAuxPar() = default;
-  TrackAuxPar(const Track& trc, float bz) { set(trc, bz); }
+  template <typename T>
+  TrackAuxPar(const T& trc, float bz)
+  {
+    set(trc, bz);
+  }
   float cosDif(const TrackAuxPar& t) const { return c * t.c + s * t.s; } // cos(alpha_this - alha_t)
   float sinDif(const TrackAuxPar& t) const { return s * t.c - c * t.s; } // sin(alpha_this - alha_t)
-  void set(const Track& trc, float bz)
+  template <typename T>
+  void set(const T& trc, float bz)
   {
     trc.getCircleParams(bz, *this, s, c);
     cc = c * c;
@@ -47,11 +51,12 @@ struct TrackAuxPar : public o2::utils::CircleXY {
 //__________________________________________________________
 //< crossing coordinates of 2 circles
 struct CrossInfo {
-  float xDCA[2];
-  float yDCA[2];
-  int nDCA;
+  static constexpr float MaxDistXYDef = 10.;
+  float xDCA[2] = {};
+  float yDCA[2] = {};
+  int nDCA = 0;
 
-  int circlesCrossInfo(const TrackAuxPar& trax0, const TrackAuxPar& trax1)
+  int circlesCrossInfo(const TrackAuxPar& trax0, const TrackAuxPar& trax1, float maxDistXY = MaxDistXYDef)
   {
     const auto& trcA = trax0.rC > trax1.rC ? trax0 : trax1; // designate the largest circle as A
     const auto& trcB = trax0.rC > trax1.rC ? trax1 : trax0;
@@ -63,6 +68,9 @@ struct CrossInfo {
     if (dist > rsum) { // circles don't touch, chose a point in between
       // the parametric equation of lines connecting the centers is
       // x = x0 + t/dist * (x1-x0), y = y0 + t/dist * (y1-y0)
+      if (dist - rsum > maxDistXY) { // too large distance
+        return nDCA;
+      }
       notTouchingXY(dist, xDist, yDist, trcA, trcB.rC);
     } else if (dist + trcB.rC < trcA.rC) { // the small circle is nestled into large one w/o touching
       // select the point of closest approach of 2 circles
@@ -119,8 +127,9 @@ struct CrossInfo {
     yDCA[0] = trcA.yC + 0.5 * (yDist * t2d);
   }
 
-  int linesCrossInfo(const TrackAuxPar& trax0, const TrackParCov& tr0,
-                     const TrackAuxPar& trax1, const TrackParCov& tr1)
+  template <typename T>
+  int linesCrossInfo(const TrackAuxPar& trax0, const T& tr0,
+                     const TrackAuxPar& trax1, const T& tr1, float maxDistXY = MaxDistXYDef)
   {
     /// closest approach of 2 straight lines
     ///  TrackParam propagation can be parameterized in lab in a form
@@ -166,15 +175,22 @@ struct CrossInfo {
       auto detI = 1. / det;
       auto t0 = det0 * detI;
       auto t1 = det1 * detI;
-      xDCA[0] = (trax0.xC + kx0 * t0 + trax1.xC + kx1 * t1) * 0.5;
-      yDCA[0] = (trax0.yC + ky0 * t0 + trax1.yC + ky1 * t1) * 0.5;
+      float addx0 = kx0 * t0, addy0 = ky0 * t0, addx1 = kx1 * t1, addy1 = ky1 * t1;
+      dx += addx1 - addx0; // recalculate XY distance at DCA
+      dy += addy1 - addy0;
+      if (dx * dx + dy * dy > maxDistXY * maxDistXY) {
+        return nDCA;
+      }
+      xDCA[0] = (trax0.xC + addx0 + trax1.xC + addx1) * 0.5;
+      yDCA[0] = (trax0.yC + addy0 + trax1.yC + addy1) * 0.5;
       nDCA = 1;
     }
     return nDCA;
   }
 
-  int circleLineCrossInfo(const TrackAuxPar& trax0, const TrackParCov& tr0,
-                          const TrackAuxPar& trax1, const TrackParCov& tr1)
+  template <typename T>
+  int circleLineCrossInfo(const TrackAuxPar& trax0, const T& tr0,
+                          const TrackAuxPar& trax1, const T& tr1, float maxDistXY = MaxDistXYDef)
   {
     /// closest approach of line and circle
     ///  TrackParam propagation can be parameterized in lab in a form
@@ -215,10 +231,14 @@ struct CrossInfo {
       yDCA[1] = traxL.yC + ky * t1;
       nDCA = 2;
     } else {
-      // there is no crossing, find the point of the closest approach on the line as the sames which is closest to the circle center
+      // there is no crossing, find the point of the closest approach on the line which is closest to the circle center
       float t = -dk * cspi2;
       float xL = traxL.xC + kx * t, yL = traxL.yC + ky * t;                                               // point on the line, need to average with point on the circle
-      float dxc = xL - traxH.xC, dyc = yL - traxH.yC, drcf = traxH.rC / std::sqrt(dxc * dxc + dyc * dyc); // radius / distance to circle center
+      float dxc = xL - traxH.xC, dyc = yL - traxH.yC, dist = std::sqrt(dxc * dxc + dyc * dyc);
+      if (dist - traxH.rC > maxDistXY) { // too large distance
+        return nDCA;
+      }
+      float drcf = traxH.rC / dist; // radius / distance to circle center
       float xH = traxH.xC + dxc * drcf, yH = traxH.yC + dyc * drcf;
       xDCA[0] = (xL + xH) * 0.5;
       yDCA[0] = (yL + yH) * 0.5;
@@ -227,16 +247,17 @@ struct CrossInfo {
     return nDCA;
   }
 
-  int set(const TrackAuxPar& trax0, const TrackParCov& tr0, const TrackAuxPar& trax1, const TrackParCov& tr1)
+  template <typename T>
+  int set(const TrackAuxPar& trax0, const T& tr0, const TrackAuxPar& trax1, const T& tr1, float maxDistXY = MaxDistXYDef)
   {
     // calculate up to 2 crossings between 2 circles
     nDCA = 0;
     if (trax0.rC > o2::constants::math::Almost0 && trax1.rC > o2::constants::math::Almost0) { // both are not straight lines
-      nDCA = circlesCrossInfo(trax0, trax1);
+      nDCA = circlesCrossInfo(trax0, trax1, maxDistXY);
     } else if (trax0.rC < o2::constants::math::Almost0 && trax1.rC < o2::constants::math::Almost0) { // both are straigt lines
-      nDCA = linesCrossInfo(trax0, tr0, trax1, tr1);
+      nDCA = linesCrossInfo(trax0, tr0, trax1, tr1, maxDistXY);
     } else {
-      nDCA = circleLineCrossInfo(trax0, tr0, trax1, tr1);
+      nDCA = circleLineCrossInfo(trax0, tr0, trax1, tr1, maxDistXY);
     }
     //
     return nDCA;
@@ -244,9 +265,10 @@ struct CrossInfo {
 
   CrossInfo() = default;
 
-  CrossInfo(const TrackAuxPar& trax0, const TrackParCov& tr0, const TrackAuxPar& trax1, const TrackParCov& tr1)
+  template <typename T>
+  CrossInfo(const TrackAuxPar& trax0, const T& tr0, const TrackAuxPar& trax1, const T& tr1, float maxDistXY = MaxDistXYDef)
   {
-    set(trax0, tr0, trax1, tr1);
+    set(trax0, tr0, trax1, tr1, maxDistXY);
   }
   ClassDefNV(CrossInfo, 1);
 };
@@ -255,3 +277,4 @@ struct CrossInfo {
 } // namespace o2
 
 #endif
+

--- a/PWGLF/NUCLEX/Utils/O2vertexer/MathUtils.h
+++ b/PWGLF/NUCLEX/Utils/O2vertexer/MathUtils.h
@@ -102,10 +102,22 @@ inline void rotateZ(float xL, float yL, float& xG, float& yG, float snAlp, float
   yG = xL * snAlp + yL * csAlp;
 }
 
+inline void rotateZd(double xL, double yL, double& xG, double& yG, double snAlp, double csAlp)
+{
+  // 2D rotation of the point by angle alpha (local to global)
+  xG = xL * csAlp - yL * snAlp;
+  yG = xL * snAlp + yL * csAlp;
+}
+
 inline void rotateZInv(float xG, float yG, float& xL, float& yL, float snAlp, float csAlp)
 {
   // inverse 2D rotation of the point by angle alpha (global to local)
   rotateZ(xG, yG, xL, yL, -snAlp, csAlp);
+}
+
+inline void rotateZInvd(double xG, double yG, double& xL, double& yL, double snAlp, double csAlp)
+{
+  rotateZd(xG, yG, xL, yL, -snAlp, csAlp);
 }
 
 inline void rotateZ(double xL, double yL, double& xG, double& yG, double snAlp, double csAlp)


### PR DESCRIPTION
PR to get the O2Vertexer in AliPhysics up to date with the current one in O2. In particular updates regarding the covariance matrix were missing in the AliPhysics version, making it difficult to validate analyses that apply selections based on this (e.g. D meson analyses in HF).

I tried to keep this PR as simple as possible (instead of propagating tens of new header files that O2 now has into AliPhysics). Regarding this I put some considerations below.

@mpuccio, @vkucera, let me know what you think.

Cheers, Luuk

----------------------------------
**Consideration w.r.t. current (01-11-22) O2 version**

General:
 - I didn't split the MathUtils class, since this would require a lot of new header files to be propagated to AliPhysics. Instead I kept the original class (adding two additional functions), and I didn't propagated the changes in O2 regarding the split MathUtils class into `DCAFitterN.h`, `HelixHelper.h`, `Track.h`, and `Primitive2D.h`

In DCAFitterN:
 - I didn't propagate the parts related to `Propagator.h` and `o2::base::Propagator::MatCorrType`. I don't think this is required for Ali-O2Physics comparisons.
 - I didn't propagate the parts related to `mRefitWithMatCorr`. I had some issues with the `restore()` call (which is new), and I don't think this is required for Ali-O2Physics comparisons.
 - For the same reason as above, I commented out `trc.invalidate()` in `getTrackParamAtPCA()`
 - I didn't separate between `TrackPar` and `TrackParCov`, i.e. all `TrackPar` types are changed to `TrackParCov` (as was also done before) and I didn't include the `createParentTrackPar()` function, only the `createParentTrackPar()`