### PR TITLE
PWGGA/GammaConv Fix for unsafe pointer issue

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvV1.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvV1.cxx
@@ -367,6 +367,7 @@ AliAnalysisTaskGammaConvV1::AliAnalysisTaskGammaConvV1(): AliAnalysisTaskSE(),
   fFileNameBroken(NULL),
   fFileWasAlreadyReported(kFALSE),
   fAODMCTrackArray(NULL),
+  fAddressChanges(NULL),
   fMapPhotonHeaders()
 {
 
@@ -680,6 +681,7 @@ AliAnalysisTaskGammaConvV1::AliAnalysisTaskGammaConvV1(const char *name):
   fFileNameBroken(NULL),
   fFileWasAlreadyReported(kFALSE),
   fAODMCTrackArray(NULL),
+  fAddressChanges(NULL),
   fMapPhotonHeaders()
 {
   // Define output slots here
@@ -2310,6 +2312,9 @@ void AliAnalysisTaskGammaConvV1::UserCreateOutputObjects(){
   tBrokenFiles = new TTree("BrokenFiles", "BrokenFiles");
   tBrokenFiles->Branch("fileName",&fFileNameBroken);
   fOutputContainer->Add(tBrokenFiles);
+  
+  fAddressChanges = new TH1F("fAddressChanges","fAddressChanges", 2, 0., 2.);
+  fOutputContainer->Add(fAddressChanges);
 
   OpenFile(1);
   PostData(1, fOutputContainer);
@@ -2368,7 +2373,22 @@ void AliAnalysisTaskGammaConvV1::UserExec(Option_t *)
   fInputEvent = InputEvent();
 
   // Set MC events
-  if(fIsMC>0) fMCEvent = MCEvent();
+  if(fIsMC>0) {
+    fMCEvent = MCEvent();
+    
+    if(fInputEvent->IsA()==AliAODEvent::Class()){
+      TClonesArray* lOldAddress = fAODMCTrackArray;
+      fAODMCTrackArray = dynamic_cast<TClonesArray*>(fInputEvent->FindListObject(AliAODMCParticle::StdBranchName()));
+      // remove next line  and fAddressChanges after first trainrun 
+      if (lOldAddress && fAODMCTrackArray!=lOldAddress) fAddressChanges->Fill(0.5);
+      
+      if (fAODMCTrackArray == NULL){
+        fAddressChanges->Fill(1.5);
+        AliInfo("AODMCTrackArray could not be loaded");
+        return;
+      }
+    }
+  }
 
   //calculating the weight for the centrality flattening
   for(Int_t iCut = 0; iCut<fnCuts; iCut++){
@@ -2416,7 +2436,10 @@ void AliAnalysisTaskGammaConvV1::UserExec(Option_t *)
     fiEventCut = dynamic_cast<AliConvEventCuts*>(fEventCutArray->At(iCut));
     fiPhotonCut = dynamic_cast<AliConversionPhotonCuts*>(fCutArray->At(fiCut));
     fiMesonCut  = dynamic_cast<AliConversionMesonCuts*>(fMesonCutArray->At(fiCut));
-
+    
+    // reset the event cuts fAODMCTrackArray to nullptr at the beginning of each event since in AliConvEventCuts it is only obtained from a new event if it's not a nullptr - hence only once at the beginning of a job. 
+    if(fIsMC) fiEventCut->ResetAODMCTrackArray(); 
+    
     Int_t eventNotAccepted = fiEventCut->IsEventAcceptedByCut(fV0Reader->GetEventCuts(),fInputEvent,fMCEvent,fIsHeavyIon,kFALSE);
     if( fIsMC == 2 ){
       Float_t xsection      = -1.;
@@ -2919,11 +2942,6 @@ void AliAnalysisTaskGammaConvV1::InitializeBDT()
 //________________________________________________________________________
 void AliAnalysisTaskGammaConvV1::ProcessPhotonBDT()
 {
-  if(!fAODMCTrackArray) fAODMCTrackArray = dynamic_cast<TClonesArray*>(fInputEvent->FindListObject(AliAODMCParticle::StdBranchName()));
-  if (fAODMCTrackArray == NULL) {
-    AliInfo("AODMCTrackArray could not be loaded");
-    return;
-  }
   // Loop over Photon Candidates allocated by ReaderV1
   for(Int_t i = 0; i < fGammaCandidates->GetEntries(); i++){
     AliAODConversionPhoton *PhotonCandidate=dynamic_cast<AliAODConversionPhoton*>(fGammaCandidates->At(i));
@@ -2989,13 +3007,6 @@ void AliAnalysisTaskGammaConvV1::ProcessTruePhotonCandidatesAOD(AliAODConversion
     magFieldFlip =  -1.0;
   }
 
-  //  TClonesArray *AODMCTrackArray = dynamic_cast<TClonesArray*>(fInputEvent->FindListObject(AliAODMCParticle::StdBranchName()));
-
-  if(!fAODMCTrackArray) fAODMCTrackArray = dynamic_cast<TClonesArray*>(fInputEvent->FindListObject(AliAODMCParticle::StdBranchName()));
-  if (fAODMCTrackArray == NULL) {
-    AliInfo("AODMCTrackArray could not be loaded");
-    return;
-  }
   if (fAODMCTrackArray != NULL && TruePhotonCandidate != NULL){
 
     AliAODMCParticle *posDaughter = (AliAODMCParticle*) fAODMCTrackArray->At(TruePhotonCandidate->GetMCLabelPositive());
@@ -3316,13 +3327,6 @@ void AliAnalysisTaskGammaConvV1::ProcessAODMCParticles()
   Double_t mcProdVtxX   = primVtxMC->GetX();
   Double_t mcProdVtxY   = primVtxMC->GetY();
   Double_t mcProdVtxZ   = primVtxMC->GetZ();
-
-  //  TClonesArray *AODMCTrackArray = dynamic_cast<TClonesArray*>(fInputEvent->FindListObject(AliAODMCParticle::StdBranchName()));
-  if(!fAODMCTrackArray) fAODMCTrackArray = dynamic_cast<TClonesArray*>(fInputEvent->FindListObject(AliAODMCParticle::StdBranchName()));
-  if (fAODMCTrackArray == NULL){
-    AliInfo("AODMCTrackArray could not be loaded");
-    return;
-  }
 
   // Check if MC generated particles should be filled for this event using the selected trigger
   if( !((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsMCTriggerSelected(fInputEvent, fMCEvent)){
@@ -3931,16 +3935,7 @@ void AliAnalysisTaskGammaConvV1::ProcessMCParticles()
 
 //________________________________________________________________________
 void AliAnalysisTaskGammaConvV1::CalculatePi0Candidates(){
-  // fAODMCTrackArray is used when the flag DoIsolatedAnalysis is True. And can only work on AODs. This "if" is necessary for any  task running in ESDs, otherwise one skips the calculation
-  if(fDoIsolatedAnalysis){
-    if (fIsMC>0){
-      if(!fAODMCTrackArray) fAODMCTrackArray = dynamic_cast<TClonesArray*>(fInputEvent->FindListObject(AliAODMCParticle::StdBranchName()));
-      if (fAODMCTrackArray == NULL){
-	AliInfo("AODMCTrackArray could not be loaded");
-	return;
-      }
-    }
-  }
+  
   // Conversion Gammas
   if(fGammaCandidates->GetEntries()>1){
     for(Int_t firstGammaIndex=0;firstGammaIndex<fGammaCandidates->GetEntries()-1;firstGammaIndex++){
@@ -4477,11 +4472,6 @@ void AliAnalysisTaskGammaConvV1::ProcessTrueMesonCandidates(AliAODConversionMoth
 //______________________________________________________________________
 void AliAnalysisTaskGammaConvV1::ProcessTrueMesonCandidatesAOD(AliAODConversionMother *Pi0Candidate, AliAODConversionPhoton *TrueGammaCandidate0, AliAODConversionPhoton *TrueGammaCandidate1)
 {
-  if(!fAODMCTrackArray) fAODMCTrackArray = dynamic_cast<TClonesArray*>(fInputEvent->FindListObject(AliAODMCParticle::StdBranchName()));
-  if (fAODMCTrackArray == NULL) {
-    AliInfo("AODMCTrackArray could not be loaded");
-    return;
-  }
   Double_t magField = fInputEvent->GetMagneticField();
   const AliVVertex* primVtxMC   = fMCEvent->GetPrimaryVertex();
   Double_t mcProdVtxX   = primVtxMC->GetX();

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvV1.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvV1.h
@@ -419,6 +419,7 @@ class AliAnalysisTaskGammaConvV1 : public AliAnalysisTaskSE {
     TObjString*                       fFileNameBroken;                            // string object for broken file name
     Bool_t                            fFileWasAlreadyReported;                    // to store if the current file was already marked broken
     TClonesArray*                     fAODMCTrackArray;                           //! pointer to track array
+    TH1F*                             fAddressChanges;                                //! count if addresses of aod mc tracks arrays ever change            
 
     AliConversionPhotonCuts::TMapPhotonBool fMapPhotonHeaders;                   // map to remember if the photon tracks are from selected headers
 
@@ -426,7 +427,7 @@ class AliAnalysisTaskGammaConvV1 : public AliAnalysisTaskSE {
 
     AliAnalysisTaskGammaConvV1(const AliAnalysisTaskGammaConvV1&); // Prevent copy-construction
     AliAnalysisTaskGammaConvV1 &operator=(const AliAnalysisTaskGammaConvV1&); // Prevent assignment
-    ClassDef(AliAnalysisTaskGammaConvV1, 56);
+    ClassDef(AliAnalysisTaskGammaConvV1, 57);
 };
 
 #endif

--- a/PWGGA/GammaConvBase/AliConvEventCuts.h
+++ b/PWGGA/GammaConvBase/AliConvEventCuts.h
@@ -411,6 +411,7 @@ class AliConvEventCuts : public AliAnalysisCuts {
       Bool_t    SetRejectExtraSignalsCut (Int_t extraSignal);
       Bool_t    SetVertexCut(Int_t vertexCut);
 
+      void    ResetAODMCTrackArray()                                                { fAODMCTrackArray = 0x0;}
       void    ResetMcHeader()                                                       { fAODMCHeader = 0x0;}
 
       void    SetPeriodEnum (TString periodName);


### PR DESCRIPTION
Up to now pointers to the aod mc track array were obtained only once for the first event of an instance of the analysis task. Since it is not guaranteed that the address of this track array stays constant over the lifetime of an analysis task this can produce unexpected behaviour.
With this change the pointer is reset for every event.