### PR TITLE
Correctly store and pass fast simulation parameters

### DIFF
--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskIDFragmentationFunction.h
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskIDFragmentationFunction.h
@@ -41,9 +41,9 @@ public:
   virtual ~AliAnalysisTaskIDFragmentationFunction();
   
   virtual void   UserCreateOutputObjects();
-  virtual void   Init();
   virtual void   LocalInit() {Init();};
-
+  void InitialiseFastSimulationFunctions();
+  
   Bool_t         FillHistograms();
   virtual void   Terminate(Option_t* );
   virtual Bool_t Notify();
@@ -103,6 +103,10 @@ public:
   
   virtual TF1** GetEfficiencyFunctions() const { return fEffFunctions;};
   virtual void SetEfficiencyFunctions(TF1** effFunctions) {fEffFunctions = new TF1*[2*AliPID::kSPECIES];for (Int_t i=0;i<2*AliPID::kSPECIES;++i)fEffFunctions[i]=effFunctions[i];};   
+  virtual void ResetEffFunctions() {delete fEffFunctions; fEffFunctions = 0x0;};
+  
+  virtual TString GetFastSimulationParameters() const { return fastSimulationParameters; };
+  virtual void SetFastSimulationParameters(TString value) { fastSimulationParameters = value; };
   
   virtual Double_t GetFastSimEffFactor() const { return fFastSimEffFactor; };
   virtual void SetFastSimEffFactor(Double_t value) { fFastSimEffFactor = value; };
@@ -303,7 +307,8 @@ public:
   Double_t fZSoftDrop;
   
   Bool_t fUseFastSimulations;
-  TF1** fEffFunctions;                       // For fast simulations
+  TString fastSimulationParameters;          // Parameter string to store FastSimulation parameters
+  TF1** fEffFunctions;                       //! For fast simulations
   Double_t fFastSimEffFactor;
   Double_t fFastSimRes;
   Double_t fFastSimResFactor;
@@ -318,7 +323,7 @@ private:
   AliAnalysisTaskIDFragmentationFunction(const  AliAnalysisTaskIDFragmentationFunction&);   //Not implemented in AliAnalysisTaskEmcalJet
   AliAnalysisTaskIDFragmentationFunction& operator=(const  AliAnalysisTaskIDFragmentationFunction);   //Not implemented AliAnalysisTaskEmcalJet
   
-  ClassDef(AliAnalysisTaskIDFragmentationFunction, 25);
+  ClassDef(AliAnalysisTaskIDFragmentationFunction, 26);
 };
 
 

--- a/PWGJE/EMCALJetTasks/UserTasks/AliPieceWisePoly.cxx
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliPieceWisePoly.cxx
@@ -10,6 +10,8 @@
 #include "AliPID.h"
 
 #include "AliPieceWisePoly.h"
+
+#include <string.h>
 using namespace std;
 
 AliPieceWisePoly::AliPieceWisePoly(Int_t parts, Double_t* cutxvalues, Int_t* polys, Double_t xmin, Double_t xmax,  Double_t* params, Int_t smooth)
@@ -149,9 +151,13 @@ double AliPieceWisePoly::Eval (double x, double* p) {
   return piecewisepolynom->Eval(x);
 }
 
-void AliPieceWisePoly::ReadFSParameters(TString parameterFile, TF1** effFunctions) {
-  if(parameterFile.Contains("alien://") && ! gGrid)
+TString AliPieceWisePoly::ReadFSParameters(TString parameterFile, TF1** effFunctions) 
+{
+  if(parameterFile.Contains("alien://") && !gGrid)
     TGrid::Connect("alien://");
+  
+  TString joinedString = "";
+  char separator = ':';
   
   TFile* f = TFile::Open(parameterFile.Data(), "READ");
   for (Int_t species=0;species<AliPID::kSPECIES;++species) {
@@ -163,30 +169,62 @@ void AliPieceWisePoly::ReadFSParameters(TString parameterFile, TF1** effFunction
       if (!name)
         cout << "Could not find " << name << "." << endl;
       
-      TString* parString = new TString(cont->GetTitle());
-      TObjArray* arrPar = parString->Tokenize(";");
-      Int_t nOfParts = (((TObjString*)(arrPar->At(0)))->GetString()).Atoi();
-      Double_t* cuts = new Double_t[nOfParts-1];
-      Int_t* nparameters = new Int_t[nOfParts]; 
+      TString parString = TString(cont->GetTitle());
+      joinedString += parString + TString(separator);
       
-      for (Int_t part = 0;part<nOfParts - 1;++part) {
-        nparameters[part] = (((TObjString*)(arrPar->At(nOfParts + part)))->GetString()).Atoi();
-        cuts[part] = (((TObjString*)(arrPar->At(1 + part)))->GetString()).Atof();
-      }
-      nparameters[nOfParts - 1] = (((TObjString*)(arrPar->At(2*nOfParts -1)))->GetString()).Atoi();
+      TString nameFunction = TString::Format("fastSimulationFunction_%s_%s", AliPID::ParticleShortName(species), charge ? "pos" : "neg");
+      TF1* func = GetFSFunctionFromString(parString, nameFunction);
       
-      AliPieceWisePoly* pwp = new AliPieceWisePoly(nOfParts,cuts,nparameters,0,50,0x0,2);
-      TString nameFunction = TString::Format("fastSimulationFunction_%s_%s",AliPID::ParticleShortName(species),charge ? "pos" : "neg");
-      TF1* func = new TF1(nameFunction.Data(),pwp,0,50,pwp->GetNOfParam());
-      for (Int_t param=0;param<pwp->GetNOfParam();++param) {
-        func->SetParameter(param,(((TObjString*)(arrPar->At(2*nOfParts + param)))->GetString()).Atof());
-      }
       effFunctions[2*species + charge] = func;
-			delete [] nparameters;
-      delete [] cuts;
-      delete arrPar;
-      delete parString;
+    }
+  }
+  f->Close();
+  delete f;
+  joinedString.Remove(TString::kTrailing, separator);
+  return joinedString;
+}
+
+void AliPieceWisePoly::ReadFSParametersFromString(TString parameterString, TF1** effFunctions)
+{
+  TObjArray* parameters = parameterString.Tokenize(":");
+  
+  Int_t position = 0;
+  for (Int_t species=0;species<AliPID::kSPECIES;++species) {
+    for (Int_t charge=0;charge<=1;++charge) {     
+      TString parString = ((TObjString*)(parameters->At(position)))->GetString();
+      
+      TString nameFunction = TString::Format("fastSimulationFunction_%s_%s", AliPID::ParticleShortName(species), charge ? "pos" : "neg");
+      TF1* func = GetFSFunctionFromString(parString, nameFunction);
+      
+      effFunctions[2*species + charge] = func;
+      position++;
     }
   }
 }
+
+
+TF1* AliPieceWisePoly::GetFSFunctionFromString(TString parameters, TString nameFunction) 
+{
+  TObjArray* arrPar = parameters.Tokenize(";");
+  Int_t nOfParts = (((TObjString*)(arrPar->At(0)))->GetString()).Atoi();
+  Double_t* cuts = new Double_t[nOfParts-1];
+  Int_t* nparameters = new Int_t[nOfParts]; 
+  
+  for (Int_t part = 0;part<nOfParts - 1;++part) {
+    nparameters[part] = (((TObjString*)(arrPar->At(nOfParts + part)))->GetString()).Atoi();
+    cuts[part] = (((TObjString*)(arrPar->At(1 + part)))->GetString()).Atof();
+  }
+  nparameters[nOfParts - 1] = (((TObjString*)(arrPar->At(2*nOfParts -1)))->GetString()).Atoi();
+  
+  AliPieceWisePoly* pwp = new AliPieceWisePoly(nOfParts,cuts,nparameters,0,50,0x0,2);
+  TF1* function = new TF1(nameFunction.Data(),pwp,0,50,pwp->GetNOfParam());
+  for (Int_t param=0;param<pwp->GetNOfParam();++param) {
+    function->SetParameter(param,(((TObjString*)(arrPar->At(2*nOfParts + param)))->GetString()).Atof());
+  }
+  delete [] nparameters;
+  delete [] cuts;
+  delete arrPar;
+  return function;
+}
+
   

--- a/PWGJE/EMCALJetTasks/UserTasks/AliPieceWisePoly.h
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliPieceWisePoly.h
@@ -17,7 +17,9 @@ public:
   Int_t GetNParts() {return nParts;};
   Double_t* GetCuts() {return cuts;};
   Int_t* GetNParameters() {return polyParameters;};
-  static void ReadFSParameters(TString parameterFile, TF1** effFunctions);
+  static TString ReadFSParameters(TString parameterFile, TF1** effFunctions);                             // Reads parameters from a fastSimParameter file into functions, additionally returns a string containing all parameters together
+  static void ReadFSParametersFromString(TString parameterString, TF1** effFunctions);  // Reads parameters from a string
+  static TF1* GetFSFunctionFromString(TString parameters, TString nameFunction);           // Gets function from parameter String
   
 private:
   AliPieceWisePoly(const AliPieceWisePoly&)           ;  //Not implemented

--- a/PWGJE/macros/AddTaskIDFragmentationFunction.C
+++ b/PWGJE/macros/AddTaskIDFragmentationFunction.C
@@ -42,9 +42,10 @@ void SetEfficiencyFunctionsFastSimulation(AliAnalysisTaskIDFragmentationFunction
   
   const Double_t kObsResolution = 0.002;  //Only change if the observed resolution is changing (external study)
   
-  AliPieceWisePoly::ReadFSParameters(fastSimParamFile.Data(), effFunctions);                                                        
+  TString parameterString = AliPieceWisePoly::ReadFSParameters(fastSimParamFile.Data(), effFunctions);                                                        
 	
   task->SetEfficiencyFunctions(effFunctions);
+  task->SetFastSimulationParameters(parameterString);    // Set string with joined parameters additionally, because the functions are transient and will not be copied. Functions are initialized again at the start of the run
   task->SetFastSimEffFactor(effFactor);
   task->SetFastSimRes(kObsResolution);   
   task->SetFastSimResFactor(resFactor);
@@ -140,6 +141,14 @@ AliAnalysisTaskIDFragmentationFunction *AddTaskIDFragmentationFunction(
 
 	// space for configuration parameter: histo bin, cuts, ...
 	// so far only default parameter used
+  
+     // Get the pointer to the existing analysis manager via the static access method.
+   //==============================================================================
+   AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
+   if (!mgr) {
+    ::Error("AddTaskIDFragmentationFunction", "No analysis manager to connect to.");
+    return NULL;
+   }
 
 	Int_t debug = -1; // debug level, -1: not set here
 	UInt_t kPhysSel = AliVEvent::kMB | AliVEvent::kINT8 | AliVEvent::kINT7;
@@ -188,7 +197,7 @@ AliAnalysisTaskIDFragmentationFunction *AddTaskIDFragmentationFunction(
 
    //******************************************************************************
 	
-	Bool_t isMC = (AliAnalysisManager::GetAnalysisManager()->GetMCtruthEventHandler() != 0x0);
+	Bool_t isMC = mgr->GetMCtruthEventHandler() != 0x0;
 
 	if (isMC) {
     std::cout << "MCtruthEventHandler found" << std::endl;
@@ -223,16 +232,6 @@ AliAnalysisTaskIDFragmentationFunction *AddTaskIDFragmentationFunction(
 			jetFinderTaskMC->SetForceBeamType(iBeamType);    
 		}
 	}  
-	 
-
-   
-   // Get the pointer to the existing analysis manager via the static access method.
-   //==============================================================================
-   AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
-   if (!mgr) {
-    ::Error("AddTaskIDFragmentationFunction", "No analysis manager to connect to.");
-    return NULL;
-   }
    
    // Check the analysis type using the event handlers connected to the analysis manager.
    //==============================================================================


### PR DESCRIPTION
Train fails because functions are not copied directly. Store them as variables so we dont have to deal with copying functions