### PR TITLE
[EMCAL-772] Move error to debug to not trash logs in case of embedding

### DIFF
--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerKernel.cxx
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerKernel.cxx
@@ -464,7 +464,7 @@ void AliEmcalTriggerMakerKernel::ReadCellData(AliVCaloCells *cells){
     if(celltime < fCellTimeLimits[0] || celltime > fCellTimeLimits[1]) continue;
 
     if ( cellId < 0 ) {
-      AliErrorStream() << "Skip: iCell = "<< iCell << " Cell Id = " << cellId <<", E = "<< amp <<", time = "<<celltime<<std::endl;
+      AliDebugStream(1) << "Skip: iCell = "<< iCell << " Cell Id = " << cellId <<", E = "<< amp <<", time = "<<celltime<<std::endl;
       continue;
     }
 


### PR DESCRIPTION
When embedding there can few dummy cells that are not removed, this is just to avoid large log files