### PR TITLE
Fixing missing return

### DIFF
--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHdEdxCorrelations.cxx
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHdEdxCorrelations.cxx
@@ -765,6 +765,7 @@ namespace PWGJE
 
         return kTRUE;
       }
+      return kFALSE;
     }
     /**
      * Determine if a jet passes the track or cluster bias and is therefore a "biased" jet.


### PR DESCRIPTION
My Run method had a path that did not return causing undefined behavior. It is now fixed.