### PR TITLE
Adding check for positive jet pt values in MC case

### DIFF
--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetEnergyFlow.h
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetEnergyFlow.h
@@ -80,7 +80,7 @@ class AliAnalysisTaskEmcalJetEnergyFlow: public AliAnalysisTaskEmcalJet {
  	 AliAnalysisTaskEmcalJetEnergyFlow(const AliAnalysisTaskEmcalJetEnergyFlow&); // not implemented
   	 AliAnalysisTaskEmcalJetEnergyFlow &operator=(const AliAnalysisTaskEmcalJetEnergyFlow&); // not implemented
 
-  	  ClassDef(AliAnalysisTaskEmcalJetEnergyFlow,16);
+  	  ClassDef(AliAnalysisTaskEmcalJetEnergyFlow,17);
 	/// \endcond
 };
 #endif


### PR DESCRIPTION
Adjusted the analysis task to only consider the cases where the jet pt is positive after background subtraction. Previously this existed only for the Dpt histogram in the data case but such a measure is now also foreseen for the MC to handle the embedded Pythia scenario. There is also a binning adjustment for the DR and jet area histograms.