### PR TITLE
PWGGA/GammaConv: Fix for processing MC particles

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.cxx
@@ -3753,21 +3753,23 @@ void AliAnalysisTaskGammaCalo::UserExec(Option_t *)
 
     if(fDoJetAnalysis) InitJets();
 
-    if(eventNotAccepted!= 0){
+    // here we have to exclude eventQuality != 4 as these are events which have a vertex outside 10cm. Therefore, no MC particles should be considered!
+    if(eventNotAccepted!= 0 && eventQuality != 4){
       fHistoNEvents[iCut]->Fill(eventNotAccepted, fWeightJetJetMC); // Check Centrality, PileUp, SDD and V0AND --> Not Accepted => eventQuality = 1
       if (fIsMC>1) fHistoNEventsWOWeight[iCut]->Fill(eventNotAccepted);
-      // cout << "event rejected due to wrong trigger: " <<eventNotAccepted << endl;
-      if (eventNotAccepted==3 && fIsMC > 0){
-        if(fInputEvent->IsA()==AliESDEvent::Class())
-          ProcessMCParticles(1);
-        if(fInputEvent->IsA()==AliAODEvent::Class())
-          ProcessAODMCParticles(1);
-      }
-      if (eventNotAccepted==5 && fIsMC > 0){
-        if(fInputEvent->IsA()==AliESDEvent::Class())
-          ProcessMCParticles(2);
-        if(fInputEvent->IsA()==AliAODEvent::Class())
-          ProcessAODMCParticles(2);
+
+      if(fIsMC > 0){
+        if (eventNotAccepted==3){ // wrong trigger selected. However, we still want to count the MC particles fot these events! If MC particles should be rejected in addition, use IsMCTriggerSelected function
+          if(fInputEvent->IsA()==AliESDEvent::Class())
+            ProcessMCParticles(1);
+          if(fInputEvent->IsA()==AliAODEvent::Class())
+            ProcessAODMCParticles(1);
+        } else if( eventNotAccepted != 1 && fIsMC > 0){ // exclude centrality/multiplicity selection from MC particles processing
+          if(fInputEvent->IsA()==AliESDEvent::Class())
+            ProcessMCParticles(2);
+          if(fInputEvent->IsA()==AliAODEvent::Class())
+            ProcessAODMCParticles(2);
+        }
       }
       continue;
     }
@@ -3776,17 +3778,17 @@ void AliAnalysisTaskGammaCalo::UserExec(Option_t *)
       fHistoNEvents[iCut]->Fill(eventQuality, fWeightJetJetMC);
       if (fIsMC>1) fHistoNEventsWOWeight[iCut]->Fill(eventQuality); // Should be 0 here
 
-      if(eventQuality == 5){ // event not accepted due to no vertex
-        if(fIsMC > 0){
+      if(fIsMC > 0){
+        if(eventQuality != 4){ // 4 = event outside of +-10cm, we dont want to count these events
           if(fInputEvent->IsA()==AliESDEvent::Class())
             ProcessMCParticles(2);
           if(fInputEvent->IsA()==AliAODEvent::Class())
             ProcessAODMCParticles(2);
         }
       }
-
       continue;
     }
+
     if(((AliConvEventCuts*)fEventCutArray->At(iCut))->GetUseSphericity()!=0){
       if(fV0Reader->GetSphericity() != -1 && fV0Reader->GetSphericity() != 0){
         if(fDoJetAnalysis && !fDoSoftAnalysis){

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvCalo.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvCalo.cxx
@@ -3481,20 +3481,23 @@ void AliAnalysisTaskGammaConvCalo::UserExec(Option_t *)
 
     if(fDoJetAnalysis) InitJets();
 
-    if(eventNotAccepted != 0){
+    // here we have to exclude eventQuality != 4 as these are events which have a vertex outside 10cm. Therefore, no MC particles should be considered!
+    if(eventNotAccepted!= 0 && eventQuality != 4){
       fHistoNEvents[iCut]->Fill(eventNotAccepted, fWeightJetJetMC); // Check Centrality, PileUp, SDD and V0AND --> Not Accepted => eventQuality = 1
       if (fIsMC>1) fHistoNEventsWOWeight[iCut]->Fill(eventNotAccepted);
       // cout << "event rejected due to wrong trigger: " <<eventNotAccepted << endl;
-      if (eventNotAccepted==3 && fIsMC > 0){
-        if(fInputEvent->IsA()==AliESDEvent::Class())
-          ProcessMCParticles(1);
-        if(fInputEvent->IsA()==AliAODEvent::Class())
-          ProcessAODMCParticles(1);
-      } else if (eventNotAccepted==5 && fIsMC > 0){
-        if(fInputEvent->IsA()==AliESDEvent::Class())
-          ProcessMCParticles(2);
-        if(fInputEvent->IsA()==AliAODEvent::Class())
-          ProcessAODMCParticles(2);
+      if(fIsMC > 0){
+        if (eventNotAccepted==3){ // wrong trigger selected. However, we still want to count the MC particles fot these events! If MC particles should be rejected in addition, use IsMCTriggerSelected function
+          if(fInputEvent->IsA()==AliESDEvent::Class())
+            ProcessMCParticles(1);
+          if(fInputEvent->IsA()==AliAODEvent::Class())
+            ProcessAODMCParticles(1);
+        } else if( eventNotAccepted != 1 && fIsMC > 0){ // exclude centrality/multiplicity selection from MC particles processing
+          if(fInputEvent->IsA()==AliESDEvent::Class())
+            ProcessMCParticles(2);
+          if(fInputEvent->IsA()==AliAODEvent::Class())
+            ProcessAODMCParticles(2);
+        }
       }
       continue;
     }
@@ -3504,8 +3507,8 @@ void AliAnalysisTaskGammaConvCalo::UserExec(Option_t *)
       fHistoNEvents[iCut]->Fill(eventQuality, fWeightJetJetMC);
       if (fIsMC>1) fHistoNEventsWOWeight[iCut]->Fill(eventQuality);
 
-      if(eventQuality == 5){ // event not accepted due to no vertex
-        if(fIsMC > 0){
+      if(fIsMC > 0){
+        if(eventQuality != 4){ // 4 = event outside of +-10cm, we dont want to count these events
           if(fInputEvent->IsA()==AliESDEvent::Class())
             ProcessMCParticles(2);
           if(fInputEvent->IsA()==AliAODEvent::Class())

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvV1.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvV1.cxx
@@ -2510,22 +2510,25 @@ void AliAnalysisTaskGammaConvV1::UserExec(Option_t *)
 
     if(fDoJetAnalysis) InitJets(); // has to be called before MC particles are processed
 
-    if(eventNotAccepted){
+    // here we have to exclude eventQuality != 4 as these are events which have a vertex outside 10cm. Therefore, no MC particles should be considered!
+    if(eventNotAccepted!= 0 && eventQuality != 4){
       // cout << "event rejected due to wrong trigger: " <<eventNotAccepted << endl;
       fHistoNEvents[iCut]->Fill(eventNotAccepted,fWeightJetJetMC); // Check Centrality, PileUp, SDD and V0AND --> Not Accepted => eventQuality = 1
       if( fIsMC > 1 ) fHistoNEventsWOWeight[iCut]->Fill(eventNotAccepted);
       if(fDoCentralityFlat > 0) fHistoNEventsWeighted[iCut]->Fill(eventNotAccepted, fWeightCentrality[iCut]*fWeightJetJetMC);
 
-      if (eventNotAccepted==3 && fIsMC > 0){
-        if(fInputEvent->IsA()==AliESDEvent::Class())
-          ProcessMCParticles(1);
-        if(fInputEvent->IsA()==AliAODEvent::Class())
-          ProcessAODMCParticles(1);
-      } else if (eventNotAccepted==5 && fIsMC > 0){
-        if(fInputEvent->IsA()==AliESDEvent::Class())
-          ProcessMCParticles(2);
-        if(fInputEvent->IsA()==AliAODEvent::Class())
-          ProcessAODMCParticles(2);
+      if(fIsMC > 0){
+        if (eventNotAccepted==3){ // wrong trigger selected. However, we still want to count the MC particles fot these events! If MC particles should be rejected in addition, use IsMCTriggerSelected function
+          if(fInputEvent->IsA()==AliESDEvent::Class())
+            ProcessMCParticles(1);
+          if(fInputEvent->IsA()==AliAODEvent::Class())
+            ProcessAODMCParticles(1);
+        } else if( eventNotAccepted != 1 && fIsMC > 0){ // exclude centrality/multiplicity selection from MC particles processing
+          if(fInputEvent->IsA()==AliESDEvent::Class())
+            ProcessMCParticles(2);
+          if(fInputEvent->IsA()==AliAODEvent::Class())
+            ProcessAODMCParticles(2);
+        }
       }
 
       continue;
@@ -2537,15 +2540,14 @@ void AliAnalysisTaskGammaConvV1::UserExec(Option_t *)
       if( fIsMC > 1 ) fHistoNEventsWOWeight[iCut]->Fill(eventQuality);
       if(fDoCentralityFlat > 0) fHistoNEventsWeighted[iCut]->Fill(eventQuality, fWeightCentrality[iCut]*fWeightJetJetMC);
 
-      if(eventQuality == 5){ // event not accepted due to no vertex
-        if(fIsMC > 0){
+      if(fIsMC > 0){
+        if(eventQuality != 4){ // 4 = event outside of +-10cm, we dont want to count these events
           if(fInputEvent->IsA()==AliESDEvent::Class())
             ProcessMCParticles(2);
           if(fInputEvent->IsA()==AliAODEvent::Class())
             ProcessAODMCParticles(2);
         }
       }
-
       continue;
     }
 

--- a/PWGGA/GammaConv/AliAnalysisTaskMesonJetCorrelation.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskMesonJetCorrelation.cxx
@@ -1715,16 +1715,18 @@ void AliAnalysisTaskMesonJetCorrelation::UserExec(Option_t*)
     // reset double counting vector
     fMesonDoubleCount.clear();
 
-    if (eventNotAccepted != 0) {
+    if (eventNotAccepted != 0 && eventQuality != 4) {
       fHistoNEvents[iCut]->Fill(eventNotAccepted, fWeightJetJetMC); // Check Centrality, PileUp, SDD and V0AND --> Not Accepted => eventQuality = 1
       if (fIsMC > 1)
         fHistoNEventsWOWeight[iCut]->Fill(eventNotAccepted);
 
-      if (eventNotAccepted == 3 && fIsMC > 0) {
-        ProcessAODMCParticles(1);
-      }
-      if (eventNotAccepted == 5 && fIsMC > 0) {
-        ProcessAODMCParticles(2);
+      if (fIsMC > 0) {
+        if (eventNotAccepted == 3) { // Event rejected due to wrong trigger, MC particles still have to be processed
+          ProcessAODMCParticles(1);
+        }
+        if (eventNotAccepted != 1) { // exclude centrality/multiplicity selection from MC particles processing
+          ProcessAODMCParticles(2);
+        }
       }
       continue;
     }
@@ -1733,6 +1735,12 @@ void AliAnalysisTaskMesonJetCorrelation::UserExec(Option_t*)
       fHistoNEvents[iCut]->Fill(eventQuality, fWeightJetJetMC);
       if (fIsMC > 1)
         fHistoNEventsWOWeight[iCut]->Fill(eventQuality); // Should be 0 here
+
+      if (fIsMC > 0) {
+        if (eventQuality != 4) { // 4 = event outside of +-10cm, we dont want to count these events
+          ProcessAODMCParticles(2);
+        }
+      }
       continue;
     }
 


### PR DESCRIPTION
- MC particles should be processed if for example, the wrong trigger was selected for the event. Currently, the number of generated particles was filled differently for different triggers. Triggered events had more counts as non-triggered due to the fact, that the non-triggered cases were captured, but others were not.
- Now, we fill the MC particles unless: The event did not have the correct centrality/multiplicity or if the vertex was outside +-10cm