### PR TITLE
Methods to retrieve generated vertex position in case of pileup

### DIFF
--- a/OADB/AliAnalysisUtils.h
+++ b/OADB/AliAnalysisUtils.h
@@ -80,7 +80,10 @@ class AliAnalysisUtils : public TObject {
   static Bool_t IsPileupInGeneratedEvent(AliMCEvent* mcEv, TString genname);
   static Bool_t IsPileupInGeneratedEvent(AliAODMCHeader* aodMCHeader, TString genname);
   static Bool_t IsPileupInGeneratedEvent(TList *lgen, TString genname, Bool_t requireSameBunch=kFALSE);
-
+  static AliVVertex* GetGeneratedPrimaryVertexOfTriggerEvent(AliMCEvent* mcEv);
+  static AliVVertex* GetGeneratedPrimaryVertexOfTriggerEvent(AliAODMCHeader* aodMCHeader);
+  static AliVVertex* GetGeneratedPrimaryVertexOfTriggerEvent(TList *lgen);
+  
   // helper methods for kink tagging in AODs
   static Bool_t IsKinkMother(AliAODTrack* track, AliAODEvent* aod);
   static Bool_t IsKinkDaughter(AliAODTrack* track);


### PR DESCRIPTION
These helper methods allow to get the generated position of the trigger collision in case of simulations with pileup.
By using AliMCEvent::GetPrimaryVertexPosition, a position of (0,0,0) is obtained found for all events simulated with pileup (this was spotted for the general purpose Monte Carlo productions anchored to Pb-Pb). This is because the header of the cocktail generator does not store a primary vertex position, given that different pileup events occur in different position.
A modification in AliMCEvent (inside AliRoot) will also be committed in the next days.