### PR TITLE
PWGGA/GammaConv: Enable possibility to read input from different jet

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskConvJet.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskConvJet.cxx
@@ -13,6 +13,9 @@
  * provided "as is" without express or implied warranty.                  *
  **************************************************************************/
 
+#include <cstddef>
+#include <cstring>
+
 #include <TObjString.h>
 #include <TClonesArray.h>
 #include <TH1F.h>
@@ -329,7 +332,7 @@ AliAnalysisTaskConvJet* AliAnalysisTaskConvJet::AddTask_GammaConvJet(
     }
   }
 
-  TString name("AliAnalysisTaskConvJet");
+  TString name(Form("AliAnalysisTaskConvJet%s", strlen(suffix) == 0 ? "" : Form("_%s", suffix)));
 
   AliAnalysisTaskConvJet* sampleTask = new AliAnalysisTaskConvJet(name);
   sampleTask->SetCaloCellsName(cellName);
@@ -367,6 +370,8 @@ AliAnalysisTaskConvJet* AliAnalysisTaskConvJet::AddTask_GammaConvJet(
   AliAnalysisDataContainer* cinput1 = mgr->GetCommonInputContainer();
   TString contname(trackName);
   contname += "_histos";
+  contname += strlen(suffix) == 0 ? "" : Form("_%s", suffix);
+  printf("contname: %s", contname.Data());
   AliAnalysisDataContainer* coutput1 = mgr->CreateContainer(contname.Data(),
                                                             TList::Class(), AliAnalysisManager::kOutputContainer,
                                                             Form("%s", AliAnalysisManager::GetCommonFileName()));

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.cxx
@@ -91,6 +91,7 @@ AliAnalysisTaskGammaCalo::AliAnalysisTaskGammaCalo(): AliAnalysisTaskSE(),
   fMesonCutArray(NULL),
   fMesonCuts(NULL),
   fConvJetReader(NULL),
+  fAddNameConvJet("Jet"),
   fOutlierJetReader(NULL),
   fConversionCuts(NULL),
   fDoJetAnalysis(kFALSE),
@@ -539,6 +540,7 @@ AliAnalysisTaskGammaCalo::AliAnalysisTaskGammaCalo(const char *name):
   fMesonCutArray(NULL),
   fMesonCuts(NULL),
   fConvJetReader(NULL),
+  fAddNameConvJet("Jet"),
   fOutlierJetReader(NULL),
   fConversionCuts(NULL),
   fDoJetAnalysis(kFALSE),
@@ -1070,8 +1072,8 @@ void AliAnalysisTaskGammaCalo::UserCreateOutputObjects(){
   }
 
   if(fDoJetAnalysis){
-    fConvJetReader=(AliAnalysisTaskConvJet*)AliAnalysisManager::GetAnalysisManager()->GetTask("AliAnalysisTaskConvJet");
-    if(!fConvJetReader){printf("Error: No AliAnalysisTaskConvJet");return;} // GetV0Reader
+    fConvJetReader=(AliAnalysisTaskConvJet*)AliAnalysisManager::GetAnalysisManager()->GetTask(Form("AliAnalysisTaskConvJet%s", fAddNameConvJet.EqualTo("") == true ? "" : Form("_%s",fAddNameConvJet.Data())));
+    if(!fConvJetReader){printf(Form("ERROR: No AliAnalysisTaskConvJet%s", fAddNameConvJet.EqualTo("") == true ? "" : Form("_%s",fAddNameConvJet.Data())));return;} // GetV0Reader
   }
   if(((AliConvEventCuts*)fEventCutArray->At(0))->GetUseJetFinderForOutliers()){
     fOutlierJetReader=(AliAnalysisTaskJetOutlierRemoval*)AliAnalysisManager::GetAnalysisManager()->GetTask("AliAnalysisTaskJetOutlierRemoval");
@@ -6694,7 +6696,7 @@ void AliAnalysisTaskGammaCalo::ProcessTrueMesonCandidates(AliAODConversionMother
   } else if(!isTruePi0 && !isTrueEta){ // Background
     if (fDoMesonQA > 0 && fDoMesonQA < 3){
       if(gamma0MotherLabel>-1 && gamma1MotherLabel>-1){ // Both Tracks are Photons and have a mother but not Pi0 or Eta
-        if(TrueGammaCandidate0->IsLargestComponentPhoton() && TrueGammaCandidate1->IsConversion()){
+        if(TrueGammaCandidate0->IsLargestComponentPhoton() && TrueGammaCandidate1->IsLargestComponentPhoton()){
           fHistoTrueBckGGInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(), tempTruePi0CandWeight);
         } else if(  (TrueGammaCandidate0->IsLargestComponentPhoton() && TrueGammaCandidate1->IsConversion() ) ||
                     (TrueGammaCandidate1->IsLargestComponentPhoton() && TrueGammaCandidate0->IsConversion() )

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.h
@@ -135,6 +135,9 @@ class AliAnalysisTaskGammaCalo : public AliAnalysisTaskSE {
     // Function to set correction task setting
     void SetCorrectionTaskSetting(TString setting) {fCorrTaskSetting = setting;}
 
+    // Function to set name of Jet container
+    void SetJetContainerAddName(TString name) { fAddNameConvJet = name; }
+
     void EventDebugMethod();
     void DebugMethod(AliAODConversionMother *pi0cand, AliAODConversionPhoton *gamma0, AliAODConversionPhoton *gamma1);
     void DebugMethodPrint1(AliAODConversionMother *pi0cand, AliAODConversionPhoton *gamma0, AliAODConversionPhoton *gamma1);
@@ -177,6 +180,7 @@ class AliAnalysisTaskGammaCalo : public AliAnalysisTaskSE {
     TList*                fMesonCutArray;                                       // List with Meson Cuts
     AliConversionMesonCuts*   fMesonCuts;                                       // MesonCutObject
     AliAnalysisTaskConvJet*   fConvJetReader;                                   // JetReader
+    TString               fAddNameConvJet;                                      // Additional Name of jet container
     AliAnalysisTaskJetOutlierRemoval*   fOutlierJetReader;                      // JetReader
     AliConversionPhotonCuts*  fConversionCuts;                                  // ConversionPhotonCutObject
     Bool_t                fDoJetAnalysis;                                       // Bool to produce Jet Plots
@@ -622,7 +626,7 @@ class AliAnalysisTaskGammaCalo : public AliAnalysisTaskSE {
     AliAnalysisTaskGammaCalo(const AliAnalysisTaskGammaCalo&);                  // Prevent copy-construction
     AliAnalysisTaskGammaCalo &operator=(const AliAnalysisTaskGammaCalo&);       // Prevent assignment
 
-    ClassDef(AliAnalysisTaskGammaCalo, 92);
+    ClassDef(AliAnalysisTaskGammaCalo, 93);
 };
 
 #endif

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvCalo.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvCalo.cxx
@@ -95,6 +95,7 @@ AliAnalysisTaskGammaConvCalo::AliAnalysisTaskGammaConvCalo(): AliAnalysisTaskSE(
   fClusterCutArray(NULL),
   fMesonCutArray(NULL),
   fConvJetReader(NULL),
+  fAddNameConvJet("Jet"),
   fOutlierJetReader(NULL),
   fDoJetAnalysis(kFALSE),
   fDoJetQA(kFALSE),
@@ -519,6 +520,7 @@ AliAnalysisTaskGammaConvCalo::AliAnalysisTaskGammaConvCalo(const char *name):
   fClusterCutArray(NULL),
   fMesonCutArray(NULL),
   fConvJetReader(NULL),
+  fAddNameConvJet("Jet"),
   fOutlierJetReader(NULL),
   fDoJetAnalysis(kFALSE),
   fDoJetQA(kFALSE),
@@ -1083,8 +1085,8 @@ void AliAnalysisTaskGammaConvCalo::UserCreateOutputObjects(){
   }
 
   if(fDoJetAnalysis){
-    fConvJetReader=(AliAnalysisTaskConvJet*)AliAnalysisManager::GetAnalysisManager()->GetTask("AliAnalysisTaskConvJet");
-    if(!fConvJetReader){printf("Error: No AliAnalysisTaskConvJet");return;} // GetV0Reader
+    fConvJetReader=(AliAnalysisTaskConvJet*)AliAnalysisManager::GetAnalysisManager()->GetTask(Form("AliAnalysisTaskConvJet%s", fAddNameConvJet.EqualTo("") == true ? "" : Form("_%s",fAddNameConvJet.Data())));
+    if(!fConvJetReader){printf(Form("ERROR: No AliAnalysisTaskConvJet%s", fAddNameConvJet.EqualTo("") == true ? "" : Form("_%s",fAddNameConvJet.Data())));return;} // GetV0Reader
   }
   if(((AliConvEventCuts*)fEventCutArray->At(0))->GetUseJetFinderForOutliers()){
     fOutlierJetReader=(AliAnalysisTaskJetOutlierRemoval*)AliAnalysisManager::GetAnalysisManager()->GetTask("AliAnalysisTaskJetOutlierRemoval");

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvCalo.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvCalo.h
@@ -42,6 +42,9 @@ class AliAnalysisTaskGammaConvCalo : public AliAnalysisTaskSE {
     // Function to set correction task setting
     void SetCorrectionTaskSetting(TString setting) {fCorrTaskSetting = setting;}
 
+    // Function to set name of Jet container
+    void SetJetContainerAddName(TString name) { fAddNameConvJet = name; }
+
     // base functions for selecting photon and meson candidates in reconstructed data
     void ProcessClusters();
     void ProcessPhotonCandidates();
@@ -184,6 +187,7 @@ class AliAnalysisTaskGammaConvCalo : public AliAnalysisTaskSE {
     TList*                              fClusterCutArray;       // List with Cluster Cuts
     TList*                              fMesonCutArray;         // List with Meson Cuts
     AliAnalysisTaskConvJet*             fConvJetReader;         //! JetReader
+    TString                             fAddNameConvJet;        // Additional Name of jet container
     AliAnalysisTaskJetOutlierRemoval*   fOutlierJetReader;      //! JetReader
     Bool_t                              fDoJetAnalysis;         //! Bool to produce Jet Plots
     Bool_t                              fDoJetQA;               //! Bool to produce Jet QA Plots
@@ -616,7 +620,7 @@ class AliAnalysisTaskGammaConvCalo : public AliAnalysisTaskSE {
     AliAnalysisTaskGammaConvCalo(const AliAnalysisTaskGammaConvCalo&); // Prevent copy-construction
     AliAnalysisTaskGammaConvCalo &operator=(const AliAnalysisTaskGammaConvCalo&); // Prevent assignment
 
-    ClassDef(AliAnalysisTaskGammaConvCalo, 72);
+    ClassDef(AliAnalysisTaskGammaConvCalo, 73);
 };
 
 #endif

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvV1.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvV1.cxx
@@ -84,6 +84,7 @@ AliAnalysisTaskGammaConvV1::AliAnalysisTaskGammaConvV1(): AliAnalysisTaskSE(),
   fMesonCutArray(NULL),
   fClusterCutArray(NULL),
   fConvJetReader(NULL),
+  fAddNameConvJet("Jet"),
   fDoJetAnalysis(kFALSE),
   fDoIsolatedAnalysis(kFALSE),
   fDoHighPtHadronAnalysis(kFALSE),
@@ -407,6 +408,7 @@ AliAnalysisTaskGammaConvV1::AliAnalysisTaskGammaConvV1(const char *name):
   fMesonCutArray(NULL),
   fClusterCutArray(NULL),
   fConvJetReader(NULL),
+  fAddNameConvJet("Jet"),
   fDoJetAnalysis(kFALSE),
   fDoIsolatedAnalysis(kFALSE),
   fDoHighPtHadronAnalysis(kFALSE),
@@ -840,8 +842,8 @@ void AliAnalysisTaskGammaConvV1::UserCreateOutputObjects(){
   if( ((AliConversionMesonCuts*)fMesonCutArray->At(0))->DoHighPtHadronAnalysis()) fDoHighPtHadronAnalysis = kTRUE;
 
   if(fDoJetAnalysis){
-    fConvJetReader=(AliAnalysisTaskConvJet*)AliAnalysisManager::GetAnalysisManager()->GetTask("AliAnalysisTaskConvJet");
-    if(!fConvJetReader){printf("Error: No AliAnalysisTaskConvJet");return;} // GetV0Reader
+    fConvJetReader=(AliAnalysisTaskConvJet*)AliAnalysisManager::GetAnalysisManager()->GetTask(Form("AliAnalysisTaskConvJet%s", fAddNameConvJet.EqualTo("") == true ? "" : Form("_%s",fAddNameConvJet.Data())));
+    if(!fConvJetReader){printf(Form("ERROR: No AliAnalysisTaskConvJet%s", fAddNameConvJet.EqualTo("") == true ? "" : Form("_%s",fAddNameConvJet.Data())));return;} // GetV0Reader
   }
 
   // Set dimenstions for THnSparse

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvV1.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvV1.h
@@ -94,6 +94,9 @@ class AliAnalysisTaskGammaConvV1 : public AliAnalysisTaskSE {
     void FillMultipleCountMap(map<Int_t,Int_t> &ma, Int_t tobechecked);
     void FillMultipleCountHistoAndClear(map<Int_t,Int_t> &ma, TH1F* hist);
     Double_t GetOriginalInvMass(const AliConversionPhotonBase * photon, AliVEvent * event) const;
+    // Function to set name of Jet container
+    void SetJetContainerAddName(TString name) { fAddNameConvJet = name; }
+
 
   protected:
     AliV0ReaderV1*                    fV0Reader;                                  //
@@ -118,6 +121,7 @@ class AliAnalysisTaskGammaConvV1 : public AliAnalysisTaskSE {
     TList*                            fMesonCutArray;                             //
     TList*                            fClusterCutArray;                           //
     AliAnalysisTaskConvJet*           fConvJetReader;                             //
+    TString                           fAddNameConvJet;                            // Additional Name of jet container
     Bool_t                            fDoJetAnalysis;                             //
     Bool_t                            fDoIsolatedAnalysis;                        //
     Bool_t                            fDoHighPtHadronAnalysis;                    //
@@ -436,7 +440,7 @@ class AliAnalysisTaskGammaConvV1 : public AliAnalysisTaskSE {
 
     AliAnalysisTaskGammaConvV1(const AliAnalysisTaskGammaConvV1&); // Prevent copy-construction
     AliAnalysisTaskGammaConvV1 &operator=(const AliAnalysisTaskGammaConvV1&); // Prevent assignment
-    ClassDef(AliAnalysisTaskGammaConvV1, 57);
+    ClassDef(AliAnalysisTaskGammaConvV1, 58);
 };
 
 #endif

--- a/PWGGA/GammaConv/AliAnalysisTaskMesonJetCorrelation.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskMesonJetCorrelation.cxx
@@ -55,6 +55,7 @@ ClassImp(AliAnalysisTaskMesonJetCorrelation)
                                                                              fGenPhaseSpace(),
                                                                              // Jet related
                                                                              fConvJetReader(nullptr),
+                                                                             fAddNameConvJet(""),
                                                                              fHighestJetVector(),
                                                                              fMaxPtJet(0),
                                                                              fOutlierJetReader(nullptr),
@@ -146,13 +147,11 @@ ClassImp(AliAnalysisTaskMesonJetCorrelation)
                                                                              fHistoInvMassVsPt({}),
                                                                              fHistoInvMassVsPt_Incl({}),
                                                                              fHistoJetPtVsFrag({}),
-                                                                             fHistoJetPtVsFrag_SB({}),
                                                                              fHistoInvMassVsPtMassCut({}),
                                                                              fHistoInvMassVsPtMassCutSB({}),
                                                                              fHistoInvMassVsPtBack({}),
                                                                              fHistoInvMassVsPtPerpCone({}),
                                                                              fHistoJetPtVsFragPerpCone({}),
-                                                                             fHistoJetPtVsFragPerpCone_SB({}),
                                                                              // jet related Histograms
                                                                              fHistoEventwJets({}),
                                                                              fHistoNJets({}),
@@ -266,6 +265,7 @@ AliAnalysisTaskMesonJetCorrelation::AliAnalysisTaskMesonJetCorrelation(const cha
                                                                                            fGenPhaseSpace(),
                                                                                            // Jet related
                                                                                            fConvJetReader(nullptr),
+                                                                                           fAddNameConvJet(""),
                                                                                            fHighestJetVector(),
                                                                                            fMaxPtJet(0),
                                                                                            fOutlierJetReader(nullptr),
@@ -357,13 +357,11 @@ AliAnalysisTaskMesonJetCorrelation::AliAnalysisTaskMesonJetCorrelation(const cha
                                                                                            fHistoInvMassVsPt({}),
                                                                                            fHistoInvMassVsPt_Incl({}),
                                                                                            fHistoJetPtVsFrag({}),
-                                                                                           fHistoJetPtVsFrag_SB({}),
                                                                                            fHistoInvMassVsPtMassCut({}),
                                                                                            fHistoInvMassVsPtMassCutSB({}),
                                                                                            fHistoInvMassVsPtBack({}),
                                                                                            fHistoInvMassVsPtPerpCone({}),
                                                                                            fHistoJetPtVsFragPerpCone({}),
-                                                                                           fHistoJetPtVsFragPerpCone_SB({}),
                                                                                            // jet related Histograms
                                                                                            fHistoEventwJets({}),
                                                                                            fHistoNJets({}),
@@ -496,9 +494,9 @@ void AliAnalysisTaskMesonJetCorrelation::UserCreateOutputObjects()
     return;
   } // GetV0Reader
 
-  fConvJetReader = (AliAnalysisTaskConvJet*)AliAnalysisManager::GetAnalysisManager()->GetTask("AliAnalysisTaskConvJet");
+  fConvJetReader = (AliAnalysisTaskConvJet*)AliAnalysisManager::GetAnalysisManager()->GetTask(Form("AliAnalysisTaskConvJet%s", fAddNameConvJet.EqualTo("") == true ? "" : Form("_%s",fAddNameConvJet.Data())));
   if (!fConvJetReader) {
-    printf("Error: No AliAnalysisTaskConvJet");
+    printf(Form("ERROR: No AliAnalysisTaskConvJet%s", fAddNameConvJet.EqualTo("") == true ? "" : Form("_%s",fAddNameConvJet.Data())));
     return;
   } // GetV0Reader
 
@@ -608,7 +606,9 @@ void AliAnalysisTaskMesonJetCorrelation::UserCreateOutputObjects()
   fHistoJetArea.resize(fnCuts);
   if (fIsMC) {
     fHistoTruevsRecJetPt.resize(fnCuts);
-    fHistoTruevsRecJetPtForTrueJets.resize(fnCuts);
+    if(!fDoLightOutput){
+      fHistoTruevsRecJetPtForTrueJets.resize(fnCuts);
+    }
     fHistoTrueJetPtVsPartonPt.resize(fnCuts);
     fHistoMatchedPtJet.resize(fnCuts);
     fHistoUnMatchedPtJet.resize(fnCuts);
@@ -633,9 +633,11 @@ void AliAnalysisTaskMesonJetCorrelation::UserCreateOutputObjects()
     fRespMatrixHandlerTrueOtherMesonInvMassVsZ.resize(fnCuts);
     fRespMatrixHandlerTrueSecondaryMesonInvMassVsPt.resize(fnCuts);
     fRespMatrixHandlerTrueSecondaryMesonInvMassVsZ.resize(fnCuts);
-    fHistoTrueMesonInvMassVsTruePt.resize(fnCuts);
-    fHistoTruePrimaryMesonInvMassPt.resize(fnCuts);
-    fHistoTrueSecondaryMesonInvMassPt.resize(fnCuts);
+    if(fDoMesonQA > 0){
+      fHistoTrueMesonInvMassVsTruePt.resize(fnCuts);
+      fHistoTruePrimaryMesonInvMassPt.resize(fnCuts);
+      fHistoTrueSecondaryMesonInvMassPt.resize(fnCuts);
+    }
 
     fHistoTrueMesonJetPtVsTruePt.resize(fnCuts);
     fHistoTrueMesonJetPtVsTrueZ.resize(fnCuts);
@@ -643,11 +645,13 @@ void AliAnalysisTaskMesonJetCorrelation::UserCreateOutputObjects()
     fHistoTrueMesonJetPtVsRecPt.resize(fnCuts);
     fHistoTrueMesonJetPtVsRecZ.resize(fnCuts);
 
-    fHistoTrueSecMesonJetPtVsRecPt.resize(fnCuts);
-    fHistoTrueSecMesonJetPtVsRecZ.resize(fnCuts);
+    if(fDoMesonQA>0){
+      fHistoTrueSecMesonJetPtVsRecPt.resize(fnCuts);
+      fHistoTrueSecMesonJetPtVsRecZ.resize(fnCuts);
 
-    fHistoTrueMesonInTrueJet_JetPtVsTruePt.resize(fnCuts);
-    fHistoTrueMesonInTrueJet_JetPtVsTrueZ.resize(fnCuts);
+      fHistoTrueMesonInTrueJet_JetPtVsTruePt.resize(fnCuts);
+      fHistoTrueMesonInTrueJet_JetPtVsTrueZ.resize(fnCuts);
+    }
 
     fRespMatrixHandlerTrueMesonInvMassVsPtDoubleCount.resize(fnCuts);
     fRespMatrixHandlerTrueMesonInvMassVsZDoubleCount.resize(fnCuts);
@@ -667,11 +671,9 @@ void AliAnalysisTaskMesonJetCorrelation::UserCreateOutputObjects()
   // fragmentation histos
   //----------------------
   fHistoJetPtVsFrag.resize(fnCuts);
-  fHistoJetPtVsFrag_SB.resize(fnCuts);
 
   // perpendicular cone
   fHistoJetPtVsFragPerpCone.resize(fnCuts);
-  fHistoJetPtVsFragPerpCone_SB.resize(fnCuts);
 
   //----------------------
   // response matrix
@@ -686,7 +688,9 @@ void AliAnalysisTaskMesonJetCorrelation::UserCreateOutputObjects()
   if (fIsMC) {
     fRespMatrixHandlerMesonPt.resize(fnCuts);
     fRespMatrixHandlerFrag.resize(fnCuts);
-    fRespMatrixHandlerFragTrueJets.resize(fnCuts);
+    if(!fDoLightOutput) {
+      fRespMatrixHandlerFragTrueJets.resize(fnCuts);
+    }
   }
 
   for (int iCut = 0; iCut < fnCuts; ++iCut) {
@@ -1041,9 +1045,10 @@ void AliAnalysisTaskMesonJetCorrelation::UserCreateOutputObjects()
     if (fIsMC) {
       fHistoTruevsRecJetPt[iCut] = new TH2F("True_JetPt_vs_Rec_JetPt", "True_JetPt_vs_Rec_JetPt", fVecBinsJetPt.size() - 1, fVecBinsJetPt.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
       fTrueJetList[iCut]->Add(fHistoTruevsRecJetPt[iCut]);
-      fHistoTruevsRecJetPtForTrueJets[iCut] = new TH2F("True_JetPt_vs_Rec_JetPt_ForTrueJets", "True_JetPt_vs_Rec_JetPt_ForTrueJets", fVecBinsJetPt.size() - 1, fVecBinsJetPt.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
-      fTrueJetList[iCut]->Add(fHistoTruevsRecJetPtForTrueJets[iCut]);
-
+      if(!fDoLightOutput){
+        fHistoTruevsRecJetPtForTrueJets[iCut] = new TH2F("True_JetPt_vs_Rec_JetPt_ForTrueJets", "True_JetPt_vs_Rec_JetPt_ForTrueJets", fVecBinsJetPt.size() - 1, fVecBinsJetPt.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
+        fTrueJetList[iCut]->Add(fHistoTruevsRecJetPtForTrueJets[iCut]);
+      }
       fHistoTrueJetPtVsPartonPt[iCut] = new TH2F("True_JetPt_vs_Parton_Pt", "True_JetPt_vs_Parton_Pt", fVecBinsJetPt.size() - 1, fVecBinsJetPt.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
       fTrueJetList[iCut]->Add(fHistoTrueJetPtVsPartonPt[iCut]);
 
@@ -1112,20 +1117,22 @@ void AliAnalysisTaskMesonJetCorrelation::UserCreateOutputObjects()
       else
         fTrueList[iCut]->Add(fRespMatrixHandlerTrueSecondaryMesonInvMassVsZ[iCut]->GetTH2("ESD_TrueSecondaryMother_InvMass_Z_JetPt"));
 
-      fHistoTrueMesonInvMassVsTruePt[iCut] = new TH2F("ESD_TrueMother_InvMass_TruePt", "ESD_TrueMother_InvMass_TruePt", fVecBinsMesonInvMass.size() - 1, fVecBinsMesonInvMass.data(), fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data());
-      fHistoTrueMesonInvMassVsTruePt[iCut]->SetXTitle("M_{#gamma#gamma} (GeV/c^{2})");
-      fHistoTrueMesonInvMassVsTruePt[iCut]->SetYTitle("p_{T} (GeV/c)");
-      fTrueList[iCut]->Add(fHistoTrueMesonInvMassVsTruePt[iCut]);
+      if(fDoMesonQA > 0){
+        fHistoTrueMesonInvMassVsTruePt[iCut] = new TH2F("ESD_TrueMother_InvMass_TruePt", "ESD_TrueMother_InvMass_TruePt", fVecBinsMesonInvMass.size() - 1, fVecBinsMesonInvMass.data(), fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data());
+        fHistoTrueMesonInvMassVsTruePt[iCut]->SetXTitle("M_{#gamma#gamma} (GeV/c^{2})");
+        fHistoTrueMesonInvMassVsTruePt[iCut]->SetYTitle("p_{T} (GeV/c)");
+        fTrueList[iCut]->Add(fHistoTrueMesonInvMassVsTruePt[iCut]);
 
-      fHistoTruePrimaryMesonInvMassPt[iCut] = new TH2F("ESD_TruePrimaryMother_InvMass_Pt", "ESD_TruePrimaryMother_InvMass_Pt", fVecBinsMesonInvMass.size() - 1, fVecBinsMesonInvMass.data(), fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data());
-      fHistoTruePrimaryMesonInvMassPt[iCut]->SetXTitle("M_{#gamma#gamma} (GeV/c^{2})");
-      fHistoTruePrimaryMesonInvMassPt[iCut]->SetYTitle("p_{T} (GeV/c)");
-      fTrueList[iCut]->Add(fHistoTruePrimaryMesonInvMassPt[iCut]);
+        fHistoTruePrimaryMesonInvMassPt[iCut] = new TH2F("ESD_TruePrimaryMother_InvMass_Pt", "ESD_TruePrimaryMother_InvMass_Pt", fVecBinsMesonInvMass.size() - 1, fVecBinsMesonInvMass.data(), fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data());
+        fHistoTruePrimaryMesonInvMassPt[iCut]->SetXTitle("M_{#gamma#gamma} (GeV/c^{2})");
+        fHistoTruePrimaryMesonInvMassPt[iCut]->SetYTitle("p_{T} (GeV/c)");
+        fTrueList[iCut]->Add(fHistoTruePrimaryMesonInvMassPt[iCut]);
 
-      fHistoTrueSecondaryMesonInvMassPt[iCut] = new TH2F("ESD_TrueSecondaryMother_InvMass_Pt", "ESD_TrueSecondaryMother_InvMass_Pt", fVecBinsMesonInvMass.size() - 1, fVecBinsMesonInvMass.data(), fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data());
-      fHistoTrueSecondaryMesonInvMassPt[iCut]->SetXTitle("M_{#gamma#gamma} (GeV/c^{2})");
-      fHistoTrueSecondaryMesonInvMassPt[iCut]->SetYTitle("p_{T} (GeV/c)");
-      fTrueList[iCut]->Add(fHistoTrueSecondaryMesonInvMassPt[iCut]);
+        fHistoTrueSecondaryMesonInvMassPt[iCut] = new TH2F("ESD_TrueSecondaryMother_InvMass_Pt", "ESD_TrueSecondaryMother_InvMass_Pt", fVecBinsMesonInvMass.size() - 1, fVecBinsMesonInvMass.data(), fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data());
+        fHistoTrueSecondaryMesonInvMassPt[iCut]->SetXTitle("M_{#gamma#gamma} (GeV/c^{2})");
+        fHistoTrueSecondaryMesonInvMassPt[iCut]->SetYTitle("p_{T} (GeV/c)");
+        fTrueList[iCut]->Add(fHistoTrueSecondaryMesonInvMassPt[iCut]);
+      }
 
       fHistoTrueMesonJetPtVsTruePt[iCut] = new TH2F("ESD_TrueMeson_TruePt_JetPt", "ESD_TrueMeson_TruePt_JetPt", fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
       fHistoTrueMesonJetPtVsTruePt[iCut]->SetXTitle("meson p_{T} (GeV/c)");
@@ -1147,39 +1154,39 @@ void AliAnalysisTaskMesonJetCorrelation::UserCreateOutputObjects()
       fHistoTrueMesonJetPtVsRecZ[iCut]->SetYTitle("Jet p_{T} (GeV/c)");
       fTrueList[iCut]->Add(fHistoTrueMesonJetPtVsRecZ[iCut]);
 
-      fHistoTrueSecMesonJetPtVsRecPt[iCut] = new TH2F("ESD_TrueSecMeson_RecPt_JetPt", "ESD_TrueSecMeson_RecPt_JetPt", fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
-      fHistoTrueSecMesonJetPtVsRecPt[iCut]->SetXTitle("Pt");
-      fHistoTrueSecMesonJetPtVsRecPt[iCut]->SetYTitle("Jet p_{T} (GeV/c)");
-      fTrueList[iCut]->Add(fHistoTrueSecMesonJetPtVsRecPt[iCut]);
+      if(fDoMesonQA > 0){
+        fHistoTrueSecMesonJetPtVsRecPt[iCut] = new TH2F("ESD_TrueSecMeson_RecPt_JetPt", "ESD_TrueSecMeson_RecPt_JetPt", fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
+        fHistoTrueSecMesonJetPtVsRecPt[iCut]->SetXTitle("Pt");
+        fHistoTrueSecMesonJetPtVsRecPt[iCut]->SetYTitle("Jet p_{T} (GeV/c)");
+        fTrueList[iCut]->Add(fHistoTrueSecMesonJetPtVsRecPt[iCut]);
 
-      fHistoTrueSecMesonJetPtVsRecZ[iCut] = new TH2F("ESD_TrueSecMeson_RecFrag_JetPt", "ESD_TrueMeson_RecFrag_JetPt", fVecBinsFragment.size() - 1, fVecBinsFragment.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
-      fHistoTrueSecMesonJetPtVsRecZ[iCut]->SetXTitle("Z");
-      fHistoTrueSecMesonJetPtVsRecZ[iCut]->SetYTitle("Jet p_{T} (GeV/c)");
-      fTrueList[iCut]->Add(fHistoTrueSecMesonJetPtVsRecZ[iCut]);
+        fHistoTrueSecMesonJetPtVsRecZ[iCut] = new TH2F("ESD_TrueSecMeson_RecFrag_JetPt", "ESD_TrueMeson_RecFrag_JetPt", fVecBinsFragment.size() - 1, fVecBinsFragment.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
+        fHistoTrueSecMesonJetPtVsRecZ[iCut]->SetXTitle("Z");
+        fHistoTrueSecMesonJetPtVsRecZ[iCut]->SetYTitle("Jet p_{T} (GeV/c)");
+        fTrueList[iCut]->Add(fHistoTrueSecMesonJetPtVsRecZ[iCut]);
 
-      fHistoTrueMesonInTrueJet_JetPtVsTruePt[iCut] = new TH2F("ESD_TrueMeson_InTrueJets_TruePt_JetPt", "ESD_TrueMeson_InTrueJets_TruePt_JetPt", fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
-      fHistoTrueMesonInTrueJet_JetPtVsTruePt[iCut]->SetXTitle("meson p_{T} (GeV/c)");
-      fHistoTrueMesonInTrueJet_JetPtVsTruePt[iCut]->SetYTitle("Jet p_{T} (GeV/c)");
-      fTrueList[iCut]->Add(fHistoTrueMesonInTrueJet_JetPtVsTruePt[iCut]);
+        fHistoTrueMesonInTrueJet_JetPtVsTruePt[iCut] = new TH2F("ESD_TrueMeson_InTrueJets_TruePt_JetPt", "ESD_TrueMeson_InTrueJets_TruePt_JetPt", fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
+        fHistoTrueMesonInTrueJet_JetPtVsTruePt[iCut]->SetXTitle("meson p_{T} (GeV/c)");
+        fHistoTrueMesonInTrueJet_JetPtVsTruePt[iCut]->SetYTitle("Jet p_{T} (GeV/c)");
+        fTrueList[iCut]->Add(fHistoTrueMesonInTrueJet_JetPtVsTruePt[iCut]);
 
-      fHistoTrueMesonInTrueJet_JetPtVsTrueZ[iCut] = new TH2F("ESD_TrueMeson_InTrueJets_TrueFrag_JetPt", "ESD_TrueMeson_InTrueJets_TrueFrag_JetPt", fVecBinsFragment.size() - 1, fVecBinsFragment.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
-      fHistoTrueMesonInTrueJet_JetPtVsTrueZ[iCut]->SetXTitle("meson z_{T}");
-      fHistoTrueMesonInTrueJet_JetPtVsTrueZ[iCut]->SetYTitle("Jet p_{T} (GeV/c)");
-      fTrueList[iCut]->Add(fHistoTrueMesonInTrueJet_JetPtVsTrueZ[iCut]);
+        fHistoTrueMesonInTrueJet_JetPtVsTrueZ[iCut] = new TH2F("ESD_TrueMeson_InTrueJets_TrueFrag_JetPt", "ESD_TrueMeson_InTrueJets_TrueFrag_JetPt", fVecBinsFragment.size() - 1, fVecBinsFragment.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
+        fHistoTrueMesonInTrueJet_JetPtVsTrueZ[iCut]->SetXTitle("meson z_{T}");
+        fHistoTrueMesonInTrueJet_JetPtVsTrueZ[iCut]->SetYTitle("Jet p_{T} (GeV/c)");
+        fTrueList[iCut]->Add(fHistoTrueMesonInTrueJet_JetPtVsTrueZ[iCut]);
 
-      fRespMatrixHandlerTrueMesonInvMassVsPtDoubleCount[iCut] = new MatrixHandler4D(fVecBinsMesonInvMass, fVecBinsMesonPt, fVecBinsJetPt, {0, 1}, fUseThNForResponse);
-      if (fUseThNForResponse)
-        fTrueList[iCut]->Add(fRespMatrixHandlerTrueMesonInvMassVsPtDoubleCount[iCut]->GetTHnSparse("ESD_TrueMother_InvMass_Pt_JetPt_DoubleCount"));
-      else
-        fTrueList[iCut]->Add(fRespMatrixHandlerTrueMesonInvMassVsPtDoubleCount[iCut]->GetTH2("ESD_TrueMother_InvMass_Pt_JetPt_DoubleCount"));
+        fRespMatrixHandlerTrueMesonInvMassVsPtDoubleCount[iCut] = new MatrixHandler4D(fVecBinsMesonInvMass, fVecBinsMesonPt, fVecBinsJetPt, {0, 1}, fUseThNForResponse);
+        if (fUseThNForResponse)
+          fTrueList[iCut]->Add(fRespMatrixHandlerTrueMesonInvMassVsPtDoubleCount[iCut]->GetTHnSparse("ESD_TrueMother_InvMass_Pt_JetPt_DoubleCount"));
+        else
+          fTrueList[iCut]->Add(fRespMatrixHandlerTrueMesonInvMassVsPtDoubleCount[iCut]->GetTH2("ESD_TrueMother_InvMass_Pt_JetPt_DoubleCount"));
 
-      fRespMatrixHandlerTrueMesonInvMassVsZDoubleCount[iCut] = new MatrixHandler4D(fVecBinsMesonInvMass, fVecBinsFragment, fVecBinsJetPt, {0, 1}, fUseThNForResponse);
-      if (fUseThNForResponse)
-        fTrueList[iCut]->Add(fRespMatrixHandlerTrueMesonInvMassVsZDoubleCount[iCut]->GetTHnSparse("ESD_TrueMother_InvMass_Z_JetPt_DoubleCount"));
-      else
-        fTrueList[iCut]->Add(fRespMatrixHandlerTrueMesonInvMassVsZDoubleCount[iCut]->GetTH2("ESD_TrueMother_InvMass_Z_JetPt_DoubleCount"));
+        fRespMatrixHandlerTrueMesonInvMassVsZDoubleCount[iCut] = new MatrixHandler4D(fVecBinsMesonInvMass, fVecBinsFragment, fVecBinsJetPt, {0, 1}, fUseThNForResponse);
+        if (fUseThNForResponse)
+          fTrueList[iCut]->Add(fRespMatrixHandlerTrueMesonInvMassVsZDoubleCount[iCut]->GetTHnSparse("ESD_TrueMother_InvMass_Z_JetPt_DoubleCount"));
+        else
+          fTrueList[iCut]->Add(fRespMatrixHandlerTrueMesonInvMassVsZDoubleCount[iCut]->GetTH2("ESD_TrueMother_InvMass_Z_JetPt_DoubleCount"));
 
-      if (fDoMesonQA) {
         fHistoMesonResponse[iCut] = new TH2F("ESD_TrueMeson_RecPt_TruePt", "ESD_TrueMeson_RecPt_TruePt", fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data(), fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data());
         fHistoMesonResponse[iCut]->SetXTitle("p_{T, rec} (GeV/c)");
         fHistoMesonResponse[iCut]->SetYTitle("p_{T, true} (GeV/c)");
@@ -1214,21 +1221,11 @@ void AliAnalysisTaskMesonJetCorrelation::UserCreateOutputObjects()
     fHistoJetPtVsFrag[iCut]->SetYTitle("p_{T, Jet} (GeV/c)");
     fESDList[iCut]->Add(fHistoJetPtVsFrag[iCut]);
 
-    fHistoJetPtVsFrag_SB[iCut] = new TH2F("ESD_Frag_JetPt_SB", "ESD_Frag_JetPt_SB", fVecBinsFragment.size() - 1, fVecBinsFragment.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
-    fHistoJetPtVsFrag_SB[iCut]->SetXTitle("z");
-    fHistoJetPtVsFrag_SB[iCut]->SetYTitle("p_{T, Jet} (GeV/c)");
-    fESDList[iCut]->Add(fHistoJetPtVsFrag_SB[iCut]);
-
     // perpendicular cone
     fHistoJetPtVsFragPerpCone[iCut] = new TH2F("ESD_Frag_JetPt_PerpCone", "ESD_Frag_JetPt_PerpCone", fVecBinsFragment.size() - 1, fVecBinsFragment.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
     fHistoJetPtVsFragPerpCone[iCut]->SetXTitle("z");
     fHistoJetPtVsFragPerpCone[iCut]->SetYTitle("p_{T, Jet} (GeV/c)");
     fESDList[iCut]->Add(fHistoJetPtVsFragPerpCone[iCut]);
-
-    fHistoJetPtVsFragPerpCone_SB[iCut] = new TH2F("ESD_Frag_JetPt_PerpCone_SB", "ESD_Frag_JetPt_PerpCone_SB", fVecBinsFragment.size() - 1, fVecBinsFragment.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
-    fHistoJetPtVsFragPerpCone_SB[iCut]->SetXTitle("z");
-    fHistoJetPtVsFragPerpCone_SB[iCut]->SetYTitle("p_{T, Jet} (GeV/c)");
-    fESDList[iCut]->Add(fHistoJetPtVsFragPerpCone_SB[iCut]);
 
     fRespMatrixHandlerMesonInvMass[iCut] = new MatrixHandler4D(fVecBinsMesonInvMass, fVecBinsMesonPt, fVecBinsJetPt, fVecBinsJetPt, fUseThNForResponse);
     if (fUseThNForResponse)
@@ -1280,11 +1277,13 @@ void AliAnalysisTaskMesonJetCorrelation::UserCreateOutputObjects()
       else
         fTrueList[iCut]->Add(fRespMatrixHandlerFrag[iCut]->GetTH2("Frag_JetPt_TrueVsRec"));
 
-      fRespMatrixHandlerFragTrueJets[iCut] = new MatrixHandler4D(fVecBinsFragment, fVecBinsFragment, fVecBinsJetPt, fVecBinsJetPt, fUseThNForResponse);
-      if (fUseThNForResponse)
-        fTrueList[iCut]->Add(fRespMatrixHandlerFragTrueJets[iCut]->GetTHnSparse("Frag_JetPt_TrueVsRec_ForTrueJets"));
-      else
-        fTrueList[iCut]->Add(fRespMatrixHandlerFragTrueJets[iCut]->GetTH2("Frag_JetPt_TrueVsRec_ForTrueJets"));
+      if(!fDoLightOutput){
+        fRespMatrixHandlerFragTrueJets[iCut] = new MatrixHandler4D(fVecBinsFragment, fVecBinsFragment, fVecBinsJetPt, fVecBinsJetPt, fUseThNForResponse);
+        if (fUseThNForResponse)
+          fTrueList[iCut]->Add(fRespMatrixHandlerFragTrueJets[iCut]->GetTHnSparse("Frag_JetPt_TrueVsRec_ForTrueJets"));
+        else
+          fTrueList[iCut]->Add(fRespMatrixHandlerFragTrueJets[iCut]->GetTH2("Frag_JetPt_TrueVsRec_ForTrueJets"));
+      }
     }
 
     // Call Sumw2 forall histograms in list
@@ -1593,7 +1592,9 @@ void AliAnalysisTaskMesonJetCorrelation::ProcessJets()
         } else {
           fHistoUnMatchedPtJet[fiCut]->Fill(fVectorJetPt.at(i), fWeightJetJetMC);
           // Fill response matrix in case that no corresponding true jet was found
-          fHistoTruevsRecJetPtForTrueJets[fiCut]->Fill(fVectorJetPt.at(i), 0.5, fWeightJetJetMC);
+          if(!fDoLightOutput){
+            fHistoTruevsRecJetPtForTrueJets[fiCut]->Fill(fVectorJetPt.at(i), 0.5, fWeightJetJetMC);
+          }
         }
       }
       if (fVectorJetPt.at(i) > fMaxPtJet) {
@@ -1615,13 +1616,17 @@ void AliAnalysisTaskMesonJetCorrelation::ProcessJets()
       if (findResults != std::end(MapRecJetsTrueJets)) {
         fHistoTrueMatchedPtJet[fiCut]->Fill(fTrueVectorJetPt.at(i), fWeightJetJetMC);
         // Fill response matrix in case that pair of true and rec jets are found
-        if (findResults->first < static_cast<int>(fVectorJetPt.size())) { // probably not needed for safety
-          fHistoTruevsRecJetPtForTrueJets[fiCut]->Fill(fVectorJetPt.at(findResults->first), fTrueVectorJetPt.at(i), fWeightJetJetMC);
+        if(!fDoLightOutput){
+          if (findResults->first < static_cast<int>(fVectorJetPt.size())) { // probably not needed for safety
+            fHistoTruevsRecJetPtForTrueJets[fiCut]->Fill(fVectorJetPt.at(findResults->first), fTrueVectorJetPt.at(i), fWeightJetJetMC);
+          }
         }
       } else {
         fHistoTrueUnMatchedPtJet[fiCut]->Fill(fTrueVectorJetPt.at(i), fWeightJetJetMC);
         // Fill response matrix in case that no corresponding rec jet was found
-        fHistoTruevsRecJetPtForTrueJets[fiCut]->Fill(0.5, fTrueVectorJetPt.at(i), fWeightJetJetMC);
+        if(!fDoLightOutput){
+          fHistoTruevsRecJetPtForTrueJets[fiCut]->Fill(0.5, fTrueVectorJetPt.at(i), fWeightJetJetMC);
+        }
       }
     }
   }
@@ -1710,6 +1715,7 @@ void AliAnalysisTaskMesonJetCorrelation::UserExec(Option_t*)
     }
 
     // Jets need to be initialized before the ProcessMCParticles because they are needed in ProcessAODMCParticles
+    if(fLocalDebugFlag) {printf("InitJets\n");}
     InitJets();
 
     // reset double counting vector
@@ -1720,6 +1726,7 @@ void AliAnalysisTaskMesonJetCorrelation::UserExec(Option_t*)
       if (fIsMC > 1)
         fHistoNEventsWOWeight[iCut]->Fill(eventNotAccepted);
 
+      if(fLocalDebugFlag) {printf("ProcessAODMCParticles\n");}
       if (fIsMC > 0) {
         if (eventNotAccepted == 3) { // Event rejected due to wrong trigger, MC particles still have to be processed
           ProcessAODMCParticles(1);
@@ -1730,7 +1737,7 @@ void AliAnalysisTaskMesonJetCorrelation::UserExec(Option_t*)
       }
       continue;
     }
-
+    if(fLocalDebugFlag) {printf("ProcessAODMCParticles\n");}
     if (eventQuality != 0) { // Event Not Accepted
       fHistoNEvents[iCut]->Fill(eventQuality, fWeightJetJetMC);
       if (fIsMC > 1)
@@ -1759,19 +1766,25 @@ void AliAnalysisTaskMesonJetCorrelation::UserExec(Option_t*)
       ProcessAODMCParticles(0);
     }
 
+    if(fLocalDebugFlag) {printf("ProcessJets\n");}
     ProcessJets();
     if (fIsConvCalo || fIsCalo) {
+      if(fLocalDebugFlag) {printf("ProcessJets\n");}
       ProcessClusters(); // process calo clusters
     }
     if (fIsConvCalo || fIsConv) {
+      if(fLocalDebugFlag) {printf("ProcessJets\n");}
       ProcessPhotonCandidates(); // Process this cuts gammas
     }
 
+    if(fLocalDebugFlag) {printf("ProcessJets\n");}
     CalculateMesonCandidates();
 
+    if(fLocalDebugFlag) {printf("ProcessJets\n");}
     CalculateBackground();
 
     if (!((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->DoGammaSwappForBg()) {
+      if(fLocalDebugFlag) {printf("UpdateEventMixData\n");}
       UpdateEventMixData();
     }
   }
@@ -1904,7 +1917,7 @@ void AliAnalysisTaskMesonJetCorrelation::ProcessClusters()
 
       double RJetPi0CandPerp = 0;
       int matchedJetPerp = -1;
-      if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->IsParticleInJet(fVectorJetEtaPerp, fVectorJetPhiPerp, fConvJetReader->Get_Jet_Radius(), etaCluster, phiCluster, matchedJetPerp, RJetPi0CandPerp)) {
+      if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->IsParticleInJet(fVectorJetEta, fVectorJetPhiPerp, fConvJetReader->Get_Jet_Radius(), etaCluster, phiCluster, matchedJetPerp, RJetPi0CandPerp)) {
         fHistoClusterPtPerpCone[fiCut]->Fill(PhotonCandidate->Pt(), fWeightJetJetMC);
       }
     }
@@ -1996,7 +2009,7 @@ void AliAnalysisTaskMesonJetCorrelation::ProcessPhotonCandidates()
           }
           double RJetPi0CandPerp = 0;
           int matchedJetPerp = -1;
-          if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->IsParticleInJet(fVectorJetEtaPerp, fVectorJetPhiPerp, fConvJetReader->Get_Jet_Radius(), PhotonCandidate->Eta(), PhotonCandidate->Phi(), matchedJetPerp, RJetPi0CandPerp)) {
+          if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->IsParticleInJet(fVectorJetEta, fVectorJetPhiPerp, fConvJetReader->Get_Jet_Radius(), PhotonCandidate->Eta(), PhotonCandidate->Phi(), matchedJetPerp, RJetPi0CandPerp)) {
             fHistoConvGammaPtPerpCone[fiCut]->Fill(PhotonCandidate->Pt(), fWeightJetJetMC);
           }
         }
@@ -2049,7 +2062,7 @@ void AliAnalysisTaskMesonJetCorrelation::ProcessPhotonCandidates()
             }
             double RJetPi0CandPerp = 0;
             int matchedJetPerp = -1;
-            if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->IsParticleInJet(fVectorJetEtaPerp, fVectorJetPhiPerp, fConvJetReader->Get_Jet_Radius(), PhotonCandidate->Eta(), PhotonCandidate->Phi(), matchedJetPerp, RJetPi0CandPerp)) {
+            if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->IsParticleInJet(fVectorJetEta, fVectorJetPhiPerp, fConvJetReader->Get_Jet_Radius(), PhotonCandidate->Eta(), PhotonCandidate->Phi(), matchedJetPerp, RJetPi0CandPerp)) {
               fHistoConvGammaPtPerpCone[fiCut]->Fill(PhotonCandidate->Pt(), fWeightJetJetMC);
             }
           }
@@ -2094,7 +2107,7 @@ void AliAnalysisTaskMesonJetCorrelation::ProcessPhotonCandidates()
           }
           double RJetPi0CandPerp = 0;
           int matchedJetPerp = -1;
-          if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->IsParticleInJet(fVectorJetEtaPerp, fVectorJetPhiPerp, fConvJetReader->Get_Jet_Radius(), PhotonCandidate->Eta(), PhotonCandidate->Phi(), matchedJetPerp, RJetPi0CandPerp)) {
+          if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->IsParticleInJet(fVectorJetEta, fVectorJetPhiPerp, fConvJetReader->Get_Jet_Radius(), PhotonCandidate->Eta(), PhotonCandidate->Phi(), matchedJetPerp, RJetPi0CandPerp)) {
             fHistoConvGammaPtPerpCone[fiCut]->Fill(PhotonCandidate->Pt(), fWeightJetJetMC);
           }
         }
@@ -2220,11 +2233,6 @@ void AliAnalysisTaskMesonJetCorrelation::FillMesonHistograms(AliAODConversionPho
         if (fDoMesonQA > 0) {
           fHistoInvMassVsPtMassCut[fiCut]->Fill(pi0cand->M(), pi0cand->Pt(), fWeightJetJetMC);
         }
-      } else if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelectedByMassCut(pi0cand, 1)) { // sideband
-        fHistoJetPtVsFrag_SB[fiCut]->Fill(z, ptJet, fWeightJetJetMC);
-        if (fDoMesonQA > 0) {
-          fHistoInvMassVsPtMassCutSB[fiCut]->Fill(pi0cand->M(), pi0cand->Pt(), fWeightJetJetMC);
-        }
       }
 
       if (fIsMC > 0) {
@@ -2236,7 +2244,7 @@ void AliAnalysisTaskMesonJetCorrelation::FillMesonHistograms(AliAODConversionPho
     // Needed for underlying event study
     double RJetPi0CandPerp = 0;
     int matchedJetPerp = -1;
-    if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->IsParticleInJet(fVectorJetEtaPerp, fVectorJetPhiPerp, fConvJetReader->Get_Jet_Radius(), pi0cand->Eta(), pi0cand->Phi(), matchedJetPerp, RJetPi0CandPerp)) {
+    if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->IsParticleInJet(fVectorJetEta, fVectorJetPhiPerp, fConvJetReader->Get_Jet_Radius(), pi0cand->Eta(), pi0cand->Phi(), matchedJetPerp, RJetPi0CandPerp)) {
 
       fHistoInvMassVsPtPerpCone[fiCut]->Fill(pi0cand->M(), pi0cand->Pt(), fWeightJetJetMC);
 
@@ -2249,8 +2257,6 @@ void AliAnalysisTaskMesonJetCorrelation::FillMesonHistograms(AliAODConversionPho
       fRespMatrixHandlerMesonInvMassVsZPerpCone[fiCut]->Fill(ptJet, 0.5, pi0cand->M(), z, fWeightJetJetMC); // Inv Mass vs. Z in Jet Pt_rec bins. Needed to subtract background in the Z-distribution
       if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelectedByMassCut(pi0cand, 0)) {     // nominal mass range
         fHistoJetPtVsFragPerpCone[fiCut]->Fill(z, ptJet, fWeightJetJetMC);
-      } else if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelectedByMassCut(pi0cand, 1)) { // sideband
-        fHistoJetPtVsFragPerpCone_SB[fiCut]->Fill(z, ptJet, fWeightJetJetMC);
       }
 
     } // end isInJet in perpendicular direction
@@ -3122,23 +3128,24 @@ void AliAnalysisTaskMesonJetCorrelation::ProcessTrueMesonCandidatesAOD(AliAODCon
   fRespMatrixHandlerTrueMesonInvMassVsPt[fiCut]->Fill(jetPtRec, 0.5, Pi0Candidate->M(), Pi0Candidate->Pt(), fWeightJetJetMC);
   fRespMatrixHandlerTrueMesonInvMassVsZ[fiCut]->Fill(jetPtRec, 0.5, Pi0Candidate->M(), z_rec, fWeightJetJetMC);
 
-  fHistoTrueMesonInvMassVsTruePt[fiCut]->Fill(Pi0Candidate->M(), trueMesonCand->Pt(), fWeightJetJetMC);
+  if(fDoMesonQA > 0){
+    fHistoTrueMesonInvMassVsTruePt[fiCut]->Fill(Pi0Candidate->M(), trueMesonCand->Pt(), fWeightJetJetMC);
 
-  if (std::find(fMesonDoubleCount.begin(), fMesonDoubleCount.end(), gamma0MotherLabel) != fMesonDoubleCount.end()) {
-    fRespMatrixHandlerTrueMesonInvMassVsPtDoubleCount[fiCut]->Fill(jetPtRec, 0.5, Pi0Candidate->M(), Pi0Candidate->Pt(), fWeightJetJetMC);
-    fRespMatrixHandlerTrueMesonInvMassVsZDoubleCount[fiCut]->Fill(jetPtRec, 0.5, Pi0Candidate->M(), z_rec, fWeightJetJetMC);
-  } else {
-    fMesonDoubleCount.push_back(gamma0MotherLabel);
+    if (std::find(fMesonDoubleCount.begin(), fMesonDoubleCount.end(), gamma0MotherLabel) != fMesonDoubleCount.end()) {
+      fRespMatrixHandlerTrueMesonInvMassVsPtDoubleCount[fiCut]->Fill(jetPtRec, 0.5, Pi0Candidate->M(), Pi0Candidate->Pt(), fWeightJetJetMC);
+      fRespMatrixHandlerTrueMesonInvMassVsZDoubleCount[fiCut]->Fill(jetPtRec, 0.5, Pi0Candidate->M(), z_rec, fWeightJetJetMC);
+    } else {
+      fMesonDoubleCount.push_back(gamma0MotherLabel);
+    }
   }
 
   // fill all primary true mesons
   bool isPrimary = ((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsConversionPrimaryAOD(fInputEvent, static_cast<AliAODMCParticle*>(fAODMCTrackArray->At(gamma0MotherLabel)), mcProdVtxX, mcProdVtxY, mcProdVtxZ);
 
   if (isPrimary) {
-    fHistoTruePrimaryMesonInvMassPt[fiCut]->Fill(mesonMassRec, mesonPtRec, fWeightJetJetMC);
-
-    // meson response matrix (no Jet included here). Only use that for x-checks as the response is probably jet pt dependent
     if (fDoMesonQA) {
+      fHistoTruePrimaryMesonInvMassPt[fiCut]->Fill(mesonMassRec, mesonPtRec, fWeightJetJetMC);
+     // meson response matrix (no Jet included here). Only use that for x-checks as the response is probably jet pt dependent
       fHistoMesonResponse[fiCut]->Fill(mesonPtRec, mesonPtTrue, fWeightJetJetMC);
     }
 
@@ -3149,8 +3156,10 @@ void AliAnalysisTaskMesonJetCorrelation::ProcessTrueMesonCandidatesAOD(AliAODCon
     fHistoTrueMesonJetPtVsRecPt[fiCut]->Fill(Pi0Candidate->Pt(), jetPtRec, fWeightJetJetMC);
 
     fRespMatrixHandlerFrag[fiCut]->Fill(jetPtRec, jetPtTrue, z_rec, z_true, fWeightJetJetMC);
-    // response matrix filled with only true jet information. As the jet pT is already corrected at the stage of the meson unfolding
-    fRespMatrixHandlerFragTrueJets[fiCut]->Fill(jetPtRec, jetPtTrue, z_rec_trueJet, z_true, fWeightJetJetMC);
+    // response matrix filled with only true jet information. 
+    if(!fDoLightOutput){
+      fRespMatrixHandlerFragTrueJets[fiCut]->Fill(jetPtRec, jetPtTrue, z_rec_trueJet, z_true, fWeightJetJetMC);
+    }
 
     fRespMatrixHandlerMesonInvMass[fiCut]->Fill(jetPtRec, jetPtTrue, Pi0Candidate->M(), Pi0Candidate->Pt(), fWeightJetJetMC);
 
@@ -3158,10 +3167,14 @@ void AliAnalysisTaskMesonJetCorrelation::ProcessTrueMesonCandidatesAOD(AliAODCon
     fRespMatrixHandlerMesonPt[fiCut]->Fill(jetPtRec, jetPtTrue, mesonPtRec, mesonPtTrue, fWeightJetJetMC);
   } else { // fill all secondary mesons
 
-    fHistoTrueSecMesonJetPtVsRecZ[fiCut]->Fill(z_rec, jetPtRec, fWeightJetJetMC);
-    fHistoTrueSecMesonJetPtVsRecPt[fiCut]->Fill(Pi0Candidate->Pt(), jetPtRec, fWeightJetJetMC);
+    if(fDoMesonQA>0){
+      fHistoTrueSecMesonJetPtVsRecZ[fiCut]->Fill(z_rec, jetPtRec, fWeightJetJetMC);
+      fHistoTrueSecMesonJetPtVsRecPt[fiCut]->Fill(Pi0Candidate->Pt(), jetPtRec, fWeightJetJetMC);
+    }
 
-    fHistoTrueSecondaryMesonInvMassPt[fiCut]->Fill(Pi0Candidate->M(), mesonPtRec, fWeightJetJetMC);
+    if(fDoMesonQA > 0){
+      fHistoTrueSecondaryMesonInvMassPt[fiCut]->Fill(Pi0Candidate->M(), mesonPtRec, fWeightJetJetMC);
+    }
     fRespMatrixHandlerTrueSecondaryMesonInvMassVsPt[fiCut]->Fill(jetPtRec, 0.5, Pi0Candidate->M(), Pi0Candidate->Pt(), fWeightJetJetMC);
     fRespMatrixHandlerTrueSecondaryMesonInvMassVsZ[fiCut]->Fill(jetPtRec, 0.5, Pi0Candidate->M(), z_rec, fWeightJetJetMC);
   }
@@ -3207,8 +3220,10 @@ void AliAnalysisTaskMesonJetCorrelation::ProcessTrueMesonCandidatesInTrueJetsAOD
   float jetPtTrue = fTrueVectorJetPt[matchedJet];
   float z_true = GetFrag(trueMesonCand, matchedJet, true);
 
-  fHistoTrueMesonInTrueJet_JetPtVsTrueZ[fiCut]->Fill(z_true, jetPtTrue, fWeightJetJetMC);
-  fHistoTrueMesonInTrueJet_JetPtVsTruePt[fiCut]->Fill(mesonPtTrue, jetPtTrue, fWeightJetJetMC);
+  if(fDoMesonQA>0){
+    fHistoTrueMesonInTrueJet_JetPtVsTrueZ[fiCut]->Fill(z_true, jetPtTrue, fWeightJetJetMC);
+    fHistoTrueMesonInTrueJet_JetPtVsTruePt[fiCut]->Fill(mesonPtTrue, jetPtTrue, fWeightJetJetMC);
+  }
 }
 
 //_____________________________________________________________________________________________________________________

--- a/PWGGA/GammaConv/AliAnalysisTaskMesonJetCorrelation.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskMesonJetCorrelation.h
@@ -113,6 +113,7 @@ class AliAnalysisTaskMesonJetCorrelation : public AliAnalysisTaskSE
   void SetUseTHnSparseForResponse(bool tmp) { fUseThNForResponse = tmp; }
   void SetMesonKind(int meson) { (meson == 0) ? fMesonPDGCode = 111 : fMesonPDGCode = 221; }
   void SetOtherMesons(std::vector<int> vec) { fOtherMesonsPDGCodes = vec; }
+  void SetJetContainerAddName(TString name) { fAddNameConvJet = name; }
 
   void SetEventCutList(Int_t nCuts,
                        TList* CutArray)
@@ -185,6 +186,7 @@ class AliAnalysisTaskMesonJetCorrelation : public AliAnalysisTaskSE
   // Jet related variables
   //-------------------------------
   AliAnalysisTaskConvJet* fConvJetReader; // JetReader
+  TString fAddNameConvJet;                // Jet container additional name
   TVector3 fHighestJetVector;             // vector px,py,pz of jet with highest momentum in the event. Needed for jet event mixing
   float fMaxPtJet;                        // pt of jet with highest pt in the event. Needed for jet ecvent mixing
 
@@ -315,7 +317,6 @@ class AliAnalysisTaskMesonJetCorrelation : public AliAnalysisTaskSE
   std::vector<TH2F*> fHistoInvMassVsPt;          //! vector of histos with inv. mass vs pt
   std::vector<TH2F*> fHistoInvMassVsPt_Incl;     //! vector of histos with inv. mass vs pt for all mesons (no in-jet criterium)
   std::vector<TH2F*> fHistoJetPtVsFrag;          //! vector of histos for jet pt vs meson-z
-  std::vector<TH2F*> fHistoJetPtVsFrag_SB;       //! vector of histos for jet pt vs meson-z in the sideband region
   std::vector<TH2F*> fHistoInvMassVsPtMassCut;   //! vector of histos with inv. mass vs. pT after cut
   std::vector<TH2F*> fHistoInvMassVsPtMassCutSB; //! vector of histos with inv. mass vs. pT after cut in Sideband
 
@@ -323,7 +324,6 @@ class AliAnalysisTaskMesonJetCorrelation : public AliAnalysisTaskSE
 
   std::vector<TH2F*> fHistoInvMassVsPtPerpCone;    //! same as fHistoInvMassVsPt but in perpendicular cone
   std::vector<TH2F*> fHistoJetPtVsFragPerpCone;    //! same as fHistoJetPtVsFrag but in perp cone
-  std::vector<TH2F*> fHistoJetPtVsFragPerpCone_SB; //! same as fHistoJetPtVsFrag_SB but in perp cone
 
   //-------------------------------
   // Jet related histograms
@@ -426,10 +426,11 @@ class AliAnalysisTaskMesonJetCorrelation : public AliAnalysisTaskSE
   std::vector<TH2F*> fHistoMCPartonPtVsFragTrueParton; //! vector of histos True parton pT vs. true Frag (mc particle based distribution) for particles originating from hard parton from Jet
 
  private:
+  static constexpr bool fLocalDebugFlag = false;
   AliAnalysisTaskMesonJetCorrelation(const AliAnalysisTaskMesonJetCorrelation&);            // Prevent copy-construction
   AliAnalysisTaskMesonJetCorrelation& operator=(const AliAnalysisTaskMesonJetCorrelation&); // Prevent assignment
 
-  ClassDef(AliAnalysisTaskMesonJetCorrelation, 8);
+  ClassDef(AliAnalysisTaskMesonJetCorrelation, 9);
 };
 
 #endif

--- a/PWGGA/GammaConv/AliCutHandlerPCM.cxx
+++ b/PWGGA/GammaConv/AliCutHandlerPCM.cxx
@@ -651,6 +651,10 @@ TString AliCutHandlerPCM::GetSpecialSettingFromAddConfig (
         tempStr.Replace(0,2,"");
         cout << Form("INFO: GetSpecialSettingFromAddConfig will use running mode '%i' for the TrackMatcher!",tempStr.Atoi()) << endl;
         return tempStr;
+      } else if(tempStr.BeginsWith("JET:") && !configString.CompareTo("JET:")){
+        tempStr.Replace(0,4,"");
+        cout << Form("INFO: GetSpecialSettingFromAddConfig will use running mode '%i' for the JetReader!",tempStr.Atoi()) << endl;
+        return tempStr;
       }else if(tempStr.CompareTo("EPCLUSTree") == 0&& !configString.CompareTo("EPCLUSTree")){
         cout << "INFO: "<< addTaskName.Data() << " activating 'EPCLUSTree'" << endl;
         return "1";

--- a/PWGGA/GammaConv/macros/AddTask_GammaCalo_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaCalo_pp.C
@@ -85,6 +85,9 @@ void AddTask_GammaCalo_pp(
   if(additionalTrainConfig.Contains("TM"))
     trackMatcherRunningMode = strTrackMatcherRunningMode.Atoi();
 
+  TString nameJetFinder = (additionalTrainConfig.Contains("JET:") == true) ? cuts.GetSpecialSettingFromAddConfig(additionalTrainConfig, "JET:", "", addTaskName) : "";
+  printf("nameJetFinder: %s\n", nameJetFinder.Data());
+
   Bool_t doTreeEOverP = kFALSE; // switch to produce EOverP tree
   TString strdoTreeEOverP             = cuts.GetSpecialSettingFromAddConfig(additionalTrainConfig, "EPCLUSTree", "", addTaskName);
   if(strdoTreeEOverP.Atoi()==1)
@@ -4971,6 +4974,7 @@ void AddTask_GammaCalo_pp(
   if(trainConfig == 106 || trainConfig == 125 || trainConfig == 145){
     task->SetInOutTimingCluster(-30e-9,35e-9);
   }
+  if(additionalTrainConfig.Contains("JET:")){task->SetJetContainerAddName(nameJetFinder);}
   task->SetLocalDebugFlag(localDebugFlag);
 
   //connect containers

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_pp.C
@@ -94,7 +94,8 @@ void AddTask_GammaConvCalo_pp(
   if(additionalTrainConfig.Contains("MaterialBudgetWeights"))
     fileNameMatBudWeights         = cuts.GetSpecialSettingFromAddConfig(additionalTrainConfig, "MaterialBudgetWeights",fileNameMatBudWeights, addTaskName);
 
-
+  TString nameJetFinder = (additionalTrainConfig.Contains("JET:") == true) ? cuts.GetSpecialSettingFromAddConfig(additionalTrainConfig, "JET:", "", addTaskName) : "";
+  
   Int_t trackMatcherRunningMode = 0; // CaloTrackMatcher running mode
   TString strTrackMatcherRunningMode  = cuts.GetSpecialSettingFromAddConfig(additionalTrainConfig, "TM", "", addTaskName);
   if(additionalTrainConfig.Contains("TM"))
@@ -4872,6 +4873,7 @@ void AddTask_GammaConvCalo_pp(
   if (initializedMatBudWeigths_existing) {
       task->SetDoMaterialBudgetWeightingOfGammasForTrueMesons(kTRUE);
   }
+  if(additionalTrainConfig.Contains("JET:")){task->SetJetContainerAddName(nameJetFinder);}
 
   //connect containers
   AliAnalysisDataContainer *coutput =

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvV1_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvV1_pp.C
@@ -78,8 +78,9 @@ void AddTask_GammaConvV1_pp(
   if(additionalTrainConfig.Contains("TM"))
     trackMatcherRunningMode = strTrackMatcherRunningMode.Atoi();
 
+  TString nameJetFinder = (additionalTrainConfig.Contains("JET:") == true) ? cuts.GetSpecialSettingFromAddConfig(additionalTrainConfig, "JET:", "", addTaskName) : "";
 
- TObjArray *rmaxFacPtHardSetting = settingMaxFacPtHard.Tokenize("_");
+  TObjArray *rmaxFacPtHardSetting = settingMaxFacPtHard.Tokenize("_");
   if(rmaxFacPtHardSetting->GetEntries()<1){cout << "ERROR: AddTask_GammaConvV1_pp during parsing of settingMaxFacPtHard String '" << settingMaxFacPtHard.Data() << "'" << endl; return;}
   Bool_t fMinPtHardSet        = kFALSE;
   Double_t minFacPtHard       = -1;
@@ -2901,6 +2902,7 @@ if(!cuts.AreValid()){
   if (initializedMatBudWeigths_existing) {
       task->SetDoMaterialBudgetWeightingOfGammasForTrueMesons(kTRUE);
   }
+  if(additionalTrainConfig.Contains("JET:")){task->SetJetContainerAddName(nameJetFinder);}
 
   //connect containers
   AliAnalysisDataContainer *coutput =

--- a/PWGGA/GammaConv/macros/AddTask_MesonJetCorr_Calo.C
+++ b/PWGGA/GammaConv/macros/AddTask_MesonJetCorr_Calo.C
@@ -78,6 +78,9 @@ void AddTask_MesonJetCorr_Calo(
   if (additionalTrainConfig.Contains("TM"))
     trackMatcherRunningMode = strTrackMatcherRunningMode.Atoi();
 
+  TString nameJetFinder = (additionalTrainConfig.Contains("JET:") == true) ? cuts.GetSpecialSettingFromAddConfig(additionalTrainConfig, "JET:", "", addTaskName) : "";
+  printf("nameJetFinder: %s\n", nameJetFinder.Data());
+
   TObjArray* rmaxFacPtHardSetting = settingMaxFacPtHard.Tokenize("_");
   if (rmaxFacPtHardSetting->GetEntries() < 1) {
     cout << "ERROR: AddTask_MesonJetCorr_pp during parsing of settingMaxFacPtHard String '" << settingMaxFacPtHard.Data() << "'" << endl;
@@ -307,6 +310,7 @@ void AddTask_MesonJetCorr_Calo(
 
   task->SetMesonKind(meson);
   task->SetIsCalo(true);
+  if(additionalTrainConfig.Contains("JET:")){task->SetJetContainerAddName(nameJetFinder);}
   task->SetEventCutList(numberOfCuts, EventCutList);
   task->SetCaloCutList(numberOfCuts, ClusterCutList);
   task->SetMesonCutList(numberOfCuts, MesonCutList);
@@ -317,9 +321,8 @@ void AddTask_MesonJetCorr_Calo(
   task->SetUseTHnSparseForResponse(enableTHnSparse);
 
   //connect containers
-  AliAnalysisDataContainer* coutput =
-    mgr->CreateContainer(!(corrTaskSetting.CompareTo("")) ? Form("MesonJetCorrelation_Calo_%i_%i", meson, trainConfig) : Form("MesonJetCorrelation_Calo_%i_%i_%s", meson, trainConfig, corrTaskSetting.Data()), TList::Class(),
-                         AliAnalysisManager::kOutputContainer, Form("MesonJetCorrelation_Calo_%i_%i.root", meson, trainConfig));
+  TString nameContainer = Form("MesonJetCorrelation_Calo_%i_%i%s%s", meson, trainConfig, corrTaskSetting.EqualTo("") == true ? "" : Form("_%s", corrTaskSetting.Data()), nameJetFinder.EqualTo("") == true ? "" : Form("_%s", nameJetFinder.Data()) );
+  AliAnalysisDataContainer* coutput = mgr->CreateContainer(nameContainer, TList::Class(), AliAnalysisManager::kOutputContainer, Form("MesonJetCorrelation_Calo_%i_%i.root", meson, trainConfig));
 
   mgr->AddTask(task);
   mgr->ConnectInput(task, 0, cinput);

--- a/PWGGA/GammaConv/macros/AddTask_MesonJetCorr_Conv.C
+++ b/PWGGA/GammaConv/macros/AddTask_MesonJetCorr_Conv.C
@@ -78,6 +78,9 @@ void AddTask_MesonJetCorr_Conv(
   if (additionalTrainConfig.Contains("TM"))
     trackMatcherRunningMode = strTrackMatcherRunningMode.Atoi();
 
+  TString nameJetFinder = (additionalTrainConfig.Contains("JET:") == true) ? cuts.GetSpecialSettingFromAddConfig(additionalTrainConfig, "JET:", "", addTaskName) : "";
+  printf("nameJetFinder: %s\n", nameJetFinder.Data());
+  
   TObjArray* rmaxFacPtHardSetting = settingMaxFacPtHard.Tokenize("_");
   if (rmaxFacPtHardSetting->GetEntries() < 1) {
     cout << "ERROR: AddTask_MesonJetCorr_pp during parsing of settingMaxFacPtHard String '" << settingMaxFacPtHard.Data() << "'" << endl;
@@ -306,17 +309,16 @@ void AddTask_MesonJetCorr_Conv(
 
   task->SetMesonKind(meson);
   task->SetIsConv(true);
+  task->SetJetContainerAddName(nameJetFinder);
   task->SetEventCutList(numberOfCuts, EventCutList);
   task->SetMesonCutList(numberOfCuts, MesonCutList);
   task->SetConversionCutList(numberOfCuts, ConvCutList);
-  //   task->SetDoMesonAnalysis(kTRUE); // I think we dont need that!
-  task->SetDoMesonQA(enableQAMesonTask); //Attention new switch for Pi0 QA
+  task->SetDoMesonQA(enableQAMesonTask); 
   task->SetUseTHnSparseForResponse(enableTHnSparse);
 
   //connect containers
-  AliAnalysisDataContainer* coutput =
-    mgr->CreateContainer(Form("MesonJetCorrelation_Conv_%i_%i", meson, trainConfig), TList::Class(),
-                         AliAnalysisManager::kOutputContainer, Form("MesonJetCorrelation_Conv_%i_%i.root", meson, trainConfig));
+  TString nameContainer = Form("MesonJetCorrelation_Conv_%i_%i%s", meson, trainConfig, nameJetFinder.EqualTo("") == true ? "" : Form("_%s", nameJetFinder.Data()) );
+  AliAnalysisDataContainer* coutput = mgr->CreateContainer(nameContainer, TList::Class(), AliAnalysisManager::kOutputContainer, Form("MesonJetCorrelation_Conv_%i_%i.root", meson, trainConfig));
 
   mgr->AddTask(task);
   cout << "before connect input\n";

--- a/PWGGA/GammaConv/macros/AddTask_MesonJetCorr_ConvCalo.C
+++ b/PWGGA/GammaConv/macros/AddTask_MesonJetCorr_ConvCalo.C
@@ -87,6 +87,9 @@ void AddTask_MesonJetCorr_ConvCalo(
   if (additionalTrainConfig.Contains("TM"))
     trackMatcherRunningMode = strTrackMatcherRunningMode.Atoi();
 
+  TString nameJetFinder = (additionalTrainConfig.Contains("JET:") == true) ? cuts.GetSpecialSettingFromAddConfig(additionalTrainConfig, "JET:", "", addTaskName) : "";
+  printf("nameJetFinder: %s\n", nameJetFinder.Data());
+
   TObjArray* rmaxFacPtHardSetting = settingMaxFacPtHard.Tokenize("_");
   if (rmaxFacPtHardSetting->GetEntries() < 1) {
     cout << "ERROR: AddTask_MesonJetCorr_pp during parsing of settingMaxFacPtHard String '" << settingMaxFacPtHard.Data() << "'" << endl;
@@ -359,6 +362,7 @@ void AddTask_MesonJetCorr_ConvCalo(
 
   task->SetMesonKind(meson);
   task->SetIsConvCalo(true);
+  task->SetJetContainerAddName(nameJetFinder);
   task->SetEventCutList(numberOfCuts, EventCutList);
   task->SetCaloCutList(numberOfCuts, ClusterCutList);
   task->SetMesonCutList(numberOfCuts, MesonCutList);
@@ -370,9 +374,8 @@ void AddTask_MesonJetCorr_ConvCalo(
   task->SetUseTHnSparseForResponse(enableTHnSparse);
 
   //connect containers
-  AliAnalysisDataContainer* coutput =
-    mgr->CreateContainer(!(corrTaskSetting.CompareTo("")) ? Form("MesonJetCorrelation_ConvCalo_%i_%i", meson, trainConfig) : Form("MesonJetCorrelation_ConvCalo_%i_%i_%s", meson, trainConfig, corrTaskSetting.Data()), TList::Class(),
-                         AliAnalysisManager::kOutputContainer, Form("MesonJetCorrelation_ConvCalo_%i_%i.root", meson, trainConfig));
+  TString nameContainer = Form("MesonJetCorrelation_ConvCalo_%i_%i%s%s", meson, trainConfig, corrTaskSetting.EqualTo("") == true ? "" : Form("_%s", corrTaskSetting.Data()), nameJetFinder.EqualTo("") == true ? "" : Form("_%s", nameJetFinder.Data()) );
+  AliAnalysisDataContainer* coutput = mgr->CreateContainer(nameContainer, TList::Class(), AliAnalysisManager::kOutputContainer, Form("MesonJetCorrelation_ConvCalo_%i_%i.root", meson, trainConfig));
 
   mgr->AddTask(task);
   mgr->ConnectInput(task, 0, cinput);


### PR DESCRIPTION
finders

- To run the meson in jet analysis using different radii, the ConvJet task now can publish using different naming shemes, which are then beeing read in by the analysis task.
- Names are passed to the analysis task via the subwagon name, similar to the correction task setting (e.g. cutNr_JET:R02)
- Perp. cone was set to be only perpendicular in phi, not in eta
- Clean up histograms (move some to higher QA, lightOutput modes) to reduce memory consumption