### PR TITLE
PWGGA/GammaConv: Adjust omega AddTasks and lambda parameters

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson.cxx
@@ -1684,11 +1684,11 @@ void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::UserCreateOutputObjects(
     if(fEnableSubLambdaOutput){
       fLambda[iCut]                                            = new TF1("fLambda","pol3",0.,30);
       if (fNDMRecoMode == 0){
-        fLambda[iCut]->SetParameters(1.01457,0.00252082,0.00102263,-0.0000217);  // Parameters taken from fits to projections of fHistopi0vsmesonmassshiftangle for PCM
+        fLambda[iCut]->SetParameters(1.15451,0.0367886,-0.00132376,0.0000071);  // Parameters taken from fits to projections of fHistopi0vsmesonmassshiftangle for PCM
       } else if(fNDMRecoMode == 1){
-        fLambda[iCut]->SetParameters(0.444968,0.288044,-0.0154603,0.000271816);  // Parameters taken from fits to projections of fHistopi0vsmesonmassshiftangle for PCMEMC
+        fLambda[iCut]->SetParameters(0.444632,0.308003,-0.0177388,0.000369535);  // Parameters taken from fits to projections of fHistopi0vsmesonmassshiftangle for PCMEMC
       } else{
-        fLambda[iCut]->SetParameters(0.265865,0.383971,-0.0153176,-0.000860089); // Parameters taken from fits to projections of fHistopi0vsmesonmassshiftangle for EMC
+        fLambda[iCut]->SetParameters(0.236562,0.420576,-0.0226939,-0.000362612); // Parameters taken from fits to projections of fHistopi0vsmesonmassshiftangle for EMC
       }
       fHistoMotherInvMassSubLambda[iCut]                       = new TH2F("ESD_InvMass_Mother_Sub_Lambda_InvMass_Neutral_Pt","ESD_InvMass_Mother_Sub_InvMass_Neutral_Pt",HistoNMassBinsSub,HistoMassRangeSub[0],HistoMassRangeSub[1], HistoNPtBins, arrPtBinning);
       fHistoMotherInvMassSubLambda[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{+} #pi^{-} %s} - #lambda#times(M_{%s}-M_{%s},PDG}) (GeV/c^{2})",NameNDMLatex.Data(),NameNDMLatex.Data(),NameNDMLatex.Data()));

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_CaloMode_pPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_CaloMode_pPb.C
@@ -307,26 +307,26 @@ void AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_CaloMode_pPb(
     cuts.AddCutHeavyMesonCalo("80010113","411790105ce30220000","32c51070a","0000003100000000","0400503000000000"); // c: No E/p cut
     cuts.AddCutHeavyMesonCalo("80010113","411790105ee30220000","32c51070a","0000003100000000","0400503000000000"); // e: E/p < 2
     cuts.AddCutHeavyMesonCalo("80010113","411790105ge30220000","32c51070a","0000003100000000","0400503000000000"); // g: E/p < 1.5
-    cuts.AddCutHeavyMesonCalo("80010113","411790105he30220000","32c51070a","0000003100000000","0400503000000000"); // h: E/p < 1.25
-    cuts.AddCutHeavyMesonCalo("80010113","411790105oe30220000","32c51070a","0000003100000000","0400503000000000"); // n: E/p < 1.75 (standard), but eta and phi varied
+    cuts.AddCutHeavyMesonCalo("80010113","411790105ne30220000","32c51070a","0000003100000000","0400503000000000"); // n: E/p < 1.75 (standard), but eta and phi varied
+    cuts.AddCutHeavyMesonCalo("80010113","411790105oe30220000","32c51070a","0000003100000000","0400503000000000"); // o: E/p < 1.75 (standard), but eta and phi varied
   }else if (trainConfig == 1104){ // Exotic cluster variations
     cuts.AddCutHeavyMesonCalo("80010113","411790105f030220000","32c51070a","0000003100000000","0400503000000000"); // 0: No exotics cut
     cuts.AddCutHeavyMesonCalo("80010113","411790105fb30220000","32c51070a","0000003100000000","0400503000000000"); // b: fExoticEnergyFracCluster = 0.95
     cuts.AddCutHeavyMesonCalo("80010113","411790105fi30220000","32c51070a","0000003100000000","0400503000000000"); // i: fExoticMinEnergyCell = 3
   }else if (trainConfig == 1105){ // Min cluster energy variations
     cuts.AddCutHeavyMesonCalo("80010113","411790105fe20220000","32c51070a","0000003100000000","0400503000000000"); // 2: E > 0.6
-    cuts.AddCutHeavyMesonCalo("80010113","411790105fe40220000","32c51070a","0000003100000000","0400503000000000"); // 3: E > 0.8
+    cuts.AddCutHeavyMesonCalo("80010113","411790105fe40220000","32c51070a","0000003100000000","0400503000000000"); // 4: E > 0.8
   }else if (trainConfig == 1106){ // NCell variation
     cuts.AddCutHeavyMesonCalo("80010113","411790105fe3n220000","32c51070a","0000003100000000","0400503000000000");
   }else if (trainConfig == 1107){ // M02 variations
     cuts.AddCutHeavyMesonCalo("80010113","411790105fe30210000","32c51070a","0000003100000000","0400503000000000"); // 1: M02 < 1
     cuts.AddCutHeavyMesonCalo("80010113","411790105fe30230000","32c51070a","0000003100000000","0400503000000000"); // 3: M02 < 0.5
   }else if (trainConfig == 1108){ // pi0 mass selection window variations
-    cuts.AddCutHeavyMesonCalo("80010113","411790105fe30220000","32c51070a","0000003r00000000","0400503000000000"); // r: 3.5 sigma, no gamma selection
     cuts.AddCutHeavyMesonCalo("80010113","411790105fe30220000","32c51070a","0000003u00000000","0400503000000000"); // u: 1.5 sigma
     cuts.AddCutHeavyMesonCalo("80010113","411790105fe30220000","32c51070a","0000003v00000000","0400503000000000"); // v: 2.5 sigma
-    cuts.AddCutHeavyMesonCalo("80010113","411790105fe30220000","32c51070a","0000003w00000000","0400503000000000"); // w: 4 sigma
     cuts.AddCutHeavyMesonCalo("80010113","411790105fe30220000","32c51070a","0000003x00000000","0400503000000000"); // x: 3 sigma
+    cuts.AddCutHeavyMesonCalo("80010113","411790105fe30220000","32c51070a","0000003r00000000","0400503000000000"); // r: 3.5 sigma, no gamma selection
+    cuts.AddCutHeavyMesonCalo("80010113","411790105fe30220000","32c51070a","0000003w00000000","0400503000000000"); // w: 4 sigma
   }else if (trainConfig == 1109){ // pi0 asymmetry variations
     cuts.AddCutHeavyMesonCalo("80010113","411790105fe30220000","32c51070a","0000005100000000","0400503000000000"); // 5: alpha < 0.75
     cuts.AddCutHeavyMesonCalo("80010113","411790105fe30220000","32c51070a","0000006100000000","0400503000000000"); // 6: alpha < 0.8

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_CaloMode_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_CaloMode_pp.C
@@ -71,7 +71,7 @@ void AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_CaloMode_pp(
         TString tempType = tempStr;
         tempType.Replace(0,9,"");
         unsmearingoutputs = tempType;
-        cout << "INFO: AddTask_GammaConvNeutralMesonPiPlPiMiPiZero_CaloMode_pPb will output the following minv_pT histograms:" << endl;
+        cout << "INFO: AddTask_GammaConvNeutralMesonPiPlPiMiPiZero_CaloMode_pp will output the following minv_pT histograms:" << endl;
         if(unsmearingoutputs.Contains("0")) cout << "- Uncorrected" << endl;
         if(unsmearingoutputs.Contains("1")) cout << "- SubNDM" << endl;
         if(unsmearingoutputs.Contains("2")) cout << "- Fixpz" << endl;
@@ -1495,26 +1495,26 @@ void AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_CaloMode_pp(
     cuts.AddCutHeavyMesonCalo("00010113","411790105ce30220000","32c51070a","0000003100000000","0400503000000000"); // c: No E/p cut
     cuts.AddCutHeavyMesonCalo("00010113","411790105ee30220000","32c51070a","0000003100000000","0400503000000000"); // e: E/p < 2
     cuts.AddCutHeavyMesonCalo("00010113","411790105ge30220000","32c51070a","0000003100000000","0400503000000000"); // g: E/p < 1.5
-    cuts.AddCutHeavyMesonCalo("00010113","411790105he30220000","32c51070a","0000003100000000","0400503000000000"); // h: E/p < 1.25
-    cuts.AddCutHeavyMesonCalo("00010113","411790105oe30220000","32c51070a","0000003100000000","0400503000000000"); // n: E/p < 1.75 (standard), but eta and phi varied
+    cuts.AddCutHeavyMesonCalo("00010113","411790105ne30220000","32c51070a","0000003100000000","0400503000000000"); // n: E/p < 1.75 (standard), but eta and phi varied
+    cuts.AddCutHeavyMesonCalo("00010113","411790105oe30220000","32c51070a","0000003100000000","0400503000000000"); // o: E/p < 1.75 (standard), but eta and phi varied
   }else if (trainConfig == 1504){ // Exotic cluster variations
     cuts.AddCutHeavyMesonCalo("00010113","411790105f030220000","32c51070a","0000003100000000","0400503000000000"); // 0: No exotics cut
     cuts.AddCutHeavyMesonCalo("00010113","411790105fb30220000","32c51070a","0000003100000000","0400503000000000"); // b: fExoticEnergyFracCluster = 0.95
     cuts.AddCutHeavyMesonCalo("00010113","411790105fi30220000","32c51070a","0000003100000000","0400503000000000"); // i: fExoticMinEnergyCell = 3
   }else if (trainConfig == 1505){ // Min cluster energy variations
     cuts.AddCutHeavyMesonCalo("00010113","411790105fe20220000","32c51070a","0000003100000000","0400503000000000"); // 2: E > 0.6
-    cuts.AddCutHeavyMesonCalo("00010113","411790105fe40220000","32c51070a","0000003100000000","0400503000000000"); // 3: E > 0.8
+    cuts.AddCutHeavyMesonCalo("00010113","411790105fe40220000","32c51070a","0000003100000000","0400503000000000"); // 4: E > 0.8
   }else if (trainConfig == 1506){ // NCell variation
     cuts.AddCutHeavyMesonCalo("00010113","411790105fe3n220000","32c51070a","0000003100000000","0400503000000000");
   }else if (trainConfig == 1507){ // M02 variations
     cuts.AddCutHeavyMesonCalo("00010113","411790105fe30210000","32c51070a","0000003100000000","0400503000000000"); // 1: M02 < 1
     cuts.AddCutHeavyMesonCalo("00010113","411790105fe30230000","32c51070a","0000003100000000","0400503000000000"); // 3: M02 < 0.5
   }else if (trainConfig == 1508){ // pi0 mass selection window variations
-    cuts.AddCutHeavyMesonCalo("00010113","411790105fe30220000","32c51070a","0000003r00000000","0400503000000000"); // r: 3.5 sigma, no gamma selection
     cuts.AddCutHeavyMesonCalo("00010113","411790105fe30220000","32c51070a","0000003u00000000","0400503000000000"); // u: 1.5 sigma
     cuts.AddCutHeavyMesonCalo("00010113","411790105fe30220000","32c51070a","0000003v00000000","0400503000000000"); // v: 2.5 sigma
-    cuts.AddCutHeavyMesonCalo("00010113","411790105fe30220000","32c51070a","0000003w00000000","0400503000000000"); // w: 4 sigma
     cuts.AddCutHeavyMesonCalo("00010113","411790105fe30220000","32c51070a","0000003x00000000","0400503000000000"); // x: 3 sigma
+    cuts.AddCutHeavyMesonCalo("00010113","411790105fe30220000","32c51070a","0000003r00000000","0400503000000000"); // r: 3.5 sigma, no gamma selection
+    cuts.AddCutHeavyMesonCalo("00010113","411790105fe30220000","32c51070a","0000003w00000000","0400503000000000"); // w: 4 sigma
   }else if (trainConfig == 1509){ // pi0 asymmetry variations
     cuts.AddCutHeavyMesonCalo("00010113","411790105fe30220000","32c51070a","0000005100000000","0400503000000000"); // 5: alpha < 0.75
     cuts.AddCutHeavyMesonCalo("00010113","411790105fe30220000","32c51070a","0000006100000000","0400503000000000"); // 6: alpha < 0.8

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_ConvMode_pPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_ConvMode_pPb.C
@@ -54,7 +54,10 @@ void AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_ConvMode_pPb(
 
   if(additionalTrainConfig.Contains("MaterialBudgetWeights"))
     fileNameMatBudWeights         = cuts.GetSpecialSettingFromAddConfig(additionalTrainConfig, "MaterialBudgetWeights",fileNameMatBudWeights, addTaskName);
+  
   //parse additionalTrainConfig flag
+  TString unsmearingoutputs = "012"; // 0: No correction, 1: One pi0 mass errer subtracted, 2: pz of pi0 corrected to fix its mass, 3: Lambda(alpha)*DeltaPi0 subtracted
+
   TObjArray *rAddConfigArr = additionalTrainConfig.Tokenize("_");
   if(rAddConfigArr->GetEntries()<1){cout << "ERROR during parsing of additionalTrainConfig String '" << additionalTrainConfig.Data() << "'" << endl; return;}
   TObjString* rAdditionalTrainConfig;
@@ -63,7 +66,16 @@ void AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_ConvMode_pPb(
     else{
       TObjString* temp = (TObjString*) rAddConfigArr->At(i);
       TString tempStr = temp->GetString();
-      cout << "INFO: nothing to do, no definition available!" << endl;
+      if(tempStr.BeginsWith("UNSMEARING")){ // 0: No correction, 1: One pi0 mass errer subtracted, 2: pz of pi0 corrected to fix its mass, 3: Lambda(alpha)*DeltaPi0 subtracted
+        TString tempType = tempStr;
+        tempType.Replace(0,9,"");
+        unsmearingoutputs = tempType;
+        cout << "INFO: AddTask_GammaConvNeutralMesonPiPlPiMiPiZero_ConvMode_pPb will output the following minv_pT histograms:" << endl;
+        if(unsmearingoutputs.Contains("0")) cout << "- Uncorrected" << endl;
+        if(unsmearingoutputs.Contains("1")) cout << "- SubNDM" << endl;
+        if(unsmearingoutputs.Contains("2")) cout << "- Fixpz" << endl;
+        if(unsmearingoutputs.Contains("3")) cout << "- SubLambda" << endl;
+      }
     }
   }
   TString sAdditionalTrainConfig = rAdditionalTrainConfig->GetString();
@@ -468,6 +480,8 @@ void AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_ConvMode_pPb(
           task->SetDoMaterialBudgetWeightingOfGammasForInvMassHistogram(kTRUE);
       }
   }
+
+  task->SetUnsmearedOutputs(unsmearingoutputs);
 
   //connect containers
   AliAnalysisDataContainer *coutput =

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_MixedMode_pPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_MixedMode_pPb.C
@@ -40,6 +40,7 @@ void AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_MixedMode_pPb(
     TString   periodNameV0Reader          = "",                       // period Name for V0Reader
     Int_t     runLightOutput              = 0,                        // run light output option 0: no light output 1: most cut histos stiched off 2: unecessary omega hists turned off as well
     Int_t     prefilterRunFlag            = 1500,                     // flag to change the prefiltering of ESD tracks. See SetHybridTrackCutsAODFiltering() in AliPrimaryPionCuts
+    Bool_t    usePtDepSelectionWindowCut  = kFALSE,                   // use pt dependent meson selection window cut
     Bool_t    enableSortingMCLabels       = kTRUE,                    // enable sorting for MC cluster labels
     Int_t     enableMatBudWeightsPi0      = 0,                        // 1 = three radial bins, 2 = 10 radial bins (2 is the default when using weights)
     TString   additionalTrainConfig       = "0"                       // additional counter for trainconfig, this has to be always the last parameter
@@ -335,15 +336,15 @@ AliVEventHandler *inputHandler=mgr->GetInputEventHandler();
     cuts.AddCutHeavyMesonPCMCalo("80010113","0dm00009f9730000dge0404000","411790105ce30220000","32c51070a","0000003f00000000","0400503000000000"); // c: No E/p cut
     cuts.AddCutHeavyMesonPCMCalo("80010113","0dm00009f9730000dge0404000","411790105ee30220000","32c51070a","0000003f00000000","0400503000000000"); // e: E/p < 2
     cuts.AddCutHeavyMesonPCMCalo("80010113","0dm00009f9730000dge0404000","411790105ge30220000","32c51070a","0000003f00000000","0400503000000000"); // g: E/p < 1.5
-    cuts.AddCutHeavyMesonPCMCalo("80010113","0dm00009f9730000dge0404000","411790105he30220000","32c51070a","0000003f00000000","0400503000000000"); // h: E/p < 1.25
-    cuts.AddCutHeavyMesonPCMCalo("80010113","0dm00009f9730000dge0404000","411790105oe30220000","32c51070a","0000003f00000000","0400503000000000"); // n: E/p < 1.75 (standard), but eta and phi varied
+    cuts.AddCutHeavyMesonPCMCalo("80010113","0dm00009f9730000dge0404000","411790105ne30220000","32c51070a","0000003f00000000","0400503000000000"); // n: E/p < 1.75 (standard), but eta and phi varied
+    cuts.AddCutHeavyMesonPCMCalo("80010113","0dm00009f9730000dge0404000","411790105oe30220000","32c51070a","0000003f00000000","0400503000000000"); // o: E/p < 1.75 (standard), but eta and phi varied
   }else if (trainConfig == 1119){ // Exotic cluster variations
     cuts.AddCutHeavyMesonPCMCalo("80010113","0dm00009f9730000dge0404000","411790105f030220000","32c51070a","0000003f00000000","0400503000000000"); // 0: No exotics cut
     cuts.AddCutHeavyMesonPCMCalo("80010113","0dm00009f9730000dge0404000","411790105fb30220000","32c51070a","0000003f00000000","0400503000000000"); // b: fExoticEnergyFracCluster = 0.95
     cuts.AddCutHeavyMesonPCMCalo("80010113","0dm00009f9730000dge0404000","411790105fi30220000","32c51070a","0000003f00000000","0400503000000000"); // i: fExoticMinEnergyCell = 3
   }else if (trainConfig == 1120){ // Min cluster energy variations
     cuts.AddCutHeavyMesonPCMCalo("80010113","0dm00009f9730000dge0404000","411790105fe20220000","32c51070a","0000003f00000000","0400503000000000"); // 2: E > 0.6
-    cuts.AddCutHeavyMesonPCMCalo("80010113","0dm00009f9730000dge0404000","411790105fe40220000","32c51070a","0000003f00000000","0400503000000000"); // 3: E > 0.8
+    cuts.AddCutHeavyMesonPCMCalo("80010113","0dm00009f9730000dge0404000","411790105fe40220000","32c51070a","0000003f00000000","0400503000000000"); // 4: E > 0.8
   }else if (trainConfig == 1121){ // NCell variation
     cuts.AddCutHeavyMesonPCMCalo("80010113","0dm00009f9730000dge0404000","411790105fe3n220000","32c51070a","0000003f00000000","0400503000000000");
   }else if (trainConfig == 1122){ // M02 variations
@@ -555,6 +556,7 @@ AliVEventHandler *inputHandler=mgr->GetInputEventHandler();
     }
 
     analysisNeutralPionCuts[i] = new AliConversionMesonCuts();
+    analysisNeutralPionCuts[i]->SetUsePtDepSelectionWindow(usePtDepSelectionWindowCut);
     if(runLightOutput>0) analysisNeutralPionCuts[i]->SetLightOutput(kTRUE);
     if( ! analysisNeutralPionCuts[i]->InitializeCutsFromCutString((cuts.GetNDMCut(i)).Data()) ) {
       cout<<"ERROR: analysisMesonCuts [ " <<i<<" ] "<<endl;

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_MixedMode_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_MixedMode_pp.C
@@ -52,6 +52,7 @@ void AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_MixedMode_pp(
   ) {
 
   AliCutHandlerPCM cuts(13);
+
   TString addTaskName                       = "AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_MixedMode_pp";
   TString fileNamePtWeights                 = cuts.GetSpecialFileNameFromString (fileNameExternalInputs, "FPTW:");
   TString fileNameMultWeights               = cuts.GetSpecialFileNameFromString (fileNameExternalInputs, "FMUW:");
@@ -62,7 +63,7 @@ void AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_MixedMode_pp(
   if(additionalTrainConfig.Contains("MaterialBudgetWeights"))
     fileNameMatBudWeights         = cuts.GetSpecialSettingFromAddConfig(additionalTrainConfig, "MaterialBudgetWeights",fileNameMatBudWeights, addTaskName);
 
-    //parse additionalTrainConfig flag
+  //parse additionalTrainConfig flag
   Int_t trackMatcherRunningMode = 0; // CaloTrackMatcher running mode
   TString unsmearingoutputs = "012"; // 0: No correction, 1: One pi0 mass errer subtracted, 2: pz of pi0 corrected to fix its mass, 3: Lambda(alpha)*DeltaPi0 subtracted, 4: Analytic PCMEMC unsmearing
 
@@ -84,7 +85,7 @@ void AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_MixedMode_pp(
         TString tempType = tempStr;
         tempType.Replace(0,9,"");
         unsmearingoutputs = tempType;
-        cout << "INFO: AddTask_GammaConvNeutralMesonPiPlPiMiPiZero_MixedMode_pPb will output the following minv_pT histograms:" << endl;
+        cout << "INFO: AddTask_GammaConvNeutralMesonPiPlPiMiPiZero_MixedMode_pp will output the following minv_pT histograms:" << endl;
         if(unsmearingoutputs.Contains("4")) cout << "- Analytic PCM unsmearing" << endl;
         else if(unsmearingoutputs.Contains("0")) cout << "- Uncorrected" << endl;
         if(unsmearingoutputs.Contains("1")) cout << "- SubNDM" << endl;
@@ -1167,15 +1168,15 @@ AliVEventHandler *inputHandler=mgr->GetInputEventHandler();
     cuts.AddCutHeavyMesonPCMCalo("00010113","0dm00009f9730000dge0404000","411790105ce30220000","32c51070a","0000003f00000000","0400503000000000"); // c: No E/p cut
     cuts.AddCutHeavyMesonPCMCalo("00010113","0dm00009f9730000dge0404000","411790105ee30220000","32c51070a","0000003f00000000","0400503000000000"); // e: E/p < 2
     cuts.AddCutHeavyMesonPCMCalo("00010113","0dm00009f9730000dge0404000","411790105ge30220000","32c51070a","0000003f00000000","0400503000000000"); // g: E/p < 1.5
-    cuts.AddCutHeavyMesonPCMCalo("00010113","0dm00009f9730000dge0404000","411790105he30220000","32c51070a","0000003f00000000","0400503000000000"); // h: E/p < 1.25
-    cuts.AddCutHeavyMesonPCMCalo("00010113","0dm00009f9730000dge0404000","411790105oe30220000","32c51070a","0000003f00000000","0400503000000000"); // n: E/p < 1.75 (standard), but eta and phi varied
+    cuts.AddCutHeavyMesonPCMCalo("00010113","0dm00009f9730000dge0404000","411790105ne30220000","32c51070a","0000003f00000000","0400503000000000"); // n: E/p < 1.75 (standard), but eta and phi varied
+    cuts.AddCutHeavyMesonPCMCalo("00010113","0dm00009f9730000dge0404000","411790105oe30220000","32c51070a","0000003f00000000","0400503000000000"); // o: E/p < 1.75 (standard), but eta and phi varied
   }else if (trainConfig == 1519){ // Exotic cluster variations
     cuts.AddCutHeavyMesonPCMCalo("00010113","0dm00009f9730000dge0404000","411790105f030220000","32c51070a","0000003f00000000","0400503000000000"); // 0: No exotics cut
     cuts.AddCutHeavyMesonPCMCalo("00010113","0dm00009f9730000dge0404000","411790105fb30220000","32c51070a","0000003f00000000","0400503000000000"); // b: fExoticEnergyFracCluster = 0.95
     cuts.AddCutHeavyMesonPCMCalo("00010113","0dm00009f9730000dge0404000","411790105fi30220000","32c51070a","0000003f00000000","0400503000000000"); // i: fExoticMinEnergyCell = 3
   }else if (trainConfig == 1520){ // Min cluster energy variations
     cuts.AddCutHeavyMesonPCMCalo("00010113","0dm00009f9730000dge0404000","411790105fe20220000","32c51070a","0000003f00000000","0400503000000000"); // 2: E > 0.6
-    cuts.AddCutHeavyMesonPCMCalo("00010113","0dm00009f9730000dge0404000","411790105fe40220000","32c51070a","0000003f00000000","0400503000000000"); // 3: E > 0.8
+    cuts.AddCutHeavyMesonPCMCalo("00010113","0dm00009f9730000dge0404000","411790105fe40220000","32c51070a","0000003f00000000","0400503000000000"); // 4: E > 0.8
   }else if (trainConfig == 1521){ // NCell variation
     cuts.AddCutHeavyMesonPCMCalo("00010113","0dm00009f9730000dge0404000","411790105fe3n220000","32c51070a","0000003f00000000","0400503000000000");
   }else if (trainConfig == 1522){ // M02 variations


### PR DESCRIPTION
- Removed obsolete calo variations
- Introduced pT dep. pi0 window for mixed modes
- Included SubLambda correction in PCM AddTask
- Adjusted Lambda parameters from new train data