### PR TITLE
Fix bug in AliNormalizationCounter.cxx and activate the multiplicity in the event counter for Xic0 analysis

### DIFF
--- a/PWGHF/vertexingHF/AliAnalysisTaskSEXicZero2XiPifromKFP.cxx
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSEXicZero2XiPifromKFP.cxx
@@ -1576,6 +1576,7 @@ void AliAnalysisTaskSEXicZero2XiPifromKFP::UserCreateOutputObjects()
   AliAnalysisDataContainer *cont = GetOutputSlot(2)->GetContainer();
   if(cont) normName = (TString)cont->GetName();
   fCounter = new AliNormalizationCounter(normName.Data());
+  fCounter->SetStudyMultiplicity(kTRUE,1.);
   fCounter->Init();
   PostData(2, fCounter);
   DefineEvent();
@@ -1706,7 +1707,7 @@ void AliAnalysisTaskSEXicZero2XiPifromKFP::UserExec(Option_t *)
 
   fNtracklets = AliVertexingHFUtils::GetNumberOfTrackletsInEtaRange(AODEvent, -1., 1.);
   AliMultSelection *MultSelection = dynamic_cast<AliMultSelection*>(AODEvent->FindListObject("MultSelection"));
-  if(MultSelection)fCentrality = MultSelection->GetMultiplicityPercentile("V0M");
+  if (MultSelection) fCentrality = MultSelection->GetMultiplicityPercentile("V0M");
 
   //------------------------------------------------
   // Check if the event has v0 candidate

--- a/PWGHF/vertexingHF/AliAnalysisTaskSEXicZero2XiPifromKFP.cxx
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSEXicZero2XiPifromKFP.cxx
@@ -1579,6 +1579,7 @@ void AliAnalysisTaskSEXicZero2XiPifromKFP::UserCreateOutputObjects()
   fCounter->SetStudyMultiplicity(kTRUE,1.);
   fCounter->Init();
   PostData(2, fCounter);
+
   DefineEvent();
   PostData(3, fTree_Event);  // postdata will notify the analysis manager of changes / updates to the 
 
@@ -1624,7 +1625,14 @@ void AliAnalysisTaskSEXicZero2XiPifromKFP::UserExec(Option_t *)
   if (!fpVtx) return;
   fHistEvents->Fill(2);
 
-  fCounter->StoreEvent(AODEvent,fAnaCuts,fIsMC);
+  Int_t vzeroMult=0, vzeroMultA=0, vzeroMultC=0;
+  AliAODVZERO *vzeroAOD = (AliAODVZERO*)AODEvent->GetVZEROData();
+  if (vzeroAOD) {
+    vzeroMultA = static_cast<Int_t>(vzeroAOD->GetMTotV0A());
+    vzeroMultC = static_cast<Int_t>(vzeroAOD->GetMTotV0C());
+    vzeroMult  = vzeroMultA + vzeroMultC;
+  }
+  fCounter->StoreEvent(AODEvent,fAnaCuts,fIsMC,vzeroMult); // Fill "AliNormalizationCounter" with V0A+V0C multiplicity
 
   //------------------------------------------------
   // MC analysis setting                                                                    

--- a/PWGHF/vertexingHF/AliNormalizationCounter.cxx
+++ b/PWGHF/vertexingHF/AliNormalizationCounter.cxx
@@ -193,7 +193,7 @@ void AliNormalizationCounter::StoreEvent(AliVEvent *event,AliRDHFCuts *rdCut,Boo
   Int_t runNumber = event->GetRunNumber();
  
   // Evaluate the multiplicity
-  if(fMultiplicity && multiplicity==-9999) Multiplicity(event);
+  if(fMultiplicity && multiplicity==-9999) multiplicity = Multiplicity(event);
 
   //Find CINT1B
   AliESDEvent *eventESD = (AliESDEvent*)event;


### PR DESCRIPTION
Fix bug with multiplicity evaluation in the function StoreEvent() and activate the multiplicity in the event counter for Xic0 -> Xi pi analysis