### PR TITLE
PWGJE: Update to Track Skimming

### DIFF
--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskTrackSkim.h
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskTrackSkim.h
@@ -87,6 +87,7 @@ class AliAnalysisTaskTrackSkim : public AliAnalysisTaskEmcalJet
   // Basic configuration
   PWG::Tools::AliYAMLConfiguration fYAMLConfig; ///<  YAML configuration file.
   bool fConfigurationInitialized;               ///<  True if the task configuration has been successfully initialized.
+  bool fChargeScaling;                          ///<  Flag explicitly whether charge scaling is enabled.
 
   TH1F* fNAcceptedFirstTrackCollection;         //!<! Keep track of number of tracks in the first collection (which also tracks events with zero accepted tracks)
 
@@ -108,7 +109,7 @@ class AliAnalysisTaskTrackSkim : public AliAnalysisTaskEmcalJet
 
  private:
   /// \cond CLASSIMP
-  ClassDef(AliAnalysisTaskTrackSkim, 1)  // Track skim
+  ClassDef(AliAnalysisTaskTrackSkim, 2)  // Track skim
   /// \endcond
 };
 


### PR DESCRIPTION
PWGJE: To keep track of the charge of a track with track skimming without the need to store a extra int per track we multiply the track pt by -1 for tracks with charge -1. This is only enabled after explicitly setting the correct flag.