### PR TITLE
[PWGGA/GammaConv] reduce size of isolation tree

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskGammaIsoTree.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaIsoTree.cxx
@@ -2529,7 +2529,7 @@ void AliAnalysisTaskGammaIsoTree::UserCreateOutputObjects()
     if(fIsMC>0) fAnalysisTree->Branch("Event_Ntrials", &fBuffer_EventNtrials,"Event_Ntrials/s");
     fAnalysisTree->Branch("Event_NPrimaryTracks", &fBuffer_EventNPrimaryTracks,"Event_NPrimaryTracks/s");
     fAnalysisTree->Branch("Event_IsTriggered", &fBuffer_EventIsTriggered,"Event_IsTriggered/O");
-    fAnalysisTree->Branch("Event_ZVertex", &fBuffer_EventZVertex,"Event_ZVertex/D");
+    fAnalysisTree->Branch("Event_ZVertex", &fBuffer_EventZVertex,"Event_ZVertex/F");
     fAnalysisTree->Branch("Event_Quality", &fBuffer_EventQuality,"Event_Quality/s");
     fAnalysisTree->Branch("Event_NotAccepted", &fBuffer_EventNotAccepted,"Event_NotAccepted/s");
     fAnalysisTree->Branch("Cluster_E","std::vector<Float_t>",&fBuffer_ClusterE);
@@ -2733,8 +2733,10 @@ void AliAnalysisTaskGammaIsoTree::UserExec(Option_t *){
       if(!fUseHistograms){
         fBuffer_EventRho = fChargedRho;
         fBuffer_EventRhoMC = fChargedRhoMC;
-        fAnalysisTree->Fill();
-        PostData(2, fAnalysisTree);
+        if (fIsMC>0){ // only fill none accepted events for MC, not needed in data
+          fAnalysisTree->Fill();
+          PostData(2, fAnalysisTree);
+        }
       }
       ResetBuffer();
       return;
@@ -2749,8 +2751,10 @@ void AliAnalysisTaskGammaIsoTree::UserExec(Option_t *){
     if(!fUseHistograms){
       fBuffer_EventRho = fChargedRho;
       fBuffer_EventRhoMC = fChargedRhoMC;
-      fAnalysisTree->Fill();
-      PostData(2, fAnalysisTree);
+      if(fIsMC>0){ // only fill none accepted events for MC, not needed in data
+        fAnalysisTree->Fill();
+        PostData(2, fAnalysisTree);
+      }
     }
     ResetBuffer();
     return;
@@ -2821,9 +2825,14 @@ void AliAnalysisTaskGammaIsoTree::UserExec(Option_t *){
   if(!fUseHistograms){
     fBuffer_EventRho = fChargedRho;
     fBuffer_EventRhoMC = fChargedRhoMC;
-    
-    fAnalysisTree->Fill();
-    PostData(2, fAnalysisTree);
+    if(fIsMC>0){
+      fAnalysisTree->Fill();
+      PostData(2, fAnalysisTree);
+    } else{ // for data only fill event tree if clusters are found
+      // if(fBuffer_ClusterE.size()>0) fAnalysisTree->Fill();
+      fAnalysisTree->Fill();
+      PostData(2, fAnalysisTree);
+    }
   }
 
   if( fIsMC > 0 && fInputEvent->IsA()==AliAODEvent::Class() && !(fV0Reader->AreAODsRelabeled())){

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaIsoTree.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaIsoTree.h
@@ -718,7 +718,7 @@ class AliAnalysisTaskGammaIsoTree : public AliAnalysisTaskSE{
     UShort_t fBuffer_EventNtrials; //
     UShort_t fBuffer_EventNPrimaryTracks; //
     Bool_t fBuffer_EventIsTriggered; //
-    Double_t fBuffer_EventZVertex; //
+    Float_t fBuffer_EventZVertex; //
     UShort_t fBuffer_EventQuality; //
     UShort_t fBuffer_EventNotAccepted; //
 
@@ -822,7 +822,7 @@ class AliAnalysisTaskGammaIsoTree : public AliAnalysisTaskSE{
     Float_t CalculateIsoCorrectionFactor(Double_t cEta, Double_t maxEta, Double_t r);
     AliAnalysisTaskGammaIsoTree(const AliAnalysisTaskGammaIsoTree&); // Prevent copy-construction
     AliAnalysisTaskGammaIsoTree& operator=(const AliAnalysisTaskGammaIsoTree&); // Prevent assignment  
-    ClassDef(AliAnalysisTaskGammaIsoTree, 45);
+    ClassDef(AliAnalysisTaskGammaIsoTree, 46);
 
 };
 


### PR DESCRIPTION
- reduced size of photon isolation tree to avoid potential crashes when merging. Reduction is achieved by using float instead of double precision for the collision vertex and by only storing accepted events in data