### PR TITLE
PWGGA/GammaConv: Fix pi0-mass range and add TOF and DCA cutstrings

### DIFF
--- a/PWGGA/GammaConv/AliPrimaryPionCuts.cxx
+++ b/PWGGA/GammaConv/AliPrimaryPionCuts.cxx
@@ -120,7 +120,7 @@ AliPrimaryPionCuts::AliPrimaryPionCuts(const char *name,const char *title) : Ali
 	fHistTPCdEdxSignalafter(NULL),
 	fHistoTOFSigbefore(NULL),
 	fHistTOFbefore(NULL),
-	fHistTOFafter(NULL),
+	fHistTOFSigafter(NULL),
 	fHistTrackDCAxyPtbefore(NULL),
 	fHistTrackDCAxyPtafter(NULL),
 	fHistTrackDCAzPtbefore(NULL),
@@ -202,7 +202,7 @@ AliPrimaryPionCuts::AliPrimaryPionCuts(const AliPrimaryPionCuts &ref) : AliAnaly
 	fHistTPCdEdxSignalafter(NULL),
 	fHistoTOFSigbefore(NULL),
 	fHistTOFbefore(NULL),
-	fHistTOFafter(NULL),
+	fHistTOFSigafter(NULL),
 	fHistTrackDCAxyPtbefore(NULL),
 	fHistTrackDCAxyPtafter(NULL),
 	fHistTrackDCAzPtbefore(NULL),
@@ -299,7 +299,7 @@ void AliPrimaryPionCuts::InitCutHistograms(TString name, Bool_t preCut,TString c
 
 
 
-        fHistTOFbefore=new TH2F(Form("Pion_TOF_before %s",cutName.Data()),"TOF pion before" ,170,0.03,20,11000,-1000,10000);
+        fHistTOFbefore=new TH2F(Form("Pion_TOF_before %s",cutName.Data()),"TOF pion before" ,170,0.03,20,100,-1000,10000);
         fHistograms->Add(fHistTOFbefore);
         axisBeforeTOF = fHistTOFbefore->GetXaxis();
 		fHistoTOFSigbefore=new TH2F(Form("Pion_TOFSig_before %s",cutName.Data()),"TOF sigma pion before"  ,170,0.05,50,400,-6,10);
@@ -325,8 +325,8 @@ void AliPrimaryPionCuts::InitCutHistograms(TString name, Bool_t preCut,TString c
       fHistTPCdEdxSignalafter=new TH2F(Form("Pion_dEdxSignal_after %s",cutName.Data()),"dEdx pion signal after" ,170,0.05,50.0,800,0.0,200);
       fHistograms->Add(fHistTPCdEdxSignalafter);
 
-      fHistTOFafter=new TH2F(Form("Pion_TOFSig_after %s",cutName.Data()),"TOF sigma pion after" ,170,0.05,50,400,-6,10);
-      fHistograms->Add(fHistTOFafter);
+      fHistTOFSigafter=new TH2F(Form("Pion_TOFSig_after %s",cutName.Data()),"TOF sigma pion after" ,170,0.05,50,400,-6,10);
+      fHistograms->Add(fHistTOFSigafter);
 
       fHistTrackDCAxyPtafter  = new TH2F(Form("hTrack_DCAxy_Pt_after %s",cutName.Data()),"DCAxy Vs Pt of tracks after",800,-4.0,4.0,400,0.,10.);
       fHistograms->Add(fHistTrackDCAxyPtafter);
@@ -359,7 +359,7 @@ void AliPrimaryPionCuts::InitCutHistograms(TString name, Bool_t preCut,TString c
       Double_t factor = TMath::Power(to/from, 1./bins);
       for(Int_t i=1; i<=bins; ++i) newBins[i] = factor * newBins[i-1];
       AxisAfter->Set(bins, newBins);
-      AxisAfter = fHistTOFafter->GetXaxis();
+      AxisAfter = fHistTOFSigafter->GetXaxis();
       AxisAfter->Set(bins, newBins);
       AxisAfter = fHistITSdEdxafter->GetXaxis();
       AxisAfter->Set(bins,newBins);
@@ -709,7 +709,7 @@ Bool_t AliPrimaryPionCuts::dEdxCuts(AliVTrack *fCurrentTrack){
 				return kFALSE;
 			}
 		}
-		if(fHistTOFafter)fHistTOFafter->Fill(fCurrentTrack->P(),fPIDResponse->NumberOfSigmasTOF(fCurrentTrack, AliPID::kPion));
+		if(fHistTOFSigafter)fHistTOFSigafter->Fill(fCurrentTrack->P(),fPIDResponse->NumberOfSigmasTOF(fCurrentTrack, AliPID::kPion));
 	} else if ( fRequireTOF == kTRUE ) {
 		if(fHistdEdxCuts)fHistdEdxCuts->Fill(cutIndex);
 		return kFALSE;
@@ -742,15 +742,15 @@ AliVTrack *AliPrimaryPionCuts::GetTrack(AliVEvent * event, Int_t label){
      		return track;
     	} else{
        		for(Int_t ii=0; ii<event->GetNumberOfTracks(); ii++) {
-       			 if(event->GetTrack(ii)) track = dynamic_cast<AliVTrack*>(event->GetTrack(ii));
-         		 if(track){
-         			 if(track->GetID() == label) {
-           			 return track;
-          }
-        }
-      }
-    }
-  }
+       			if(event->GetTrack(ii)) track = dynamic_cast<AliVTrack*>(event->GetTrack(ii));
+         		if(track){
+         			if(track->GetID() == label) {
+           			return track;
+          			}
+        		}		
+     		 }
+    	}
+  	}
 	cout << "track not found " << label << " " << event->GetNumberOfTracks() << endl;
 	return NULL;
 }

--- a/PWGGA/GammaConv/AliPrimaryPionCuts.h
+++ b/PWGGA/GammaConv/AliPrimaryPionCuts.h
@@ -178,9 +178,11 @@ class AliPrimaryPionCuts : public AliAnalysisCuts {
 	Bool_t   fDoWeights;
     Double_t fMaxDCAToVertexZ;
     Double_t fMaxDCAToVertexXY;
+    Bool_t fUsePtDepZDCA;
     Bool_t fUsePtDepXYDCA;
     Bool_t fUseDCAToVertex2D;
     TString fMaxDCAToVertexXYPtDep;
+    TString fMaxDCAToVertexZPtDep;
 	Int_t  fRunFlag; // runflag used to set track prefiltering
 	
 
@@ -196,6 +198,7 @@ class AliPrimaryPionCuts : public AliAnalysisCuts {
 	TH2F *fHistTPCdEdxafter; // TPC dEdx after cuts
 	TH2F *fHistTPCdEdxSignalbefore; //TPC dEdx signal before
 	TH2F *fHistTPCdEdxSignalafter; //TPC dEdx signal  after
+	TH2F *fHistoTOFSigbefore; // TOF signal after cuts
 	TH2F *fHistTOFbefore; // TOF after cuts
 	TH2F *fHistTOFafter; // TOF after cuts
 	TH2F *fHistTrackDCAxyPtbefore;
@@ -218,7 +221,7 @@ class AliPrimaryPionCuts : public AliAnalysisCuts {
 	AliPrimaryPionCuts& operator=(const AliPrimaryPionCuts&); // not implemented
 
 
-    ClassDef(AliPrimaryPionCuts,15)
+    ClassDef(AliPrimaryPionCuts,16)
 };
 
 #endif

--- a/PWGGA/GammaConv/AliPrimaryPionCuts.h
+++ b/PWGGA/GammaConv/AliPrimaryPionCuts.h
@@ -189,7 +189,7 @@ class AliPrimaryPionCuts : public AliAnalysisCuts {
 
 	// Histograms
 	TObjString *fCutString; // cut number used for analysis
-  TString fCutStringRead;
+  	TString fCutStringRead;
 	TH1F *fHistCutIndex; // bookkeeping for cuts
 	TH1F *fHistdEdxCuts;  // bookkeeping for dEdx cuts
 	TH2F *fHistITSdEdxbefore; // ITS dEdx before cuts
@@ -198,9 +198,9 @@ class AliPrimaryPionCuts : public AliAnalysisCuts {
 	TH2F *fHistTPCdEdxafter; // TPC dEdx after cuts
 	TH2F *fHistTPCdEdxSignalbefore; //TPC dEdx signal before
 	TH2F *fHistTPCdEdxSignalafter; //TPC dEdx signal  after
-	TH2F *fHistoTOFSigbefore; // TOF signal after cuts
-	TH2F *fHistTOFbefore; // TOF after cuts
-	TH2F *fHistTOFafter; // TOF after cuts
+	TH2F *fHistoTOFSigbefore; // TOF signal before cuts
+	TH2F *fHistTOFbefore; // TOF before cuts
+	TH2F *fHistTOFSigafter; // TOF signal after cuts
 	TH2F *fHistTrackDCAxyPtbefore;
 	TH2F *fHistTrackDCAxyPtafter;
 	TH2F *fHistTrackDCAzPtbefore;

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_ConvMode_pPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_ConvMode_pPb.C
@@ -221,6 +221,13 @@ void AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_ConvMode_pPb(
     cuts.AddCutHeavyMesonPCM("80010113","0dm00009f9730000dge0404000","32c51070a","0103113s00000000","0153503000000000"); // PCM 2 sigma, pT > 0.4
     cuts.AddCutHeavyMesonPCM("80010113","0dm00009f9730000dge0404000","32c51070a","0103123s00000000","0153503000000000"); // PCM 2 sigma, pT > 0.7
     cuts.AddCutHeavyMesonPCM("80010113","0dm00009f9730000dge0404000","32c51070a","0103133s00000000","0153503000000000"); // PCM 2 sigma, pT > 0.9
+  }else if (trainConfig == 1011){ // TOF+DCA variations to increase charged pion purity
+    cuts.AddCutHeavyMesonPCM("80010113","0dm00009f9730000dge0404000","32c51070a","0000003z00000000","0400503000000000"); // Standard
+    cuts.AddCutHeavyMesonPCM("80010113","0dm00009f9730000dge0404000","32c51072a","0000003z00000000","0400503000000000"); // TOF PID if available +-5 sigma
+    cuts.AddCutHeavyMesonPCM("80010113","0dm00009f9730000dge0404000","32c31070a","0000003z00000000","0400503000000000"); // DCA xy pT dep.
+    cuts.AddCutHeavyMesonPCM("80010113","0dm00009f9730000dge0404000","32c31072a","0000003z00000000","0400503000000000"); // TOF PID if available +-5 sigma + DCA xy pT dep.
+    cuts.AddCutHeavyMesonPCM("80010113","0dm00009f9730000dge0404000","32c71070a","0000003z00000000","0400503000000000"); // DCA xyz pT dep.
+    cuts.AddCutHeavyMesonPCM("80010113","0dm00009f9730000dge0404000","32c71072a","0000003z00000000","0400503000000000"); // TOF PID if available +-5 sigma + DCA xyz pT dep.
 
     // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
     // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/PWGGA/GammaConvBase/AliConversionMesonCuts.cxx
+++ b/PWGGA/GammaConvBase/AliConversionMesonCuts.cxx
@@ -4869,10 +4869,10 @@ Bool_t AliConversionMesonCuts::MesonIsSelectedByMassCut(AliAODConversionMother *
           //----------
           //Width
           //----------
-          if ((meson->Pt())<1){
-              pt=1;
-          } else if ((meson->Pt())>10){
-              pt=10;
+          if ((meson->Pt())<0.5){
+              pt=0.5;
+          } else if ((meson->Pt())>7){
+              pt=7;
           } else {
               pt=(meson->Pt());
           }


### PR DESCRIPTION
- Added cutstrings to use TOF and restrict DCA for omega reconstruction
- Fixed TOF histogram labeling (->signal)
- Add pT dep. cut on the DCA_z for charged pions
- Fixed pi0 width for PCM pi0 mass cut