### PR TITLE
Fixed a library related bug at SVtaskMCFilter

### DIFF
--- a/PWGCF/Correlations/JCORRAN/Pro/AliJCDijetAna.cxx
+++ b/PWGCF/Correlations/JCORRAN/Pro/AliJCDijetAna.cxx
@@ -857,18 +857,21 @@ void AliJCDijetAna::CalculateDeltaM(int iJetSet, unsigned uLead, unsigned uSuble
     fastjet::PseudoJet doubleDeltaCone_fifthAlt = bgsubtrJeFifth1 + bgsubtrJeFifth2Alt;
 
     dijet = dijets.at(iJetSet).at(1).at(0) + dijets.at(iJetSet).at(1).at(1);
+    mjj=dijet.m();
 
-    fDeltaM=dijet.m()-doubleDeltaCone_fifth.m();
-    double fDeltaMAlt=dijet.m()-doubleDeltaCone_fifthAlt.m();
+    fDeltaM=mjj-doubleDeltaCone_fifth.m();
+    double fDeltaMAlt=mjj-doubleDeltaCone_fifthAlt.m();
     fhistos->fh_dijetdeltaM5[iJetSet]->Fill(fDeltaM,hisWeight);
     fhistos->fh_dijetdeltaM5Alt[iJetSet]->Fill(fDeltaMAlt,hisWeight);
+    int iDijetBin2 = fhistos->GetDijetMClass(mjj);
+    fhistos->fh_dijetdeltaM5Binned[iJetSet][iDijetBin2]->Fill(fDeltaMAlt,hisWeight);
     if(bConeNearJet)    fhistos->fh_dijetdeltaM5NearCone[iJetSet]->Fill(fDeltaM,hisWeight);
     if(bConeNearJetAlt) fhistos->fh_dijetdeltaM5NearConeAlt[iJetSet]->Fill(fDeltaMAlt,hisWeight);
     if(bConesOverlap) fhistos->fh_events[lcentBin]->Fill("cones overlap", 1.0);
     if(bConesOverlapAlt) fhistos->fh_events[lcentBin]->Fill("cones overlap alt", 1.0);
     fhistos->fh_dijetMLocalRho[iJetSet]->Fill(doubleDeltaCone_fifth.m(),hisWeight);
     fhistos->fh_dijetMLocalRhoAlt[iJetSet]->Fill(doubleDeltaCone_fifthAlt.m(),hisWeight);
-    fhistos->fh_deltaMResponse[iJetSet]->Fill(dijet.m()+fDeltaM, dijet.m(),hisWeight);
+    fhistos->fh_deltaMResponse[iJetSet]->Fill(mjj+fDeltaMAlt, mjj,hisWeight);
 
     return;
 }

--- a/PWGCF/Correlations/JCORRAN/Pro/AliJCDijetAna.h
+++ b/PWGCF/Correlations/JCORRAN/Pro/AliJCDijetAna.h
@@ -158,7 +158,7 @@ class AliJCDijetAna : public TObject
         unique_ptr<fastjet::ClusterSequenceArea> cs_bge;
 #endif
 
-        ClassDef(AliJCDijetAna, 1); // ClassDef needed if inheriting from TObject
+        ClassDef(AliJCDijetAna, 2); // ClassDef needed if inheriting from TObject
 
 };
 

--- a/PWGCF/Correlations/JCORRAN/Pro/AliJCDijetHistos.cxx
+++ b/PWGCF/Correlations/JCORRAN/Pro/AliJCDijetHistos.cxx
@@ -126,6 +126,7 @@ AliJCDijetHistos::AliJCDijetHistos() :
     fh_deltaLocalRhoAlt(),
     fh_dijetdeltaM5(),
     fh_dijetdeltaM5Alt(),
+    fh_dijetdeltaM5Binned(),
     fh_dijetdeltaM5NearCone(),
     fh_dijetdeltaM5NearConeAlt(),
     fh_dijetMLocalRho(),
@@ -238,6 +239,7 @@ AliJCDijetHistos::AliJCDijetHistos(const AliJCDijetHistos& obj) :
     fh_deltaLocalRhoAlt(obj.fh_deltaLocalRhoAlt),
     fh_dijetdeltaM5(obj.fh_dijetdeltaM5),
     fh_dijetdeltaM5Alt(obj.fh_dijetdeltaM5Alt),
+    fh_dijetdeltaM5Binned(obj.fh_dijetdeltaM5Binned),
     fh_dijetdeltaM5NearCone(obj.fh_dijetdeltaM5NearCone),
     fh_dijetdeltaM5NearConeAlt(obj.fh_dijetdeltaM5NearConeAlt),
     fh_dijetMLocalRho(obj.fh_dijetMLocalRho),
@@ -770,6 +772,10 @@ void AliJCDijetHistos::CreateEventTrackHistos(){
     fh_dijetdeltaM5Alt
         << TH1D("h_dijetdeltaM5Alt", "h_dijetdeltaM5Alt", 751, -250.5, 500.5)
         << fJetBin << "END" ;
+
+    fh_dijetdeltaM5Binned
+        << TH1D("h_dijetdeltaM5Binned", "h_dijetdeltaM5Binned", 751, -250.5, 500.5)
+        << fJetBin << fMBin << "END" ;
 
     fh_dijetdeltaM5NearCone
         << TH1D("h_dijetdeltaM5NearCone", "h_dijetdeltaM5NearCone", 751, -250.5, 500.5)

--- a/PWGCF/Correlations/JCORRAN/Pro/AliJCDijetHistos.h
+++ b/PWGCF/Correlations/JCORRAN/Pro/AliJCDijetHistos.h
@@ -173,6 +173,7 @@ class AliJCDijetHistos : public AliJHistogramInterface
         AliJTH1D fh_deltaLocalRhoAlt;            //! // Difference of localrho1 and localrho2
         AliJTH1D fh_dijetdeltaM5;             //! // Dijet deltaM
         AliJTH1D fh_dijetdeltaM5Alt;             //! // Dijet deltaM
+        AliJTH1D fh_dijetdeltaM5Binned;             //! // Dijet deltaM
         AliJTH1D fh_dijetdeltaM5NearCone;             //! // Dijet deltaM
         AliJTH1D fh_dijetdeltaM5NearConeAlt;             //! // Dijet deltaM
         AliJTH1D fh_dijetMLocalRho;            //! // Dijet deltaM with localrho

--- a/PWGCF/Correlations/JCORRAN/Pro/AliJCDijetTask.h
+++ b/PWGCF/Correlations/JCORRAN/Pro/AliJCDijetTask.h
@@ -171,6 +171,6 @@ class AliJCDijetTask : public AliAnalysisTaskSE {
         PWG::Tools::AliYAMLConfiguration fYAMLConfig; ///< yaml configuration
         TString fsAnchorPeriod;
 
-        ClassDef(AliJCDijetTask, 1); 
+        ClassDef(AliJCDijetTask, 2); 
 };
 #endif // ALIJCDIJETTASK_H

--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskSVtaskMCFilter.h
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskSVtaskMCFilter.h
@@ -55,6 +55,7 @@ class AliAnalysisTaskSVtaskMCFilter : public AliAnalysisTaskEmcal
    void     SetFilteredTracksName(const Char_t* name){   fFilteredTracksName   = name;  }
    void     SetFilteredClustersName(const Char_t* name){ fFilteredClustersName = name;  }
    void     SetFilterType(Int_t param){                  fFilterType           = param; }
+   TString  GetGenerator(Int_t label, AliAODMCHeader* header);
 
  protected:
    void ExecOnce();
@@ -78,7 +79,7 @@ class AliAnalysisTaskSVtaskMCFilter : public AliAnalysisTaskEmcal
     AliAnalysisTaskSVtaskMCFilter(const AliAnalysisTaskSVtaskMCFilter &source);
     AliAnalysisTaskSVtaskMCFilter& operator=(const AliAnalysisTaskSVtaskMCFilter& source);
 
-    ClassDef(AliAnalysisTaskSVtaskMCFilter, 3);
+    ClassDef(AliAnalysisTaskSVtaskMCFilter, 4);
 };
 
 #endif


### PR DESCRIPTION
Reimplemented a function GetGenerator from AliVertexingHFUtils to the SVtaskMCFilter as the run would crash when using the function from HFUtils. I tried fixing the problem without copying it in numerous ways but unsuccesfully. Also added a histogram to the dijet code unrelated to this problem.