### PR TITLE
Optional no-event-selection mode

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.cxx
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.cxx
@@ -138,6 +138,7 @@ AliAnalysisTaskEmcal::AliAnalysisTaskEmcal() :
   fMCRejectFilter(kFALSE),
   fCountDownscaleCorrectedEvents(kFALSE),
   fUseBuiltinEventSelection(kFALSE),
+  fUseNoEventSelection(false),
   fReadPyxsecFast(true),
   fPtHardAndJetPtFactor(0.),
   fPtHardAndClusterPtFactor(0.),
@@ -265,6 +266,7 @@ AliAnalysisTaskEmcal::AliAnalysisTaskEmcal(const char *name, Bool_t histo) :
   fMCRejectFilter(kFALSE),
   fCountDownscaleCorrectedEvents(kFALSE),
   fUseBuiltinEventSelection(kFALSE),
+  fUseNoEventSelection(false),
   fReadPyxsecFast(true),
   fPtHardAndJetPtFactor(0.),
   fPtHardAndClusterPtFactor(0.),
@@ -1272,6 +1274,7 @@ Bool_t AliAnalysisTaskEmcal::HasTriggerType(TriggerType trigger)
 }
 
 Bool_t AliAnalysisTaskEmcal::IsEventSelected(){
+  if(fUseNoEventSelection) return true;
   if(fUseBuiltinEventSelection) return IsEventSelectedInternal();
   if(!IsTriggerSelected()) return false;
   if(!CheckMCOutliers()) return false;

--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.h
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.h
@@ -614,6 +614,16 @@ class AliAnalysisTaskEmcal : public AliAnalysisTaskSE {
    */
   void                        SetUseBuiltinEventSelection(Bool_t doUse)            { fUseBuiltinEventSelection = doUse                  ; }
 
+   /**
+   * @brief Do not apply any event selection, process all events
+   * @param[in] doUse It true no event selection is applied
+   * 
+   * Feature is only intended for service wagons based on the AliAnalysisTaskEmcal which do not 
+   * know the event selection in consumer tasks in the train and as such should process all events
+   * in order not to apply a bias on other tasks due to its own internal event selection
+   */
+  void                        SetUseNoEventSelection(Bool_t doUse)                 { fUseNoEventSelection = doUse                       ; }
+
   /**
    * @brief Use fast method for PYTHIA cross section reading
    * @param doRead If true the fast method is used for cross section reading
@@ -1411,6 +1421,7 @@ class AliAnalysisTaskEmcal : public AliAnalysisTaskSE {
   Bool_t                      fMCRejectFilter;             ///< enable the filtering of events by tail rejection
   Bool_t                      fCountDownscaleCorrectedEvents; ///< Count event number corrected for downscaling
   Bool_t                      fUseBuiltinEventSelection;   ///< Use builtin event selection of the AliAnalysisTaskEmcal instead of AliEventCuts
+  Bool_t                      fUseNoEventSelection;        ///< Do not apply event selection but process every event (for service tasks and MC-gen based tasks)
   Bool_t                      fReadPyxsecFast;             ///< Use fast method for pythia cross section reading
   Float_t                     fPtHardAndJetPtFactor;       ///< Factor between ptHard and jet pT to reject/accept event.
   Float_t                     fPtHardAndClusterPtFactor;   ///< Factor between ptHard and cluster pT to reject/accept event.


### PR DESCRIPTION
Needed for service wagon which should run under
conditions as loose as possible to not create a bias
on consumer wagons which might have a different
(less strict) event selection