### PR TITLE
Overhaul of GFWFlow & friends, details in the comments:

### DIFF
--- a/PWGCF/FLOW/GF/AliAnalysisTaskGFWFlow.cxx
+++ b/PWGCF/FLOW/GF/AliAnalysisTaskGFWFlow.cxx
@@ -39,11 +39,9 @@ ClassImp(AliAnalysisTaskGFWFlow);
 
 AliAnalysisTaskGFWFlow::AliAnalysisTaskGFWFlow():
   AliAnalysisTaskSE(),
-  debugpar(0),
   fTriggerType(AliVEvent::kINT7),
   fProduceWeights(kTRUE),
   fWeightList(0),
-  fWeightFile(0),
   fCentMap(0),
   fWeights(0),
   fFC(0),
@@ -68,11 +66,9 @@ AliAnalysisTaskGFWFlow::AliAnalysisTaskGFWFlow():
 };
 AliAnalysisTaskGFWFlow::AliAnalysisTaskGFWFlow(const char *name, Bool_t ProduceWeights, Bool_t IsMC, Bool_t IsTrain):
   AliAnalysisTaskSE(name),
-  debugpar(0),
   fTriggerType(AliVEvent::kINT7),
   fProduceWeights(ProduceWeights),
   fWeightList(0),
-  fWeightFile(0),
   fCentMap(0),
   fWeights(0),
   fFC(0),
@@ -95,7 +91,7 @@ AliAnalysisTaskGFWFlow::AliAnalysisTaskGFWFlow(const char *name, Bool_t ProduceW
 {
   if(!fProduceWeights) {
     if(fIsTrain) DefineInput(1,TH1D::Class());
-    else DefineInput(1,TFile::Class());
+    else DefineInput(1,TList::Class());
   }
   DefineOutput(1,(fProduceWeights?TList::Class():AliGFWFlowContainer::Class()));
   DefineOutput(2,TH1D::Class());
@@ -286,8 +282,8 @@ void AliAnalysisTaskGFWFlow::UserCreateOutputObjects(){
       fCentMap = (TH1D*) GetInputData(1);
       if(!fCentMap) AliFatal("Could not fetch centrality map!\n");
     } else {
-      fWeightFile = (TFile*) GetInputData(1);
-      if(!fWeightFile) { AliFatal("Could not retrieve weight list!\n"); return; };
+      fWeightList = (TList*) GetInputData(1);
+      if(!fWeightList) { AliFatal("Could not retrieve weight list!\n"); return; };
     };
     CreateCorrConfigs();
   };
@@ -306,7 +302,7 @@ AliMCEvent *AliAnalysisTaskGFWFlow::FetchMCEvent(Double_t &impactParameter) {
   return ev;*/
 
   //The old implementation
-  if(!fIsTrain) { AliFatal("Snap, Jim! Ain't no train here!\n"); return 0; }
+  if(!fIsTrain) { AliFatal("Snap, Jim! Ain't no train here! :(\n"); return 0; }
   AliMCEvent* ev = dynamic_cast<AliMCEvent*>(MCEvent());
   if(!ev) { AliFatal("MC event not found!"); return 0; }
   if(fOverrideCentrality>=0) return ev;
@@ -491,9 +487,11 @@ Bool_t AliAnalysisTaskGFWFlow::CheckTriggerVsCentrality(Double_t l_cent) {
   return kTRUE;
 }
 Bool_t AliAnalysisTaskGFWFlow::LoadWeights(Int_t runno) { //Cannot be used when running on the trains
-  if(fWeightFile) {
-    fWeights = (AliGFWWeights*)fWeightFile->Get(Form("w%i%s",runno,GetSystPF(BitIndex(fEvNomFlag), BitIndex(fTrNomFlag)).Data()));
+  TString wName=Form("w%i%s",runno,GetSystPF(BitIndex(fEvNomFlag), BitIndex(fTrNomFlag)).Data());
+  if(fWeightList) {
+    fWeights = (AliGFWWeights*)fWeightList->FindObject(wName.Data());
     if(!fWeights) {
+      fWeightList->ls();
       AliFatal("Weights could not be found in the list!\n");
       return kFALSE;
     };
@@ -606,80 +604,87 @@ void AliAnalysisTaskGFWFlow::CreateCorrConfigs() {
   corrconfigs.push_back(GetConf("MidGapPV52","poiGapPos refGapPos | olGapPos {5} refGapNeg {-5}", kTRUE));
 }
 void AliAnalysisTaskGFWFlow::SetupFlagsByIndex(Int_t ind) {
-  fEvNomFlag=1<<kNominal;
-  fTrNomFlag=1<<kFB96;
+  SetupFlagsByIndex(ind,fEvNomFlag,fTrNomFlag);
+}
+void AliAnalysisTaskGFWFlow::SetupFlagsByIndex(const Int_t &ind, UInt_t &l_EvFlag, UInt_t &l_TrFlag) {
+  l_EvFlag=1<<kNominal;
+  l_TrFlag=1<<kFB96;
   switch(ind) {
     default: // also 0
       break;
     //Event flags:
     case 1:
-      fEvNomFlag = 1<<kVtx9;
+      l_EvFlag = 1<<kVtx9;
       break;
     case 2:
-      fEvNomFlag = 1<<kVtx7;
+      l_EvFlag = 1<<kVtx7;
       break;
     case 3:
-      fEvNomFlag = 1<<kVtx5;
+      l_EvFlag = 1<<kVtx5;
       break;
     //Track flags:
     case 4:
-      fTrNomFlag = 1<<kFB768;
+      l_TrFlag = 1<<kFB768;
       break;
     case 5:
-      fTrNomFlag = 1<<kDCAz10;
+      l_TrFlag = 1<<kDCAz10;
       break;
     case 6:
-      fTrNomFlag = 1<<kDCAz05;
+      l_TrFlag = 1<<kDCAz05;
       break;
     case 7:
-      fTrNomFlag = 1<<kDCA4Sigma;
+      l_TrFlag = 1<<kDCA4Sigma;
       break;
     case 8:
-      fTrNomFlag = 1<<kDCA10Sigma;
+      l_TrFlag = 1<<kDCA10Sigma;
       break;
     case 9:
-      fTrNomFlag = 1<<kChiSq2;
+      l_TrFlag = 1<<kChiSq2;
       break;
     case 10:
-      fTrNomFlag = 1<<kChiSq3;
+      l_TrFlag = 1<<kChiSq3;
       break;
     case 11:
-      fTrNomFlag = 1<<kNTPC80;
+      l_TrFlag = 1<<kNTPC80;
       break;
     case 12:
-      fTrNomFlag = 1<<kNTPC90;
+      l_TrFlag = 1<<kNTPC90;
       break;
     case 13:
-      fTrNomFlag = 1<<kNTPC100;
+      l_TrFlag = 1<<kNTPC100;
       break;
     case 14:
-      fTrNomFlag = 1<<kFB768Tuned;
+      l_TrFlag = 1<<kFB768Tuned;
       break;
     case 15:
-      fTrNomFlag = 1<<kFB96Tuned;
+      l_TrFlag = 1<<kFB96Tuned;
       break;
     case 16:
-      fTrNomFlag = 1<<kFB768DCAz;
+      l_TrFlag = 1<<kFB768DCAz;
       break;
     case 17:
-      fTrNomFlag = 1<<kFB768DCAxyLow;
+      l_TrFlag = 1<<kFB768DCAxyLow;
       break;
     case 18:
-      fTrNomFlag = 1<<kFB768DCAxyHigh;
+      l_TrFlag = 1<<kFB768DCAxyHigh;
       break;
     case 19:
-      fTrNomFlag = 1<<kFB768ChiSq2;
+      l_TrFlag = 1<<kFB768ChiSq2;
       break;
     case 20:
-      fTrNomFlag = 1<<kFB768ChiSq3;
+      l_TrFlag = 1<<kFB768ChiSq3;
       break;
     case 21:
-      fTrNomFlag = 1<<kFB768nTPC;
+      l_TrFlag = 1<<kFB768nTPC;
       break;
     case 22:
-      fTrNomFlag = 1<<kFB96MergedDCA;
-    case 23:
-      fTrNomFlag = 1<<kChiSq25;
+      l_TrFlag = 1<<kFB96MergedDCA;
+      break;
+    case 23: //This will now be used for rebinned NUA test
+      l_TrFlag = 1<<kChiSq25;
+      break;
+    case 24:
+      l_TrFlag = 1<<kRebinnedNUA;
       break;
   }
 }

--- a/PWGCF/FLOW/GF/AliAnalysisTaskGFWFlow.h
+++ b/PWGCF/FLOW/GF/AliAnalysisTaskGFWFlow.h
@@ -11,8 +11,9 @@ Extention of Generic Flow (https://arxiv.org/abs/1312.3572)
 #include "TStopwatch.h"
 #include "AliGFW.h"
 #include "AliVEvent.h"
+#include "GFWFlags.h"
 #include "AliGFWFilter.h"
-
+// #include "TGrid.h"
 
 class TList;
 class TH1D;
@@ -39,7 +40,6 @@ class AliAnalysisUtils;
 using namespace GFWFlags;
 class AliAnalysisTaskGFWFlow : public AliAnalysisTaskSE {
  public:
-  Int_t debugpar;
   AliAnalysisTaskGFWFlow();
   AliAnalysisTaskGFWFlow(const char *name, Bool_t ProduceWeights=kTRUE, Bool_t IsMC=kTRUE, Bool_t IsTrain=kFALSE);
   virtual ~AliAnalysisTaskGFWFlow();
@@ -50,7 +50,8 @@ class AliAnalysisTaskGFWFlow : public AliAnalysisTaskSE {
   void SetPtBins(Int_t nBins, Double_t *bins, Double_t RFpTMin=-1, Double_t RFpTMax=-1); //Also set the RF pT acceptance
   //In case we want custom nominal flags (defaults are the first ones)
   void SetNominalFlags(Int_t lEvFlagIndex, Int_t lTrFlagIndex) { fEvNomFlag=(1<<lEvFlagIndex); fTrNomFlag=(1<<lTrFlagIndex); };
-  void SetupFlagsByIndex(Int_t ind); //Just a [hardcoded] helper, so that one doesn't have to manually go through all the flags
+  void SetupFlagsByIndex(Int_t ind); //Local envelope for the function below
+  static void SetupFlagsByIndex(const Int_t &ind, UInt_t &l_EvFlag, UInt_t &l_TrFlag); //Function to setup flags. Static, so one is able to call from the outside
   void SetCustomNoFlags(Int_t nEvFlags, Int_t nTrFlags) {fTotTrackFlags=nTrFlags; fTotEvFlags=nEvFlags; };
   vector<AliGFW::CorrConfig> corrconfigs; //! do not store
   AliGFW::CorrConfig GetConf(TString head, TString desc, Bool_t ptdif) { return fGFW->GetCorrelatorConfig(desc,head,ptdif);};
@@ -65,7 +66,6 @@ class AliAnalysisTaskGFWFlow : public AliAnalysisTaskSE {
   UInt_t fTriggerType; //Need to store this for it to be able to work on trains
   Bool_t fProduceWeights;
   TList *fWeightList; //! Stored via PostData
-  TFile *fWeightFile; //! File with weights, read-only
   TH1D *fCentMap; //! centrality map for on-fly trains
   AliGFWWeights *fWeights; //! these are stored in a list now
   AliGFWFlowContainer *fFC; // Flow container

--- a/PWGCF/FLOW/GF/AliGFWFilter.cxx
+++ b/PWGCF/FLOW/GF/AliGFWFilter.cxx
@@ -167,6 +167,8 @@ void AliGFWFilter::CreateStandardCutMasks(kLocalTrackFlags lStandardChi2Cut) {
   fTrackMasks.push_back(klFB96 + klDCAz20 + klDCAxy2010 + klDCAxy2011 + lStandardChi2Cut + klNTPCcls70);
   //Standard FB96 with chi2 < 2.5 cut -- for testing LHC15o_pass1, assuming that standard is 4.0
   fTrackMasks.push_back(klFB96 + klDCAz20 + klDCAxy2011 + klTPCchi2PC25 + klNTPCcls70);
+  //Same as the nominal tracks, but need to replicate for NUA rebinning
+  fTrackMasks.push_back(klFB96 + klDCAz20 + klDCAxy2011 + lStandardChi2Cut + klNTPCcls70);
 
   //Event cuts:
   // if(!fEventMasks) fEventMasks = new UInt_t[gNEventFlags];

--- a/PWGCF/FLOW/GF/AliGFWFilter.h
+++ b/PWGCF/FLOW/GF/AliGFWFilter.h
@@ -19,69 +19,8 @@
 #include "AliAODInputHandler.h"
 #include "AliAODVertex.h"
 #include "AliEventCuts.h"
+#include "GFWFlags.h"
 using namespace std;
-namespace GFWFlags {
-  enum kLocalEventFlags {
-    klEventCuts =      BIT(0), //Event cuts (AliEventCuts)
-    klVtxOK =          BIT(1), //Vertex rezolution
-    klVtxZ10 =         BIT(2), //Vtx. z < 10 cm
-    klVtxZ5 =          BIT(3), //Vtx. z < 5 cm
-    klVtxZ7 =          BIT(4), //Vtx. z < 7 cm
-    klVtxZ9 =          BIT(5)  //Vtx. z < 9 cm
-  };
-  enum kLocalTrackFlags {
-    klFB32 =           BIT(0), //FB32
-    klFB64 =           BIT(1), //FB64
-    klFB256 =          BIT(2), //FB256
-    klFB512 =          BIT(3), //FB512
-    klFB96 =           BIT(4), //FB96 ( 32 || 64)
-    klFB96Tuned =      BIT(5), //FB96 with fraction of shared TPC Clusters < 0.4 (for compatibility with FB768Tuned)
-    klFB768 =          BIT(6), //FB768 (256 || 512)
-    klFB768Tuned =     BIT(7), //FB768 where 512 FB requires a hit on first SDD (for compatibility with FB96Tuned)
-    klSharedClusters = BIT(8), //fraction of shared TPC clusters < 0.4
-    klHitOnSDD =       BIT(9), //hit on first layer of SDD
-    klNoSPD =          BIT(10), //hit on first layer of SDD
-    klDCAz20 =         BIT(11),//DCA z < 2 cm
-    klDCAz10 =         BIT(12),//DCA z < 1 cm
-    klDCAz05 =         BIT(13),//DCA z < 0.5 cm
-    klDCAxy2010 =      BIT(14),//DCAxy cut tuned to 2010
-    klDCAxy2011 =      BIT(15),//DCAxy cut tuned to 2011
-    klDCAxy8Sigma =    BIT(16),//DCAxy cut on 8 sigma, 2011
-    klDCAxy4Sigma =    BIT(17),//DCAxy cut on 4 sigma, 2011
-    klDCAxy10Sigma =   BIT(18),//DCAxy cut on 10 sigma, 2011
-    klTPCchi2PC25 =    BIT(19),//TPC chi2/cluster < 2.5
-    klTPCchi2PC20 =    BIT(20),//TPC chi2/cluster < 2.0
-    klTPCchi2PC30 =    BIT(21),//TPC chi2/cluster < 3.0
-    klTPCchi2PC40 =    BIT(22),//TPC chi2/cluster < 4.0
-    klNTPCcls70 =      BIT(23),//Number of TPC clusters 70
-    klNTPCcls80 =      BIT(24),//Number of TPC clusters 80
-    klNTPCcls90 =      BIT(25),//Number of TPC clusters 90
-    klNTPCcls100 =     BIT(26)//Number of TPC clusters 100
-  };
-  enum EventFlags { kNominal=0, kVtx9, kVtx7, kVtx5, kAllEvFlags}; //Better keep these as uint_t so that we reuse them as array indeces
-  enum TrackFlags { kFB96=0, kFB768,
-                    kDCAz10, kDCAz05,
-                    kDCA4Sigma, kDCA10Sigma,
-                    kChiSq2, kChiSq3,
-                    kNTPC80, kNTPC90, kNTPC100,
-                    kFB96Tuned, kFB768Tuned, //These are for developing purposes and shouldn't be used!
-                    kFB768DCAz,
-                    kFB768DCAxyLow,
-                    kFB768DCAxyHigh,
-                    kFB768ChiSq2, kFB768ChiSq3,
-                    kFB768nTPC, kFB96MergedDCA,
-                    kChiSq25, //For testing purposes on 15_pass1 data
-                    kAllTrFlags
-                  };
-  static const Int_t BitIndex(const UInt_t &lFlag) {
-    if(lFlag==0) return -1;
-    for(Int_t i=0;i<sizeof(lFlag)*8;i++) if(lFlag&(1<<i)) return i;
-    return -1;
-  };
-  static const TString GetSystPF(UInt_t lEv, UInt_t lTr) { return TString(Form("_Ev%i_Tr%i",lEv,lTr)); };
-  const Int_t gNTrackFlags=21;
-  const Int_t gNEventFlags=4;
-};
 using namespace GFWFlags;
 class AliGFWFlags: public TNamed
 {

--- a/PWGCF/FLOW/GF/AliGFWWeights.cxx
+++ b/PWGCF/FLOW/GF/AliGFWWeights.cxx
@@ -19,6 +19,15 @@ AliGFWWeights::AliGFWWeights():
   fbinsPt(0)
 {
 };
+AliGFWWeights::AliGFWWeights(const AliGFWWeights& target):
+  TNamed(target)
+{
+  fDataFilled = target.fDataFilled;
+  fMCFilled = target.fMCFilled;
+  if(target.fW_data) fW_data = (TObjArray*)target.fW_data->Clone(target.fW_data->GetName());
+  if(target.fW_mcrec) fW_mcrec = (TObjArray*)target.fW_mcrec->Clone(target.fW_mcrec->GetName());
+  if(target.fW_mcgen) fW_mcgen = (TObjArray*)target.fW_mcgen->Clone(target.fW_mcgen->GetName());
+};
 AliGFWWeights::~AliGFWWeights()
 {
   delete fW_data;

--- a/PWGCF/FLOW/GF/AliGFWWeights.h
+++ b/PWGCF/FLOW/GF/AliGFWWeights.h
@@ -19,6 +19,7 @@ class AliGFWWeights: public TNamed
 {
  public:
   AliGFWWeights();
+  AliGFWWeights(const AliGFWWeights&);
   ~AliGFWWeights();
   void Init(Bool_t AddData=kTRUE, Bool_t AddM=kTRUE);
   void Fill(Double_t phi, Double_t eta, Double_t vz, Double_t pt, Double_t cent, Int_t htype, Double_t weight=1); //htype: 0 for data, 1 for mc rec, 2 for mc gen

--- a/PWGCF/FLOW/GF/CMakeLists.txt
+++ b/PWGCF/FLOW/GF/CMakeLists.txt
@@ -95,6 +95,8 @@ endif()
 
 # Headers from sources
 string(REPLACE ".cxx" ".h" HDRS "${SRCS}")
+# Also add the header with GFW flags
+list(APPEND HDRS GFWFlags.h)
 
 # Generate the dictionary
 # It will create G_ARG1.cxx and G_ARG1.h / ARG1 = function first argument

--- a/PWGCF/FLOW/GF/GFWFlags.h
+++ b/PWGCF/FLOW/GF/GFWFlags.h
@@ -1,0 +1,66 @@
+#ifndef GFWFLAGS__H
+#define GFWFLAGS__H
+namespace GFWFlags {
+  enum kLocalEventFlags {
+    klEventCuts =      BIT(0), //Event cuts (AliEventCuts)
+    klVtxOK =          BIT(1), //Vertex rezolution
+    klVtxZ10 =         BIT(2), //Vtx. z < 10 cm
+    klVtxZ5 =          BIT(3), //Vtx. z < 5 cm
+    klVtxZ7 =          BIT(4), //Vtx. z < 7 cm
+    klVtxZ9 =          BIT(5)  //Vtx. z < 9 cm
+  };
+  enum kLocalTrackFlags {
+    klFB32 =           BIT(0), //FB32
+    klFB64 =           BIT(1), //FB64
+    klFB256 =          BIT(2), //FB256
+    klFB512 =          BIT(3), //FB512
+    klFB96 =           BIT(4), //FB96 ( 32 || 64)
+    klFB96Tuned =      BIT(5), //FB96 with fraction of shared TPC Clusters < 0.4 (for compatibility with FB768Tuned)
+    klFB768 =          BIT(6), //FB768 (256 || 512)
+    klFB768Tuned =     BIT(7), //FB768 where 512 FB requires a hit on first SDD (for compatibility with FB96Tuned)
+    klSharedClusters = BIT(8), //fraction of shared TPC clusters < 0.4
+    klHitOnSDD =       BIT(9), //hit on first layer of SDD
+    klNoSPD =          BIT(10), //hit on first layer of SDD
+    klDCAz20 =         BIT(11),//DCA z < 2 cm
+    klDCAz10 =         BIT(12),//DCA z < 1 cm
+    klDCAz05 =         BIT(13),//DCA z < 0.5 cm
+    klDCAxy2010 =      BIT(14),//DCAxy cut tuned to 2010
+    klDCAxy2011 =      BIT(15),//DCAxy cut tuned to 2011
+    klDCAxy8Sigma =    BIT(16),//DCAxy cut on 8 sigma, 2011
+    klDCAxy4Sigma =    BIT(17),//DCAxy cut on 4 sigma, 2011
+    klDCAxy10Sigma =   BIT(18),//DCAxy cut on 10 sigma, 2011
+    klTPCchi2PC25 =    BIT(19),//TPC chi2/cluster < 2.5
+    klTPCchi2PC20 =    BIT(20),//TPC chi2/cluster < 2.0
+    klTPCchi2PC30 =    BIT(21),//TPC chi2/cluster < 3.0
+    klTPCchi2PC40 =    BIT(22),//TPC chi2/cluster < 4.0
+    klNTPCcls70 =      BIT(23),//Number of TPC clusters 70
+    klNTPCcls80 =      BIT(24),//Number of TPC clusters 80
+    klNTPCcls90 =      BIT(25),//Number of TPC clusters 90
+    klNTPCcls100 =     BIT(26)//Number of TPC clusters 100
+  };
+  enum EventFlags { kNominal=0, kVtx9, kVtx7, kVtx5, kAllEvFlags}; //Better keep these as uint_t so that we reuse them as array indeces
+  enum TrackFlags { kFB96=0, kFB768,
+                    kDCAz10, kDCAz05,
+                    kDCA4Sigma, kDCA10Sigma,
+                    kChiSq2, kChiSq3,
+                    kNTPC80, kNTPC90, kNTPC100,
+                    kFB96Tuned, kFB768Tuned, //These are for developing purposes and shouldn't be used!
+                    kFB768DCAz,
+                    kFB768DCAxyLow,
+                    kFB768DCAxyHigh,
+                    kFB768ChiSq2, kFB768ChiSq3,
+                    kFB768nTPC, kFB96MergedDCA,
+                    kChiSq25, //For testing purposes on 15_pass1 data
+                    kRebinnedNUA, //For testing effects of NUA rebinning
+                    kAllTrFlags
+                  };
+  static inline const Int_t BitIndex(const UInt_t &lFlag) {
+    if(lFlag==0) return -1;
+    for(Int_t i=0;i<sizeof(lFlag)*8;i++) if(lFlag&(1<<i)) return i;
+    return -1;
+  };
+  static inline const TString GetSystPF(UInt_t lEv, UInt_t lTr) { return TString(Form("_Ev%i_Tr%i",lEv,lTr)); };
+  const Int_t gNTrackFlags=22;
+  const Int_t gNEventFlags=4;
+};
+#endif

--- a/PWGCF/FLOW/GF/PWGCFFLOWGFLinkDef.h
+++ b/PWGCF/FLOW/GF/PWGCFFLOWGFLinkDef.h
@@ -45,6 +45,7 @@
 #pragma link C++ class AliAnalysisTaskFlowPPTask+;
 #pragma link C++ class AliAnalysisTaskGFWFlow+;
 #pragma link C++ class AliGFWFlags+;
+#pragma link C++ defined_in AliGFWFilter;
 #pragma link C++ class AliGFWFilter+;
 #pragma link C++ class AliGFWFilterTask+;
 #pragma link C++ class AliAnalysisTaskJetQ+;
@@ -63,6 +64,7 @@
 #pragma link C++ class AliLWFMDTrack+;
 #pragma link C++ class AliLWEvent+;
 #pragma link C++ class AliAnalysisTaskLWTree+;
-
+#pragma link C++ namespace GFWFlags;
+#pragma link C++ defined_in GFWFlags;
 
 #endif


### PR DESCRIPTION
--  Moving GFWFlags to a separate header for easier configuration.
--  NUAs are now stored in a TFile, and not as TList. The weight list is now generated on-fly in AddMacro, and only relevant weights are considered.
-- Set everything up to run a test for different NUA binning, as the standard NUAs are too heavy to be stored in a file.
-- AliGFWWeights has a deep copy constructor now