### PR TITLE
PWGGA/GammaConv: Add option to use central event selection in meson task

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskMesonJetCorrelation.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskMesonJetCorrelation.cxx
@@ -34,6 +34,7 @@ ClassImp(AliAnalysisTaskMesonJetCorrelation)
                                                                              fInputEvent(nullptr),
                                                                              fMCEvent(nullptr),
                                                                              fAODMCTrackArray(nullptr),
+                                                                             fAliEventCuts(false),
                                                                              // cut folders
                                                                              fCutFolder(nullptr),
                                                                              fESDList(nullptr),
@@ -82,6 +83,7 @@ ClassImp(AliAnalysisTaskMesonJetCorrelation)
                                                                              fUseThNForResponse(true),
                                                                              fEnableSortForClusMC(true),
                                                                              fFillDCATree(false),
+                                                                             fUseCentralEventSelection(true),
                                                                              // aod relabeling
                                                                              fMCEventPos(nullptr),
                                                                              fMCEventNeg(nullptr),
@@ -263,6 +265,7 @@ AliAnalysisTaskMesonJetCorrelation::AliAnalysisTaskMesonJetCorrelation(const cha
                                                                                            fInputEvent(nullptr),
                                                                                            fMCEvent(nullptr),
                                                                                            fAODMCTrackArray(nullptr),
+                                                                                           fAliEventCuts(false),
                                                                                            // cut folders
                                                                                            fCutFolder(nullptr),
                                                                                            fESDList(nullptr),
@@ -311,6 +314,7 @@ AliAnalysisTaskMesonJetCorrelation::AliAnalysisTaskMesonJetCorrelation(const cha
                                                                                            fUseThNForResponse(true),
                                                                                            fEnableSortForClusMC(true),
                                                                                            fFillDCATree(false),
+                                                                                           fUseCentralEventSelection(true),
                                                                                            // aod relabeling
                                                                                            fMCEventPos(nullptr),
                                                                                            fMCEventNeg(nullptr),
@@ -480,6 +484,9 @@ AliAnalysisTaskMesonJetCorrelation::AliAnalysisTaskMesonJetCorrelation(const cha
                                                                                            fDCATree_JetPt(0),
                                                                                            fDCATree_isTrueMeson(false)
 {
+  // Do not perform trigger selection in the AliEvent cuts but let the task do this before
+  fAliEventCuts.OverrideAutomaticTriggerSelection(AliVEvent::kAny, true);
+
   // Define output slots here
   DefineOutput(1, TList::Class());
   DefineOutput(2, TTree::Class());
@@ -1370,6 +1377,10 @@ void AliAnalysisTaskMesonJetCorrelation::UserCreateOutputObjects()
           fTrueList[iCut]->Add(fRespMatrixHandlerFragTrueJets[iCut]->GetTH2("Frag_JetPt_TrueVsRec_ForTrueJets"));
       }
     }
+    
+    if(fUseCentralEventSelection){
+      fAliEventCuts.AddQAplotsToList(fESDList[iCut]);
+    }
 
     // Call Sumw2 forall histograms in list
     if (fIsMC) {
@@ -1810,6 +1821,12 @@ void AliAnalysisTaskMesonJetCorrelation::UserExec(Option_t*)
         fHistoNEvents[iCut]->Fill(10, fWeightJetJetMC);
         if (fIsMC > 1)
           fHistoNEventsWOWeight[iCut]->Fill(10);
+        continue;
+      }
+    }
+    
+    if(fUseCentralEventSelection){
+      if(!fAliEventCuts.AcceptEvent(fInputEvent)){
         continue;
       }
     }

--- a/PWGGA/GammaConv/AliAnalysisTaskMesonJetCorrelation.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskMesonJetCorrelation.h
@@ -116,6 +116,7 @@ class AliAnalysisTaskMesonJetCorrelation : public AliAnalysisTaskSE
   void SetOtherMesons(std::vector<int> vec) { fOtherMesonsPDGCodes = vec; }
   void SetJetContainerAddName(TString name) { fAddNameConvJet = name; }
   void SetFillMesonDCATree(bool tmp) { fFillDCATree = tmp; }
+  void SetDoUseCentralEvtSelection(bool tmp) { fUseCentralEventSelection = tmp; }
 
   void SetEventCutList(Int_t nCuts,
                        TList* CutArray)
@@ -160,6 +161,7 @@ class AliAnalysisTaskMesonJetCorrelation : public AliAnalysisTaskSE
   AliVEvent* fInputEvent;         // current event
   AliMCEvent* fMCEvent;           // corresponding MC event
   TClonesArray* fAODMCTrackArray; // pointer to track array
+  AliEventCuts fAliEventCuts;     ///<  Event cuts (run2 defaults)
 
   //-------------------------------
   // Lists for cut folders and output containers
@@ -219,6 +221,7 @@ class AliAnalysisTaskMesonJetCorrelation : public AliAnalysisTaskSE
   bool fUseThNForResponse;                              // flag if THnSparse or TH2 should be used for the 4d response matrices
   bool fEnableSortForClusMC;                            // flag if cluster mc labels should be sorted
   bool fFillDCATree;                                    // flag if DCA tree should be filled or not
+  bool fUseCentralEventSelection;                       // flag if central event selection (AliEventSelection.cxx) should be used
   //-------------------------------
   // conversions
   //-------------------------------
@@ -459,7 +462,7 @@ class AliAnalysisTaskMesonJetCorrelation : public AliAnalysisTaskSE
   AliAnalysisTaskMesonJetCorrelation(const AliAnalysisTaskMesonJetCorrelation&);            // Prevent copy-construction
   AliAnalysisTaskMesonJetCorrelation& operator=(const AliAnalysisTaskMesonJetCorrelation&); // Prevent assignment
 
-  ClassDef(AliAnalysisTaskMesonJetCorrelation, 11);
+  ClassDef(AliAnalysisTaskMesonJetCorrelation, 12);
 };
 
 #endif

--- a/PWGGA/GammaConv/macros/AddTask_MesonJetCorr_Calo.C
+++ b/PWGGA/GammaConv/macros/AddTask_MesonJetCorr_Calo.C
@@ -49,6 +49,7 @@ void AddTask_MesonJetCorr_Calo(
   TString periodNameAnchor = "",               //
   // special settings
   Bool_t enableSortingMCLabels = kTRUE, // enable sorting for MC cluster labels
+  bool useCentralEvtSelection = true,
   // subwagon config
   TString additionalTrainConfig = "0" // additional counter for trainconfig
 
@@ -344,6 +345,7 @@ void AddTask_MesonJetCorr_Calo(
   task->SetDoMesonQA(enableQAMesonTask); //Attention new switch for Pi0 QA
                                          //   task->SetDoClusterQA(enableQAClusterTask);  //Attention new switch small for Cluster QA
   task->SetUseTHnSparseForResponse(enableTHnSparse);
+  task->SetDoUseCentralEvtSelection(useCentralEvtSelection);
 
   //connect containers
   TString nameContainer = Form("MesonJetCorrelation_Calo_%i_%i%s%s", meson, trainConfig, corrTaskSetting.EqualTo("") == true ? "" : Form("_%s", corrTaskSetting.Data()), nameJetFinder.EqualTo("") == true ? "" : Form("_%s", nameJetFinder.Data()) );

--- a/PWGGA/GammaConv/macros/AddTask_MesonJetCorr_Conv.C
+++ b/PWGGA/GammaConv/macros/AddTask_MesonJetCorr_Conv.C
@@ -51,6 +51,7 @@ void AddTask_MesonJetCorr_Conv(
   // special settings
   Bool_t enableChargedPrimary = kFALSE,
   bool doFillMesonDCATree = false, // swith to enable filling the meson DCA tree for pile-up estimation
+  bool useCentralEvtSelection = true,
   // subwagon config
   TString additionalTrainConfig = "0" // additional counter for trainconfig + special settings
 )
@@ -320,6 +321,7 @@ void AddTask_MesonJetCorr_Conv(
   task->SetUseTHnSparseForResponse(enableTHnSparse);
   if(enableMatBudWeightsPi0) task->SetDoMaterialBudgetWeightingOfGammasForTrueMesons(true);
   if(doFillMesonDCATree) task->SetFillMesonDCATree(true);
+  task->SetDoUseCentralEvtSelection(useCentralEvtSelection);
 
   //connect containers
   TString nameContainer = Form("MesonJetCorrelation_Conv_%i_%i%s", meson, trainConfig, nameJetFinder.EqualTo("") == true ? "" : Form("_%s", nameJetFinder.Data()) );

--- a/PWGGA/GammaConv/macros/AddTask_MesonJetCorr_ConvCalo.C
+++ b/PWGGA/GammaConv/macros/AddTask_MesonJetCorr_ConvCalo.C
@@ -59,6 +59,7 @@ void AddTask_MesonJetCorr_ConvCalo(
   Double_t smearPar = 0.,                // conv photon smearing params
   Double_t smearParConst = 0.,           // conv photon smearing params
   Bool_t doPrimaryTrackMatching = kTRUE, // enable basic track matching for all primary tracks to cluster
+  bool useCentralEvtSelection = true,
   // subwagon config
   TString additionalTrainConfig = "0" // additional counter for trainconfig
 )
@@ -400,7 +401,7 @@ void AddTask_MesonJetCorr_ConvCalo(
   task->SetDoMesonQA(enableQAMesonTask); //Attention new switch for Pi0 QA
                                          //   task->SetDoClusterQA(enableQAClusterTask);  //Attention new switch small for Cluster QA
   task->SetUseTHnSparseForResponse(enableTHnSparse);
-
+  task->SetDoUseCentralEvtSelection(useCentralEvtSelection);
   //connect containers
   TString nameContainer = Form("MesonJetCorrelation_ConvCalo_%i_%i%s%s", meson, trainConfig, corrTaskSetting.EqualTo("") == true ? "" : Form("_%s", corrTaskSetting.Data()), nameJetFinder.EqualTo("") == true ? "" : Form("_%s", nameJetFinder.Data()) );
   AliAnalysisDataContainer* coutput = mgr->CreateContainer(nameContainer, TList::Class(), AliAnalysisManager::kOutputContainer, Form("MesonJetCorrelation_ConvCalo_%i_%i.root", meson, trainConfig));


### PR DESCRIPTION
- A few more events with jets are rejected due to pile-up
- Can be switched on using the add task argument