### PR TITLE
Added D0 in spherocity calculation

### DIFF
--- a/PWGHF/vertexingHF/AliVertexingHFUtils.cxx
+++ b/PWGHF/vertexingHF/AliVertexingHFUtils.cxx
@@ -3597,8 +3597,9 @@ void AliVertexingHFUtils::GetGeneratedSpherocity(TClonesArray *arrayMC,
     Float_t phi  = part->Phi();
     Int_t charge = part->Charge();
     Bool_t isPhysPrim = part->IsPhysicalPrimary();
+    Bool_t isD0 = (TMath::Abs(part->GetPdgCode()) == 421);  //Added in the spherocity calculation for D0 and D* analyses
     if(!isPhysPrim) continue;
-    if(charge==0) continue;
+    if(charge==0 && !isD0) continue;
     if(eta<etaMin || eta>etaMax) continue;
     if(pt<ptMin || pt>ptMax) continue;
 


### PR DESCRIPTION
This is a test to reduce the bias obtained in the closure test of D mesons analyses. The D0 is the only neutral particle that we are including in the calculation, while D* and D+ are included already.