### PR TITLE
Rewritten signal loss classes and new initial classes for closureTest

### DIFF
--- a/PWGMM/UE/UeKNO/AliAnalysisTaskFlatenicity.h
+++ b/PWGMM/UE/UeKNO/AliAnalysisTaskFlatenicity.h
@@ -2,6 +2,25 @@
 /* See cxx source for full Copyright notice */
 /* Add a description of your MPI analysis */
 
+
+/*!ap  info
+AliAnalysisTaskFlatenicity__2a.h        Modified Antonio Paz    2023-mar29
+AliAnalysisTaskFlatenicity.h     Created antonio ortiz (received by !ap on 2023jan12)
+*/
+
+/*
+!ap  Changes 2023mar29
+ -  Added    fnDetec
+ -  Added    FillMCarray
+ -  Redefined   MCchargedProdu   to   GetMCchargedTrueDists  
+    (from 0 parameters to 4 parameters)
+ -  Redefined   MCchargedAuth   to   GetMCchargedDistributionsTrue  
+    (from 0 parameters to 4 parameters)
+ -  Added   fnRecon  
+ -  Added  FillArray
+    
+*/
+
 #ifndef AliAnalysisTaskFlatenicity_H
 #define AliAnalysisTaskFlatenicity_H
 
@@ -42,8 +61,12 @@ public:
   void ExtractMultiplicitiesMC();
   void MakeMCanalysis();
   void MakeDataanalysis();
-  void MCchargedProdu();
-  void MCchargedAuth();
+  void GetMCchargedTrueDists(  Int_t multGen,
+                                    const std::vector<Float_t> &ptGen,
+                                    const std::vector<Int_t> &idGen);
+  void GetMCchargedDetDists(  Int_t multRec,
+                                    const std::vector<Float_t> &ptRec,
+                                    const std::vector<Int_t> &idRec);
 
   void SetPtMin(Double_t val) {
     fPtMin = val;
@@ -61,6 +84,11 @@ public:
   }
 
   bool HasRecVertex();
+  
+  Int_t FillMCarray(std::vector<Float_t> &pt, std::vector<Int_t> &id);
+
+  Int_t FillArray(std::vector<Float_t> &pt, std::vector<Int_t> &id, 
+                    std::vector<Int_t> &isprim);
 
 protected:
 private:
@@ -88,6 +116,8 @@ private:
   TString fDetFlat;
   Bool_t fRemoveTrivialScaling;
   Int_t fnGen;
+  Int_t fnDetec;
+  Int_t fnRecon;
   AliPIDResponse *fPIDResponse;
   AliAnalysisFilter *fTrackFilter;
   TList *fOutputList; //! output list in the root file


### PR DESCRIPTION
Code tested using localtest and also tested in pure local machine.   Fully consistent results between previous version and this version.

!ap  Changes 2023mar29
 -  Split    MCchargedProdu()  and also   MCchargedAuth()  in two parts.
     -  Added    AliAnalysisTaskFlatenicity::FillMCarray    which is the first
        part of    MCchargedProdu   and  MCchargedAuth.
     -  Added    ptMC   idMC   to store values of generated charged
        particles
     -  Activated   fnGen     to store return of    FillMCarray    for  Ncharged
        generated    (fnGen was already defined in the class, but unused)
     -  Using   FillMCarray  to obtain    fnGen   and to fill vectors  ptMC
        idMC     which will be fed to      GetMCchargedTrueDists
     -  Redefined   MCchargedProdu   to    GetMCchargedTrueDists
        (From requiring 0 parameters, to requiring 3 parameters.  Inspired by
        AliAnalysisTaskFlatenicity::GetMultiplicityDistributionsTrue()  )
     -  Added      ptDetMC   idDetMC     to store values of detected
        charged particles
     -  Added   fnDetec     to store return of    FillMCarray    for  Ncharged
        filtered
     -  Using   FillMCarray  to obtain    fnDetec   and to fill vectors  ptDetMC
        idDetMC     to be fed to      GetMCchargedDetDists
     -  Redefined   MCchargedAuth   to    GetMCchargedDetDists
        (From requiring 0 parameters, to requiring 3 parameters.  Inspired by
        AliAnalysisTaskFlatenicity::GetMultiplicityDistributions()  )

 -  Added initial classes to implement a   MCclosureTest
     -  Added class   FillArray   to  process  fESD tracks
     -  Added   fnRecon     to store return of  FillArray for   Ncharged
        reconstructed
     -  Using   FillArray  to obtain    fnRecon   and to fill vectors   ptRecon
        idRecon  isprimRecon