### PR TITLE
Migration of AliGFW away from root-specific classes

### DIFF
--- a/PWGCF/FLOW/GF/AliAnalysisTaskDeform.cxx
+++ b/PWGCF/FLOW/GF/AliAnalysisTaskDeform.cxx
@@ -1262,7 +1262,7 @@ Bool_t AliAnalysisTaskDeform::FillFCs(const AliGFW::CorrConfig &corconf, const D
     val = fGFW->Calculate(corconf,0,kFALSE).real()/dnx;
     if(debug) printf("FillFCs: val = %f\n",val);
     if(TMath::Abs(val)<1)
-      fFC->FillProfile(corconf.Head.Data(),cent,val,(fUseEventWeightOne)?1.0:dnx,rndmn);
+      fFC->FillProfile(corconf.Head.c_str(),cent,val,(fUseEventWeightOne)?1.0:dnx,rndmn);
     return kTRUE;
   };
   return kTRUE;
@@ -1374,7 +1374,7 @@ Bool_t AliAnalysisTaskDeform::Fillv2dPtFCs(const AliGFW::CorrConfig &corconf, co
   if(!corconf.pTDif) {
     val = fGFW->Calculate(corconf,0,kFALSE).real()/dnx;
     if(TMath::Abs(val)<1)
-      ((AliGFWFlowContainer*)fV2dPtList->At(index))->FillProfile(corconf.Head.Data(),dpt,val,dnx,rndmn);
+      ((AliGFWFlowContainer*)fV2dPtList->At(index))->FillProfile(corconf.Head.c_str(),dpt,val,dnx,rndmn);
     return kTRUE;
   };
   return kTRUE;

--- a/PWGCF/FLOW/GF/AliAnalysisTaskDeform.cxx
+++ b/PWGCF/FLOW/GF/AliAnalysisTaskDeform.cxx
@@ -1374,7 +1374,7 @@ Bool_t AliAnalysisTaskDeform::Fillv2dPtFCs(const AliGFW::CorrConfig &corconf, co
   if(!corconf.pTDif) {
     val = fGFW->Calculate(corconf,0,kFALSE).real()/dnx;
     if(TMath::Abs(val)<1)
-      ((AliGFWFlowContainer*)fV2dPtList->At(index))->FillProfile(corconf.Head.Data(),dpt,val,dnx,rndmn);
+      ((AliGFWFlowContainer*)fV2dPtList->At(index))->FillProfile(corconf.Head.c_str(),dpt,val,dnx,rndmn);
     return kTRUE;
   };
   return kTRUE;

--- a/PWGCF/FLOW/GF/AliAnalysisTaskDeform.cxx
+++ b/PWGCF/FLOW/GF/AliAnalysisTaskDeform.cxx
@@ -1374,7 +1374,7 @@ Bool_t AliAnalysisTaskDeform::Fillv2dPtFCs(const AliGFW::CorrConfig &corconf, co
   if(!corconf.pTDif) {
     val = fGFW->Calculate(corconf,0,kFALSE).real()/dnx;
     if(TMath::Abs(val)<1)
-      ((AliGFWFlowContainer*)fV2dPtList->At(index))->FillProfile(corconf.Head.c_str(),dpt,val,dnx,rndmn);
+      ((AliGFWFlowContainer*)fV2dPtList->At(index))->FillProfile(corconf.Head.Data(),dpt,val,dnx,rndmn);
     return kTRUE;
   };
   return kTRUE;

--- a/PWGCF/FLOW/GF/AliAnalysisTaskDeform.cxx
+++ b/PWGCF/FLOW/GF/AliAnalysisTaskDeform.cxx
@@ -315,7 +315,7 @@ void AliAnalysisTaskDeform::UserCreateOutputObjects(){
   if(!fDCAxyFunctionalForm.IsNull()) { fGFWSelection->SetPtDepDCAXY(fDCAxyFunctionalForm); }
   OpenFile(1);
   SetupAxes();
- 
+
   switch (fStageSwitch) {
     case 1:
       CreateWeightOutputObjects();
@@ -380,7 +380,7 @@ void AliAnalysisTaskDeform::CreateWeightOutputObjects(){
       fWeights[i]->Init(!fIsMC,fIsMC);
       fWeightList->Add(fWeights[i]);
     }
-    int nEventCutLabel = 6; 
+    int nEventCutLabel = 6;
     fEventCount = new TH1D("fEventCount","Event counter",nEventCutLabel,0,nEventCutLabel);
     TString eventCutLabel[6]={"Input","Centrality","Trigger","AliEventCuts","Vertex","Tracks"};
     for(int i=0;i<nEventCutLabel;++i) fEventCount->GetXaxis()->SetBinLabel(i+1,eventCutLabel[i].Data());
@@ -405,12 +405,12 @@ void AliAnalysisTaskDeform::CreateEfficiencyOutputObjects(){
       fDetectorResponse[i] = new TH2D(Form("fDetectorResponse_%s",spNames[i].Data()),Form("Detector Response %s",spNames[i].Data()),l_NNchBins,l_NchBins,l_NNchBins,l_NchBins);
       fSpectraList->Add(fDetectorResponse[i]);
     }
-    int nEventCutLabel = 6; 
+    int nEventCutLabel = 6;
     fEventCount = new TH1D("fEventCount","Event counter",nEventCutLabel,0,nEventCutLabel);
     TString eventCutLabel[6]={"Input","Centrality","Trigger","AliEventCuts","Vertex","Tracks"};
     for(int i=0;i<nEventCutLabel;++i) fEventCount->GetXaxis()->SetBinLabel(i+1,eventCutLabel[i].Data());
     fSpectraList->Add(fEventCount);
-    PostData(1,fSpectraList); 
+    PostData(1,fSpectraList);
 }
 void AliAnalysisTaskDeform::CreateVnMptOutputObjects(){
     fRndm = new TRandom(0);
@@ -418,7 +418,7 @@ void AliAnalysisTaskDeform::CreateVnMptOutputObjects(){
     const char* species[] = {"_ch","_pi","_ka","_pr"};
     int endPID = (fDisablePID)?1:4;
     if(!fIsMC) LoadCorrectionsFromLists(); //Efficiencies and NUA are only for the data or if specified for pseudoefficiencies
-    
+
     if(fOnTheFly)
     {
       printf("Creating OTF objects\n");
@@ -568,7 +568,7 @@ void AliAnalysisTaskDeform::CreateVnMptOutputObjects(){
 
     fGFW->AddRegion("PiMid",9,powsFull,-fEtaAcceptance,fEtaAcceptance,1,32);
     fGFW->AddRegion("KaMid",9,powsFull,-fEtaAcceptance,fEtaAcceptance,1,64);
-    fGFW->AddRegion("PrMid",9,powsFull,-fEtaAcceptance,fEtaAcceptance,1,128);  
+    fGFW->AddRegion("PrMid",9,powsFull,-fEtaAcceptance,fEtaAcceptance,1,128);
     CreateCorrConfigs();
     printf("Flow container created\n");
     //Covariance
@@ -579,7 +579,7 @@ void AliAnalysisTaskDeform::CreateVnMptOutputObjects(){
     fCovariance[0] = new AliProfileBS(Form("covmpt_%s",spNames[0].Data()),Form("covmpt_%s",spNames[0].Data()),fNMultiBins,fMultiBins);
     fCovList->Add(fCovariance[0]);
     fCovariance[1] = new AliProfileBS(Form("covnopt_%s",spNames[0].Data()),Form("covnopt_%s",spNames[0].Data()),fNMultiBins,fMultiBins);
-    fCovList->Add(fCovariance[1]); 
+    fCovList->Add(fCovariance[1]);
     fCovariance[2] = new AliProfileBS(Form("covmpt_v3_%s",spNames[0].Data()),Form("covmpt_v3_%s",spNames[0].Data()),fNMultiBins,fMultiBins);
     fCovList->Add(fCovariance[2]);
     fCovariance[3] = new AliProfileBS(Form("covnopt_v3_%s",spNames[0].Data()),Form("covnopt_v3_%s",spNames[0].Data()),fNMultiBins,fMultiBins);
@@ -643,7 +643,7 @@ void AliAnalysisTaskDeform::CreateVnMptOutputObjects(){
       fCovariancePID[4*i] = new AliProfileBS(Form("covmpt_%s",spNames[i+1].Data()),Form("covmpt_%s",spNames[i+1].Data()),fNMultiBins,fMultiBins);
       fCovList->Add(fCovariancePID[4*i]);
       fCovariancePID[1+4*i] = new AliProfileBS(Form("covnopt_%s",spNames[i+1].Data()),Form("covnopt_%s",spNames[i+1].Data()),fNMultiBins,fMultiBins);
-      fCovList->Add(fCovariancePID[1+4*i]); 
+      fCovList->Add(fCovariancePID[1+4*i]);
       fCovariancePID[2+4*i] = new AliProfileBS(Form("covmpt_v3_%s",spNames[i+1].Data()),Form("covmpt_v3_%s",spNames[i+1].Data()),fNMultiBins,fMultiBins);
       fCovList->Add(fCovariancePID[2+4*i]);
       fCovariancePID[3+4*i] = new AliProfileBS(Form("covnopt_v3_%s",spNames[i+1].Data()),Form("covnopt_v3_%s",spNames[i+1].Data()),fNMultiBins,fMultiBins);
@@ -658,7 +658,7 @@ void AliAnalysisTaskDeform::CreateVnMptOutputObjects(){
     fQAList = new TList();
     fQAList->SetOwner(kTRUE);
     fEventCuts.AddQAplotsToList(fQAList,kTRUE);
-    int nEventCutLabel = 6; 
+    int nEventCutLabel = 6;
     fEventCount = new TH1D("fEventCount","Event counter",nEventCutLabel,0,nEventCutLabel);
     TString eventCutLabel[6]={"Input","Centrality","Trigger","AliEventCuts","Vertex","Tracks"};
     for(int i=0;i<nEventCutLabel;++i) fEventCount->GetXaxis()->SetBinLabel(i+1,eventCutLabel[i].Data());
@@ -714,7 +714,7 @@ void AliAnalysisTaskDeform::UserExec(Option_t*) {
   if(!l_MultSel) { AliFatal("MultSelection not found\n"); return; }
   Double_t l_Cent  = l_MultSel->GetMultiplicityPercentile(fCentEst->Data());
   if(l_Cent<0) return;
-  if(fUseNchInV0M && (l_Cent>fV0MCentMax||l_Cent<fV0MCentMin)) return; 
+  if(fUseNchInV0M && (l_Cent>fV0MCentMax||l_Cent<fV0MCentMin)) return;
   fEventCount->Fill("Centrality",1);
   if(!fBypassTriggerAndEventCuts)
     if(!CheckTrigger(l_Cent)) return;
@@ -1086,14 +1086,14 @@ void AliAnalysisTaskDeform::VnMpt(AliAODEvent *fAOD, const Double_t &vz, const D
       if(TMath::Abs(leta)<fEtaAcceptance) nTotNoTracksMC++; //Nch calculated in EtaNch region
       if(leta<-fEtaV2Sep) {
         FillWPCounter(wpPtSubN[0],1,pt);
-        if(!fDisablePID) FillWPCounter(wpPtSubN[PIDIndex],1,pt); 
+        if(!fDisablePID) FillWPCounter(wpPtSubN[PIDIndex],1,pt);
       }
       if(leta > fEtaV2Sep) {
         FillWPCounter(wpPtSubP[0],1,pt);
-        if(!fDisablePID && PIDIndex > 0) FillWPCounter(wpPtSubP[PIDIndex],1,pt); 
+        if(!fDisablePID && PIDIndex > 0) FillWPCounter(wpPtSubP[PIDIndex],1,pt);
       }
       if(TMath::Abs(leta)<fEtaMpt)  { //for mean pt, only consider -0.4-0.4 region
-        FillWPCounter(wp[0],1,pt); 
+        FillWPCounter(wp[0],1,pt);
         FillWPCounter(wpPt[0],1,pt);
         if(!fDisablePID && PIDIndex > 0) { FillWPCounter(wp[PIDIndex],1,pt); FillWPCounter(wpPt[PIDIndex],1,pt); }
       }
@@ -1113,7 +1113,7 @@ void AliAnalysisTaskDeform::VnMpt(AliAODEvent *fAOD, const Double_t &vz, const D
       if(fRequirePositive && lTrack->Charge()<0) continue;
       Int_t PIDIndex = 0;
       if(!fDisablePID) PIDIndex = GetBayesPIDIndex(lTrack)+1;
-    
+
       Double_t leta = lTrack->Eta();
       Double_t trackXYZ[] = {0.,0.,0.};
       //Counting FB128 for QA:
@@ -1126,11 +1126,11 @@ void AliAnalysisTaskDeform::VnMpt(AliAODEvent *fAOD, const Double_t &vz, const D
       Double_t lpt = lTrack->Pt();
       Double_t weff = (fUse2DEff)?fEfficiency[iCent][0]->GetBinContent(fEfficiency[iCent][0]->FindBin(lpt,leta)):fEfficiencies[iCent]->GetBinContent(fEfficiencies[iCent]->FindBin(lpt));
       if(weff==0.0) continue;
-      weff = 1./weff; 
+      weff = 1./weff;
       if(leta<-fEtaV2Sep) FillWPCounter(wpPtSubN[0],(fUseNUEOne)?1.0:weff,lpt);
       if(leta > fEtaV2Sep) FillWPCounter(wpPtSubP[0],(fUseNUEOne)?1.0:weff,lpt);
-      if(TMath::Abs(lTrack->Eta())<fEtaMpt)  { 
-        FillWPCounter(wp[0],(fUseNUEOne)?1.0:weff,lpt); 
+      if(TMath::Abs(lTrack->Eta())<fEtaMpt)  {
+        FillWPCounter(wp[0],(fUseNUEOne)?1.0:weff,lpt);
         FillWPCounter(wpPt[0],(fUseNUEOne)?1.0:weff,lpt);
       }
       Double_t wacc = fWeights[0]->GetNUA(lTrack->Phi(),lTrack->Eta(),vz);
@@ -1140,8 +1140,8 @@ void AliAnalysisTaskDeform::VnMpt(AliAODEvent *fAOD, const Double_t &vz, const D
         Double_t weff_PID = (fUse2DEff)?fEfficiency[iCent][PIDIndex]->GetBinContent(fEfficiency[iCent][PIDIndex]->FindBin(lpt,leta)):weff;
         if(weff_PID== 0.0) continue;
         weff_PID = 1./weff_PID;
-        if(TMath::Abs(lTrack->Eta())<fEtaMpt)  { 
-          FillWPCounter(wp[PIDIndex],(fUseNUEOne)?1.0:weff_PID,lpt); 
+        if(TMath::Abs(lTrack->Eta())<fEtaMpt)  {
+          FillWPCounter(wp[PIDIndex],(fUseNUEOne)?1.0:weff_PID,lpt);
           FillWPCounter(wpPt[PIDIndex],(fUseNUEOne)?1.0:weff_PID,lpt);
         }
         Double_t wacc_PID = (fUsePIDNUA)?fWeights[PIDIndex]->GetNUA(lTrack->Phi(),lTrack->Eta(),vz):wacc;
@@ -1223,7 +1223,7 @@ void AliAnalysisTaskDeform::VnMpt(AliAODEvent *fAOD, const Double_t &vz, const D
   if(pt2corr[1]!=0) {
     double pt2ev = pt2corr[0]/pt2corr[1];
     FillCovariance(fCovariance[12],corrconfigs.at(0),l_Multi,pt2ev,pt2corr[1],l_Random); //v2-pt^2
-    FillCovariance(fCovariance[13],corrconfigs.at(0),l_Multi,1,pt2corr[1],l_Random); 
+    FillCovariance(fCovariance[13],corrconfigs.at(0),l_Multi,1,pt2corr[1],l_Random);
     FillCovariance(fCovariance[14],corrconfigs.at(3),l_Multi,pt2ev,pt2corr[1],l_Random); //v3-pt^2
     FillCovariance(fCovariance[15],corrconfigs.at(3),l_Multi,1,pt2corr[1],l_Random);
   }
@@ -1231,13 +1231,13 @@ void AliAnalysisTaskDeform::VnMpt(AliAODEvent *fAOD, const Double_t &vz, const D
     if(pt3corr[1]!=0) {
     double pt3ev = pt3corr[0]/pt3corr[1];
     FillCovariance(fCovariance[16],corrconfigs.at(0),l_Multi,pt3ev,pt3corr[1],l_Random); //v2-pt^3
-    FillCovariance(fCovariance[17],corrconfigs.at(0),l_Multi,1,pt3corr[1],l_Random); 
+    FillCovariance(fCovariance[17],corrconfigs.at(0),l_Multi,1,pt3corr[1],l_Random);
   }
   vector<double> pt4corr = fPtCont[0]->getEventCorrelation(4,0);
   if(pt4corr[1]!=0) {
     double pt4ev = pt4corr[0]/pt4corr[1];
     FillCovariance(fCovariance[18],corrconfigs.at(0),l_Multi,pt4ev,pt4corr[1],l_Random); //v2-pt^4
-    FillCovariance(fCovariance[19],corrconfigs.at(0),l_Multi,1,pt4corr[1],l_Random); 
+    FillCovariance(fCovariance[19],corrconfigs.at(0),l_Multi,1,pt4corr[1],l_Random);
   }
   if(fFillMptPowers) {
       FillCovariance(fCovariancePowerMpt[0],corrconfigs.at(0),l_Multi,mptev*mptev,wp[0][0]*wp[0][0],l_Random);
@@ -1255,11 +1255,11 @@ void AliAnalysisTaskDeform::VnMpt(AliAODEvent *fAOD, const Double_t &vz, const D
 }
 Bool_t AliAnalysisTaskDeform::FillFCs(const AliGFW::CorrConfig &corconf, const Double_t &cent, const Double_t &rndmn, const Bool_t debug) {
   Double_t dnx, val;
-  dnx = fGFW->Calculate(corconf,0,kTRUE).Re();
+  dnx = fGFW->Calculate(corconf,0,kTRUE).real();
   if(debug) printf("FillFCs: dnx = %f\n",dnx);
   if(dnx==0) return kFALSE;
   if(!corconf.pTDif) {
-    val = fGFW->Calculate(corconf,0,kFALSE).Re()/dnx;
+    val = fGFW->Calculate(corconf,0,kFALSE).real()/dnx;
     if(debug) printf("FillFCs: val = %f\n",val);
     if(TMath::Abs(val)<1)
       fFC->FillProfile(corconf.Head.Data(),cent,val,(fUseEventWeightOne)?1.0:dnx,rndmn);
@@ -1291,7 +1291,7 @@ void AliAnalysisTaskDeform::ProcessOnTheFly() {
     if(l_eta<-fEtaV2Sep) FillWPCounter(wpPtSubN[0],1,l_pt);
     if(l_eta > fEtaV2Sep) FillWPCounter(wpPtSubP[0],1,l_pt);
     if(TMath::Abs(l_eta)<fEtaMpt)  { //for mean pt, only consider -0.4-0.4 region
-      FillWPCounter(wp,1,l_pt); 
+      FillWPCounter(wp,1,l_pt);
       FillWPCounter(wpPt[0],1,l_pt);
     }  //Actually, no need for if() statememnt now since GFW knows about eta's, so I can fill it all the time
     fGFW->Fill(l_eta,1,l_phi,1,3); //filling both gap (bit mask 1) and full (bit mas 2). Since this is MC, weight is 1.
@@ -1341,7 +1341,7 @@ void AliAnalysisTaskDeform::ProcessOnTheFly() {
   if(pt2corr[1]!=0) {
     double pt2ev = pt2corr[0]/pt2corr[1];
     FillCovariance(fCovariance[12],corrconfigs.at(0),l_Cent,pt2ev,pt2corr[1],l_Random); //v2-pt^2
-    FillCovariance(fCovariance[13],corrconfigs.at(0),l_Cent,1,pt2corr[1],l_Random); 
+    FillCovariance(fCovariance[13],corrconfigs.at(0),l_Cent,1,pt2corr[1],l_Random);
     FillCovariance(fCovariance[14],corrconfigs.at(3),l_Cent,pt2ev,pt2corr[1],l_Random); //v3-pt^2
     FillCovariance(fCovariance[15],corrconfigs.at(3),l_Cent,1,pt2corr[1],l_Random);
   }
@@ -1349,13 +1349,13 @@ void AliAnalysisTaskDeform::ProcessOnTheFly() {
     if(pt3corr[1]!=0) {
     double pt3ev = pt3corr[0]/pt3corr[1];
     FillCovariance(fCovariance[16],corrconfigs.at(0),l_Cent,pt3ev,pt3corr[1],l_Random); //v2-pt^3
-    FillCovariance(fCovariance[17],corrconfigs.at(0),l_Cent,1,pt3corr[1],l_Random); 
+    FillCovariance(fCovariance[17],corrconfigs.at(0),l_Cent,1,pt3corr[1],l_Random);
   }
   vector<double> pt4corr = fPtCont[0]->getEventCorrelation(4,0);
   if(pt4corr[1]!=0) {
     double pt4ev = pt4corr[0]/pt4corr[1];
     FillCovariance(fCovariance[18],corrconfigs.at(0),l_Cent,pt4ev,pt4corr[1],l_Random); //v2-pt^4
-    FillCovariance(fCovariance[19],corrconfigs.at(0),l_Cent,1,pt4corr[1],l_Random); 
+    FillCovariance(fCovariance[19],corrconfigs.at(0),l_Cent,1,pt4corr[1],l_Random);
   }
   //Covariance of vn with powers of mpt
   if(fFillMptPowers) {
@@ -1369,10 +1369,10 @@ void AliAnalysisTaskDeform::ProcessOnTheFly() {
 Bool_t AliAnalysisTaskDeform::Fillv2dPtFCs(const AliGFW::CorrConfig &corconf, const Double_t &dpt, const Double_t &rndmn, const Int_t index) {
   if(!index || index>fV2dPtList->GetEntries()) return kFALSE;
   Double_t dnx, val;
-  dnx = fGFW->Calculate(corconf,0,kTRUE).Re();
+  dnx = fGFW->Calculate(corconf,0,kTRUE).real();
   if(dnx==0) return kFALSE;
   if(!corconf.pTDif) {
-    val = fGFW->Calculate(corconf,0,kFALSE).Re()/dnx;
+    val = fGFW->Calculate(corconf,0,kFALSE).real()/dnx;
     if(TMath::Abs(val)<1)
       ((AliGFWFlowContainer*)fV2dPtList->At(index))->FillProfile(corconf.Head.Data(),dpt,val,dnx,rndmn);
     return kTRUE;
@@ -1381,10 +1381,10 @@ Bool_t AliAnalysisTaskDeform::Fillv2dPtFCs(const AliGFW::CorrConfig &corconf, co
 };
 Bool_t AliAnalysisTaskDeform::FillCovariance(AliProfileBS *target, const AliGFW::CorrConfig &corconf, const Double_t &cent, const Double_t &d_mpt, const Double_t &dw_mpt, const Double_t &l_rndm) {
   Double_t dnx, val;
-  dnx = fGFW->Calculate(corconf,0,kTRUE).Re();
+  dnx = fGFW->Calculate(corconf,0,kTRUE).real();
   if(dnx==0) return kFALSE;
   if(!corconf.pTDif) {
-    val = fGFW->Calculate(corconf,0,kFALSE).Re()/dnx;
+    val = fGFW->Calculate(corconf,0,kFALSE).real()/dnx;
     if(TMath::Abs(val)<1)
       target->FillProfile(cent,val*d_mpt,(fUseEventWeightOne)?1.0:dnx*dw_mpt,l_rndm);
     return kTRUE;
@@ -1413,7 +1413,7 @@ void AliAnalysisTaskDeform::CreateCorrConfigs() {
   if(!fDisablePID){
     corrconfigs.push_back(GetConf("PiGap22","PiRefP {2} PiRefN {-2}", kFALSE));
     corrconfigs.push_back(GetConf("KaGap22","KaRefP {2} KaRefN {-2}", kFALSE));
-    corrconfigs.push_back(GetConf("PrGap22","PrRefP {2} PrRefN {-2}", kFALSE));   
+    corrconfigs.push_back(GetConf("PrGap22","PrRefP {2} PrRefN {-2}", kFALSE));
 
     corrconfigs.push_back(GetConf("PiFull22","PiMid {2 -2}", kFALSE));
     corrconfigs.push_back(GetConf("KaFull22","KaMid {2 -2}", kFALSE));
@@ -1443,17 +1443,17 @@ void AliAnalysisTaskDeform::CreateCorrConfigs() {
     corrconfigs.push_back(GetConf("KaFull34","KaMid {3 3 -3 -3}", kFALSE));
     corrconfigs.push_back(GetConf("PrFull34","PrMid {3 3 -3 -3}", kFALSE));
 
-    corrconfigs.push_back(GetConf("PiSC234","PiRefP {2 3} PiRefN {-2 -3}", kFALSE));    
-    corrconfigs.push_back(GetConf("KaSC234","KaRefP {2 3} KaRefN {-2 -3}", kFALSE));    
-    corrconfigs.push_back(GetConf("PrSC234","PrRefP {2 3} PrRefN {-2 -3}", kFALSE));   
+    corrconfigs.push_back(GetConf("PiSC234","PiRefP {2 3} PiRefN {-2 -3}", kFALSE));
+    corrconfigs.push_back(GetConf("KaSC234","KaRefP {2 3} KaRefN {-2 -3}", kFALSE));
+    corrconfigs.push_back(GetConf("PrSC234","PrRefP {2 3} PrRefN {-2 -3}", kFALSE));
 
-    corrconfigs.push_back(GetConf("PiGap26","PiRefP {2 2 2} PiRefN {-2 -2 -2}",kFALSE));  // 
-    corrconfigs.push_back(GetConf("KaGap26","KaRefP {2 2 2} KaRefN {-2 -2 -2}",kFALSE));  // 
-    corrconfigs.push_back(GetConf("PrGap26","PrRefP {2 2 2} PrRefN {-2 -2 -2}",kFALSE));  //  
+    corrconfigs.push_back(GetConf("PiGap26","PiRefP {2 2 2} PiRefN {-2 -2 -2}",kFALSE));  //
+    corrconfigs.push_back(GetConf("KaGap26","KaRefP {2 2 2} KaRefN {-2 -2 -2}",kFALSE));  //
+    corrconfigs.push_back(GetConf("PrGap26","PrRefP {2 2 2} PrRefN {-2 -2 -2}",kFALSE));  //
 
     corrconfigs.push_back(GetConf("PiDiff22","PiMid {2} mid {-2}",kFALSE));
     corrconfigs.push_back(GetConf("KaDiff22","KaMid {2} mid {-2}",kFALSE));
-    corrconfigs.push_back(GetConf("PrDiff22","PrMid {2} mid {-2}",kFALSE));  
+    corrconfigs.push_back(GetConf("PrDiff22","PrMid {2} mid {-2}",kFALSE));
 
     corrconfigs.push_back(GetConf("PiDiff24","PiMid {2} mid {2 -2 -2}",kFALSE));
     corrconfigs.push_back(GetConf("KaDiff24","KaMid {2} mid {2 -2 -2}",kFALSE));
@@ -1512,7 +1512,7 @@ void AliAnalysisTaskDeform::LoadCorrectionsFromLists(){
     TString lBase(""); //base
     TString lSubfix(""); //subfix
     for(int i(0);i<4;++i) {
-      lBase = Form("weight%s",species[i]); 
+      lBase = Form("weight%s",species[i]);
       lSubfix = fGFWSelection->NeedsExtraWeight()?fGFWSelection->GetSystPF():"";
       lBase+=lSubfix;
       fWeights[i] = (AliGFWWeights*)fWeightList->FindObject(lBase.Data());

--- a/PWGCF/FLOW/GF/AliAnalysisTaskDeform.h
+++ b/PWGCF/FLOW/GF/AliAnalysisTaskDeform.h
@@ -74,7 +74,7 @@ class AliAnalysisTaskDeform : public AliAnalysisTaskSE {
   //void ProduceEfficiencies(AliESDEvent *fAOD, const Double_t &vz, const Double_t &l_Cent, Double_t *vtxp);
   void VnMpt(AliAODEvent *fAOD, const Double_t &vz, const Double_t &l_Cent, Double_t *vtxp);
   Int_t GetStageSwitch(TString instr);
-  AliGFW::CorrConfig GetConf(TString head, TString desc, Bool_t ptdif) { return fGFW->GetCorrelatorConfig(desc,head,ptdif);};
+  AliGFW::CorrConfig GetConf(TString head, TString desc, Bool_t ptdif) { return fGFW->GetCorrelatorConfig(desc.Data(),head.Data(),ptdif);};
   void CreateCorrConfigs();
   void LoadWeightAndMPT();
   void LoadCorrectionsFromLists();

--- a/PWGCF/FLOW/GF/AliAnalysisTaskDeform.h
+++ b/PWGCF/FLOW/GF/AliAnalysisTaskDeform.h
@@ -1,7 +1,7 @@
 #ifndef DEFORMATION__H
 #define DEFORMATION__H
 #include "AliAnalysisTaskSE.h"
-// #include "TComplex.h"
+#include "TComplex.h"
 #include "AliEventCuts.h"
 #include "AliVEvent.h"
 #include "AliGFW.h"
@@ -27,7 +27,7 @@ class TH2D;
 class TH3D;
 class TProfile;
 class TProfile2D;
-// class TComplex;
+class TComplex;
 class AliAODEvent;
 class AliVTrack;
 class AliVVertex;

--- a/PWGCF/FLOW/GF/AliAnalysisTaskDeform.h
+++ b/PWGCF/FLOW/GF/AliAnalysisTaskDeform.h
@@ -1,7 +1,7 @@
 #ifndef DEFORMATION__H
 #define DEFORMATION__H
 #include "AliAnalysisTaskSE.h"
-#include "TComplex.h"
+// #include "TComplex.h"
 #include "AliEventCuts.h"
 #include "AliVEvent.h"
 #include "AliGFW.h"
@@ -27,7 +27,7 @@ class TH2D;
 class TH3D;
 class TProfile;
 class TProfile2D;
-class TComplex;
+// class TComplex;
 class AliAODEvent;
 class AliVTrack;
 class AliVVertex;
@@ -149,7 +149,7 @@ class AliAnalysisTaskDeform : public AliAnalysisTaskSE {
   Bool_t fOnTheFly;
   AliMCEvent *fMCEvent; //! MC event
   Bool_t fUseRecoNchForMC; //Flag to use Nch from reconstructed, when running MC closure
-  TRandom *fRndm; 
+  TRandom *fRndm;
   Int_t fNBootstrapProfiles; //Number of profiles for bootstrapping
   Bool_t fFillAdditionalQA;
   TAxis *fPtAxis;
@@ -175,7 +175,7 @@ class AliAnalysisTaskDeform : public AliAnalysisTaskSE {
   Double_t fEtaMpt;
   Double_t fEtaLow;
   Double_t fEtaAcceptance;
-  Double_t fEtaV2Sep; 
+  Double_t fEtaV2Sep;
   Double_t fchPtMin;
   Double_t fchPtMax;
   Bool_t fUseChargedPtCut;
@@ -243,13 +243,13 @@ class AliAnalysisTaskDeform : public AliAnalysisTaskSE {
   TH1D* fPtMptAcceptance; //!
   Double_t fImpactParameterMC;
   int EventNo;
-  unsigned int fEventWeight; 
+  unsigned int fEventWeight;
   vector<vector<vector<double>>>  wpPt;
   vector<vector<vector<double>>>  wpPtSubP;
   vector<vector<vector<double>>>  wpPtSubN;
-  std::map<double,double> centralitymap;  
-  static const Int_t      fNumHarms = 20;            
-  static const Int_t      fNumPowers = 20;            
+  std::map<double,double> centralitymap;
+  static const Int_t      fNumHarms = 20;
+  static const Int_t      fNumPowers = 20;
   TComplex Qvector[fNumHarms][fNumPowers];
   AliESDtrackCuts *fStdTPCITS2011; //Needed for counting tracks for custom event cuts
   Bool_t FillFCs(const AliGFW::CorrConfig &corconf, const Double_t &cent, const Double_t &rndmn, const Bool_t deubg=kFALSE);

--- a/PWGCF/FLOW/GF/AliAnalysisTaskGFWFlow.cxx
+++ b/PWGCF/FLOW/GF/AliAnalysisTaskGFWFlow.cxx
@@ -511,19 +511,19 @@ void AliAnalysisTaskGFWFlow::NotifyRun() {
 }
 Bool_t AliAnalysisTaskGFWFlow::FillFCs(AliGFW::CorrConfig corconf, Double_t cent, Double_t rndmn, Bool_t DisableOverlap) {
   Double_t dnx, val;
-  dnx = fGFW->Calculate(corconf,0,kTRUE).Re();
+  dnx = fGFW->Calculate(corconf,0,kTRUE).real();
   if(dnx==0) return kFALSE;
   if(!corconf.pTDif) {
-    val = fGFW->Calculate(corconf,0,kFALSE).Re()/dnx;
+    val = fGFW->Calculate(corconf,0,kFALSE).real()/dnx;
     if(TMath::Abs(val)<1)
       fFC->FillProfile(corconf.Head.Data(),cent,val,dnx,rndmn);
     return kTRUE;
   };
   Bool_t NeedToDisable=kFALSE;
   for(Int_t i=1;i<=fPtAxis->GetNbins();i++) {
-    dnx = fGFW->Calculate(corconf,i-1,kTRUE,NeedToDisable).Re();
+    dnx = fGFW->Calculate(corconf,i-1,kTRUE,NeedToDisable).real();
     if(dnx==0) continue;
-    val = fGFW->Calculate(corconf,i-1,kFALSE,NeedToDisable).Re()/dnx;
+    val = fGFW->Calculate(corconf,i-1,kFALSE,NeedToDisable).real()/dnx;
     if(TMath::Abs(val)<1)
       fFC->FillProfile(Form("%s_pt_%i",corconf.Head.Data(),i),cent,val,dnx,rndmn);
   };

--- a/PWGCF/FLOW/GF/AliAnalysisTaskGFWFlow.cxx
+++ b/PWGCF/FLOW/GF/AliAnalysisTaskGFWFlow.cxx
@@ -516,7 +516,7 @@ Bool_t AliAnalysisTaskGFWFlow::FillFCs(AliGFW::CorrConfig corconf, Double_t cent
   if(!corconf.pTDif) {
     val = fGFW->Calculate(corconf,0,kFALSE).real()/dnx;
     if(TMath::Abs(val)<1)
-      fFC->FillProfile(corconf.Head.Data(),cent,val,dnx,rndmn);
+      fFC->FillProfile(corconf.Head.c_str(),cent,val,dnx,rndmn);
     return kTRUE;
   };
   Bool_t NeedToDisable=kFALSE;
@@ -525,7 +525,7 @@ Bool_t AliAnalysisTaskGFWFlow::FillFCs(AliGFW::CorrConfig corconf, Double_t cent
     if(dnx==0) continue;
     val = fGFW->Calculate(corconf,i-1,kFALSE,NeedToDisable).real()/dnx;
     if(TMath::Abs(val)<1)
-      fFC->FillProfile(Form("%s_pt_%i",corconf.Head.Data(),i),cent,val,dnx,rndmn);
+      fFC->FillProfile(Form("%s_pt_%i",corconf.Head.c_str(),i),cent,val,dnx,rndmn);
   };
   return kTRUE;
 };

--- a/PWGCF/FLOW/GF/AliAnalysisTaskGFWFlow.h
+++ b/PWGCF/FLOW/GF/AliAnalysisTaskGFWFlow.h
@@ -5,7 +5,7 @@ Extention of Generic Flow (https://arxiv.org/abs/1312.3572)
 #ifndef ALIANALYSISTASKGFWFLOW__H
 #define ALIANALYSISTASKGFWFLOW__H
 #include "AliAnalysisTaskSE.h"
-#include "TComplex.h"
+// #include "TComplex.h"
 #include "AliVParticle.h"
 #include "TAxis.h"
 #include "TStopwatch.h"
@@ -21,7 +21,7 @@ class TH2D;
 class TH3D;
 class TProfile;
 class TProfile2D;
-class TComplex;
+// class TComplex;
 class AliVEvent;
 class AliAODEvent;
 class AliVTrack;

--- a/PWGCF/FLOW/GF/AliAnalysisTaskGFWFlow.h
+++ b/PWGCF/FLOW/GF/AliAnalysisTaskGFWFlow.h
@@ -54,7 +54,7 @@ class AliAnalysisTaskGFWFlow : public AliAnalysisTaskSE {
   static void SetupFlagsByIndex(const Int_t &ind, UInt_t &l_EvFlag, UInt_t &l_TrFlag); //Function to setup flags. Static, so one is able to call from the outside
   void SetCustomNoFlags(Int_t nEvFlags, Int_t nTrFlags) {fTotTrackFlags=nTrFlags; fTotEvFlags=nEvFlags; };
   vector<AliGFW::CorrConfig> corrconfigs; //! do not store
-  AliGFW::CorrConfig GetConf(TString head, TString desc, Bool_t ptdif) { return fGFW->GetCorrelatorConfig(desc,head,ptdif);};
+  AliGFW::CorrConfig GetConf(TString head, TString desc, Bool_t ptdif) { return fGFW->GetCorrelatorConfig(desc.Data(),head.Data(),ptdif);};
   void CreateCorrConfigs();
   void SetTriggerType(UInt_t newval) { fTriggerType = newval; };
   Bool_t CheckTriggerVsCentrality(Double_t l_cent); //Hard cuts on centrality for special triggers

--- a/PWGCF/FLOW/GF/AliAnalysisTaskGFWPIDFlow.cxx
+++ b/PWGCF/FLOW/GF/AliAnalysisTaskGFWPIDFlow.cxx
@@ -650,26 +650,26 @@ void AliAnalysisTaskGFWPIDFlow::FillCustomWeights(AliAODEvent *fAOD, Double_t vz
 }
 
 Bool_t AliAnalysisTaskGFWPIDFlow::GetIntValAndDNX(AliGFW::CorrConfig corconf, Double_t &l_val, Double_t &l_dnx) {
-  l_dnx = fGFW->Calculate(corconf,0,kTRUE).Re();
+  l_dnx = fGFW->Calculate(corconf,0,kTRUE).real();
   if(l_dnx==0) return kFALSE;
-  l_val = fGFW->Calculate(corconf,0,kFALSE).Re()/l_dnx;
+  l_val = fGFW->Calculate(corconf,0,kFALSE).real()/l_dnx;
   if(TMath::Abs(l_val)>1) return kFALSE;
   return kTRUE;
 };
 Bool_t AliAnalysisTaskGFWPIDFlow::FillFCs(AliGFW::CorrConfig corconf, Double_t cent, Double_t rndmn, Bool_t EnableDebug) {
   Double_t dnx, val;
   if(!corconf.pTDif) {
-    dnx = fGFW->Calculate(corconf,0,kTRUE).Re();
+    dnx = fGFW->Calculate(corconf,0,kTRUE).real();
     if(dnx==0) return kFALSE;
-    val = fGFW->Calculate(corconf,0,kFALSE).Re()/dnx;
+    val = fGFW->Calculate(corconf,0,kFALSE).real()/dnx;
     if(TMath::Abs(val)<1)
       fFC->FillProfile(corconf.Head.Data(),cent,val,dnx,rndmn);
     return kTRUE;
   } else {
     for(Int_t i=1; i<=fPtAxis->GetNbins();i++) {
-      dnx = fGFW->Calculate(corconf,i-1,kTRUE).Re();
+      dnx = fGFW->Calculate(corconf,i-1,kTRUE).real();
       if(dnx==0) continue;
-      val = fGFW->Calculate(corconf,i-1,kFALSE).Re()/dnx;
+      val = fGFW->Calculate(corconf,i-1,kFALSE).real()/dnx;
       if(EnableDebug) printf("dnx cut passed. Dnx = %f\t val = %f\n",dnx,val);
       if(TMath::Abs(val)<1) {
         fFC->FillProfile(Form("%s_pt_%i",corconf.Head.Data(),i),cent,val,dnx,rndmn);
@@ -681,10 +681,10 @@ Bool_t AliAnalysisTaskGFWPIDFlow::FillFCs(AliGFW::CorrConfig corconf, Double_t c
 };
 Bool_t AliAnalysisTaskGFWPIDFlow::FillCovariance(AliGFW::CorrConfig corconf, Double_t cent, Double_t d_mpt, Double_t dw_mpt) {
   Double_t dnx, val;
-  dnx = fGFW->Calculate(corconf,0,kTRUE).Re();
+  dnx = fGFW->Calculate(corconf,0,kTRUE).real();
   if(dnx==0) return kFALSE;
   if(!corconf.pTDif) {
-    val = fGFW->Calculate(corconf,0,kFALSE).Re()/dnx;
+    val = fGFW->Calculate(corconf,0,kFALSE).real()/dnx;
     if(TMath::Abs(val)<1)
       fCovariance->Fill(cent,val*d_mpt,dnx*dw_mpt);
     return kTRUE;

--- a/PWGCF/FLOW/GF/AliAnalysisTaskGFWPIDFlow.cxx
+++ b/PWGCF/FLOW/GF/AliAnalysisTaskGFWPIDFlow.cxx
@@ -663,7 +663,7 @@ Bool_t AliAnalysisTaskGFWPIDFlow::FillFCs(AliGFW::CorrConfig corconf, Double_t c
     if(dnx==0) return kFALSE;
     val = fGFW->Calculate(corconf,0,kFALSE).real()/dnx;
     if(TMath::Abs(val)<1)
-      fFC->FillProfile(corconf.Head.Data(),cent,val,dnx,rndmn);
+      fFC->FillProfile(corconf.Head.c_str(),cent,val,dnx,rndmn);
     return kTRUE;
   } else {
     for(Int_t i=1; i<=fPtAxis->GetNbins();i++) {
@@ -672,8 +672,8 @@ Bool_t AliAnalysisTaskGFWPIDFlow::FillFCs(AliGFW::CorrConfig corconf, Double_t c
       val = fGFW->Calculate(corconf,i-1,kFALSE).real()/dnx;
       if(EnableDebug) printf("dnx cut passed. Dnx = %f\t val = %f\n",dnx,val);
       if(TMath::Abs(val)<1) {
-        fFC->FillProfile(Form("%s_pt_%i",corconf.Head.Data(),i),cent,val,dnx,rndmn);
-      if(EnableDebug) printf("Just filled %s with %f and %f\n",Form("%s_pt_%i",corconf.Head.Data(),i),val,dnx);
+        fFC->FillProfile(Form("%s_pt_%i",corconf.Head.c_str(),i),cent,val,dnx,rndmn);
+      if(EnableDebug) printf("Just filled %s with %f and %f\n",Form("%s_pt_%i",corconf.Head.c_str(),i),val,dnx);
       }
     }
   }

--- a/PWGCF/FLOW/GF/AliAnalysisTaskGFWPIDFlow.h
+++ b/PWGCF/FLOW/GF/AliAnalysisTaskGFWPIDFlow.h
@@ -5,7 +5,7 @@ Extention of Generic Flow (https://arxiv.org/abs/1312.3572)
 #ifndef AliAnalysisTaskGFWPIDFlow__H
 #define AliAnalysisTaskGFWPIDFlow__H
 #include "AliAnalysisTaskSE.h"
-#include "TComplex.h"
+// #include "TComplex.h"
 #include "AliEventCuts.h"
 #include "AliVEvent.h"
 #include "AliGFW.h"
@@ -17,7 +17,7 @@ class TH2D;
 class TH3D;
 class TProfile;
 class TProfile2D;
-class TComplex;
+// class TComplex;
 class AliAODEvent;
 class AliVTrack;
 class AliVVertex;

--- a/PWGCF/FLOW/GF/AliAnalysisTaskGFWPIDFlow.h
+++ b/PWGCF/FLOW/GF/AliAnalysisTaskGFWPIDFlow.h
@@ -52,7 +52,7 @@ class AliAnalysisTaskGFWPIDFlow : public AliAnalysisTaskSE {
   void FillMeanPt(AliAODEvent*, Double_t vz, Double_t l_Cent);
   void FillCK(AliAODEvent *fAOD, Double_t vz, Double_t l_Cent);
   Int_t GetStageSwitch(TString instr);
-  AliGFW::CorrConfig GetConf(TString head, TString desc, Bool_t ptdif) { return fGFW->GetCorrelatorConfig(desc,head,ptdif);};
+  AliGFW::CorrConfig GetConf(TString head, TString desc, Bool_t ptdif) { return fGFW->GetCorrelatorConfig(desc.Data(),head.Data(),ptdif);};
   void CreateCorrConfigs();
   void LoadWeightAndMPT(AliAODEvent*);
   void GetSingleWeightFromList(AliGFWWeights **inWeights, Int_t runno, TString pf="");

--- a/PWGCF/FLOW/GF/AliAnalysisTaskJetQ.cxx
+++ b/PWGCF/FLOW/GF/AliAnalysisTaskJetQ.cxx
@@ -374,10 +374,10 @@ void AliAnalysisTaskJetQ::SetupFlowOutput() {
 //Have to be very careful here to fill the correct pt bins!
 void AliAnalysisTaskJetQ::FillFCs(AliGFW::CorrConfig corconf, Double_t cent, Double_t rndmn, const Bool_t &TrFound) {
   Double_t dnx, val;
-  dnx = fGFW->Calculate(corconf,0,kTRUE).Re();
+  dnx = fGFW->Calculate(corconf,0,kTRUE).real();
   if(dnx==0) return;
   if(!corconf.pTDif) {
-    val = fGFW->Calculate(corconf,0,kFALSE).Re()/dnx;
+    val = fGFW->Calculate(corconf,0,kFALSE).real()/dnx;
     if(TMath::Abs(val)<1) {
       fFCIncl->FillProfile(corconf.Head.Data(),cent,val,dnx,rndmn);
       if(TrFound) fFCTrig->FillProfile(corconf.Head.Data(),cent,val,dnx,rndmn);
@@ -386,9 +386,9 @@ void AliAnalysisTaskJetQ::FillFCs(AliGFW::CorrConfig corconf, Double_t cent, Dou
   };
   //It seems that here filling I end up filling non-existing bins. Try to check in GFWFlowContainer what is (attempted) to access
   for(Int_t i=corconf.ptInd.back()+1;i<=fPtAxis->GetNbins();i++) { //It's kind of a triangle. If ref flow starts at ptInd 1, then (1,1) is calculated as integrated, so we start from (1,2)
-    dnx = fGFW->Calculate(corconf,i,kTRUE).Re();
+    dnx = fGFW->Calculate(corconf,i,kTRUE).real();
     if(dnx==0) continue;
-    val = fGFW->Calculate(corconf,i,kFALSE).Re()/dnx;
+    val = fGFW->Calculate(corconf,i,kFALSE).real()/dnx;
     if(TMath::Abs(val)<1) {
       fFCIncl->FillProfile(Form("%s_pt_%i",corconf.Head.Data(),i),cent,val,dnx,rndmn);
       if(TrFound) fFCTrig->FillProfile(Form("%s_pt_%i",corconf.Head.Data(),i),cent,val,dnx,rndmn);

--- a/PWGCF/FLOW/GF/AliAnalysisTaskJetQ.cxx
+++ b/PWGCF/FLOW/GF/AliAnalysisTaskJetQ.cxx
@@ -379,8 +379,8 @@ void AliAnalysisTaskJetQ::FillFCs(AliGFW::CorrConfig corconf, Double_t cent, Dou
   if(!corconf.pTDif) {
     val = fGFW->Calculate(corconf,0,kFALSE).real()/dnx;
     if(TMath::Abs(val)<1) {
-      fFCIncl->FillProfile(corconf.Head.Data(),cent,val,dnx,rndmn);
-      if(TrFound) fFCTrig->FillProfile(corconf.Head.Data(),cent,val,dnx,rndmn);
+      fFCIncl->FillProfile(corconf.Head.c_str(),cent,val,dnx,rndmn);
+      if(TrFound) fFCTrig->FillProfile(corconf.Head.c_str(),cent,val,dnx,rndmn);
     };
     return;
   };
@@ -390,8 +390,8 @@ void AliAnalysisTaskJetQ::FillFCs(AliGFW::CorrConfig corconf, Double_t cent, Dou
     if(dnx==0) continue;
     val = fGFW->Calculate(corconf,i,kFALSE).real()/dnx;
     if(TMath::Abs(val)<1) {
-      fFCIncl->FillProfile(Form("%s_pt_%i",corconf.Head.Data(),i),cent,val,dnx,rndmn);
-      if(TrFound) fFCTrig->FillProfile(Form("%s_pt_%i",corconf.Head.Data(),i),cent,val,dnx,rndmn);
+      fFCIncl->FillProfile(Form("%s_pt_%i",corconf.Head.c_str(),i),cent,val,dnx,rndmn);
+      if(TrFound) fFCTrig->FillProfile(Form("%s_pt_%i",corconf.Head.c_str(),i),cent,val,dnx,rndmn);
     };
   };
 };

--- a/PWGCF/FLOW/GF/AliAnalysisTaskJetQ.h
+++ b/PWGCF/FLOW/GF/AliAnalysisTaskJetQ.h
@@ -56,7 +56,7 @@ class AliAnalysisTaskJetQ : public AliAnalysisTaskSE
 
         void fixPhi(Double_t &inPhi) { if(inPhi<-C_PI_HALF) inPhi+=C_TWOPI; else if(inPhi>C_PI_TH) inPhi-=C_TWOPI; };
         void setupAxis(Int_t &nBins, Double_t *&bins, vector<Double_t> &binCont, TAxis *&ax) {if(binCont.size()>0) binCont.clear(); for(Int_t i=0;i<=nBins;i++) binCont.push_back(bins[i]); if(ax) delete ax; ax = new TAxis(nBins, bins); };
-        AliGFW::CorrConfig GetConf(TString head, TString desc, Bool_t ptdif) { return fGFW->GetCorrelatorConfig(desc,head,ptdif);};
+        AliGFW::CorrConfig GetConf(TString head, TString desc, Bool_t ptdif) { return fGFW->GetCorrelatorConfig(desc.Data(),head.Data(),ptdif);};
         void FillFCs(Double_t cent, Double_t rndm, const Bool_t &TrFound) {for(auto a : corrconfigs) FillFCs(a,cent,rndm,TrFound); };
         void FillFCs(AliGFW::CorrConfig corconf, Double_t cent, Double_t rndmn, const Bool_t &TrFound);
         AliAODEvent *fAOD; //! do not store

--- a/PWGCF/FLOW/GF/AliAnalysisTaskMeanPtV2Corr.cxx
+++ b/PWGCF/FLOW/GF/AliAnalysisTaskMeanPtV2Corr.cxx
@@ -591,11 +591,11 @@ void AliAnalysisTaskMeanPtV2Corr::CovSkipMpt(AliGFWFlags *lFlags, AliAODEvent *f
 }
 Bool_t AliAnalysisTaskMeanPtV2Corr::FillFCs(const AliGFW::CorrConfig &corconf, const Double_t &cent, const Double_t &rndmn, const Bool_t debug) {
   Double_t dnx, val;
-  dnx = fGFW->Calculate(corconf,0,kTRUE).Re();
+  dnx = fGFW->Calculate(corconf,0,kTRUE).real();
   if(debug) printf("FillFCs: dnx = %f\n",dnx);
   if(dnx==0) return kFALSE;
   if(!corconf.pTDif) {
-    val = fGFW->Calculate(corconf,0,kFALSE).Re()/dnx;
+    val = fGFW->Calculate(corconf,0,kFALSE).real()/dnx;
     if(debug) printf("FillFCs: val = %f\n",val);
     if(TMath::Abs(val)<1)
       fFC->FillProfile(corconf.Head.Data(),cent,val,fUseWeightsOne?1:dnx,rndmn);
@@ -606,10 +606,10 @@ Bool_t AliAnalysisTaskMeanPtV2Corr::FillFCs(const AliGFW::CorrConfig &corconf, c
 Bool_t AliAnalysisTaskMeanPtV2Corr::Fillv2dPtFCs(const AliGFW::CorrConfig &corconf, const Double_t &dpt, const Double_t &rndmn, const Int_t index) {
   if(!index || index>fV2dPtList->GetEntries()) return kFALSE;
   Double_t dnx, val;
-  dnx = fGFW->Calculate(corconf,0,kTRUE).Re();
+  dnx = fGFW->Calculate(corconf,0,kTRUE).real();
   if(dnx==0) return kFALSE;
   if(!corconf.pTDif) {
-    val = fGFW->Calculate(corconf,0,kFALSE).Re()/dnx;
+    val = fGFW->Calculate(corconf,0,kFALSE).real()/dnx;
     if(TMath::Abs(val)<1)
       ((AliGFWFlowContainer*)fV2dPtList->At(index))->FillProfile(corconf.Head.Data(),dpt,val,fUseWeightsOne?1:dnx,rndmn);
     return kTRUE;
@@ -619,10 +619,10 @@ Bool_t AliAnalysisTaskMeanPtV2Corr::Fillv2dPtFCs(const AliGFW::CorrConfig &corco
 
 Bool_t AliAnalysisTaskMeanPtV2Corr::FillCovariance(AliProfileBS *target, const AliGFW::CorrConfig &corconf, const Double_t &cent, const Double_t &d_mpt, const Double_t &dw_mpt, const Double_t &l_rndm) {
   Double_t dnx, val;
-  dnx = fGFW->Calculate(corconf,0,kTRUE).Re();
+  dnx = fGFW->Calculate(corconf,0,kTRUE).real();
   if(dnx==0) return kFALSE;
   if(!corconf.pTDif) {
-    val = fGFW->Calculate(corconf,0,kFALSE).Re()/dnx;
+    val = fGFW->Calculate(corconf,0,kFALSE).real()/dnx;
     if(TMath::Abs(val)<1)
       target->FillProfile(cent,val*d_mpt,fUseWeightsOne?1:dnx*dw_mpt,l_rndm);
     return kTRUE;

--- a/PWGCF/FLOW/GF/AliAnalysisTaskMeanPtV2Corr.cxx
+++ b/PWGCF/FLOW/GF/AliAnalysisTaskMeanPtV2Corr.cxx
@@ -598,7 +598,7 @@ Bool_t AliAnalysisTaskMeanPtV2Corr::FillFCs(const AliGFW::CorrConfig &corconf, c
     val = fGFW->Calculate(corconf,0,kFALSE).real()/dnx;
     if(debug) printf("FillFCs: val = %f\n",val);
     if(TMath::Abs(val)<1)
-      fFC->FillProfile(corconf.Head.Data(),cent,val,fUseWeightsOne?1:dnx,rndmn);
+      fFC->FillProfile(corconf.Head.c_str(),cent,val,fUseWeightsOne?1:dnx,rndmn);
     return kTRUE;
   };
   return kTRUE;
@@ -611,7 +611,7 @@ Bool_t AliAnalysisTaskMeanPtV2Corr::Fillv2dPtFCs(const AliGFW::CorrConfig &corco
   if(!corconf.pTDif) {
     val = fGFW->Calculate(corconf,0,kFALSE).real()/dnx;
     if(TMath::Abs(val)<1)
-      ((AliGFWFlowContainer*)fV2dPtList->At(index))->FillProfile(corconf.Head.Data(),dpt,val,fUseWeightsOne?1:dnx,rndmn);
+      ((AliGFWFlowContainer*)fV2dPtList->At(index))->FillProfile(corconf.Head.c_str(),dpt,val,fUseWeightsOne?1:dnx,rndmn);
     return kTRUE;
   };
   return kTRUE;

--- a/PWGCF/FLOW/GF/AliAnalysisTaskMeanPtV2Corr.h
+++ b/PWGCF/FLOW/GF/AliAnalysisTaskMeanPtV2Corr.h
@@ -64,7 +64,7 @@ class AliAnalysisTaskMeanPtV2Corr : public AliAnalysisTaskSE {
   void SetupFlagsByIndex(Int_t); //Setting up event and track flags
   void CovSkipMpt(AliGFWFlags *lFlags, AliAODEvent *fAOD, const Double_t &vz, const Double_t &l_Cent, Double_t *vtxp);
   Int_t GetStageSwitch(TString instr);
-  AliGFW::CorrConfig GetConf(TString head, TString desc, Bool_t ptdif) { return fGFW->GetCorrelatorConfig(desc,head,ptdif);};
+  AliGFW::CorrConfig GetConf(TString head, TString desc, Bool_t ptdif) { return fGFW->GetCorrelatorConfig(desc.Data(),head.Data(),ptdif);};
   void CreateCorrConfigs();
   void FillWPCounter(Double_t[5], Double_t, Double_t);
   Bool_t LoadMyWeights(const Int_t &lRunNo = 0);

--- a/PWGCF/FLOW/GF/AliAnalysisTaskMeanPtV2Corr.h
+++ b/PWGCF/FLOW/GF/AliAnalysisTaskMeanPtV2Corr.h
@@ -2,7 +2,7 @@
 #ifndef MEANPTV2CORRELATIONS__H
 #define MEANPTV2CORRELATIONS__H
 #include "AliAnalysisTaskSE.h"
-#include "TComplex.h"
+// #include "TComplex.h"
 #include "AliEventCuts.h"
 #include "AliVEvent.h"
 #include "AliGFW.h"
@@ -31,7 +31,7 @@ class TH2D;
 class TH3D;
 class TProfile;
 class TProfile2D;
-class TComplex;
+// class TComplex;
 class AliAODEvent;
 class AliVTrack;
 class AliVVertex;

--- a/PWGCF/FLOW/GF/AliGFW.cxx
+++ b/PWGCF/FLOW/GF/AliGFW.cxx
@@ -17,7 +17,7 @@ AliGFW::~AliGFW() {
     pItr->DestroyComplexVectorArray();
 };
 
-void AliGFW::AddRegion(TString refName, Int_t lNhar, Int_t lNpar, Double_t lEtaMin, Double_t lEtaMax, Int_t lNpT, Int_t BitMask) {
+void AliGFW::AddRegion(string refName, Int_t lNhar, Int_t lNpar, Double_t lEtaMin, Double_t lEtaMax, Int_t lNpT, Int_t BitMask) {
   if(lNpT < 1) {
     printf("Number of pT bins cannot be less than 1! Not adding anything.\n");
     return;
@@ -26,7 +26,7 @@ void AliGFW::AddRegion(TString refName, Int_t lNhar, Int_t lNpar, Double_t lEtaM
     printf("Eta min. cannot be more than eta max! Not adding...\n");
     return;
   };
-  if(refName.EqualTo("")) {
+  if(refName=="") {
     printf("Region must have a name!\n");
     return;
   };
@@ -41,7 +41,7 @@ void AliGFW::AddRegion(TString refName, Int_t lNhar, Int_t lNpar, Double_t lEtaM
   lOneRegion.BitMask = BitMask; //Bit mask
   AddRegion(lOneRegion);
 };
-void AliGFW::AddRegion(TString refName, Int_t lNhar, Int_t *lNparVec, Double_t lEtaMin, Double_t lEtaMax, Int_t lNpT, Int_t BitMask) {
+void AliGFW::AddRegion(string refName, Int_t lNhar, Int_t *lNparVec, Double_t lEtaMin, Double_t lEtaMax, Int_t lNpT, Int_t BitMask) {
   if(lNpT < 1) {
     printf("Number of pT bins cannot be less than 1! Not adding anything.\n");
     return;
@@ -50,7 +50,7 @@ void AliGFW::AddRegion(TString refName, Int_t lNhar, Int_t *lNparVec, Double_t l
     printf("Eta min. cannot be more than eta max! Not adding...\n");
     return;
   };
-  if(refName.EqualTo("")) {
+  if(refName=="") {
     printf("Region must have a name!\n");
     return;
   };
@@ -154,8 +154,7 @@ complex<Double_t> AliGFW::RecursiveCorr(AliGFWCumulant *qpoi, AliGFWCumulant *qr
 void AliGFW::Clear() {
   for(auto ptr = fCumulants.begin(); ptr!=fCumulants.end(); ++ptr) ptr->ResetQs();
 };
-AliGFW::CorrConfig AliGFW::GetCorrelatorConfig(TString config1, TString head, Bool_t ptdif) {
-  string config=config1.Data();
+AliGFW::CorrConfig AliGFW::GetCorrelatorConfig(string config, string head, Bool_t ptdif) {
   //First remove all ; and ,:
   s_replace_all(config,","," ");
   s_replace_all(config,";"," ");

--- a/PWGCF/FLOW/GF/AliGFW.cxx
+++ b/PWGCF/FLOW/GF/AliGFW.cxx
@@ -66,17 +66,11 @@ void AliGFW::AddRegion(string refName, Int_t lNhar, Int_t *lNparVec, Double_t lE
   lOneRegion.BitMask = BitMask; //Bit mask
   AddRegion(lOneRegion);
 };
-void AliGFW::SplitRegions() {
-  //Simple case. Will not look for overlaps, etc. Everything is left for end-used
-};
-
 Int_t AliGFW::CreateRegions() {
   if(fRegions.size()<1) {
     printf("No regions set. Skipping...\n");
     return 0;
   };
-  SplitRegions();
-  //for(auto pitr = fRegions.begin(); pitr!=fRegions.end(); pitr++) pitr->PrintStructure();
   Int_t nRegions=0;
   for(auto pItr=fRegions.begin(); pItr!=fRegions.end(); pItr++) {
     AliGFWCumulant *lCumulant = new AliGFWCumulant();
@@ -96,7 +90,7 @@ void AliGFW::Fill(Double_t eta, Int_t ptin, Double_t phi, Double_t weight, Int_t
   if(!fInitialized) return;
   for(Int_t i=0;i<(Int_t)fRegions.size();++i) {
     if(fRegions.at(i).EtaMin<eta && fRegions.at(i).EtaMax>eta && (fRegions.at(i).BitMask&mask))
-      fCumulants.at(i).FillArray(eta,ptin,phi,weight,SecondWeight);
+      fCumulants.at(i).FillArray(ptin,phi,weight,SecondWeight);
   };
 };
 complex<Double_t> AliGFW::TwoRec(Int_t n1, Int_t n2, Int_t p1, Int_t p2, Int_t ptbin, AliGFWCumulant *r1, AliGFWCumulant *r2, AliGFWCumulant *r3) {
@@ -303,6 +297,4 @@ Bool_t AliGFW::s_tokenize(string &instr, string &subs, Int_t &spos, const string
   subs = instr.substr(spos,lpos-spos);
   spos=lpos+1;
   return kTRUE;
-  //2 -2
-  //0123 ->4
 }

--- a/PWGCF/FLOW/GF/AliGFW.cxx
+++ b/PWGCF/FLOW/GF/AliGFW.cxx
@@ -291,7 +291,7 @@ void AliGFW::s_replace_all(string &instr, const string &pattern1, const string &
   while(lpos>-1) { s_replace(instr,pattern1,pattern2,lpos); lpos=s_index(instr,pattern1,lpos); };
 };
 Bool_t AliGFW::s_tokenize(string &instr, string &subs, Int_t &spos, const string &delim) {
-  if(spos<0 || spos>=instr.size()) {spos=-1; subs=""; return kFALSE;};
+  if(spos<0 || spos>=(Int_t)instr.size()) {spos=-1; subs=""; return kFALSE;};
   Int_t lpos = s_index(instr,delim,spos);
   if(lpos<0) lpos=instr.size();
   subs = instr.substr(spos,lpos-spos);

--- a/PWGCF/FLOW/GF/AliGFW.cxx
+++ b/PWGCF/FLOW/GF/AliGFW.cxx
@@ -99,21 +99,21 @@ void AliGFW::Fill(Double_t eta, Int_t ptin, Double_t phi, Double_t weight, Int_t
       fCumulants.at(i).FillArray(eta,ptin,phi,weight,SecondWeight);
   };
 };
-TComplex AliGFW::TwoRec(Int_t n1, Int_t n2, Int_t p1, Int_t p2, Int_t ptbin, AliGFWCumulant *r1, AliGFWCumulant *r2, AliGFWCumulant *r3) {
-  TComplex part1 = r1->Vec(n1,p1,ptbin);
-  TComplex part2 = r2->Vec(n2,p2,ptbin);
-  TComplex part3 = r3?r3->Vec(n1+n2,p1+p2,ptbin):TComplex(0,0);
-  TComplex formula = part1*part2-part3;
+complex<Double_t> AliGFW::TwoRec(Int_t n1, Int_t n2, Int_t p1, Int_t p2, Int_t ptbin, AliGFWCumulant *r1, AliGFWCumulant *r2, AliGFWCumulant *r3) {
+  complex<Double_t> part1 = r1->Vec(n1,p1,ptbin);
+  complex<Double_t> part2 = r2->Vec(n2,p2,ptbin);
+  complex<Double_t> part3 = r3?r3->Vec(n1+n2,p1+p2,ptbin):complex<Double_t>(0.,0.);
+  complex<Double_t> formula = part1*part2-part3;
   return formula;
 };
-TComplex AliGFW::RecursiveCorr(AliGFWCumulant *qpoi, AliGFWCumulant *qref, AliGFWCumulant *qol, Int_t ptbin, vector<Int_t> &hars) {
+complex<Double_t> AliGFW::RecursiveCorr(AliGFWCumulant *qpoi, AliGFWCumulant *qref, AliGFWCumulant *qol, Int_t ptbin, vector<Int_t> &hars) {
   vector<Int_t> pows;
   for(Int_t i=0; i<(Int_t)hars.size(); i++)
     pows.push_back(1);
   return RecursiveCorr(qpoi, qref, qol, ptbin, hars, pows);
 };
 
-TComplex AliGFW::RecursiveCorr(AliGFWCumulant *qpoi, AliGFWCumulant *qref, AliGFWCumulant *qol, Int_t ptbin, vector<Int_t> &hars, vector<Int_t> &pows) {
+complex<Double_t> AliGFW::RecursiveCorr(AliGFWCumulant *qpoi, AliGFWCumulant *qref, AliGFWCumulant *qol, Int_t ptbin, vector<Int_t> &hars, vector<Int_t> &pows) {
   if((pows.at(0)!=1) && qol) qpoi=qol; //if the power of POI is not unity, then always use overlap (if defined).
   //Only valid for 1 particle of interest though!
   if(hars.size()<2) return qpoi->Vec(hars.at(0),pows.at(0),ptbin);
@@ -122,7 +122,7 @@ TComplex AliGFW::RecursiveCorr(AliGFWCumulant *qpoi, AliGFWCumulant *qref, AliGF
   Int_t powlast=pows.at(pows.size()-1);
   hars.erase(hars.end()-1);
   pows.erase(pows.end()-1);
-  TComplex formula = RecursiveCorr(qpoi, qref, qol, ptbin, hars, pows)*qref->Vec(harlast,powlast);
+  complex<Double_t> formula = RecursiveCorr(qpoi, qref, qol, ptbin, hars, pows)*qref->Vec(harlast,powlast);
   Int_t lDegeneracy=1;
   Int_t harSize = (Int_t)hars.size();
   for(Int_t i=harSize-1;i>=0;i--) {
@@ -140,7 +140,7 @@ TComplex AliGFW::RecursiveCorr(AliGFWCumulant *qpoi, AliGFWCumulant *qref, AliGF
     //Otherwise, if we are not working with the 1st entry (dif.), then overlap will always be from qref
     //One should thus (probably) make a check if i=0, then qovl=qpoi, otherwise qovl=qref. But need to think more
     //-- This is not aplicable anymore, since the overlap is explicitly specified
-    TComplex subtractVal = RecursiveCorr(qpoi, qref, qol, ptbin, hars, pows);
+    complex<Double_t> subtractVal = RecursiveCorr(qpoi, qref, qol, ptbin, hars, pows);
     if(lDegeneracy>1) { subtractVal *= lDegeneracy; lDegeneracy=1; };
     formula-=subtractVal;
     hars.at(i)-=harlast;
@@ -153,88 +153,31 @@ TComplex AliGFW::RecursiveCorr(AliGFWCumulant *qpoi, AliGFWCumulant *qref, AliGF
 };
 void AliGFW::Clear() {
   for(auto ptr = fCumulants.begin(); ptr!=fCumulants.end(); ++ptr) ptr->ResetQs();
-  fCalculatedNames.clear();
-  fCalculatedQs.clear();
 };
-TComplex AliGFW::Calculate(TString config, Bool_t SetHarmsToZero) {
-  if(config.EqualTo("")) {
-    printf("Configuration empty!\n");
-    return TComplex(0,0);
-  };
-  TString tmp;
-  Ssiz_t sz1=0;
-  TComplex ret(1,0);
-  while(config.Tokenize(tmp,sz1,"}")) {
-    if(SetHarmsToZero) SetHarmonicsToZero(tmp);
-    TComplex val=CalculateSingle(tmp);
-    ret*=val;
-    fCalculatedQs.push_back(val);
-    fCalculatedNames.push_back(tmp);
-  };
-  return ret;
-};
-TComplex AliGFW::CalculateSingle(TString config) {
+AliGFW::CorrConfig AliGFW::GetCorrelatorConfig(TString config1, TString head, Bool_t ptdif) {
+  string config=config1.Data();
   //First remove all ; and ,:
-  config.ReplaceAll(","," ");
-  config.ReplaceAll(";"," ");
-  //Then make sure we don't have any double-spaces:
-  while(config.Index("  ")>-1) config.ReplaceAll("  "," ");
-  vector<Int_t> regs;
-  vector<Int_t> hars;
-  Int_t ptbin=0;
-  Ssiz_t sz1=0;
-  Ssiz_t szend=0;
-  TString ts, ts2;
-  //find the pT-bin:
-  if(config.Tokenize(ts,sz1,"(")) {
-    config.Tokenize(ts,sz1,")");
-    ptbin=ts.Atoi();
-  };
-  //Fetch region descriptor
-  if(sz1<0) sz1=0;
-  if(!config.Tokenize(ts,szend,"{")) {
-    printf("Could not find harmonics!\n");
-    return TComplex(0,0);
-  };
-  //Fetch regions
-  while(ts.Tokenize(ts2,sz1," ")) {
-    if(sz1>=szend) break;
-    Int_t ind=FindRegionByName(ts2);
-    if(ts2.EqualTo(" ") || ts2.EqualTo("")) continue;
-    if(ind<0) {
-      printf("Could not find region named %s!\n",ts2.Data());
-      break;
-    };
-    regs.push_back(ind);
-  };
-  //Fetch harmonics
-  while(config.Tokenize(ts,szend," ")) hars.push_back(ts.Atoi());
-  if(regs.size()==1) return Calculate(regs.at(0),hars);
-  return Calculate(regs.at(0),regs.at(1),hars,ptbin);
-};
-AliGFW::CorrConfig AliGFW::GetCorrelatorConfig(TString config, TString head, Bool_t ptdif) {
-  //First remove all ; and ,:
-  config.ReplaceAll(","," ");
-  config.ReplaceAll(";"," ");
-  config.ReplaceAll("| ","|");
+  s_replace_all(config,","," ");
+  s_replace_all(config,";"," ");
+  s_replace_all(config,"| ","|");
   //If pT-bin is provided, then look for & remove space before "(" (so that it's clean afterwards)
-  while(config.Index(" (")>-1) config.ReplaceAll(" (","(");
+  while(s_index(config," (")>-1) s_replace_all(config," (","(");
   //Then make sure we don't have any double-spaces:
-  while(config.Index("  ")>-1) config.ReplaceAll("  "," ");
+  while(s_index(config,"  ")>-1) s_replace_all(config,"  "," ");
   vector<Int_t> regs;
   vector<Int_t> hars;
-  Ssiz_t sz1=0;
-  Ssiz_t szend=0;
-  TString ts, ts2;
+  Int_t sz1=0;
+  Int_t szend=0;
+  string ts, ts2;
   CorrConfig ReturnConfig;
   //Fetch region descriptor
-  if(!config.Tokenize(ts,szend,"{")) {
-    printf("Could not find harmonics!\n");
+  if(!s_tokenize(config,ts,szend,"{")) {
+    printf("Could not find any harmonics!\n");
     return ReturnConfig;
   };
   szend=0;
   Int_t counter=0;
-  while(config.Tokenize(ts,szend,"{")) {
+  while(s_tokenize(config,ts,szend,"{")) {
     counter++;
     ReturnConfig.Regs.push_back(vector<Int_t> {});
     ReturnConfig.Hars.push_back(vector<Int_t> {});
@@ -242,42 +185,42 @@ AliGFW::CorrConfig AliGFW::GetCorrelatorConfig(TString config, TString head, Boo
     ReturnConfig.Overlap.push_back(-1); //initially, assume no overlap
     //Check if there's a particular pT bin I should be using here. If so, store it (otherwise, it's bin 0)
     Int_t ptbin=-1;
-    Ssiz_t sz2=0;
-    if(ts.Contains("(")) {
-      if(!ts.Contains(")")) {printf("Missing \")\" in the configurator. Returning...\n"); return ReturnConfig; };
-      sz2 = ts.Index("(");
+    Int_t sz2=0;
+    if(s_contains(ts,"(")) {
+      if(!s_contains(ts,")")) {printf("Missing \")\" in the configurator. Returning...\n"); return ReturnConfig; };
+      sz2 = s_index(ts,"(");
       sz1=sz2+1;
-      ts.Tokenize(ts2,sz1,")");
-      ptbin=ts2.Atoi();
-      ts.Remove(sz2,(sz1-sz2+1));
+      s_tokenize(ts,ts2,sz1,")");
+      ptbin=stoi(ts2);
+      ts.erase(sz2,(sz1-sz2+1));
       szend-=(sz1-sz2); //szend also becomes shorter
       //also need to remove this from config now:
-      sz2 = config.Index("(");
-      sz1 = config.Index(")");
-      config.Remove(sz2,sz1-sz2+1);
+      sz2 = s_index(config,"(");
+      sz1 = s_index(config,")");
+      config.erase(sz2,sz1-sz2+1);
     };
     ReturnConfig.ptInd.push_back(ptbin);
     sz1=0;
     //Fetch regions
-    while(ts.Tokenize(ts2,sz1," ")) {
+    while(s_tokenize(ts,ts2,sz1," ")) {
       if(sz1>=szend) break;
-      Bool_t isOverlap=ts2.Contains("|");
-      if(isOverlap) ts2.Remove(0,1); //If overlap, remove the delimiter |
+      Bool_t isOverlap=s_contains(ts2,"|");
+      if(isOverlap) ts2.erase(0,1); //If overlap, remove the delimiter |
       Int_t ind=FindRegionByName(ts2);
-      if(ts2.EqualTo(" ") || ts2.EqualTo("")) continue;
+      if(ts2 == " " || ts2 == "") continue;
       if(ind<0) {
-        printf("Could not find region named %s!\n",ts2.Data());
+        printf("Could not find region named %s!\n",ts2.c_str());
         break;
       };
       if(!isOverlap)
         ReturnConfig.Regs.at(counter-1).push_back(ind);
       else ReturnConfig.Overlap.at((int)ReturnConfig.Overlap.size()-1) = ind;
     };
-    TString harstr;
-    config.Tokenize(harstr,szend,"}");
-    Ssiz_t dummys=0;
+    string harstr;
+    s_tokenize(config,harstr,szend,"}");
+    Int_t dummys=0;
     //Fetch harmonics
-    while(harstr.Tokenize(ts,dummys," ")) ReturnConfig.Hars.at(counter-1).push_back(ts.Atoi());
+    while(s_tokenize(harstr,ts,dummys," ")) ReturnConfig.Hars.at(counter-1).push_back(stoi(ts));
   };
   ReturnConfig.Head = head;
   ReturnConfig.pTDif = ptdif;
@@ -285,24 +228,24 @@ AliGFW::CorrConfig AliGFW::GetCorrelatorConfig(TString config, TString head, Boo
   return ReturnConfig;
 };
 
-TComplex AliGFW::Calculate(Int_t poi, Int_t ref, vector<Int_t> hars, Int_t ptbin) {
+complex<Double_t> AliGFW::Calculate(Int_t poi, Int_t ref, vector<Int_t> hars, Int_t ptbin) {
   AliGFWCumulant *qref = &fCumulants.at(ref);
   AliGFWCumulant *qpoi = &fCumulants.at(poi);
   AliGFWCumulant *qovl = qpoi;
   return RecursiveCorr(qpoi, qref, qovl, ptbin, hars);
 };
-// TComplex AliGFW::Calculate(CorrConfig corconf, Int_t ptbin, Bool_t SetHarmsToZero, Bool_t DisableOverlap) {
+// complex<Double_t> AliGFW::Calculate(CorrConfig corconf, Int_t ptbin, Bool_t SetHarmsToZero, Bool_t DisableOverlap) {
 //    vector<Int_t> ptbins;
 //    for(Int_t i=0;i<(Int_t)corconf.size();i++) ptbins.push_back(ptbin);
 //    return Calculate(corconf,ptbins,SetHarmsToZero,DisableOverlap);
 // }
-TComplex AliGFW::Calculate(CorrConfig corconf, Int_t ptbin, Bool_t SetHarmsToZero, Bool_t DisableOverlap) {
-  if(corconf.Regs.size()==0) return TComplex(0,0); //Check if we have any regions at all
-  // if(ptbins.size()!=corconf.Regs.size()) {printf("Number of pT-bins is not the same as number of subevents!\n"); return TComplex(0,0); };
-  TComplex retval(1,0);
+complex<Double_t> AliGFW::Calculate(CorrConfig corconf, Int_t ptbin, Bool_t SetHarmsToZero, Bool_t DisableOverlap) {
+  if(corconf.Regs.size()==0) return complex<Double_t>(0,0); //Check if we have any regions at all
+  // if(ptbins.size()!=corconf.Regs.size()) {printf("Number of pT-bins is not the same as number of subevents!\n"); return complex<Double_t>(0,0); };
+  complex<Double_t> retval(1,0);
   Int_t ptInd;
   for(Int_t i=0;i<(Int_t)corconf.Regs.size();i++) { //looping over all regions
-    if(corconf.Regs.at(i).size()==0)  return TComplex(0,0); //again, if no regions in the current subevent, then quit immediatelly
+    if(corconf.Regs.at(i).size()==0)  return complex<Double_t>(0,0); //again, if no regions in the current subevent, then quit immediatelly
     ptInd = corconf.ptInd.at(i); //for i=0 (potentially, POI)
     if(ptInd<0) ptInd = ptbin;
     // Int_t ptbin = ptbins.at(i);
@@ -313,13 +256,13 @@ TComplex AliGFW::Calculate(CorrConfig corconf, Int_t ptbin, Bool_t SetHarmsToZer
     //and regions themselves
     AliGFWCumulant *qref = &fCumulants.at(ref);
     AliGFWCumulant *qpoi = &fCumulants.at(poi);
-    if(!qref->IsPtBinFilled(ptInd)) return TComplex(0,0); //if REF is not filled, don't even continue. Could be redundant, but should save little CPU time
-    if(!qpoi->IsPtBinFilled(ptInd)) return TComplex(0,0);//if POI is not filled, don't even continue. Could be redundant, but should save little CPU time
+    if(!qref->IsPtBinFilled(ptInd)) return complex<Double_t>(0,0); //if REF is not filled, don't even continue. Could be redundant, but should save little CPU time
+    if(!qpoi->IsPtBinFilled(ptInd)) return complex<Double_t>(0,0);//if POI is not filled, don't even continue. Could be redundant, but should save little CPU time
     AliGFWCumulant *qovl=0;
     //Check if in the ref. region we have enough particles (no. of particles in the region >= no of harmonics for subevent)
     Int_t sz1 = corconf.Hars.at(i).size();
     if(poi!=ref) sz1--;
-    if(qref->GetN() < sz1) return TComplex(0,0);
+    if(qref->GetN() < sz1) return complex<Double_t>(0,0);
     //Then, figure the overlap
     if(ovl > -1) //if overlap is defined, then (unless it's explicitly disabled)
       qovl = DisableOverlap?0:&fCumulants.at(ovl);
@@ -330,36 +273,37 @@ TComplex AliGFW::Calculate(CorrConfig corconf, Int_t ptbin, Bool_t SetHarmsToZer
   return retval;
 };
 
-TComplex AliGFW::Calculate(Int_t poi, vector<Int_t> hars) {
+complex<Double_t> AliGFW::Calculate(Int_t poi, vector<Int_t> hars) {
   AliGFWCumulant *qpoi = &fCumulants.at(poi);
   return RecursiveCorr(qpoi, qpoi, qpoi, 0, hars);
 };
-Int_t AliGFW::FindRegionByName(TString refName) {
-  for(Int_t i=0;i<(Int_t)fRegions.size();i++) if(fRegions.at(i).rName.EqualTo(refName)) return i;
+Int_t AliGFW::FindRegionByName(string refName) {
+  for(Int_t i=0;i<(Int_t)fRegions.size();i++) if(fRegions.at(i).rName == refName) return i;
   return -1;
 };
-Int_t AliGFW::FindCalculated(TString identifier) {
-  if(fCalculatedNames.size()==0) return -1;
-  for(Int_t i=0;i<(Int_t)fCalculatedNames.size();i++) {
-    if(fCalculatedNames.at(i).EqualTo(identifier)) return i;
-  };
-  return -1;
+//String processing:
+Int_t AliGFW::s_index(string &instr, const string &pattern, const Int_t &spos) {
+  return instr.find(pattern,spos);
 };
-Bool_t AliGFW::SetHarmonicsToZero(TString &instr) {
-  TString tmp;
-  Ssiz_t sz1=0, sz2;
-  if(!instr.Tokenize(tmp,sz1,"{")) {
-    printf("AliGFW::SetHarmonicsToZero: could not find \"{\" token in %s\n",instr.Data());
-    return kFALSE;
-  };
-  sz2=sz1;
-  Int_t indc=0;
-  while(instr.Tokenize(tmp,sz1," ")) indc++;
-  if(!indc) {
-    printf("AliGFW::SetHarmonicsToZero: did not find any harmonics in %s, nothing to replace\n",instr.Data());
-    return kFALSE;
-  };
-  instr.Remove(sz2);
-  for(Int_t i=0;i<indc;i++) instr.Append("0 ");
+Bool_t AliGFW::s_contains(string &instr, const string &pattern) {
+  return (s_index(instr,pattern)>-1);
+};
+void AliGFW::s_replace(string &instr, const string &pattern1, const string &pattern2, const Int_t &spos) {
+  Int_t lpos = s_index(instr,pattern1,spos);
+  if(lpos<0) return;
+  instr.replace(lpos,pattern1.size(),pattern2);
+};
+void AliGFW::s_replace_all(string &instr, const string &pattern1, const string &pattern2) {
+  Int_t lpos=s_index(instr,pattern1);
+  while(lpos>-1) { s_replace(instr,pattern1,pattern2,lpos); lpos=s_index(instr,pattern1,lpos); };
+};
+Bool_t AliGFW::s_tokenize(string &instr, string &subs, Int_t &spos, const string &delim) {
+  if(spos<0 || spos>=instr.size()) {spos=-1; subs=""; return kFALSE;};
+  Int_t lpos = s_index(instr,delim,spos);
+  if(lpos<0) lpos=instr.size();
+  subs = instr.substr(spos,lpos-spos);
+  spos=lpos+1;
   return kTRUE;
-};
+  //2 -2
+  //0123 ->4
+}

--- a/PWGCF/FLOW/GF/AliGFW.h
+++ b/PWGCF/FLOW/GF/AliGFW.h
@@ -11,7 +11,6 @@ If used, modified, or distributed, please aknowledge the author of this code.
 #include <vector>
 #include <utility>
 #include <algorithm>
-#include "TObjArray.h"
 #include <complex>
 using std::vector;
 using std::complex;
@@ -28,17 +27,6 @@ class AliGFW {
     bool operator<(const Region& a) const {
       return EtaMin < a.EtaMin;
     };
-    Region operator=(const Region& a) {
-      Nhar=a.Nhar;
-      Npar=a.Npar;
-      NparVec=a.NparVec;
-      NpT =a.NpT;
-      EtaMin=a.EtaMin;
-      EtaMax=a.EtaMax;
-      rName=a.rName;
-      BitMask=a.BitMask;
-      return *this;
-    };
     void PrintStructure() {printf("%s: eta [%f.. %f].",rName.c_str(),EtaMin,EtaMax); };
   };
   struct CorrConfig {
@@ -53,28 +41,23 @@ class AliGFW {
   ~AliGFW();
   vector<Region> fRegions;
   vector<AliGFWCumulant> fCumulants;
-  vector<Int_t> fEmptyInt;
   void AddRegion(string refName, Int_t lNhar, Int_t lNpar, Double_t lEtaMin, Double_t lEtaMax, Int_t lNpT=1, Int_t BitMask=1);
   void AddRegion(string refName, Int_t lNhar, Int_t *lNparVec, Double_t lEtaMin, Double_t lEtaMax, Int_t lNpT=1, Int_t BitMask=1);
   Int_t CreateRegions();
   void Fill(Double_t eta, Int_t ptin, Double_t phi, Double_t weight, Int_t mask, Double_t secondWeight=-1);
-  void Clear();// { for(auto ptr = fCumulants.begin(); ptr!=fCumulants.end(); ++ptr) ptr->ResetQs(); };
+  void Clear();
   AliGFWCumulant GetCumulant(Int_t index) { return fCumulants.at(index); };
   CorrConfig GetCorrelatorConfig(string config, string head = "", Bool_t ptdif=kFALSE);
   complex<Double_t> Calculate(CorrConfig corconf, Int_t ptbin, Bool_t SetHarmsToZero, Bool_t DisableOverlap=kFALSE);
-  // complex<Double_t> Calculate(CorrConfig corconf, vector<Int_t> ptbins, Bool_t SetHarmsToZero, Bool_t DisableOverlap=kFALSE);
 public:
   Bool_t fInitialized;
-  void SplitRegions();
-  AliGFWCumulant fEmptyCumulant;
   complex<Double_t> TwoRec(Int_t n1, Int_t n2, Int_t p1, Int_t p2, Int_t ptbin, AliGFWCumulant*, AliGFWCumulant*, AliGFWCumulant*);
   complex<Double_t> RecursiveCorr(AliGFWCumulant *qpoi, AliGFWCumulant *qref, AliGFWCumulant *qol, Int_t ptbin, vector<Int_t> &hars, vector<Int_t> &pows); //POI, Ref. flow, overlapping region
   complex<Double_t> RecursiveCorr(AliGFWCumulant *qpoi, AliGFWCumulant *qref, AliGFWCumulant *qol, Int_t ptbin, vector<Int_t> &hars); //POI, Ref. flow, overlapping region
-  //Deprecated and not used (for now):
   void AddRegion(Region inreg) { fRegions.push_back(inreg); };
   Region GetRegion(Int_t index) { return fRegions.at(index); };
   Int_t FindRegionByName(string refName);
-  //Calculateing functions:
+  //Calculating functions:
   complex<Double_t> Calculate(Int_t poi, Int_t ref, vector<Int_t> hars, Int_t ptbin=0); //For differential, need POI and reference
   complex<Double_t> Calculate(Int_t poi, vector<Int_t> hars); //For integrated case
   //Operations on strings. Equivalent to TString operations, but one to rid of root dependence

--- a/PWGCF/FLOW/GF/AliGFW.h
+++ b/PWGCF/FLOW/GF/AliGFW.h
@@ -11,7 +11,6 @@ If used, modified, or distributed, please aknowledge the author of this code.
 #include <vector>
 #include <utility>
 #include <algorithm>
-#include "TString.h"
 #include "TObjArray.h"
 #include <complex>
 using std::vector;
@@ -55,13 +54,13 @@ class AliGFW {
   vector<Region> fRegions;
   vector<AliGFWCumulant> fCumulants;
   vector<Int_t> fEmptyInt;
-  void AddRegion(TString refName, Int_t lNhar, Int_t lNpar, Double_t lEtaMin, Double_t lEtaMax, Int_t lNpT=1, Int_t BitMask=1);
-  void AddRegion(TString refName, Int_t lNhar, Int_t *lNparVec, Double_t lEtaMin, Double_t lEtaMax, Int_t lNpT=1, Int_t BitMask=1);
+  void AddRegion(string refName, Int_t lNhar, Int_t lNpar, Double_t lEtaMin, Double_t lEtaMax, Int_t lNpT=1, Int_t BitMask=1);
+  void AddRegion(string refName, Int_t lNhar, Int_t *lNparVec, Double_t lEtaMin, Double_t lEtaMax, Int_t lNpT=1, Int_t BitMask=1);
   Int_t CreateRegions();
   void Fill(Double_t eta, Int_t ptin, Double_t phi, Double_t weight, Int_t mask, Double_t secondWeight=-1);
   void Clear();// { for(auto ptr = fCumulants.begin(); ptr!=fCumulants.end(); ++ptr) ptr->ResetQs(); };
   AliGFWCumulant GetCumulant(Int_t index) { return fCumulants.at(index); };
-  CorrConfig GetCorrelatorConfig(TString config, TString head = "", Bool_t ptdif=kFALSE);
+  CorrConfig GetCorrelatorConfig(string config, string head = "", Bool_t ptdif=kFALSE);
   complex<Double_t> Calculate(CorrConfig corconf, Int_t ptbin, Bool_t SetHarmsToZero, Bool_t DisableOverlap=kFALSE);
   // complex<Double_t> Calculate(CorrConfig corconf, vector<Int_t> ptbins, Bool_t SetHarmsToZero, Bool_t DisableOverlap=kFALSE);
 public:

--- a/PWGCF/FLOW/GF/AliGFW.h
+++ b/PWGCF/FLOW/GF/AliGFW.h
@@ -13,8 +13,10 @@ If used, modified, or distributed, please aknowledge the author of this code.
 #include <algorithm>
 #include "TString.h"
 #include "TObjArray.h"
+#include <complex>
 using std::vector;
-
+using std::complex;
+using std::string;
 class AliGFW {
  public:
   struct Region {
@@ -23,7 +25,7 @@ class AliGFW {
     Double_t EtaMin=-999;
     Double_t EtaMax=-999;
     Int_t BitMask=1;
-    TString rName="";
+    string rName="";
     bool operator<(const Region& a) const {
       return EtaMin < a.EtaMin;
     };
@@ -38,21 +40,15 @@ class AliGFW {
       BitMask=a.BitMask;
       return *this;
     };
-    void PrintStructure() {printf("%s: eta [%f.. %f].",rName.Data(),EtaMin,EtaMax); };
+    void PrintStructure() {printf("%s: eta [%f.. %f].",rName.c_str(),EtaMin,EtaMax); };
   };
   struct CorrConfig {
     vector<vector<Int_t>> Regs {};
     vector<vector<Int_t>> Hars {};
     vector<Int_t> Overlap;
     vector<Int_t> ptInd;
-    /*vector<Int_t> Regs {};
-    vector<Int_t> Hars {};
-    vector<Int_t> Regs2 {};
-    vector<Int_t> Hars2 {};
-    Int_t Overlap1=-1;
-    Int_t Overlap2=-1;*/
     Bool_t pTDif=kFALSE;
-    TString Head="";
+    string Head="";
   };
   AliGFW();
   ~AliGFW();
@@ -65,31 +61,28 @@ class AliGFW {
   void Fill(Double_t eta, Int_t ptin, Double_t phi, Double_t weight, Int_t mask, Double_t secondWeight=-1);
   void Clear();// { for(auto ptr = fCumulants.begin(); ptr!=fCumulants.end(); ++ptr) ptr->ResetQs(); };
   AliGFWCumulant GetCumulant(Int_t index) { return fCumulants.at(index); };
-  TComplex Calculate(TString config, Bool_t SetHarmsToZero=kFALSE);
   CorrConfig GetCorrelatorConfig(TString config, TString head = "", Bool_t ptdif=kFALSE);
-  TComplex Calculate(CorrConfig corconf, Int_t ptbin, Bool_t SetHarmsToZero, Bool_t DisableOverlap=kFALSE);
-  // TComplex Calculate(CorrConfig corconf, vector<Int_t> ptbins, Bool_t SetHarmsToZero, Bool_t DisableOverlap=kFALSE);
- private:
+  complex<Double_t> Calculate(CorrConfig corconf, Int_t ptbin, Bool_t SetHarmsToZero, Bool_t DisableOverlap=kFALSE);
+  // complex<Double_t> Calculate(CorrConfig corconf, vector<Int_t> ptbins, Bool_t SetHarmsToZero, Bool_t DisableOverlap=kFALSE);
+public:
   Bool_t fInitialized;
   void SplitRegions();
   AliGFWCumulant fEmptyCumulant;
-  TComplex TwoRec(Int_t n1, Int_t n2, Int_t p1, Int_t p2, Int_t ptbin, AliGFWCumulant*, AliGFWCumulant*, AliGFWCumulant*);
-  TComplex RecursiveCorr(AliGFWCumulant *qpoi, AliGFWCumulant *qref, AliGFWCumulant *qol, Int_t ptbin, vector<Int_t> &hars, vector<Int_t> &pows); //POI, Ref. flow, overlapping region
-  TComplex RecursiveCorr(AliGFWCumulant *qpoi, AliGFWCumulant *qref, AliGFWCumulant *qol, Int_t ptbin, vector<Int_t> &hars); //POI, Ref. flow, overlapping region
+  complex<Double_t> TwoRec(Int_t n1, Int_t n2, Int_t p1, Int_t p2, Int_t ptbin, AliGFWCumulant*, AliGFWCumulant*, AliGFWCumulant*);
+  complex<Double_t> RecursiveCorr(AliGFWCumulant *qpoi, AliGFWCumulant *qref, AliGFWCumulant *qol, Int_t ptbin, vector<Int_t> &hars, vector<Int_t> &pows); //POI, Ref. flow, overlapping region
+  complex<Double_t> RecursiveCorr(AliGFWCumulant *qpoi, AliGFWCumulant *qref, AliGFWCumulant *qol, Int_t ptbin, vector<Int_t> &hars); //POI, Ref. flow, overlapping region
   //Deprecated and not used (for now):
   void AddRegion(Region inreg) { fRegions.push_back(inreg); };
   Region GetRegion(Int_t index) { return fRegions.at(index); };
-  Int_t FindRegionByName(TString refName);
-  vector<TString> fCalculatedNames;
-  vector<TComplex> fCalculatedQs;
-  Int_t FindCalculated(TString identifier);
+  Int_t FindRegionByName(string refName);
   //Calculateing functions:
-  TComplex Calculate(Int_t poi, Int_t ref, vector<Int_t> hars, Int_t ptbin=0); //For differential, need POI and reference
-  TComplex Calculate(Int_t poi, vector<Int_t> hars); //For integrated case
-  //Process one string (= one region)
-  TComplex CalculateSingle(TString config);
-
-  Bool_t SetHarmonicsToZero(TString &instr);
-
+  complex<Double_t> Calculate(Int_t poi, Int_t ref, vector<Int_t> hars, Int_t ptbin=0); //For differential, need POI and reference
+  complex<Double_t> Calculate(Int_t poi, vector<Int_t> hars); //For integrated case
+  //Operations on strings. Equivalent to TString operations, but one to rid of root dependence
+  Int_t s_index(string &instr, const string &pattern, const Int_t &spos=0);
+  Bool_t s_contains(string &instr, const string &pattern);
+  void s_replace(string &instr, const string &pattern1, const string &pattern2, const Int_t &spos=0);
+  void s_replace_all(string &instr, const string &pattern1, const string &pattern2);
+  Bool_t s_tokenize(string &instr, string &substr, Int_t &spos, const string &delim);
 };
 #endif

--- a/PWGCF/FLOW/GF/AliGFWCumulant.cxx
+++ b/PWGCF/FLOW/GF/AliGFWCumulant.cxx
@@ -20,25 +20,23 @@ AliGFWCumulant::AliGFWCumulant():
 
 AliGFWCumulant::~AliGFWCumulant()
 {
-  //printf("Destructor (?) for some reason called?\n");
-  //DestroyComplexVectorArray();
 };
-void AliGFWCumulant::FillArray(Double_t eta, Int_t ptin, Double_t phi, Double_t weight, Double_t SecondWeight) {
+void AliGFWCumulant::FillArray(Int_t ptin, Double_t phi, Double_t weight, Double_t SecondWeight) {
   if(!fInitialized)
     CreateComplexVectorArray(1,1,1);
   if(fPt==1) ptin=0; //If one bin, then just fill it straight; otherwise, if ptin is out-of-range, do not fill
   else if(ptin<0 || ptin>=fPt) return;
   fFilledPts[ptin] = kTRUE;
   for(Int_t lN = 0; lN<fN; lN++) {
-    Double_t lSin = TMath::Sin(lN*phi); //No need to recalculate for each power
-    Double_t lCos = TMath::Cos(lN*phi); //No need to recalculate for each power
+    Double_t lSin = sin(lN*phi); //No need to recalculate for each power
+    Double_t lCos = cos(lN*phi); //No need to recalculate for each power
     for(Int_t lPow=0; lPow<PW(lN); lPow++) {
       Double_t lPrefactor = 0;
       //Dont calculate it twice; multiplication is cheaper that power
       //Also, if second weight is specified, then keep the first weight with power no more than 1, and us the other weight otherwise
       //this is important when POIs are a subset of REFs and have different weights than REFs
-      if(SecondWeight>0 && lPow>1) lPrefactor = TMath::Power(SecondWeight, lPow-1)*weight;
-      else lPrefactor = TMath::Power(weight,lPow);
+      if(SecondWeight>0 && lPow>1) lPrefactor = pow(SecondWeight, lPow-1)*weight;
+      else lPrefactor = pow(weight,lPow);
       Double_t qsin = lPrefactor * lSin;
       Double_t qcos = lPrefactor * lCos;
       fQvector[ptin][lN][lPow]+=complex<Double_t>(qcos,qsin);

--- a/PWGCF/FLOW/GF/AliGFWCumulant.cxx
+++ b/PWGCF/FLOW/GF/AliGFWCumulant.cxx
@@ -6,7 +6,6 @@ A container to store Q vectors for one subevent with an extra layer to recursive
 If used, modified, or distributed, please aknowledge the author of this code.
 */
 #include "AliGFWCumulant.h"
-
 AliGFWCumulant::AliGFWCumulant():
   fQvector(0),
   fUsed(kBlank),
@@ -42,7 +41,7 @@ void AliGFWCumulant::FillArray(Double_t eta, Int_t ptin, Double_t phi, Double_t 
       else lPrefactor = TMath::Power(weight,lPow);
       Double_t qsin = lPrefactor * lSin;
       Double_t qcos = lPrefactor * lCos;
-      fQvector[ptin][lN][lPow](fQvector[ptin][lN][lPow].Re()+qcos,fQvector[ptin][lN][lPow].Im()+qsin);//+=TComplex(qcos,qsin);
+      fQvector[ptin][lN][lPow]+=complex<Double_t>(qcos,qsin);
     };
   };
   Inc();
@@ -53,7 +52,7 @@ void AliGFWCumulant::ResetQs() {
     fFilledPts[i] = kFALSE;
     for(Int_t lN=0;lN<fN;lN++) {
       for(Int_t lPow=0;lPow<PW(lN);lPow++) {
-  	       fQvector[i][lN][lPow](0.,0.);
+  	       fQvector[i][lN][lPow] = fNullQ;
       };
     };
   };
@@ -88,23 +87,23 @@ void AliGFWCumulant::CreateComplexVectorArrayVarPower(Int_t N, vector<Int_t> Pow
   fPt=Pt;
   fFilledPts = new Bool_t[Pt];
   fPowVec = PowVec;
-  fQvector = new TComplex**[fPt];
+  fQvector = new complex<Double_t>**[fPt];
   for(Int_t i=0;i<fPt;i++) {
-    fQvector[i] = new TComplex*[fN];
+    fQvector[i] = new complex<Double_t>*[fN];
   };
   for(Int_t l_n=0;l_n<fN;l_n++) {
     for(Int_t i=0;i<fPt;i++) {
-      fQvector[i][l_n] = new TComplex[PW(l_n)];
+      fQvector[i][l_n] = new complex<Double_t>[PW(l_n)];
     };
   };
   ResetQs();
   fInitialized=kTRUE;
 };
-TComplex AliGFWCumulant::Vec(Int_t n, Int_t p, Int_t ptbin) {
+complex<Double_t> AliGFWCumulant::Vec(Int_t n, Int_t p, Int_t ptbin) {
   if(!fInitialized) return 0;
   if(ptbin>=fPt || ptbin<0) ptbin=0;
   if(n>=0) return fQvector[ptbin][n][p];
-  return TComplex::Conjugate(fQvector[ptbin][-n][p]);
+  return conj(fQvector[ptbin][-n][p]);
 };
 Bool_t AliGFWCumulant::IsPtBinFilled(Int_t ptb) {
    if(!fFilledPts) return kFALSE;

--- a/PWGCF/FLOW/GF/AliGFWCumulant.h
+++ b/PWGCF/FLOW/GF/AliGFWCumulant.h
@@ -7,9 +7,10 @@ If used, modified, or distributed, please aknowledge the author of this code.
 */
 #ifndef ALIGFWCUMULANT__H
 #define ALIGFWCUMULANT__H
-#include "TMath.h"
-#include "TAxis.h"
+#include "RtypesCore.h" //needed for root types only. Irrelevant, if running c++-SA code
+#include <cmath>
 #include <complex>
+#include <vector>
 using std::vector;
 using std::complex;
 class AliGFWCumulant {
@@ -17,28 +18,28 @@ class AliGFWCumulant {
   AliGFWCumulant();
   ~AliGFWCumulant();
   void ResetQs();
-  void FillArray(Double_t eta, Int_t ptin, Double_t phi, Double_t weight=1, Double_t SecondWeight=-1);
+  void FillArray(Int_t ptin, Double_t phi, Double_t weight=1, Double_t SecondWeight=-1);
   enum UsedFlags_t {kBlank = 0, kFull=1, kPt=2};
   void SetType(UInt_t infl) { DestroyComplexVectorArray(); fUsed = infl; };
   void Inc() { fNEntries++; };
   Int_t GetN() { return fNEntries; };
-  // protected:
+  Bool_t IsPtBinFilled(Int_t ptb);
+  void CreateComplexVectorArray(Int_t N=1, Int_t P=1, Int_t Pt=1);
+  void CreateComplexVectorArrayVarPower(Int_t N=1, vector<Int_t> Pvec={1}, Int_t Pt=1);
+  Int_t PW(Int_t ind) { return fPowVec.at(ind); }; //No checks to speed up, be carefull!!!
+  void DestroyComplexVectorArray();
+  complex<Double_t> Vec(Int_t, Int_t, Int_t ptbin=0); //envelope class to summarize pt-dif. Q-vec getter
+ protected:
   complex<Double_t> ***fQvector;
   UInt_t fUsed;
   Int_t fNEntries;
   //Q-vectors. Could be done recursively, but maybe defining each one of them explicitly is easier to read
-  complex<Double_t> Vec(Int_t, Int_t, Int_t ptbin=0); //envelope class to summarize pt-dif. Q-vec getter
   Int_t fN; //! Harmonics
   Int_t fPow; //! Power
   vector<Int_t> fPowVec; //! Powers array
   Int_t fPt; //!fPt bins
   Bool_t *fFilledPts;
   Bool_t fInitialized; //Arrays are initialized
-  void CreateComplexVectorArray(Int_t N=1, Int_t P=1, Int_t Pt=1);
-  void CreateComplexVectorArrayVarPower(Int_t N=1, vector<Int_t> Pvec={1}, Int_t Pt=1);
-  Int_t PW(Int_t ind) { return fPowVec.at(ind); }; //No checks to speed up, be carefull!!!
-  void DestroyComplexVectorArray();
-  Bool_t IsPtBinFilled(Int_t ptb);
   complex<Double_t> fNullQ = complex<Double_t>(0.,0.);
 };
 

--- a/PWGCF/FLOW/GF/AliGFWCumulant.h
+++ b/PWGCF/FLOW/GF/AliGFWCumulant.h
@@ -7,11 +7,11 @@ If used, modified, or distributed, please aknowledge the author of this code.
 */
 #ifndef ALIGFWCUMULANT__H
 #define ALIGFWCUMULANT__H
-#include "TComplex.h"
-#include "TNamed.h"
 #include "TMath.h"
 #include "TAxis.h"
+#include <complex>
 using std::vector;
+using std::complex;
 class AliGFWCumulant {
  public:
   AliGFWCumulant();
@@ -23,11 +23,11 @@ class AliGFWCumulant {
   void Inc() { fNEntries++; };
   Int_t GetN() { return fNEntries; };
   // protected:
-  TComplex ***fQvector;
+  complex<Double_t> ***fQvector;
   UInt_t fUsed;
   Int_t fNEntries;
   //Q-vectors. Could be done recursively, but maybe defining each one of them explicitly is easier to read
-  TComplex Vec(Int_t, Int_t, Int_t ptbin=0); //envelope class to summarize pt-dif. Q-vec getter
+  complex<Double_t> Vec(Int_t, Int_t, Int_t ptbin=0); //envelope class to summarize pt-dif. Q-vec getter
   Int_t fN; //! Harmonics
   Int_t fPow; //! Power
   vector<Int_t> fPowVec; //! Powers array
@@ -39,6 +39,7 @@ class AliGFWCumulant {
   Int_t PW(Int_t ind) { return fPowVec.at(ind); }; //No checks to speed up, be carefull!!!
   void DestroyComplexVectorArray();
   Bool_t IsPtBinFilled(Int_t ptb);
+  complex<Double_t> fNullQ = complex<Double_t>(0.,0.);
 };
 
 #endif


### PR DESCRIPTION
Removed all dependences in the core of AliGFW from TComplex and TString. Cleaned up the code from deprecated methods. All tasks that are using the framework have been adjusted accordingly. The AliGFW is still working in ROOT types (Double_t, Int_t, etc.) for the sake of it, the types are included in AliGFWCumulant.h header. A completely root-free version is on my github (vvislavi/GFW_Core)