### PR TITLE
PWGGA/GammaConv: Add TOF Kaon and Proton rejection option to omega task

### DIFF
--- a/PWGGA/GammaConv/AliPrimaryPionCuts.cxx
+++ b/PWGGA/GammaConv/AliPrimaryPionCuts.cxx
@@ -90,6 +90,7 @@ AliPrimaryPionCuts::AliPrimaryPionCuts(const char *name,const char *title) : Ali
 	fPIDnSigmaBelowPionLineTOF(-100), // RRnewTOF
 	fUseCorrectedTPCClsInfo(kFALSE),
 	fUseTOFpid(kFALSE),
+	fUseTOFKpRejection(kFALSE),
 	fRequireTOF(kFALSE),
 	fDoMassCut(kFALSE),
     fDoMassCut_WithNDM(kFALSE),
@@ -704,7 +705,13 @@ Bool_t AliPrimaryPionCuts::dEdxCuts(AliVTrack *fCurrentTrack){
     	}
 		if(fHistTOFSigbefore) fHistTOFSigbefore->Fill(fCurrentTrack->P(),fPIDResponse->NumberOfSigmasTOF(fCurrentTrack, AliPID::kPion));
 		if(fUseTOFpid){
-			if( fPIDResponse->NumberOfSigmasTOF(fCurrentTrack, AliPID::kPion)>fPIDnSigmaAbovePionLineTOF ||
+			if(fUseTOFKpRejection){	// Reject pions, if they are outside the pion band AND inside the kaon or proton band of the TOF
+				if(   (fPIDResponse->NumberOfSigmasTOF(fCurrentTrack, AliPID::kPion)>fPIDnSigmaAbovePionLineTOF  || fPIDResponse->NumberOfSigmasTOF(fCurrentTrack, AliPID::kPion)<fPIDnSigmaBelowPionLineTOF    )
+				   && (fabs(fPIDResponse->NumberOfSigmasTOF(fCurrentTrack, AliPID::kKaon))<fPIDnSigmaAroundKpTOF || fabs(fPIDResponse->NumberOfSigmasTOF(fCurrentTrack, AliPID::kProton))<fPIDnSigmaAroundKpTOF ) ){
+					if(fHistdEdxCuts)fHistdEdxCuts->Fill(cutIndex);
+					return kFALSE;
+				}
+			} else if( fPIDResponse->NumberOfSigmasTOF(fCurrentTrack, AliPID::kPion)>fPIDnSigmaAbovePionLineTOF ||
 				fPIDResponse->NumberOfSigmasTOF(fCurrentTrack, AliPID::kPion)<fPIDnSigmaBelowPionLineTOF ){
 				if(fHistdEdxCuts)fHistdEdxCuts->Fill(cutIndex);
 				return kFALSE;
@@ -1505,6 +1512,38 @@ Bool_t AliPrimaryPionCuts::SetTOFPionPIDCut(Int_t TOFelectronPID){
 			fUseTOFpid  = kTRUE;
 			fPIDnSigmaBelowPionLineTOF= -3;
 			fPIDnSigmaAbovePionLineTOF=  3;
+			break;
+		case 6: // Kaon + proton rejection
+			fRequireTOF = kFALSE;
+			fUseTOFpid = kTRUE;
+			fUseTOFKpRejection = kTRUE;
+			fPIDnSigmaBelowPionLineTOF=-3;
+			fPIDnSigmaAbovePionLineTOF=3;
+			fPIDnSigmaAroundKpTOF=3;
+			break;
+		case 7: // Kaon + proton rejection
+			fRequireTOF = kFALSE;
+			fUseTOFpid = kTRUE;
+			fUseTOFKpRejection = kTRUE;
+			fPIDnSigmaBelowPionLineTOF=-3;
+			fPIDnSigmaAbovePionLineTOF=3;
+			fPIDnSigmaAroundKpTOF=2;
+			break;
+		case 8: // Kaon + proton rejection
+			fRequireTOF = kFALSE;
+			fUseTOFpid = kTRUE;
+			fUseTOFKpRejection = kTRUE;
+			fPIDnSigmaBelowPionLineTOF=-3;
+			fPIDnSigmaAbovePionLineTOF=3;
+			fPIDnSigmaAroundKpTOF=1;
+			break;
+		case 9: // Kaon + proton rejection
+			fRequireTOF = kFALSE;
+			fUseTOFpid = kTRUE;
+			fUseTOFKpRejection = kTRUE;
+			fPIDnSigmaBelowPionLineTOF=-5;
+			fPIDnSigmaAbovePionLineTOF=5;
+			fPIDnSigmaAroundKpTOF=3;
 			break;
 		default:
 			cout<<"Warning: TOFPionCut not defined "<<TOFelectronPID<<endl;

--- a/PWGGA/GammaConv/AliPrimaryPionCuts.h
+++ b/PWGGA/GammaConv/AliPrimaryPionCuts.h
@@ -165,8 +165,10 @@ class AliPrimaryPionCuts : public AliAnalysisCuts {
 	Double_t fPIDnSigmaBelowPionLineTPC; // sigma cut TPC
 	Double_t fPIDnSigmaAbovePionLineTOF; // sigma cut TOF
 	Double_t fPIDnSigmaBelowPionLineTOF; // sigma cut TOF 
+	Double_t fPIDnSigmaAroundKpTOF; // sigma around kaons and protons for Kp rejection
 	Bool_t   fUseCorrectedTPCClsInfo; // flag to use corrected tpc cl info
 	Bool_t   fUseTOFpid; // flag to use tof pid
+	Bool_t   fUseTOFKpRejection; // flag to use tof to reject kaons and protons
 	Bool_t   fRequireTOF; //flg to analyze only tracks with TOF signal
     Bool_t   fDoMassCut;
     Bool_t   fDoMassCut_WithNDM;

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_ConvMode_pPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_ConvMode_pPb.C
@@ -221,13 +221,18 @@ void AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_ConvMode_pPb(
     cuts.AddCutHeavyMesonPCM("80010113","0dm00009f9730000dge0404000","32c51070a","0103113s00000000","0153503000000000"); // PCM 2 sigma, pT > 0.4
     cuts.AddCutHeavyMesonPCM("80010113","0dm00009f9730000dge0404000","32c51070a","0103123s00000000","0153503000000000"); // PCM 2 sigma, pT > 0.7
     cuts.AddCutHeavyMesonPCM("80010113","0dm00009f9730000dge0404000","32c51070a","0103133s00000000","0153503000000000"); // PCM 2 sigma, pT > 0.9
-  }else if (trainConfig == 1011){ // TOF+DCA variations to increase charged pion purity
-    cuts.AddCutHeavyMesonPCM("80010113","0dm00009f9730000dge0404000","32c51070a","0000003z00000000","0400503000000000"); // Standard
-    cuts.AddCutHeavyMesonPCM("80010113","0dm00009f9730000dge0404000","32c51072a","0000003z00000000","0400503000000000"); // TOF PID if available +-5 sigma
-    cuts.AddCutHeavyMesonPCM("80010113","0dm00009f9730000dge0404000","32c31070a","0000003z00000000","0400503000000000"); // DCA xy pT dep.
-    cuts.AddCutHeavyMesonPCM("80010113","0dm00009f9730000dge0404000","32c31072a","0000003z00000000","0400503000000000"); // TOF PID if available +-5 sigma + DCA xy pT dep.
-    cuts.AddCutHeavyMesonPCM("80010113","0dm00009f9730000dge0404000","32c71070a","0000003z00000000","0400503000000000"); // DCA xyz pT dep.
-    cuts.AddCutHeavyMesonPCM("80010113","0dm00009f9730000dge0404000","32c71072a","0000003z00000000","0400503000000000"); // TOF PID if available +-5 sigma + DCA xyz pT dep.
+  }else if (trainConfig == 1011){ // TOF variations to increase charged pion purity
+    cuts.AddCutHeavyMesonPCM("80010113","0dm00009f9730000dge0404000","32c51076a","0000003z00000000","0400503000000000"); // TOF Kaon Proton rejection
+    cuts.AddCutHeavyMesonPCM("80010113","0dm00009f9730000dge0404000","32c51070a","0000003z00000000","0400503000000000"); // No cut
+    cuts.AddCutHeavyMesonPCM("80010113","0dm00009f9730000dge0404000","32c51072a","0000003z00000000","0400503000000000"); // TOF Pion selection
+    cuts.AddCutHeavyMesonPCM("80010113","0dm00009f9730000dge0404000","32c51077a","0000003z00000000","0400503000000000"); // TOF Kaon Proton rejection
+    cuts.AddCutHeavyMesonPCM("80010113","0dm00009f9730000dge0404000","32c51078a","0000003z00000000","0400503000000000"); // TOF Kaon Proton rejection
+    cuts.AddCutHeavyMesonPCM("80010113","0dm00009f9730000dge0404000","32c51079a","0000003z00000000","0400503000000000"); // TOF Kaon Proton rejection
+  }else if (trainConfig == 1012){ // DCA variations to increase charged pion purity
+    cuts.AddCutHeavyMesonPCM("80010113","0dm00009f9730000dge0404000","32c41076a","0000003z00000000","0400503000000000"); // TOF Kaon Proton rejection + DCA 0.5/3
+    cuts.AddCutHeavyMesonPCM("80010113","0dm00009f9730000dge0404000","32c31076a","0000003z00000000","0400503000000000"); // TOF Kaon Proton rejection + DCA pTdep/3
+    cuts.AddCutHeavyMesonPCM("80010113","0dm00009f9730000dge0404000","32c71076a","0000003z00000000","0400503000000000"); // TOF Kaon Proton rejection + DCA pTdep/pTdep
+
 
     // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
     // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++


### PR DESCRIPTION
- Add rejection option, when TOF signal close to Kaon or Proton
- Add Cutstrings for TOF and DCA variations