### PR TITLE
PWGGA/GammaConv: Add radius dependence to meson-jet corr.

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskConvJet.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskConvJet.cxx
@@ -62,7 +62,10 @@ AliAnalysisTaskConvJet::AliAnalysisTaskConvJet() : AliAnalysisTaskEmcalJet(),
                                                    fTrueVectorJetPhi(0),
                                                    fTrueVectorJetR(0),
                                                    fTrueVectorJetParton(0),
-                                                   fTrueVectorJetPartonPt(0)
+                                                   fTrueVectorJetPartonPt(0),
+                                                   fTrueVectorJetPartonPx(0),
+                                                   fTrueVectorJetPartonPy(0),
+                                                   fTrueVectorJetPartonPz(0)
 {
 }
 
@@ -86,7 +89,10 @@ AliAnalysisTaskConvJet::AliAnalysisTaskConvJet(const char* name) : AliAnalysisTa
                                                                    fTrueVectorJetPhi(0),
                                                                    fTrueVectorJetR(0),
                                                                    fTrueVectorJetParton(0),
-                                                                   fTrueVectorJetPartonPt(0)
+                                                                   fTrueVectorJetPartonPt(0),
+                                                                   fTrueVectorJetPartonPx(0),
+                                                                   fTrueVectorJetPartonPy(0),
+                                                                   fTrueVectorJetPartonPz(0)
 {
   SetMakeGeneralHistograms(kTRUE);
 }
@@ -197,6 +203,9 @@ void AliAnalysisTaskConvJet::FindPartonsJet(TClonesArray* arrMCPart)
   // Loop over all primary MC particle
   fTrueVectorJetParton.resize(fTrueNJets);
   fTrueVectorJetPartonPt.resize(fTrueNJets);
+  fTrueVectorJetPartonPx.resize(fTrueNJets);
+  fTrueVectorJetPartonPy.resize(fTrueNJets);
+  fTrueVectorJetPartonPz.resize(fTrueNJets);
   std::vector<double> partonEnergy(fTrueNJets, -1);
   double JetR2 = Get_Jet_Radius() * Get_Jet_Radius();
 
@@ -230,6 +239,10 @@ void AliAnalysisTaskConvJet::FindPartonsJet(TClonesArray* arrMCPart)
         partonEnergy[indexNearestJet] = particle->Pt();
         fTrueVectorJetParton[indexNearestJet] = i;
         fTrueVectorJetPartonPt[indexNearestJet] = particle->Pt();
+        fTrueVectorJetPartonPx[indexNearestJet] = particle->Px();
+        fTrueVectorJetPartonPy[indexNearestJet] = particle->Py();
+        fTrueVectorJetPartonPz[indexNearestJet] = particle->Pz();
+        
       }
     }
   }

--- a/PWGGA/GammaConv/AliAnalysisTaskConvJet.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskConvJet.h
@@ -61,6 +61,9 @@ class AliAnalysisTaskConvJet : public AliAnalysisTaskEmcalJet
 
   std::vector<int> GetTrueVectorJetParton() { return fTrueVectorJetParton; }
   std::vector<double> GetTrueVectorJetPartonPt() { return fTrueVectorJetPartonPt; }
+  std::vector<double> GetTrueVectorJetPartonPx() { return fTrueVectorJetPartonPx; }
+  std::vector<double> GetTrueVectorJetPartonPy() { return fTrueVectorJetPartonPy; }
+  std::vector<double> GetTrueVectorJetPartonPz() { return fTrueVectorJetPartonPz; }
 
   Double_t Get_Jet_Radius()
   {
@@ -105,13 +108,16 @@ class AliAnalysisTaskConvJet : public AliAnalysisTaskEmcalJet
 
   std::vector<int> fTrueVectorJetParton;      // vector containing the mc stack id from the leading parton ("seed of the jet")
   std::vector<double> fTrueVectorJetPartonPt; // vector containing the pt of the leading parton ("seed of the jet")
+  std::vector<double> fTrueVectorJetPartonPx; // vector containing the pt of the leading parton ("seed of the jet")
+  std::vector<double> fTrueVectorJetPartonPy; // vector containing the pt of the leading parton ("seed of the jet")
+  std::vector<double> fTrueVectorJetPartonPz; // vector containing the pt of the leading parton ("seed of the jet")
 
  private:
   AliAnalysisTaskConvJet(const AliAnalysisTaskConvJet&);
   AliAnalysisTaskConvJet& operator=(const AliAnalysisTaskConvJet&);
 
   /// \cond CLASSIMP
-  ClassDef(AliAnalysisTaskConvJet, 13);
+  ClassDef(AliAnalysisTaskConvJet, 14);
   /// \endcond
 };
 #endif

--- a/PWGGA/GammaConv/AliAnalysisTaskMesonJetCorrelation.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskMesonJetCorrelation.cxx
@@ -84,6 +84,7 @@ ClassImp(AliAnalysisTaskMesonJetCorrelation)
                                                                              fEnableSortForClusMC(true),
                                                                              fFillDCATree(false),
                                                                              fUseCentralEventSelection(true),
+                                                                             fUsePtForZCalc(false),
                                                                              // aod relabeling
                                                                              fMCEventPos(nullptr),
                                                                              fMCEventNeg(nullptr),
@@ -96,8 +97,10 @@ ClassImp(AliAnalysisTaskMesonJetCorrelation)
                                                                              fVecBinsPhotonPt({}),
                                                                              fVecBinsClusterPt({}),
                                                                              fVecBinsMesonPt({}),
+                                                                             fVecBinsMesonPtCoarse({}),
                                                                              fVecBinsJetPt({}),
                                                                              fVecBinsFragment({}),
+                                                                             fVecBinsMesonJetRadius({}),
                                                                              vecEquidistFromMinus05({}),
                                                                              // Jet vectors
                                                                              fVectorJetPt({}),
@@ -118,6 +121,9 @@ ClassImp(AliAnalysisTaskMesonJetCorrelation)
                                                                              fTrueVectorJetPhi({}),
                                                                              fTrueVectorJetPartonID({}),
                                                                              fTrueVectorJetPartonPt({}),
+                                                                             fTrueVectorJetPartonPx({}),
+                                                                             fTrueVectorJetPartonPy({}),
+                                                                             fTrueVectorJetPartonPz({}),
                                                                              fVectorJetEtaPerp({}),
                                                                              fVectorJetPhiPerp({}),
                                                                              MapRecJetsTrueJets(),
@@ -131,6 +137,10 @@ ClassImp(AliAnalysisTaskMesonJetCorrelation)
                                                                              fRespMatrixHandlerMesonBackInvMassVsPt({}),
                                                                              fRespMatrixHandlerMesonInvMassPerpCone({}),
                                                                              fRespMatrixHandlerMesonInvMassVsZPerpCone({}),
+                                                                             fRespMatrixHandlerMesonPtRadius({}),
+                                                                             fRespMatrixHandlerMesonPtTrueRadius({}),
+                                                                             fRespMatrixHandlerMesonPtInvMassRadius({}),
+                                                                             fRespMatrixHandlerMesonBackPtInvMassRadius({}),
                                                                              // basic Histograms
                                                                              fHistoNEvents({}),
                                                                              fHistoNEventsWOWeight({}),
@@ -187,6 +197,9 @@ ClassImp(AliAnalysisTaskMesonJetCorrelation)
                                                                              fRespMatrixHandlerTrueOtherMesonInvMassVsZ({}),
                                                                              fRespMatrixHandlerTrueSecondaryMesonInvMassVsPt({}),
                                                                              fRespMatrixHandlerTrueSecondaryMesonInvMassVsZ({}),
+                                                                             fRespMatrixHandlerTrueMesonPtRadius({}),
+                                                                             fRespMatrixHandlerTrueMesonTruePtRadius({}),
+                                                                             fRespMatrixHandlerTrueSecondaryMesonPtRadius({}),
                                                                              fHistoTrueMesonInvMassVsTruePt({}),
                                                                              fHistoTruePrimaryMesonInvMassPt({}),
                                                                              fHistoTrueSecondaryMesonInvMassPt({}),
@@ -224,6 +237,7 @@ ClassImp(AliAnalysisTaskMesonJetCorrelation)
                                                                              fHistoMCMesonPtNotTriggered({}),
                                                                              fHistoMCMesonPtNoVertex({}),
                                                                              fHistoMCMesonPt({}),
+                                                                             fHistoInclusiveMCMesonPt({}),
                                                                              fHistoMCMesonWOEvtWeightPt({}),
                                                                              fHistoMCMesonInAccPt({}),
                                                                              fHistoMCMesonInAccPtNotTriggered({}),
@@ -244,6 +258,8 @@ ClassImp(AliAnalysisTaskMesonJetCorrelation)
                                                                              fHistoMCPartonPtVsFrag({}),
                                                                              fHistoMCJetPtVsFragTrueParton({}),
                                                                              fHistoMCPartonPtVsFragTrueParton({}),
+                                                                             fHistoMCJetPtVsMesonPtVsRadius({}),
+                                                                             fHistoMCJetPtVsMesonPtVsRadiusInAcc({}),
                                                                              fDCATree({}),
                                                                              fDCATree_InvMass(0),
                                                                              fDCATree_Pt(0),
@@ -315,6 +331,7 @@ AliAnalysisTaskMesonJetCorrelation::AliAnalysisTaskMesonJetCorrelation(const cha
                                                                                            fEnableSortForClusMC(true),
                                                                                            fFillDCATree(false),
                                                                                            fUseCentralEventSelection(true),
+                                                                                           fUsePtForZCalc(false),
                                                                                            // aod relabeling
                                                                                            fMCEventPos(nullptr),
                                                                                            fMCEventNeg(nullptr),
@@ -327,8 +344,10 @@ AliAnalysisTaskMesonJetCorrelation::AliAnalysisTaskMesonJetCorrelation(const cha
                                                                                            fVecBinsPhotonPt({}),
                                                                                            fVecBinsClusterPt({}),
                                                                                            fVecBinsMesonPt({}),
+                                                                                           fVecBinsMesonPtCoarse({}),
                                                                                            fVecBinsJetPt({}),
                                                                                            fVecBinsFragment({}),
+                                                                                           fVecBinsMesonJetRadius({}),
                                                                                            vecEquidistFromMinus05({}),
                                                                                            // Jet vectors
                                                                                            fVectorJetPt({}),
@@ -349,6 +368,9 @@ AliAnalysisTaskMesonJetCorrelation::AliAnalysisTaskMesonJetCorrelation(const cha
                                                                                            fTrueVectorJetPhi({}),
                                                                                            fTrueVectorJetPartonID({}),
                                                                                            fTrueVectorJetPartonPt({}),
+                                                                                           fTrueVectorJetPartonPx({}),
+                                                                                           fTrueVectorJetPartonPy({}),
+                                                                                           fTrueVectorJetPartonPz({}),
                                                                                            fVectorJetEtaPerp({}),
                                                                                            fVectorJetPhiPerp({}),
                                                                                            MapRecJetsTrueJets(),
@@ -362,6 +384,10 @@ AliAnalysisTaskMesonJetCorrelation::AliAnalysisTaskMesonJetCorrelation(const cha
                                                                                            fRespMatrixHandlerMesonBackInvMassVsPt({}),
                                                                                            fRespMatrixHandlerMesonInvMassPerpCone({}),
                                                                                            fRespMatrixHandlerMesonInvMassVsZPerpCone({}),
+                                                                                           fRespMatrixHandlerMesonPtRadius({}),
+                                                                                           fRespMatrixHandlerMesonPtTrueRadius({}),
+                                                                                           fRespMatrixHandlerMesonPtInvMassRadius({}),
+                                                                                           fRespMatrixHandlerMesonBackPtInvMassRadius({}),
                                                                                            // basic Histograms
                                                                                            fHistoNEvents({}),
                                                                                            fHistoNEventsWOWeight({}),
@@ -418,6 +444,9 @@ AliAnalysisTaskMesonJetCorrelation::AliAnalysisTaskMesonJetCorrelation(const cha
                                                                                            fRespMatrixHandlerTrueOtherMesonInvMassVsZ({}),
                                                                                            fRespMatrixHandlerTrueSecondaryMesonInvMassVsPt({}),
                                                                                            fRespMatrixHandlerTrueSecondaryMesonInvMassVsZ({}),
+                                                                                           fRespMatrixHandlerTrueMesonPtRadius({}),
+                                                                                           fRespMatrixHandlerTrueMesonTruePtRadius({}),
+                                                                                           fRespMatrixHandlerTrueSecondaryMesonPtRadius({}),
                                                                                            fHistoTrueMesonInvMassVsTruePt({}),
                                                                                            fHistoTruePrimaryMesonInvMassPt({}),
                                                                                            fHistoTrueSecondaryMesonInvMassPt({}),
@@ -455,6 +484,7 @@ AliAnalysisTaskMesonJetCorrelation::AliAnalysisTaskMesonJetCorrelation(const cha
                                                                                            fHistoMCMesonPtNotTriggered({}),
                                                                                            fHistoMCMesonPtNoVertex({}),
                                                                                            fHistoMCMesonPt({}),
+                                                                                           fHistoInclusiveMCMesonPt({}),
                                                                                            fHistoMCMesonWOEvtWeightPt({}),
                                                                                            fHistoMCMesonInAccPt({}),
                                                                                            fHistoMCMesonInAccPtNotTriggered({}),
@@ -475,6 +505,8 @@ AliAnalysisTaskMesonJetCorrelation::AliAnalysisTaskMesonJetCorrelation(const cha
                                                                                            fHistoMCPartonPtVsFrag({}),
                                                                                            fHistoMCJetPtVsFragTrueParton({}),
                                                                                            fHistoMCPartonPtVsFragTrueParton({}),
+                                                                                           fHistoMCJetPtVsMesonPtVsRadius({}),
+                                                                                           fHistoMCJetPtVsMesonPtVsRadiusInAcc({}),
                                                                                            fDCATree({}),
                                                                                            fDCATree_InvMass(0),
                                                                                            fDCATree_Pt(0),
@@ -510,9 +542,9 @@ void AliAnalysisTaskMesonJetCorrelation::Terminate(const Option_t*)
 }
 
 //_____________________________________________________________________________
-Bool_t AliAnalysisTaskMesonJetCorrelation::Notify()
+bool AliAnalysisTaskMesonJetCorrelation::Notify()
 {
-  for (Int_t iCut = 0; iCut < fnCuts; iCut++) {
+  for (int iCut = 0; iCut < fnCuts; iCut++) {
     if (((AliConvEventCuts*)fEventCutArray->At(iCut))->GetPeriodEnum() == AliConvEventCuts::kNoPeriod && ((AliConvEventCuts*)fV0Reader->GetEventCuts())->GetPeriodEnum() != AliConvEventCuts::kNoPeriod) {
       ((AliConvEventCuts*)fEventCutArray->At(iCut))->SetPeriodEnumExplicit(((AliConvEventCuts*)fV0Reader->GetEventCuts())->GetPeriodEnum());
     } else if (((AliConvEventCuts*)fEventCutArray->At(iCut))->GetPeriodEnum() == AliConvEventCuts::kNoPeriod) {
@@ -536,7 +568,7 @@ void AliAnalysisTaskMesonJetCorrelation::UserCreateOutputObjects()
   }
   if (fOutputContainer == NULL) {
     fOutputContainer = new TList();
-    fOutputContainer->SetOwner(kTRUE);
+    fOutputContainer->SetOwner(true);
   }
 
   // Initialize V0 reader
@@ -612,6 +644,7 @@ void AliAnalysisTaskMesonJetCorrelation::UserCreateOutputObjects()
     fHistoMCMesonPtNotTriggered.resize(fnCuts);
     fHistoMCMesonPtNoVertex.resize(fnCuts);
     fHistoMCMesonPt.resize(fnCuts);
+    fHistoInclusiveMCMesonPt.resize(fnCuts);
     fHistoMCMesonWOEvtWeightPt.resize(fnCuts);
     fHistoMCMesonInAccPt.resize(fnCuts);
     fHistoMCMesonInAccPtNotTriggered.resize(fnCuts);
@@ -631,6 +664,8 @@ void AliAnalysisTaskMesonJetCorrelation::UserCreateOutputObjects()
     fHistoMCPartonPtVsFrag.resize(fnCuts);
     fHistoMCJetPtVsFragTrueParton.resize(fnCuts);
     fHistoMCPartonPtVsFragTrueParton.resize(fnCuts);
+    fHistoMCJetPtVsMesonPtVsRadius.resize(fnCuts);
+    fHistoMCJetPtVsMesonPtVsRadiusInAcc.resize(fnCuts);
   }
 
   //----------------------
@@ -692,6 +727,9 @@ void AliAnalysisTaskMesonJetCorrelation::UserCreateOutputObjects()
     fRespMatrixHandlerTrueOtherMesonInvMassVsZ.resize(fnCuts);
     fRespMatrixHandlerTrueSecondaryMesonInvMassVsPt.resize(fnCuts);
     fRespMatrixHandlerTrueSecondaryMesonInvMassVsZ.resize(fnCuts);
+    fRespMatrixHandlerTrueMesonPtRadius.resize(fnCuts);
+    fRespMatrixHandlerTrueMesonTruePtRadius.resize(fnCuts);
+    fRespMatrixHandlerTrueSecondaryMesonPtRadius.resize(fnCuts);
     if(fDoMesonQA > 0){
       fHistoTrueMesonInvMassVsTruePt.resize(fnCuts);
       fHistoTruePrimaryMesonInvMassPt.resize(fnCuts);
@@ -744,12 +782,18 @@ void AliAnalysisTaskMesonJetCorrelation::UserCreateOutputObjects()
   // perpendicular cone
   fRespMatrixHandlerMesonInvMassVsZPerpCone.resize(fnCuts);
   fRespMatrixHandlerMesonInvMassPerpCone.resize(fnCuts);
+  // vs. radius and pt
+  fRespMatrixHandlerMesonPtInvMassRadius.resize(fnCuts);
+  fRespMatrixHandlerMesonBackPtInvMassRadius.resize(fnCuts);
   if (fIsMC) {
     fRespMatrixHandlerMesonPt.resize(fnCuts);
     fRespMatrixHandlerFrag.resize(fnCuts);
     if(!fDoLightOutput) {
       fRespMatrixHandlerFragTrueJets.resize(fnCuts);
     }
+    // vs radius and pt
+    fRespMatrixHandlerMesonPtRadius.resize(fnCuts);
+    fRespMatrixHandlerMesonPtTrueRadius.resize(fnCuts);
   }
 
   if(fIsConv && fFillDCATree){
@@ -772,33 +816,33 @@ void AliAnalysisTaskMesonJetCorrelation::UserCreateOutputObjects()
 
     fCutFolder[iCut] = new TList();
     fCutFolder[iCut]->SetName(Form("Cut Number %s", cutString.Data()));
-    fCutFolder[iCut]->SetOwner(kTRUE);
+    fCutFolder[iCut]->SetOwner(true);
     fOutputContainer->Add(fCutFolder[iCut]);
 
     fESDList[iCut] = new TList();
     fESDList[iCut]->SetName(Form("%s ESD histograms", cutString.Data()));
-    fESDList[iCut]->SetOwner(kTRUE);
+    fESDList[iCut]->SetOwner(true);
     fCutFolder[iCut]->Add(fESDList[iCut]);
 
     fJetList[iCut] = new TList();
     fJetList[iCut]->SetName(Form("%s Jet histograms", cutString.Data()));
-    fJetList[iCut]->SetOwner(kTRUE);
+    fJetList[iCut]->SetOwner(true);
     fCutFolder[iCut]->Add(fJetList[iCut]);
 
     if (fIsMC) {
       fTrueJetList[iCut] = new TList();
       fTrueJetList[iCut]->SetName(Form("%s True Jet histograms", cutString.Data()));
-      fTrueJetList[iCut]->SetOwner(kTRUE);
+      fTrueJetList[iCut]->SetOwner(true);
       fCutFolder[iCut]->Add(fTrueJetList[iCut]);
 
       fTrueList[iCut] = new TList();
       fTrueList[iCut]->SetName(Form("%s True histograms", cutString.Data()));
-      fTrueList[iCut]->SetOwner(kTRUE);
+      fTrueList[iCut]->SetOwner(true);
       fCutFolder[iCut]->Add(fTrueList[iCut]);
 
       fMCList[iCut] = new TList();
       fMCList[iCut]->SetName(Form("%s MC histograms", cutString.Data()));
-      fMCList[iCut]->SetOwner(kTRUE);
+      fMCList[iCut]->SetOwner(true);
       fCutFolder[iCut]->Add(fMCList[iCut]);
     }
 
@@ -999,6 +1043,10 @@ void AliAnalysisTaskMesonJetCorrelation::UserCreateOutputObjects()
       fHistoMCMesonPtNoVertex[iCut]->SetXTitle("p_{T} (GeV/c)");
       fMCList[iCut]->Add(fHistoMCMesonPtNoVertex[iCut]);
 
+      fHistoInclusiveMCMesonPt[iCut] = new TH1F("MC_Pi0_Pt_inclusive", "MC_Pi0_Pt_inclusive", fVecBinsPhotonPt.size() - 1, fVecBinsPhotonPt.data());
+      fHistoInclusiveMCMesonPt[iCut]->SetXTitle("p_{T} (GeV/c)");
+      fMCList[iCut]->Add(fHistoInclusiveMCMesonPt[iCut]);
+
       fHistoMCMesonWOEvtWeightPt[iCut] = new TH1F("MC_Pi0_WOEventWeights_Pt", "MC_Pi0_WOEventWeights_Pt", fVecBinsPhotonPt.size() - 1, fVecBinsPhotonPt.data());
       fHistoMCMesonWOEvtWeightPt[iCut]->SetXTitle("p_{T} (GeV/c)");
       fMCList[iCut]->Add(fHistoMCMesonWOEvtWeightPt[iCut]);
@@ -1086,7 +1134,20 @@ void AliAnalysisTaskMesonJetCorrelation::UserCreateOutputObjects()
       fHistoMCPartonPtVsFragTrueParton[iCut]->SetXTitle("z (true)");
       fHistoMCPartonPtVsFragTrueParton[iCut]->SetYTitle("p_{T, parton, jet} (GeV/c)");
       fMCList[iCut]->Add(fHistoMCPartonPtVsFragTrueParton[iCut]);
-    }
+
+      fHistoMCJetPtVsMesonPtVsRadius[iCut] = new TH3F("MC_PtMeson_PtJet_Radius", "MC_PtMeson_PtJet_Radius", fVecBinsMesonPtCoarse.size() - 1, fVecBinsMesonPtCoarse.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data(), fVecBinsMesonJetRadius.size()-1, fVecBinsMesonJetRadius.data());
+      fHistoMCJetPtVsMesonPtVsRadius[iCut]->SetXTitle("p_{T, meson}");
+      fHistoMCJetPtVsMesonPtVsRadius[iCut]->SetYTitle("p_{T, jet}");
+      fHistoMCJetPtVsMesonPtVsRadius[iCut]->SetZTitle("radius");
+      fMCList[iCut]->Add(fHistoMCJetPtVsMesonPtVsRadius[iCut]);
+
+      fHistoMCJetPtVsMesonPtVsRadiusInAcc[iCut] = new TH3F("MC_PtMeson_PtJet_Radius_InAcc", "MC_PtMeson_PtJet_Radius_InAcc", fVecBinsMesonPtCoarse.size() - 1, fVecBinsMesonPtCoarse.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data(), fVecBinsMesonJetRadius.size()-1, fVecBinsMesonJetRadius.data());
+      fHistoMCJetPtVsMesonPtVsRadiusInAcc[iCut]->SetXTitle("p_{T, meson}");
+      fHistoMCJetPtVsMesonPtVsRadiusInAcc[iCut]->SetYTitle("p_{T, jet}");
+      fHistoMCJetPtVsMesonPtVsRadiusInAcc[iCut]->SetZTitle("radius");
+      fMCList[iCut]->Add(fHistoMCJetPtVsMesonPtVsRadiusInAcc[iCut]);
+
+    } // end MC generated histos
 
     // conversion photons
     if (fIsMC && !fIsCalo) {
@@ -1208,6 +1269,29 @@ void AliAnalysisTaskMesonJetCorrelation::UserCreateOutputObjects()
         fTrueList[iCut]->Add(fRespMatrixHandlerTrueSecondaryMesonInvMassVsZ[iCut]->GetTHnSparse("ESD_TrueSecondaryMother_InvMass_Z_JetPt"));
       else
         fTrueList[iCut]->Add(fRespMatrixHandlerTrueSecondaryMesonInvMassVsZ[iCut]->GetTH2("ESD_TrueSecondaryMother_InvMass_Z_JetPt"));
+
+      // inv. mass vs. radius
+      std::vector<std::vector<double>> vecXAxisRadius = {fVecBinsMesonInvMass, fVecBinsMesonPtCoarse, fVecBinsMesonJetRadius};
+      std::vector<std::vector<double>> vecYAxisRadius = {fVecBinsJetPt, {0, 1}, {0, 1}};
+
+      fRespMatrixHandlerTrueMesonPtRadius[iCut] = new MatrixHandlerNDim(vecXAxisRadius, vecYAxisRadius, fUseThNForResponse);
+      if (fUseThNForResponse)
+        fTrueList[iCut]->Add(fRespMatrixHandlerTrueMesonPtRadius[iCut]->GetTHnSparse("ESD_TrueMother_InvMass_Pt_JetPt_Radius"));
+      else
+        fTrueList[iCut]->Add(fRespMatrixHandlerTrueMesonPtRadius[iCut]->GetTH2("ESD_TrueMother_InvMass_Pt_JetPt_Radius"));
+
+      fRespMatrixHandlerTrueMesonTruePtRadius[iCut] = new MatrixHandlerNDim(vecXAxisRadius, vecYAxisRadius, fUseThNForResponse);
+      if (fUseThNForResponse)
+        fTrueList[iCut]->Add(fRespMatrixHandlerTrueMesonTruePtRadius[iCut]->GetTHnSparse("ESD_TrueMother_InvMass_TruePt_JetPt_Radius"));
+      else
+        fTrueList[iCut]->Add(fRespMatrixHandlerTrueMesonTruePtRadius[iCut]->GetTH2("ESD_TrueMother_InvMass_TruePt_JetPt_Radius"));
+
+      fRespMatrixHandlerTrueSecondaryMesonPtRadius[iCut] = new MatrixHandlerNDim(vecXAxisRadius, vecYAxisRadius, fUseThNForResponse);
+      if (fUseThNForResponse)
+        fTrueList[iCut]->Add(fRespMatrixHandlerTrueSecondaryMesonPtRadius[iCut]->GetTHnSparse("ESD_TrueSecondaryMother_InvMass_Pt_JetPt_Radius"));
+      else
+        fTrueList[iCut]->Add(fRespMatrixHandlerTrueSecondaryMesonPtRadius[iCut]->GetTH2("ESD_TrueSecondaryMother_InvMass_Pt_JetPt_Radius"));
+
 
       if(fDoMesonQA > 0){
         fHistoTrueMesonInvMassVsTruePt[iCut] = new TH2F("ESD_TrueMother_InvMass_TruePt", "ESD_TrueMother_InvMass_TruePt", fVecBinsMesonInvMass.size() - 1, fVecBinsMesonInvMass.data(), fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data());
@@ -1356,6 +1440,23 @@ void AliAnalysisTaskMesonJetCorrelation::UserCreateOutputObjects()
     else
       fESDList[iCut]->Add(fRespMatrixHandlerMesonInvMassPerpCone[iCut]->GetTH2("InvMassVsPt_JetPt_PerpCone"));
 
+    std::vector<std::vector<double>> vecXAxisInvMassPtRadius = {fVecBinsMesonInvMass, fVecBinsMesonPtCoarse, fVecBinsMesonJetRadius};
+    std::vector<std::vector<double>> vecYAxisJetPt = {fVecBinsJetPt, {0, 1}, {0, 1}};
+    fRespMatrixHandlerMesonPtInvMassRadius[iCut] = new MatrixHandlerNDim(vecXAxisInvMassPtRadius, vecYAxisJetPt, fUseThNForResponse);
+    if (fUseThNForResponse)
+      fESDList[iCut]->Add(fRespMatrixHandlerMesonPtInvMassRadius[iCut]->GetTHnSparse("InvMassVsPtVsR_JetPt"));
+    else
+      fESDList[iCut]->Add(fRespMatrixHandlerMesonPtInvMassRadius[iCut]->GetTH2("InvMassVsPtVsR_JetPt"));
+
+    fRespMatrixHandlerMesonBackPtInvMassRadius[iCut] = new MatrixHandlerNDim(vecXAxisInvMassPtRadius, vecYAxisJetPt, fUseThNForResponse);
+    if (fUseThNForResponse)
+      fESDList[iCut]->Add(fRespMatrixHandlerMesonBackPtInvMassRadius[iCut]->GetTHnSparse("InvMassVsPtVsR_Background_JetPt"));
+    else
+      fESDList[iCut]->Add(fRespMatrixHandlerMesonBackPtInvMassRadius[iCut]->GetTH2("InvMassVsPtVsR_Background_JetPt"));
+
+    //-----------------------------------------------//
+    // ----------------- MC related ---------------- //
+    //-----------------------------------------------//
     if (fIsMC) {
       fRespMatrixHandlerMesonPt[iCut] = new MatrixHandler4D(fVecBinsMesonPt, fVecBinsMesonPt, fVecBinsJetPt, fVecBinsJetPt, fUseThNForResponse);
       if (fUseThNForResponse)
@@ -1376,7 +1477,20 @@ void AliAnalysisTaskMesonJetCorrelation::UserCreateOutputObjects()
         else
           fTrueList[iCut]->Add(fRespMatrixHandlerFragTrueJets[iCut]->GetTH2("Frag_JetPt_TrueVsRec_ForTrueJets"));
       }
-    }
+      
+      std::vector<std::vector<double>> vecXAxisRadius = {fVecBinsJetPt, fVecBinsMesonJetRadius, fVecBinsMesonPtCoarse};
+      fRespMatrixHandlerMesonPtRadius[iCut] = new MatrixHandlerNDim(vecXAxisRadius, vecXAxisRadius, fUseThNForResponse);
+      if (fUseThNForResponse)
+        fTrueList[iCut]->Add(fRespMatrixHandlerMesonPtRadius[iCut]->GetTHnSparse("JetPt_Radius_MesonPt_TrueVsRec"));
+      else
+        fTrueList[iCut]->Add(fRespMatrixHandlerMesonPtRadius[iCut]->GetTH2("JetPt_Radius_MesonPt_TrueVsRec"));
+
+      fRespMatrixHandlerMesonPtTrueRadius[iCut] = new MatrixHandlerNDim(vecXAxisRadius, vecXAxisRadius, fUseThNForResponse);
+      if (fUseThNForResponse)
+        fTrueList[iCut]->Add(fRespMatrixHandlerMesonPtTrueRadius[iCut]->GetTHnSparse("MesonPt_JetPt_TrueRadius_TrueVsRec"));
+      else
+        fTrueList[iCut]->Add(fRespMatrixHandlerMesonPtTrueRadius[iCut]->GetTH2("MesonPt_JetPt_TrueRadius_TrueVsRec"));
+    } // end MC related
     
     if(fUseCentralEventSelection){
       fAliEventCuts.AddQAplotsToList(fESDList[iCut]);
@@ -1541,6 +1655,11 @@ void AliAnalysisTaskMesonJetCorrelation::MakeBinning()
       break;
   }
   //---------------------------
+  // Course Meson pt Binning
+  //---------------------------
+  fVecBinsMesonPtCoarse = {0, 1, 2, 5, 10, 20, 50};
+
+  //---------------------------
   // Jet pt Binning
   //---------------------------
   double valJetPt = 0;
@@ -1576,6 +1695,11 @@ void AliAnalysisTaskMesonJetCorrelation::MakeBinning()
     else
       break;
   }
+
+  //---------------------------
+  // Radius Binning
+  //---------------------------
+  fVecBinsMesonJetRadius = {0, 0.05, 0.1, 0.2, 0.3, 0.4};
 
   //---------------------------
   // Equidistant binning starting at -0.5
@@ -1643,6 +1767,9 @@ void AliAnalysisTaskMesonJetCorrelation::InitJets()
     fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi();
     fTrueVectorJetPartonID = fConvJetReader->GetTrueVectorJetParton();
     fTrueVectorJetPartonPt = fConvJetReader->GetTrueVectorJetPartonPt();
+    fTrueVectorJetPartonPx = fConvJetReader->GetTrueVectorJetPartonPx();
+    fTrueVectorJetPartonPy = fConvJetReader->GetTrueVectorJetPartonPy();
+    fTrueVectorJetPartonPz = fConvJetReader->GetTrueVectorJetPartonPz();
   }
 }
 
@@ -1680,12 +1807,12 @@ void AliAnalysisTaskMesonJetCorrelation::ProcessJets()
       }
 
       if (fIsMC > 0 && fConvJetReader->GetNJets() > 0 && fConvJetReader->GetTrueNJets() > 0) {
-        Double_t min = 100;
+        double min = 100;
         int match = -1;
         for (int j = 0; j < fConvJetReader->GetTrueNJets(); j++) {
-          Double_t R_jetjet;
-          Double_t DeltaEta = fVectorJetEta.at(i) - fTrueVectorJetEta.at(j);
-          Double_t DeltaPhi = abs(fVectorJetPhi.at(i) - fTrueVectorJetPhi.at(j));
+          double R_jetjet;
+          double DeltaEta = fVectorJetEta.at(i) - fTrueVectorJetEta.at(j);
+          double DeltaPhi = abs(fVectorJetPhi.at(i) - fTrueVectorJetPhi.at(j));
           if (DeltaPhi > M_PI) {
             DeltaPhi = 2 * M_PI - DeltaPhi;
           }
@@ -1755,7 +1882,7 @@ void AliAnalysisTaskMesonJetCorrelation::UserExec(Option_t*)
     fMCEvent = MCEvent();
 
   int eventQuality = ((AliConvEventCuts*)fV0Reader->GetEventCuts())->GetEventQuality();
-  if (fInputEvent->IsIncompleteDAQ() == kTRUE)
+  if (fInputEvent->IsIncompleteDAQ() == true)
     eventQuality = 2; // incomplete event
   // Event Not Accepted due to MC event missing or wrong trigger for V0ReaderV1 or because it is incomplete => abort processing of this event/file
   if (eventQuality == 2 || eventQuality == 3) {
@@ -1772,8 +1899,8 @@ void AliAnalysisTaskMesonJetCorrelation::UserExec(Option_t*)
   }
 
   if (fIsMC > 0 && fInputEvent->IsA() == AliAODEvent::Class() && !(fV0Reader->AreAODsRelabeled())) {
-    RelabelAODPhotonCandidates(kTRUE); // In case of AODMC relabeling MC
-    fV0Reader->RelabelAODs(kTRUE);
+    RelabelAODPhotonCandidates(true); // In case of AODMC relabeling MC
+    fV0Reader->RelabelAODs(true);
   }
 
   // Get Event Plane Angle
@@ -1785,16 +1912,16 @@ void AliAnalysisTaskMesonJetCorrelation::UserExec(Option_t*)
 
   for (int iCut = 0; iCut < fnCuts; iCut++) {
     fiCut = iCut;
-    Bool_t isRunningEMCALrelAna = kFALSE;
+    bool isRunningEMCALrelAna = false;
     if (fIsCalo || fIsConvCalo) {
       if (((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetClusterType() == 1)
-        isRunningEMCALrelAna = kTRUE;
+        isRunningEMCALrelAna = true;
     }
 
     int eventNotAccepted = ((AliConvEventCuts*)fEventCutArray->At(iCut))->IsEventAcceptedByCut(fV0Reader->GetEventCuts(), fInputEvent, fMCEvent, fIsHeavyIon, isRunningEMCALrelAna);
     if (fIsMC == 2) {
-      Float_t xsection = -1.;
-      Float_t ntrials = -1.;
+      float xsection = -1.;
+      float ntrials = -1.;
       ((AliConvEventCuts*)fEventCutArray->At(iCut))->GetXSectionAndNTrials(fMCEvent, xsection, ntrials, fInputEvent);
       if ((xsection == -1.) || (ntrials == -1.))
         AliFatal(Form("ERROR: GetXSectionAndNTrials returned invalid xsection/ntrials, periodName from V0Reader: '%s'", fV0Reader->GetPeriodName().Data()));
@@ -1804,16 +1931,16 @@ void AliAnalysisTaskMesonJetCorrelation::UserExec(Option_t*)
 
     fWeightJetJetMC = 1;
     if (fIsMC > 0) {
-      Float_t maxjetpt = -1.;
-      Float_t pthard = -1;
+      float maxjetpt = -1.;
+      float pthard = -1;
       if (((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetUseJetFinderForOutliers())
         maxjetpt = fOutlierJetReader->GetMaxJetPt();
-      Bool_t isMCJet = ((AliConvEventCuts*)fEventCutArray->At(iCut))->IsJetJetMCEventAccepted(fMCEvent, fWeightJetJetMC, pthard, fInputEvent, maxjetpt);
+      bool isMCJet = ((AliConvEventCuts*)fEventCutArray->At(iCut))->IsJetJetMCEventAccepted(fMCEvent, fWeightJetJetMC, pthard, fInputEvent, maxjetpt);
       if (isMCJet && (fIsMC == 2)) {
         fHistoPtHardJJWeight[iCut]->Fill(pthard, fWeightJetJetMC);
       }
       if (fIsMC == 3) {
-        Double_t weightMult = ((AliConvEventCuts*)fEventCutArray->At(iCut))->GetWeightForMultiplicity(fV0Reader->GetNumberOfPrimaryTracks());
+        double weightMult = ((AliConvEventCuts*)fEventCutArray->At(iCut))->GetWeightForMultiplicity(fV0Reader->GetNumberOfPrimaryTracks());
         fWeightJetJetMC = fWeightJetJetMC * weightMult;
       }
 
@@ -1906,8 +2033,8 @@ void AliAnalysisTaskMesonJetCorrelation::UserExec(Option_t*)
   }
 
   if (fIsMC > 0 && fInputEvent->IsA() == AliAODEvent::Class() && !(fV0Reader->AreAODsRelabeled())) {
-    RelabelAODPhotonCandidates(kFALSE); // Back to ESDMC Label
-    fV0Reader->RelabelAODs(kFALSE);
+    RelabelAODPhotonCandidates(false); // Back to ESDMC Label
+    fV0Reader->RelabelAODs(false);
   }
   PostData(1, fOutputContainer);
 
@@ -1944,11 +2071,11 @@ void AliAnalysisTaskMesonJetCorrelation::ProcessClusters()
   int NClusinJets = 0;
 
   // match tracks to clusters
-  ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->MatchTracksToClusters(fInputEvent, fWeightJetJetMC, kTRUE, fMCEvent);
+  ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->MatchTracksToClusters(fInputEvent, fWeightJetJetMC, true, fMCEvent);
 
   for (Long_t i = 0; i < nclus; i++) {
-    Double_t tempClusterWeight = fWeightJetJetMC;
-    // Double_t tempPhotonWeight = fWeightJetJetMC;
+    double tempClusterWeight = fWeightJetJetMC;
+    // double tempPhotonWeight = fWeightJetJetMC;
     AliVCluster* clus = NULL;
     if (fInputEvent->IsA() == AliESDEvent::Class()) {
       if (arrClustersProcess)
@@ -1979,7 +2106,7 @@ void AliAnalysisTaskMesonJetCorrelation::ProcessClusters()
     }
 
     // vertex
-    Double_t vertex[3] = {0};
+    double vertex[3] = {0};
     InputEvent()->GetPrimaryVertex()->GetXYZ(vertex);
 
     // TLorentzvector with cluster
@@ -2039,8 +2166,8 @@ void AliAnalysisTaskMesonJetCorrelation::ProcessClusters()
       }
     }
 
-    fIsFromDesiredHeader = kTRUE;
-    // bool fIsOverlappingWithOtherHeader = kFALSE;
+    fIsFromDesiredHeader = true;
+    // bool fIsOverlappingWithOtherHeader = false;
     // bool fAllowOverlapHeaders = true;
     // test whether largest contribution to cluster orginates in added signals
     if (fIsMC > 0 && ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetSignalRejection() > 0) {
@@ -2048,12 +2175,12 @@ void AliAnalysisTaskMesonJetCorrelation::ProcessClusters()
       // if (((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsParticleFromBGEvent(PhotonCandidate->GetCaloPhotonMCLabel(0), fMCEvent, fInputEvent) == 2 && ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetSignalRejection() == 4)
       //   tempPhotonWeight = 1;
       // if (((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsParticleFromBGEvent(PhotonCandidate->GetCaloPhotonMCLabel(0), fMCEvent, fInputEvent) == 0)
-      // fIsFromDesiredHeader = kFALSE;
+      // fIsFromDesiredHeader = false;
       // if (clus->GetNLabels() > 1) {
       // int* mclabelsCluster = clus->GetLabels();
       // for (int l = 1; l < (int)clus->GetNLabels(); l++) {
       //   if (((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsParticleFromBGEvent(mclabelsCluster[l], fMCEvent, fInputEvent, false) == 0)
-      //     fIsOverlappingWithOtherHeader = kTRUE;
+      //     fIsOverlappingWithOtherHeader = true;
       // }
       // }
     }
@@ -2079,11 +2206,11 @@ void AliAnalysisTaskMesonJetCorrelation::ProcessPhotonCandidates()
 
   if (((AliConversionPhotonCuts*)fConvCutArray->At(fiCut))->GetDoElecDeDxPostCalibration()) {
     if (!(((AliConversionPhotonCuts*)fConvCutArray->At(fiCut))->LoadElecDeDxPostCalibration(fInputEvent->GetRunNumber()))) {
-      AliFatal(Form("ERROR: LoadElecDeDxPostCalibration returned kFALSE for %d despite being requested!", fInputEvent->GetRunNumber()));
+      AliFatal(Form("ERROR: LoadElecDeDxPostCalibration returned false for %d despite being requested!", fInputEvent->GetRunNumber()));
     }
   }
 
-  Double_t magField = fInputEvent->GetMagneticField();
+  double magField = fInputEvent->GetMagneticField();
   int nV0 = 0;
   TList* GammaCandidatesStepOne = new TList();
   TList* GammaCandidatesStepTwo = new TList();
@@ -2093,7 +2220,7 @@ void AliAnalysisTaskMesonJetCorrelation::ProcessPhotonCandidates()
     AliAODConversionPhoton* PhotonCandidate = (AliAODConversionPhoton*)fReaderGammas->At(i);
     if (!PhotonCandidate)
       continue;
-    fIsFromDesiredHeader = kTRUE;
+    fIsFromDesiredHeader = true;
 
     double weightMatBudgetGamma = 1.;
     if (fDoMaterialBudgetWeightingOfGammasForTrueMesons && ((AliConversionPhotonCuts*)fConvCutArray->At(fiCut))->GetMaterialBudgetWeightsInitialized()) {
@@ -2105,7 +2232,7 @@ void AliAnalysisTaskMesonJetCorrelation::ProcessPhotonCandidates()
     //   if(isPosFromMBHeader == 0 && ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetSignalRejection() != 3) continue;
     //   int isNegFromMBHeader = ((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsParticleFromBGEvent(PhotonCandidate->GetMCLabelNegative(), fMCEvent, fInputEvent);
     //   if(isNegFromMBHeader == 0 && ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetSignalRejection() != 3) continue;
-    //   if( (isNegFromMBHeader+isPosFromMBHeader) != 4) fIsFromDesiredHeader = kFALSE;
+    //   if( (isNegFromMBHeader+isPosFromMBHeader) != 4) fIsFromDesiredHeader = false;
     // }
 
     if (!((AliConversionPhotonCuts*)fConvCutArray->At(fiCut))->PhotonIsSelected(PhotonCandidate, fInputEvent))
@@ -2152,7 +2279,7 @@ void AliAnalysisTaskMesonJetCorrelation::ProcessPhotonCandidates()
       AliAODConversionPhoton* PhotonCandidate = (AliAODConversionPhoton*)GammaCandidatesStepOne->At(i);
       if (!PhotonCandidate)
         continue;
-      fIsFromDesiredHeader = kTRUE;
+      fIsFromDesiredHeader = true;
 
       double weightMatBudgetGamma = 1.;
       if (fDoMaterialBudgetWeightingOfGammasForTrueMesons && ((AliConversionPhotonCuts*)fConvCutArray->At(fiCut))->GetMaterialBudgetWeightsInitialized()) {
@@ -2163,7 +2290,7 @@ void AliAnalysisTaskMesonJetCorrelation::ProcessPhotonCandidates()
         int isPosFromMBHeader = ((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsParticleFromBGEvent(PhotonCandidate->GetMCLabelPositive(), fMCEvent, fInputEvent);
         int isNegFromMBHeader = ((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsParticleFromBGEvent(PhotonCandidate->GetMCLabelNegative(), fMCEvent, fInputEvent);
         if ((isNegFromMBHeader + isPosFromMBHeader) != 4)
-          fIsFromDesiredHeader = kFALSE;
+          fIsFromDesiredHeader = false;
       }
 
       if (!((AliConversionPhotonCuts*)fConvCutArray->At(fiCut))->RejectSharedElectronV0s(PhotonCandidate, i, GammaCandidatesStepOne->GetEntries()))
@@ -2200,7 +2327,7 @@ void AliAnalysisTaskMesonJetCorrelation::ProcessPhotonCandidates()
 
       if (!PhotonCandidate)
         continue;
-      fIsFromDesiredHeader = kTRUE;
+      fIsFromDesiredHeader = true;
 
       double weightMatBudgetGamma = 1.;
       if (fDoMaterialBudgetWeightingOfGammasForTrueMesons && ((AliConversionPhotonCuts*)fConvCutArray->At(fiCut))->GetMaterialBudgetWeightsInitialized()) {
@@ -2211,7 +2338,7 @@ void AliAnalysisTaskMesonJetCorrelation::ProcessPhotonCandidates()
         int isPosFromMBHeader = ((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsParticleFromBGEvent(PhotonCandidate->GetMCLabelPositive(), fMCEvent, fInputEvent);
         int isNegFromMBHeader = ((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsParticleFromBGEvent(PhotonCandidate->GetMCLabelNegative(), fMCEvent, fInputEvent);
         if ((isNegFromMBHeader + isPosFromMBHeader) != 4)
-          fIsFromDesiredHeader = kFALSE;
+          fIsFromDesiredHeader = false;
       }
       if (!((AliConversionPhotonCuts*)fConvCutArray->At(fiCut))->RejectToCloseV0s(PhotonCandidate, GammaCandidatesStepTwo, i))
         continue;
@@ -2332,7 +2459,7 @@ void AliAnalysisTaskMesonJetCorrelation::FillMesonHistograms(AliAODConversionPho
   AliAODConversionMother* pi0cand = new AliAODConversionMother(gamma0, gamma1);
   pi0cand->SetLabels(firstGammaIndex, secondGammaIndex);
 
-  if ((((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelected(pi0cand, kTRUE, ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift(), gamma0->GetLeadingCellID(), gamma1->GetLeadingCellID(), gamma0->GetIsCaloPhoton(), gamma1->GetIsCaloPhoton()))) {
+  if ((((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelected(pi0cand, true, ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift(), gamma0->GetLeadingCellID(), gamma1->GetLeadingCellID(), gamma0->GetIsCaloPhoton(), gamma1->GetIsCaloPhoton()))) {
 
     double weightMatBudget = 1.;
     if(fDoMaterialBudgetWeightingOfGammasForTrueMesons){
@@ -2358,6 +2485,10 @@ void AliAnalysisTaskMesonJetCorrelation::FillMesonHistograms(AliAODConversionPho
 
       // Fill the inv. mass histograms for all jet pTs
       fRespMatrixHandlerMesonInvMass[fiCut]->Fill(ptJet, 0.5, pi0cand->M(), pi0cand->Pt(), fWeightJetJetMC*weightMatBudget);
+
+      std::vector<double> vecFillInvMassPtR = {pi0cand->M(), pi0cand->Pt(), RJetPi0Cand};
+      std::vector<double> vecFillJetPt = {ptJet, 0.5, 0.5};
+      fRespMatrixHandlerMesonPtInvMassRadius[fiCut]->Fill(vecFillInvMassPtR, vecFillJetPt, fWeightJetJetMC*weightMatBudget);
 
       // Fill Z histograms
       float z = GetFrag(pi0cand, matchedJet, false);
@@ -2423,13 +2554,30 @@ float AliAnalysisTaskMesonJetCorrelation::GetFrag(AliAODConversionMother* Pi0Can
   if (matchedJet < 0) {
     return 0;
   }
+  
   float z = 0;
-  if (isTrueJet == 1) {
-    z = Pi0Candidate->Pt() / fTrueVectorJetPt[matchedJet];
-  } else if (isTrueJet == 2) {
-    z = Pi0Candidate->Pt() / fTrueVectorJetPartonPt[matchedJet];
+  
+  if(fUsePtForZCalc){
+    if (isTrueJet == 1) {
+      z = (fTrueVectorJetPt[matchedJet] == 0) ? 0 : Pi0Candidate->Pt() / fTrueVectorJetPt[matchedJet];
+    } else if (isTrueJet == 2) {
+      z = (fTrueVectorJetPartonPt[matchedJet] == 0) ? 0 : Pi0Candidate->Pt() / fTrueVectorJetPartonPt[matchedJet];
+    } else {
+      z = (fVectorJetPt[matchedJet] == 0) ? 0 : Pi0Candidate->Pt() / fVectorJetPt[matchedJet];
+    }
   } else {
-    z = Pi0Candidate->Pt() / fVectorJetPt[matchedJet];
+    std::array<float, 3> arrJetP; // px, py, pz
+    if (isTrueJet == 1) {
+      arrJetP = {static_cast<float>(fTrueVectorJetPx[matchedJet]), static_cast<float>(fTrueVectorJetPy[matchedJet]), static_cast<float>(fTrueVectorJetPz[matchedJet])};
+    } else if (isTrueJet == 2) {
+      arrJetP = {static_cast<float>(fTrueVectorJetPartonPx[matchedJet]), static_cast<float>(fTrueVectorJetPartonPy[matchedJet]), static_cast<float>(fTrueVectorJetPartonPz[matchedJet])};
+    } else {
+      arrJetP = {static_cast<float>(fVectorJetPx[matchedJet]), static_cast<float>(fVectorJetPy[matchedJet]), static_cast<float>(fVectorJetPz[matchedJet])};
+    }
+
+    float scalarProd = std::abs(Pi0Candidate->Px()*arrJetP[0] + Pi0Candidate->Py()*arrJetP[1] + Pi0Candidate->Pz()*arrJetP[1]);
+    float JetP2 = arrJetP[0]*arrJetP[0] + arrJetP[1]*arrJetP[1] + arrJetP[2]*arrJetP[2];
+    z = (JetP2 == 0) ? 0 : scalarProd/JetP2;
   }
   return z;
 }
@@ -2440,18 +2588,78 @@ float AliAnalysisTaskMesonJetCorrelation::GetFrag(AliAODMCParticle* Pi0Candidate
   if (!((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->DoJetAnalysis()) {
     return 0;
   }
+  
   if (matchedJet < 0) {
     return 0;
   }
-  float z = 0;
-  if (isTrueJet == 1) {
-    z = Pi0Candidate->Pt() / fTrueVectorJetPt[matchedJet];
-  } else if (isTrueJet == 2) {
-    z = Pi0Candidate->Pt() / fTrueVectorJetPartonPt[matchedJet];
+
+  float z=0;
+  if(fUsePtForZCalc){
+    // old way to calculate z
+    if (isTrueJet == 1) {
+      z = (fTrueVectorJetPt[matchedJet] == 0) ? 0 : Pi0Candidate->Pt() / fTrueVectorJetPt[matchedJet];
+    } else if (isTrueJet == 2) {
+      z = (fTrueVectorJetPartonPt[matchedJet] == 0) ? 0 : Pi0Candidate->Pt() / fTrueVectorJetPartonPt[matchedJet];
+    } else {
+      z = (fVectorJetPt[matchedJet] == 0) ? 0 : Pi0Candidate->Pt() / fVectorJetPt[matchedJet];
+    }
+
   } else {
-    z = Pi0Candidate->Pt() / fVectorJetPt[matchedJet];
+    std::array<float, 3> arrJetP; // px, py, pz
+    if (isTrueJet == 1) {
+      arrJetP = {static_cast<float>(fTrueVectorJetPx[matchedJet]), static_cast<float>(fTrueVectorJetPy[matchedJet]), static_cast<float>(fTrueVectorJetPz[matchedJet])};
+    } else if (isTrueJet == 2) {
+      arrJetP = {static_cast<float>(fTrueVectorJetPartonPx[matchedJet]), static_cast<float>(fTrueVectorJetPartonPy[matchedJet]), static_cast<float>(fTrueVectorJetPartonPz[matchedJet])};
+    } else {
+      arrJetP = {static_cast<float>(fVectorJetPx[matchedJet]), static_cast<float>(fVectorJetPy[matchedJet]), static_cast<float>(fVectorJetPz[matchedJet])};
+    }
+
+    float scalarProd = std::abs(Pi0Candidate->Px()*arrJetP[0] + Pi0Candidate->Py()*arrJetP[1] + Pi0Candidate->Pz()*arrJetP[1]);
+    float JetP2 = arrJetP[0]*arrJetP[0] + arrJetP[1]*arrJetP[1] + arrJetP[2]*arrJetP[2];
+    z = (JetP2 == 0) ? 0 : scalarProd/JetP2;
   }
+  
   return z;
+}
+
+//________________________________________________________________________
+/// \brief function to get the distance in etaphi between a particle and a jet
+float AliAnalysisTaskMesonJetCorrelation::GetRadiusJetPart(AliAODConversionMother* Pi0Candidate, const int matchedJet, int isTrueJet){
+
+  if (matchedJet < 0) {
+    return 0;
+  }
+  float dEta = 0;
+  float dPhi = 0;
+  if (isTrueJet == 1) {
+    dEta = Pi0Candidate->Eta() - fTrueVectorJetEta[matchedJet];
+    dPhi = Pi0Candidate->Phi() - fTrueVectorJetPhi[matchedJet];
+  } else {
+    dEta = Pi0Candidate->Eta() - fVectorJetEta[matchedJet];
+    dPhi = Pi0Candidate->Phi() - fVectorJetPhi[matchedJet];
+  }
+  float radius = sqrt(dEta*dEta + dPhi*dPhi );
+  return radius;
+}
+
+//________________________________________________________________________
+/// \brief function to get the distance in etaphi between a particle and a jet
+float AliAnalysisTaskMesonJetCorrelation::GetRadiusJetPart(AliAODMCParticle* Pi0Candidate, const int matchedJet, int isTrueJet){
+
+  if (matchedJet < 0) {
+    return 0;
+  }
+  float dEta = 0;
+  float dPhi = 0;
+  if (isTrueJet == 1) {
+    dEta = Pi0Candidate->Eta() - fTrueVectorJetEta[matchedJet];
+    dPhi = Pi0Candidate->Phi() - fTrueVectorJetPhi[matchedJet];
+  } else {
+    dEta = Pi0Candidate->Eta() - fVectorJetEta[matchedJet];
+    dPhi = Pi0Candidate->Phi() - fVectorJetPhi[matchedJet];
+  }
+  float radius = sqrt(dEta*dEta + dPhi*dPhi );
+  return radius;
 }
 
 //________________________________________________________________________
@@ -2484,7 +2692,7 @@ void AliAnalysisTaskMesonJetCorrelation::CalculateBackgroundMix()
           if (!(((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->CheckDistanceToBadChannelSwapping(cellID, fInputEvent, ((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->GetDistanceToBorderForBg()))) {
             std::unique_ptr<AliAODConversionMother> backgroundCandidate(std::make_unique<AliAODConversionMother>(gammaMix.get(), ((AliAODConversionPhoton*)currentEventGamma)));
 
-            if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelected(backgroundCandidate.get(), kFALSE, ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift(), cellID, ((AliAODConversionPhoton*)currentEventGamma)->GetLeadingCellID())) {
+            if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelected(backgroundCandidate.get(), false, ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift(), cellID, ((AliAODConversionPhoton*)currentEventGamma)->GetLeadingCellID())) {
               // Fill histograms here
               FillInvMassBackHistograms(backgroundCandidate.get());
             }
@@ -2505,7 +2713,7 @@ void AliAnalysisTaskMesonJetCorrelation::CalculateBackgroundMix()
 
             std::unique_ptr<AliAODConversionMother> backgroundCandidate(std::make_unique<AliAODConversionMother>(gammaMix.get(), ((AliAODConversionPhoton*)currentEventGamma)));
 
-            if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelected(backgroundCandidate.get(), kFALSE, ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift(), cellID, -1)) {
+            if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelected(backgroundCandidate.get(), false, ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift(), cellID, -1)) {
               // Fill histograms here
               FillInvMassBackHistograms(backgroundCandidate.get());
             }
@@ -2525,7 +2733,7 @@ void AliAnalysisTaskMesonJetCorrelation::CalculateBackgroundMix()
           if (fabs(gammaMix->Eta()) > ((AliConversionPhotonCuts*)fConvCutArray->At(fiCut))->GetEtaCut()) {
             std::unique_ptr<AliAODConversionMother> backgroundCandidate(std::make_unique<AliAODConversionMother>(gammaMix.get(), ((AliAODConversionPhoton*)currentEventGamma)));
 
-            if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelected(backgroundCandidate.get(), kFALSE, ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift(), -1, -1)) {
+            if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelected(backgroundCandidate.get(), false, ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift(), -1, -1)) {
               // Fill histograms here
               FillInvMassBackHistograms(backgroundCandidate.get());
             }
@@ -2542,8 +2750,8 @@ void AliAnalysisTaskMesonJetCorrelation::CalculateBackgroundSwapp()
 {
   // cout << "CalculateBackgroundSwapp" << endl;
 
-  std::vector<std::array<Double_t, 2>> vSwappingInvMassPT;
-  std::vector<std::array<Double_t, 2>> vSwappingInvMassPTAlphaCut;
+  std::vector<std::array<double, 2>> vSwappingInvMassPT;
+  std::vector<std::array<double, 2>> vSwappingInvMassPTAlphaCut;
   vSwappingInvMassPT.clear();
   vSwappingInvMassPTAlphaCut.clear();
   vSwappingInvMassPT.resize(0);
@@ -2578,7 +2786,7 @@ void AliAnalysisTaskMesonJetCorrelation::CalculateBackgroundSwapp()
             }
             std::unique_ptr<AliAODConversionMother> backgroundCandidate(std::make_unique<AliAODConversionMother>(swappedGammas[iSwapped].get(), ((AliAODConversionPhoton*)currentEventGoodV0Temp3)));
             if (!(((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->CheckDistanceToBadChannelSwapping(cellIDRotatedPhoton[iSwapped], fInputEvent, ((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->GetDistanceToBorderForBg())) && swappedGammas[iSwapped]->P() > ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetMinClusterEnergy()) {
-              if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelected(backgroundCandidate.get(), kFALSE, ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift(), cellIDRotatedPhoton[iSwapped], ((AliAODConversionPhoton*)currentEventGoodV0Temp3)->GetLeadingCellID())) {
+              if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelected(backgroundCandidate.get(), false, ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift(), cellIDRotatedPhoton[iSwapped], ((AliAODConversionPhoton*)currentEventGoodV0Temp3)->GetLeadingCellID())) {
                 // Fill histograms here
                 FillInvMassBackHistograms(backgroundCandidate.get());
               }
@@ -2612,7 +2820,7 @@ void AliAnalysisTaskMesonJetCorrelation::CalculateBackgroundSwapp()
             if (swappedGammas[1]->Eta() < ((AliConversionPhotonCuts*)fConvCutArray->At(fiCut))->GetEtaCut()) {
               std::unique_ptr<AliAODConversionMother> backgroundCandidate(std::make_unique<AliAODConversionMother>(swappedGammas[1].get(), ((AliAODConversionPhoton*)currentEventGoodV0Temp3)));
 
-              if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelected(backgroundCandidate.get(), kFALSE, ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift(), -1, ((AliAODConversionPhoton*)currentEventGoodV0Temp3)->GetLeadingCellID())) {
+              if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelected(backgroundCandidate.get(), false, ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift(), -1, ((AliAODConversionPhoton*)currentEventGoodV0Temp3)->GetLeadingCellID())) {
                 // Fill histograms here
                 FillInvMassBackHistograms(backgroundCandidate.get());
               }
@@ -2629,7 +2837,7 @@ void AliAnalysisTaskMesonJetCorrelation::CalculateBackgroundSwapp()
               std::unique_ptr<AliAODConversionMother> backgroundCandidate(std::make_unique<AliAODConversionMother>(swappedGammas[0].get(), ((AliAODConversionPhoton*)currentEventGoodV0Temp3)));
 
               if (!(((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->CheckDistanceToBadChannelSwapping(cellIDRotatedPhoton, fInputEvent, ((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->GetDistanceToBorderForBg())) && swappedGammas[0]->P() > ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetMinClusterEnergy()) {
-                if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelected(backgroundCandidate.get(), kFALSE, ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift(), cellIDRotatedPhoton, -1)) {
+                if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelected(backgroundCandidate.get(), false, ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift(), cellIDRotatedPhoton, -1)) {
                   // Fill histograms here
                   FillInvMassBackHistograms(backgroundCandidate.get());
                 }
@@ -2664,7 +2872,7 @@ void AliAnalysisTaskMesonJetCorrelation::CalculateBackgroundSwapp()
 
             std::unique_ptr<AliAODConversionMother> backgroundCandidate(std::make_unique<AliAODConversionMother>(swappedGammas[iSwapped].get(), ((AliAODConversionPhoton*)currentEventGoodV0Temp3)));
             if (swappedGammas[iSwapped]->Eta() < ((AliConversionPhotonCuts*)fConvCutArray->At(fiCut))->GetEtaCut()) {
-              if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelected(backgroundCandidate.get(), kFALSE, ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift(), -1, -1)) {
+              if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelected(backgroundCandidate.get(), false, ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift(), -1, -1)) {
                 // Fill histograms here
                 FillInvMassBackHistograms(backgroundCandidate.get());
               }
@@ -2696,6 +2904,12 @@ void AliAnalysisTaskMesonJetCorrelation::FillInvMassBackHistograms(AliAODConvers
   float z = GetFrag(backgroundCandidate, matchedJet, false);
   fRespMatrixHandlerMesonBackInvMassVsPt[fiCut]->Fill(ptJet, 0.5, backgroundCandidate->M(), backgroundCandidate->Pt(), fWeightJetJetMC); // Inv Mass vs. meson Pt in Jet Pt_rec bins. Needed to subtract background in the Pt-distribution
   fRespMatrixHandlerMesonBackInvMassVsZ[fiCut]->Fill(ptJet, 0.5, backgroundCandidate->M(), z, fWeightJetJetMC);                          // Inv Mass vs. Z in Jet Pt_rec bins. Needed to subtract background in the Z-distribution
+
+  // Fill as function of radius
+  std::vector<double> vecFillInvMassPtR = {backgroundCandidate->M(), backgroundCandidate->Pt(), RJetPi0Cand};
+  std::vector<double> vecFillJetPt = {ptJet, 0.5, 0.5};
+  fRespMatrixHandlerMesonBackPtInvMassRadius[fiCut]->Fill(vecFillInvMassPtR, vecFillJetPt, fWeightJetJetMC);
+
 }
 
 //__________________________________________________________________________
@@ -2705,13 +2919,13 @@ void AliAnalysisTaskMesonJetCorrelation::FillInvMassBackHistograms(AliAODConvers
 std::array<std::unique_ptr<AliAODConversionPhoton>, 2> AliAnalysisTaskMesonJetCorrelation::GetGammasSwapped(AliAODConversionPhoton* currentEventGoodV0Temp1, AliAODConversionPhoton* currentEventGoodV0Temp2)
 {
 
-  Double_t rotationAngle = TMath::Pi() / 2.0; // 0.78539816339; // rotaion angle 90°
+  double rotationAngle = TMath::Pi() / 2.0; // 0.78539816339; // rotaion angle 90°
 
   // Needed for TGenPhaseSpace
   TVector3 tvEtaPhigamma1, tvEtaPhigamma2, tvEtaPhigamma1Decay, tvEtaPhigamma2Decay, tvNormBeforeDecay, tvNormAfterDecay;
-  Float_t asymBeforeDecay = 0.;
-  Float_t asymAfterDecay = 0.;
-  Double_t massGamma[2] = {0, 0};
+  float asymBeforeDecay = 0.;
+  float asymAfterDecay = 0.;
+  double massGamma[2] = {0, 0};
 
   TLorentzVector lvRotationPhoton1; // photon candidates which get rotated
   TLorentzVector lvRotationPhoton2; // photon candidates which get rotated
@@ -2734,7 +2948,7 @@ std::array<std::unique_ptr<AliAODConversionPhoton>, 2> AliAnalysisTaskMesonJetCo
     if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->GammaSwappMethodBg() == 0)
       rotationAngle = TMath::Pi() / 2.0;                                                        // rotate by 90 degree
     else if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->GammaSwappMethodBg() == 1) { // rotate by random angle between
-      Double_t temp = (fRandom.Rndm() < 0.5) ? 0 : TMath::Pi();
+      double temp = (fRandom.Rndm() < 0.5) ? 0 : TMath::Pi();
       rotationAngle = temp + TMath::Pi() / 3.0 + fRandom.Rndm() * TMath::Pi() / 3.0;
     }
     lvRotationPhoton1.Rotate(rotationAngle, lvRotationPion);
@@ -2810,9 +3024,9 @@ void AliAnalysisTaskMesonJetCorrelation::ProcessAODMCParticles(int isCurrentEven
 {
 
   const AliVVertex* primVtxMC = fMCEvent->GetPrimaryVertex();
-  Double_t mcProdVtxX = primVtxMC->GetX();
-  Double_t mcProdVtxY = primVtxMC->GetY();
-  Double_t mcProdVtxZ = primVtxMC->GetZ();
+  double mcProdVtxX = primVtxMC->GetX();
+  double mcProdVtxY = primVtxMC->GetY();
+  double mcProdVtxZ = primVtxMC->GetZ();
 
   if (!fAODMCTrackArray)
     fAODMCTrackArray = dynamic_cast<TClonesArray*>(fInputEvent->FindListObject(AliAODMCParticle::StdBranchName()));
@@ -2846,7 +3060,7 @@ void AliAnalysisTaskMesonJetCorrelation::ProcessAODMCParticles(int isCurrentEven
       continue;
     }
 
-    Bool_t isPrimary = ((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsConversionPrimaryAOD(fInputEvent, particle, mcProdVtxX, mcProdVtxY, mcProdVtxZ);
+    bool isPrimary = ((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsConversionPrimaryAOD(fInputEvent, particle, mcProdVtxX, mcProdVtxY, mcProdVtxZ);
     if (isPrimary) {
 
       int isMCFromMBHeader = -1;
@@ -2855,7 +3069,7 @@ void AliAnalysisTaskMesonJetCorrelation::ProcessAODMCParticles(int isCurrentEven
         if (isMCFromMBHeader == 0 && ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetSignalRejection() != 3)
           continue;
       }
-      // if(!((AliConversionPhotonCuts*)fConvCutArray->At(fiCut))->InPlaneOutOfPlaneCut(particle->Phi(),fEventPlaneAngle,kFALSE)) continue;
+      // if(!((AliConversionPhotonCuts*)fConvCutArray->At(fiCut))->InPlaneOutOfPlaneCut(particle->Phi(),fEventPlaneAngle,false)) continue;
 
       // check photons
       if (matchedJet >= 0 && MCParticleIsSelected(particle, fIsConv, false)) { // here we state that this is a conversion, however this also works for calo photons on generator level!
@@ -2895,7 +3109,7 @@ void AliAnalysisTaskMesonJetCorrelation::ProcessAODMCParticles(int isCurrentEven
         }
       } // end if photons
       // check for photon conversions
-      // if(((AliConversionPhotonCuts*)fConvCutArray->At(fiCut))->PhotonIsSelectedAODMC(particle,fAODMCTrackArray,kTRUE)){
+      // if(((AliConversionPhotonCuts*)fConvCutArray->At(fiCut))->PhotonIsSelectedAODMC(particle,fAODMCTrackArray,true)){
       // for(int daughterIndex=particle->GetDaughterLabel(0);daughterIndex<=particle->GetDaughterLabel(1);daughterIndex++){
       //   AliAODMCParticle *tmpDaughter = static_cast<AliAODMCParticle*>(fAODMCTrackArray->At(daughterIndex));
       //   if(!tmpDaughter) continue;
@@ -2903,8 +3117,8 @@ void AliAnalysisTaskMesonJetCorrelation::ProcessAODMCParticles(int isCurrentEven
       // if(!fDoLightOutput) fHistoMCConvGammaPt[fiCut]->Fill(particle->Pt(),fWeightJetJetMC);
       // }
 
-      Double_t mesonY = 1.e30;
-      Double_t ratio = 0;
+      double mesonY = 1.e30;
+      double ratio = 0;
       if (particle->E() != TMath::Abs(particle->Pz())) {
         ratio = (particle->E() + particle->Pz()) / (particle->E() - particle->Pz());
       }
@@ -2939,15 +3153,15 @@ void AliAnalysisTaskMesonJetCorrelation::ProcessAODMCParticles(int isCurrentEven
 
           AliAODMCParticle* daughter0 = static_cast<AliAODMCParticle*>(fAODMCTrackArray->At(particle->GetDaughterLabel(0)));
           AliAODMCParticle* daughter1 = static_cast<AliAODMCParticle*>(fAODMCTrackArray->At(particle->GetDaughterLabel(1)));
-          Float_t weighted = 1;
+          float weighted = 1;
           if (((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsParticleFromBGEvent(i, fMCEvent, fInputEvent)) {
             if (particle->Pt() > 0.005) {
               weighted = ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetWeightForMeson(i, 0x0, fInputEvent);
             }
           }
 
-          // Double_t mesonY = 1.e30;
-          // Double_t ratio = 0;
+          // double mesonY = 1.e30;
+          // double ratio = 0;
           if (particle->E() != TMath::Abs(particle->Pz())) {
             ratio = (particle->E() + particle->Pz()) / (particle->E() - particle->Pz());
           }
@@ -2978,6 +3192,9 @@ void AliAnalysisTaskMesonJetCorrelation::ProcessAODMCParticles(int isCurrentEven
             fHistoMCJetPtVsMesonPt[fiCut]->Fill(particle->Pt(), fTrueVectorJetPt[matchedJet], weighted * fWeightJetJetMC);
             fHistoMCPartonPtVsFrag[fiCut]->Fill(z_parton, fTrueVectorJetPartonPt[matchedJet], weighted * fWeightJetJetMC);
 
+            // FIll radius vs. jet pt vs meson pt histogram
+            fHistoMCJetPtVsMesonPtVsRadius[fiCut]->Fill(particle->Pt(), fTrueVectorJetPt[matchedJet], RJetPi0Cand, weighted * fWeightJetJetMC);
+
             if (IsParticleFromPartonFrag(particle, fTrueVectorJetPartonID[matchedJet])) {
               fHistoMCJetPtVsFragTrueParton[fiCut]->Fill(z_jet, fTrueVectorJetPt[matchedJet], weighted * fWeightJetJetMC);
               fHistoMCPartonPtVsFragTrueParton[fiCut]->Fill(z_parton, fTrueVectorJetPartonPt[matchedJet], weighted * fWeightJetJetMC);
@@ -2995,6 +3212,7 @@ void AliAnalysisTaskMesonJetCorrelation::ProcessAODMCParticles(int isCurrentEven
                 fHistoMCMesonInAccPt[fiCut]->Fill(particle->Pt(), weighted * fWeightJetJetMC); // MC Pi0 with gamma in acc
                 fHistoMCJetPtVsFragInAcc[fiCut]->Fill(z_jet, fTrueVectorJetPt[matchedJet], weighted * fWeightJetJetMC);
                 fHistoMCJetPtVsMesonPtInAcc[fiCut]->Fill(particle->Pt(), fTrueVectorJetPt[matchedJet], weighted * fWeightJetJetMC);
+                fHistoMCJetPtVsMesonPtVsRadiusInAcc[fiCut]->Fill(particle->Pt(), fTrueVectorJetPt[matchedJet], RJetPi0Cand, weighted * fWeightJetJetMC);
                 if (isCurrentEventSelected == 1)
                   fHistoMCMesonInAccPtNotTriggered[fiCut]->Fill(particle->Pt(), weighted * fWeightJetJetMC); // MC Pi0 with gamma in acc for not triggered events
                 if (fIsMC > 1)
@@ -3138,7 +3356,7 @@ int AliAnalysisTaskMesonJetCorrelation::GetPhotonMotherLabel(AliAODConversionPho
     AliAODMCParticle* positiveMC = static_cast<AliAODMCParticle*>(fAODMCTrackArray->At(gammaCand->GetMCLabelPositive()));
     AliAODMCParticle* negativeMC = static_cast<AliAODMCParticle*>(fAODMCTrackArray->At(gammaCand->GetMCLabelNegative()));
 
-    Int_t gamma0MCLabel = -1;
+    int gamma0MCLabel = -1;
     if (!positiveMC || !negativeMC) {
       return -1;
     }
@@ -3149,8 +3367,8 @@ int AliAnalysisTaskMesonJetCorrelation::GetPhotonMotherLabel(AliAODConversionPho
       gammaMotherLabel = gammaMC0->GetMother();
     }
 
-    Int_t tmpGammaMotherlabel = gammaMotherLabel;
-    Int_t SaftyLoopCounter = 0;
+    int tmpGammaMotherlabel = gammaMotherLabel;
+    int SaftyLoopCounter = 0;
     while (tmpGammaMotherlabel > 0 && SaftyLoopCounter < 100) {
       SaftyLoopCounter++;
       if (((AliAODMCParticle*)fAODMCTrackArray->At(tmpGammaMotherlabel))->GetPdgCode() != 111 && ((AliAODMCParticle*)fAODMCTrackArray->At(tmpGammaMotherlabel))->GetPdgCode() != 221) {
@@ -3168,7 +3386,7 @@ int AliAnalysisTaskMesonJetCorrelation::GetPhotonMotherLabel(AliAODConversionPho
 void AliAnalysisTaskMesonJetCorrelation::ProcessTrueClusterCandidatesAOD(AliAODConversionPhoton* TruePhotonCandidate)
 {
 
-  Double_t tempPhotonWeight = fWeightJetJetMC;
+  double tempPhotonWeight = fWeightJetJetMC;
   AliAODMCParticle* Photon = NULL;
   if (!fAODMCTrackArray)
     fAODMCTrackArray = dynamic_cast<TClonesArray*>(fInputEvent->FindListObject(AliAODMCParticle::StdBranchName()));
@@ -3255,6 +3473,8 @@ bool AliAnalysisTaskMesonJetCorrelation::ProcessTrueMesonCandidatesAOD(AliAODCon
   float z_rec_trueJet = GetFrag(Pi0Candidate, indexTrueJet, true);
   float z_true = GetFrag(trueMesonCand, indexTrueJet, true);
 
+  float RJetPi0CandTrue = GetRadiusJetPart(Pi0Candidate, indexTrueJet, true);
+
   // fill all other mesons (eta and eta prime in case pi0 is selected etc.)
   if (isTrueOtherParticle) {
     fRespMatrixHandlerTrueOtherMesonInvMassVsPt[fiCut]->Fill(jetPtRec, 0.5, Pi0Candidate->M(), z_rec, fWeightJetJetMC*weightMatBudget);
@@ -3268,6 +3488,15 @@ bool AliAnalysisTaskMesonJetCorrelation::ProcessTrueMesonCandidatesAOD(AliAODCon
   // fill all true mesons (primary + secondaries)
   fRespMatrixHandlerTrueMesonInvMassVsPt[fiCut]->Fill(jetPtRec, 0.5, Pi0Candidate->M(), Pi0Candidate->Pt(), fWeightJetJetMC*weightMatBudget);
   fRespMatrixHandlerTrueMesonInvMassVsZ[fiCut]->Fill(jetPtRec, 0.5, Pi0Candidate->M(), z_rec, fWeightJetJetMC*weightMatBudget);
+
+  // fill as function of radius
+  std::vector<double> vecFillRecInvMass = {mesonMassRec, mesonPtRec, RJetPi0Cand};
+  std::vector<double> vecFillJetPt = {jetPtRec, 0.5, 0.5};
+  fRespMatrixHandlerTrueMesonPtRadius[fiCut]->Fill(vecFillRecInvMass, vecFillJetPt,  fWeightJetJetMC*weightMatBudget);
+
+  std::vector<double> vecFillRecInvMassTrue = {mesonMassRec, mesonPtTrue, RJetPi0CandTrue};
+  std::vector<double> vecFillJetPtTrue = {jetPtTrue, 0.5, 0.5};
+  fRespMatrixHandlerTrueMesonTruePtRadius[fiCut]->Fill(vecFillRecInvMassTrue, vecFillJetPtTrue,  fWeightJetJetMC*weightMatBudget);
 
   if(fDoMesonQA > 0){
     fHistoTrueMesonInvMassVsTruePt[fiCut]->Fill(Pi0Candidate->M(), trueMesonCand->Pt(), fWeightJetJetMC*weightMatBudget);
@@ -3306,6 +3535,14 @@ bool AliAnalysisTaskMesonJetCorrelation::ProcessTrueMesonCandidatesAOD(AliAODCon
 
     // fill 4d response matrix
     fRespMatrixHandlerMesonPt[fiCut]->Fill(jetPtRec, jetPtTrue, mesonPtRec, mesonPtTrue, fWeightJetJetMC*weightMatBudget);
+
+    std::vector<double> vecFillRec = {jetPtRec, RJetPi0Cand, mesonPtRec};
+    std::vector<double> vecFillTrue = {jetPtTrue, RJetPi0Cand, mesonPtTrue};
+    std::vector<double> vecFillTrueRadius = {jetPtTrue, RJetPi0CandTrue, mesonPtTrue};
+    fRespMatrixHandlerMesonPtRadius[fiCut]->Fill(vecFillRec, vecFillTrue,  fWeightJetJetMC*weightMatBudget);
+    fRespMatrixHandlerMesonPtTrueRadius[fiCut]->Fill(vecFillRec, vecFillTrueRadius,  fWeightJetJetMC*weightMatBudget);
+
+
   } else { // fill all secondary mesons
 
     if(fDoMesonQA>0){
@@ -3318,6 +3555,14 @@ bool AliAnalysisTaskMesonJetCorrelation::ProcessTrueMesonCandidatesAOD(AliAODCon
     }
     fRespMatrixHandlerTrueSecondaryMesonInvMassVsPt[fiCut]->Fill(jetPtRec, 0.5, Pi0Candidate->M(), Pi0Candidate->Pt(), fWeightJetJetMC*weightMatBudget);
     fRespMatrixHandlerTrueSecondaryMesonInvMassVsZ[fiCut]->Fill(jetPtRec, 0.5, Pi0Candidate->M(), z_rec, fWeightJetJetMC*weightMatBudget);
+
+    // Fill as function of radius
+    fRespMatrixHandlerTrueSecondaryMesonPtRadius[fiCut]->Fill(vecFillRecInvMass, vecFillJetPt,  fWeightJetJetMC*weightMatBudget);
+
+    std::vector<double> vecFillRec = {jetPtRec, mesonPtRec, RJetPi0Cand};
+    std::vector<double> vecFillDummy = {0.5, 0.5, 0.5};
+    fRespMatrixHandlerTrueSecondaryMesonPtRadius[fiCut]->Fill(vecFillRec, vecFillDummy,  fWeightJetJetMC*weightMatBudget);
+    
   }
   return true;
 }
@@ -3373,11 +3618,11 @@ void AliAnalysisTaskMesonJetCorrelation::ProcessTruePhotonCandidatesAOD(AliAODCo
 {
 
   const AliVVertex* primVtxMC = fMCEvent->GetPrimaryVertex();
-  Double_t mcProdVtxX = primVtxMC->GetX();
-  Double_t mcProdVtxY = primVtxMC->GetY();
-  Double_t mcProdVtxZ = primVtxMC->GetZ();
+  double mcProdVtxX = primVtxMC->GetX();
+  double mcProdVtxY = primVtxMC->GetY();
+  double mcProdVtxZ = primVtxMC->GetZ();
 
-  Double_t magField = fInputEvent->GetMagneticField();
+  double magField = fInputEvent->GetMagneticField();
 
   if (!fAODMCTrackArray)
     fAODMCTrackArray = dynamic_cast<TClonesArray*>(fInputEvent->FindListObject(AliAODMCParticle::StdBranchName()));
@@ -3474,7 +3719,7 @@ void AliAnalysisTaskMesonJetCorrelation::FillMesonDCATree(AliAODConversionMother
 }
 
 //________________________________________________________________________
-void AliAnalysisTaskMesonJetCorrelation::RelabelAODPhotonCandidates(Bool_t mode)
+void AliAnalysisTaskMesonJetCorrelation::RelabelAODPhotonCandidates(bool mode)
 {
 
   // Relabeling For AOD Event
@@ -3504,8 +3749,8 @@ void AliAnalysisTaskMesonJetCorrelation::RelabelAODPhotonCandidates(Bool_t mode)
     fESDArrayPos[iGamma] = PhotonCandidate->GetTrackLabelPositive();
     fESDArrayNeg[iGamma] = PhotonCandidate->GetTrackLabelNegative();
 
-    Bool_t AODLabelPos = kFALSE;
-    Bool_t AODLabelNeg = kFALSE;
+    bool AODLabelPos = false;
+    bool AODLabelNeg = false;
 
     for (int i = 0; i < fInputEvent->GetNumberOfTracks(); i++) {
       AliAODTrack* tempDaughter = static_cast<AliAODTrack*>(fInputEvent->GetTrack(i));
@@ -3513,14 +3758,14 @@ void AliAnalysisTaskMesonJetCorrelation::RelabelAODPhotonCandidates(Bool_t mode)
         if (tempDaughter->GetID() == PhotonCandidate->GetTrackLabelPositive()) {
           PhotonCandidate->SetMCLabelPositive(TMath::Abs(tempDaughter->GetLabel()));
           PhotonCandidate->SetLabelPositive(i);
-          AODLabelPos = kTRUE;
+          AODLabelPos = true;
         }
       }
       if (!AODLabelNeg) {
         if (tempDaughter->GetID() == PhotonCandidate->GetTrackLabelNegative()) {
           PhotonCandidate->SetMCLabelNegative(TMath::Abs(tempDaughter->GetLabel()));
           PhotonCandidate->SetLabelNegative(i);
-          AODLabelNeg = kTRUE;
+          AODLabelNeg = true;
         }
       }
       if (AODLabelNeg && AODLabelPos) {

--- a/PWGGA/GammaConv/AliAnalysisTaskMesonJetCorrelation.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskMesonJetCorrelation.h
@@ -72,10 +72,12 @@ class AliAnalysisTaskMesonJetCorrelation : public AliAnalysisTaskSE
   void ProcessTrueBackgroundCandidatesAOD(AliAODConversionMother* Pi0Candidate, AliAODConversionPhoton* TrueGammaCandidate0, AliAODConversionPhoton* TrueGammaCandidate1, const int matchedJet, const float RJetPi0Cand);
   float GetFrag(AliAODConversionMother* Pi0Candidate, const int matchedJet, int isTrueJet);
   float GetFrag(AliAODMCParticle* Pi0Candidate, const int matchedJet, int isTrueJet);
+  float GetRadiusJetPart(AliAODConversionMother* Pi0Candidate, const int matchedJet, int isTrueJet);
+  float GetRadiusJetPart(AliAODMCParticle* Pi0Candidate, const int matchedJet, int isTrueJet);
   void FillMesonDCATree(AliAODConversionMother* Pi0Candidate, AliAODConversionPhoton* gamma0, AliAODConversionPhoton* gamma1, const int matchedJet, const bool isTrueMeson);
 
   // MC functions
-  void ProcessAODMCParticles(Int_t isCurrentEventSelected = 0);
+  void ProcessAODMCParticles(int isCurrentEventSelected = 0);
   void ProcessTrueClusterCandidatesAOD(AliAODConversionPhoton* TruePhotonCandidate);
   void ProcessTruePhotonCandidatesAOD(AliAODConversionPhoton* TruePhotonCandidate);
   bool MCParticleIsSelected(AliAODMCParticle* particle1, AliAODMCParticle* particle2, bool checkConversion);
@@ -97,11 +99,11 @@ class AliAnalysisTaskMesonJetCorrelation : public AliAnalysisTaskSE
   void CallSumw2ForLists(TList* l);
 
   // Setters
-  void SetIsMC(Int_t isMC) { fIsMC = isMC; }
-  void SetLightOutput(Int_t flag) { fDoLightOutput = flag; }
-  void SetDoMesonQA(Int_t flag) { fDoMesonQA = flag; }
-  void SetDoPhotonQA(Int_t flag) { fDoPhotonQA = flag; }
-  void SetDoClusterQA(Int_t flag) { fDoClusterQA = flag; }
+  void SetIsMC(int isMC) { fIsMC = isMC; }
+  void SetLightOutput(int flag) { fDoLightOutput = flag; }
+  void SetDoMesonQA(int flag) { fDoMesonQA = flag; }
+  void SetDoPhotonQA(int flag) { fDoPhotonQA = flag; }
+  void SetDoClusterQA(int flag) { fDoClusterQA = flag; }
   // Function to set correction task setting
   void SetCorrectionTaskSetting(TString setting) { fCorrTaskSetting = setting; }
   void SetDoMaterialBudgetWeightingOfGammasForTrueMesons(Bool_t flag) { fDoMaterialBudgetWeightingOfGammasForTrueMesons = flag; }
@@ -110,15 +112,16 @@ class AliAnalysisTaskMesonJetCorrelation : public AliAnalysisTaskSE
   void SetIsConvCalo(bool isConvCalo) { fIsConvCalo = isConvCalo; }
   void SetIsHeavyIon(int flag) { fIsHeavyIon = flag; }
   void SetV0ReaderName(TString name) { fV0ReaderName = name; }
-  void SetTrackMatcherRunningMode(Int_t mode) { fTrackMatcherRunningMode = mode; }
+  void SetTrackMatcherRunningMode(int mode) { fTrackMatcherRunningMode = mode; }
   void SetUseTHnSparseForResponse(bool tmp) { fUseThNForResponse = tmp; }
   void SetMesonKind(int meson) { (meson == 0) ? fMesonPDGCode = 111 : fMesonPDGCode = 221; }
   void SetOtherMesons(std::vector<int> vec) { fOtherMesonsPDGCodes = vec; }
   void SetJetContainerAddName(TString name) { fAddNameConvJet = name; }
   void SetFillMesonDCATree(bool tmp) { fFillDCATree = tmp; }
   void SetDoUseCentralEvtSelection(bool tmp) { fUseCentralEventSelection = tmp; }
+  void SetUsePtForCalcZ(bool tmp) { fUsePtForZCalc = tmp; }
 
-  void SetEventCutList(Int_t nCuts,
+  void SetEventCutList(int nCuts,
                        TList* CutArray)
   {
     fnCuts = nCuts;
@@ -126,7 +129,7 @@ class AliAnalysisTaskMesonJetCorrelation : public AliAnalysisTaskSE
   }
 
   // Setting the cut lists for the conversion photons
-  void SetConversionCutList(Int_t nCuts,
+  void SetConversionCutList(int nCuts,
                             TList* CutArray)
   {
     fnCuts = nCuts;
@@ -134,7 +137,7 @@ class AliAnalysisTaskMesonJetCorrelation : public AliAnalysisTaskSE
   }
 
   // Setting the cut lists for the calo photons
-  void SetCaloCutList(Int_t nCuts,
+  void SetCaloCutList(int nCuts,
                       TList* CutArray)
   {
     fnCuts = nCuts;
@@ -142,7 +145,7 @@ class AliAnalysisTaskMesonJetCorrelation : public AliAnalysisTaskSE
   }
 
   // Setting the cut lists for the meson
-  void SetMesonCutList(Int_t nCuts,
+  void SetMesonCutList(int nCuts,
                        TList* CutArray)
   {
     fnCuts = nCuts;
@@ -222,13 +225,14 @@ class AliAnalysisTaskMesonJetCorrelation : public AliAnalysisTaskSE
   bool fEnableSortForClusMC;                            // flag if cluster mc labels should be sorted
   bool fFillDCATree;                                    // flag if DCA tree should be filled or not
   bool fUseCentralEventSelection;                       // flag if central event selection (AliEventSelection.cxx) should be used
+  bool fUsePtForZCalc;                                  // flag if z = pt_meson/pt_jet or if its z = (P_{meson}*P_{jet})/|P_{Jet}^{2}|
   //-------------------------------
   // conversions
   //-------------------------------
-  Int_t* fMCEventPos;  //!
-  Int_t* fMCEventNeg;  //!
-  Int_t* fESDArrayPos; //!
-  Int_t* fESDArrayNeg; //!
+  int* fMCEventPos;  //!
+  int* fMCEventNeg;  //!
+  int* fESDArrayPos; //!
+  int* fESDArrayNeg; //!
 
   //-------------------------------
   // Materil Budged Weights
@@ -242,8 +246,10 @@ class AliAnalysisTaskMesonJetCorrelation : public AliAnalysisTaskSE
   std::vector<double> fVecBinsPhotonPt;       //! photon/cluster pt binning
   std::vector<double> fVecBinsClusterPt;      //! cluster binning until high pT
   std::vector<double> fVecBinsMesonPt;        //! meson pt binning
+  std::vector<double> fVecBinsMesonPtCoarse;  //! coarse meson pt binning
   std::vector<double> fVecBinsJetPt;          //! jet pt binning
   std::vector<double> fVecBinsFragment;       //! z (fragmentation function) binning
+  std::vector<double> fVecBinsMesonJetRadius; //! radius binning
   std::vector<double> vecEquidistFromMinus05; //! aequdistant binning starting from -0.5
 
   //-------------------------------
@@ -267,6 +273,9 @@ class AliAnalysisTaskMesonJetCorrelation : public AliAnalysisTaskSE
   vector<double> fTrueVectorJetPhi;      //! Vector of True JetPhi
   vector<int> fTrueVectorJetPartonID;    //! Vector of parton id matched to true jet
   vector<double> fTrueVectorJetPartonPt; //! Vector of parton pt matched to true jet
+  vector<double> fTrueVectorJetPartonPx; //! Vector of parton pt matched to true jet
+  vector<double> fTrueVectorJetPartonPy; //! Vector of parton pt matched to true jet
+  vector<double> fTrueVectorJetPartonPz; //! Vector of parton pt matched to true jet
 
   vector<double> fVectorJetEtaPerp; //! vector of jet -eta (opposite eta to original jet)
   vector<double> fVectorJetPhiPerp; //! vector of jet phi + 90 degree (perpendicular to original jet)
@@ -286,6 +295,12 @@ class AliAnalysisTaskMesonJetCorrelation : public AliAnalysisTaskSE
   std::vector<MatrixHandler4D*> fRespMatrixHandlerMesonInvMassPerpCone;    //! Same as fRespMatrixHandlerMesonInvMass but in perpendicular cone
   std::vector<MatrixHandler4D*> fRespMatrixHandlerMesonInvMassVsZPerpCone; //! Same as fRespMatrixHandlerMesonInvMassVsZ but in perpendicular cone
 
+  // Ndimensional matrix handler used
+  std::vector<MatrixHandlerNDim*> fRespMatrixHandlerMesonPtRadius;            //! Response matrix for true vs. rec pt for each jet pt true vs. rec. bin for different radii
+  std::vector<MatrixHandlerNDim*> fRespMatrixHandlerMesonPtTrueRadius;        //! Response matrix for true vs. rec pt for each jet pt true vs. rec. bin for different radii
+  std::vector<MatrixHandlerNDim*> fRespMatrixHandlerMesonPtInvMassRadius;     //! Reconstructed jet pt, inv. mass, meson pt and radius of jet and meson
+  std::vector<MatrixHandlerNDim*> fRespMatrixHandlerMesonBackPtInvMassRadius; //! Reconstructed jet pt, inv. mass, meson pt and radius of jet and meson
+  
   //-------------------------------
   // basic histograms
   //-------------------------------
@@ -372,6 +387,9 @@ class AliAnalysisTaskMesonJetCorrelation : public AliAnalysisTaskSE
   std::vector<MatrixHandler4D*> fRespMatrixHandlerTrueOtherMesonInvMassVsZ;      //! vector of histos inv. mass vs. Z for true other mesons (if selected meson is pi0, other mesons are etas and eta prime etc.)
   std::vector<MatrixHandler4D*> fRespMatrixHandlerTrueSecondaryMesonInvMassVsPt; //! vector of histos inv. mass vs. pT for true secondary mesons
   std::vector<MatrixHandler4D*> fRespMatrixHandlerTrueSecondaryMesonInvMassVsZ;  //! vector of histos inv. mass vs. pT for true secondary mesons
+  std::vector<MatrixHandlerNDim*> fRespMatrixHandlerTrueMesonPtRadius;           //! vector of histos inv. mass vs. pT vs. radius fo true mesons
+  std::vector<MatrixHandlerNDim*> fRespMatrixHandlerTrueMesonTruePtRadius;       //! vector of histos inv. mass vs. pT vs. radius fo true mesons
+  std::vector<MatrixHandlerNDim*> fRespMatrixHandlerTrueSecondaryMesonPtRadius;  //! vector of histos inv. mass vs. pT vs. radius fo true secondary mesons
   std::vector<TH2F*> fHistoTrueMesonInvMassVsTruePt;                             //! vector of histos inv. mass vs. true pT for true mesons
   std::vector<TH2F*> fHistoTruePrimaryMesonInvMassPt;                            //! vector of histos inv. mass vs. pT for true primary mesons
   std::vector<TH2F*> fHistoTrueSecondaryMesonInvMassPt;                          //! vector of histos inv. mass vs. pT for true secondary mesons
@@ -421,6 +439,7 @@ class AliAnalysisTaskMesonJetCorrelation : public AliAnalysisTaskSE
   std::vector<TH1F*> fHistoMCMesonPtNotTriggered;      //! vector of histos mesons which are in events that are not triggered
   std::vector<TH1F*> fHistoMCMesonPtNoVertex;          //! vector of histos mesons which are in events that have no vertex
   std::vector<TH1F*> fHistoMCMesonPt;                  //! vector of histos meson pt
+  std::vector<TH1F*> fHistoInclusiveMCMesonPt;         //! vector of histos meson pt for in+outside
   std::vector<TH1F*> fHistoMCMesonWOEvtWeightPt;       //! vector of histos meson pt without event weights
   std::vector<TH1F*> fHistoMCMesonInAccPt;             //! vector of histos mesons in acceptance
   std::vector<TH1F*> fHistoMCMesonInAccPtNotTriggered; //! vector of histos mesons in acceptance which are in events that are not triggered
@@ -429,21 +448,23 @@ class AliAnalysisTaskMesonJetCorrelation : public AliAnalysisTaskSE
   std::vector<TH2F*> fHistoMCSecMesonPtvsSource;       //! vector of histos secondary mesons from different sources vs. pt
   std::vector<TH1F*> fHistoMCSecMesonSource;           //! vector of histos secondary mesons from different sources
   std::vector<TH2F*> fHistoMCSecMesonInAccPtvsSource;  //! vector of histos accepted secondary mesons from different sources vs. pt
-
+  
   //-------------------------------
   // mc generated histograms jet-meson corr
   //-------------------------------
-  std::vector<TH2F*> fHistoMCJetPtVsMesonPt;           //! vector of histos True Jet pT vs. true Meson Pt (mc particle based distribution)
-  std::vector<TH2F*> fHistoMCJetPtVsMesonPtInAcc;      //! vector of histos True Jet pT vs. true Meson Pt (for mesons in detector acceptance)
-  std::vector<TH2F*> fHistoMCJetPtVsFrag;              //! vector of histos True Jet pT vs. true Frag (mc particle based distribution)
-  std::vector<TH2F*> fHistoMCJetPtVsFragInAcc;         //! vector of histos True Jet pT vs. true Frag (for mesons in detector acceptance)
-  std::vector<TH2F*> fHistoMCJetPtVsFrag_Sec;          //! vector of histos True Jet pT vs. true Frag (mc particle based distribution for secondaries)
-  std::vector<TH2F*> fHistoMCRecJetPtVsFrag;           //! vector of histos with True Jet pT vs true Frag inside rec. jets (to find the meson reconstruction effi)
-  std::vector<TH2F*> fHistoMCRecJetPtVsMesonPt;        //! vector of histos with True Jet pT vs true meson pt inside rec. jets (to find the meson reconstruction effi)
-  std::vector<TH2F*> fHistoMCJetPtVsMesonPt_Sec;       //! vector of histos True Jet pT vs. true meson pt (mc particle based distribution for secondaries)
-  std::vector<TH2F*> fHistoMCPartonPtVsFrag;           //! vector of histos True parton pT vs. true Frag (mc particle based distribution)
-  std::vector<TH2F*> fHistoMCJetPtVsFragTrueParton;    //! vector of histos True Jet pT vs. true Frag (mc particle based distribution) for particles originating from hard parton from Jet
-  std::vector<TH2F*> fHistoMCPartonPtVsFragTrueParton; //! vector of histos True parton pT vs. true Frag (mc particle based distribution) for particles originating from hard parton from Jet
+  std::vector<TH2F*> fHistoMCJetPtVsMesonPt;              //! vector of histos True Jet pT vs. true Meson Pt (mc particle based distribution)
+  std::vector<TH2F*> fHistoMCJetPtVsMesonPtInAcc;         //! vector of histos True Jet pT vs. true Meson Pt (for mesons in detector acceptance)
+  std::vector<TH2F*> fHistoMCJetPtVsFrag;                 //! vector of histos True Jet pT vs. true Frag (mc particle based distribution)
+  std::vector<TH2F*> fHistoMCJetPtVsFragInAcc;            //! vector of histos True Jet pT vs. true Frag (for mesons in detector acceptance)
+  std::vector<TH2F*> fHistoMCJetPtVsFrag_Sec;             //! vector of histos True Jet pT vs. true Frag (mc particle based distribution for secondaries)
+  std::vector<TH2F*> fHistoMCRecJetPtVsFrag;              //! vector of histos with True Jet pT vs true Frag inside rec. jets (to find the meson reconstruction effi)
+  std::vector<TH2F*> fHistoMCRecJetPtVsMesonPt;           //! vector of histos with True Jet pT vs true meson pt inside rec. jets (to find the meson reconstruction effi)
+  std::vector<TH2F*> fHistoMCJetPtVsMesonPt_Sec;          //! vector of histos True Jet pT vs. true meson pt (mc particle based distribution for secondaries)
+  std::vector<TH2F*> fHistoMCPartonPtVsFrag;              //! vector of histos True parton pT vs. true Frag (mc particle based distribution)
+  std::vector<TH2F*> fHistoMCJetPtVsFragTrueParton;       //! vector of histos True Jet pT vs. true Frag (mc particle based distribution) for particles originating from hard parton from Jet
+  std::vector<TH2F*> fHistoMCPartonPtVsFragTrueParton;    //! vector of histos True parton pT vs. true Frag (mc particle based distribution) for particles originating from hard parton from Jet
+  std::vector<TH3F*> fHistoMCJetPtVsMesonPtVsRadius;      //! vector of histos True jet pT vs. true meson pt vs jet-meson radius for particles originating from hard parton from Jet
+  std::vector<TH3F*> fHistoMCJetPtVsMesonPtVsRadiusInAcc; //! vector of histos True jet pT vs. true meson pt vs jet-meson radius for particles originating from hard parton from Jet
 
   //-------------------------------
   // DCA tree for PCM pile-up estimation
@@ -462,7 +483,7 @@ class AliAnalysisTaskMesonJetCorrelation : public AliAnalysisTaskSE
   AliAnalysisTaskMesonJetCorrelation(const AliAnalysisTaskMesonJetCorrelation&);            // Prevent copy-construction
   AliAnalysisTaskMesonJetCorrelation& operator=(const AliAnalysisTaskMesonJetCorrelation&); // Prevent assignment
 
-  ClassDef(AliAnalysisTaskMesonJetCorrelation, 12);
+  ClassDef(AliAnalysisTaskMesonJetCorrelation, 13);
 };
 
 #endif

--- a/PWGGA/GammaConvBase/AliResponseMatrixHelper.h
+++ b/PWGGA/GammaConvBase/AliResponseMatrixHelper.h
@@ -41,7 +41,7 @@ class MatrixHandler4D
   MatrixHandler4D(MatrixHandler4D&&) = delete;                 // move ctor
   MatrixHandler4D& operator=(const MatrixHandler4D&) = delete; // copy assignment
   MatrixHandler4D& operator=(MatrixHandler4D&&) = delete;      // move assignment
-  virtual ~MatrixHandler4D();
+  virtual ~MatrixHandler4D() = default;
 
   int getBinIndexMesonX(const double val) const;
   int getBinIndexMesonY(const double val) const;
@@ -77,6 +77,63 @@ class MatrixHandler4D
   THnSparseF* hSparseResponse = nullptr;
 
   ClassDef(MatrixHandler4D, 3)
+};
+
+
+
+class MatrixHandlerNDim
+{
+
+ public:
+  MatrixHandlerNDim() = default;
+  MatrixHandlerNDim(std::vector<std::vector<double>> arrBinsX, std::vector<std::vector<double>> arrBinsY, bool useTHN = false);
+  MatrixHandlerNDim(std::vector<std::vector<double>> arrBinsX, std::vector<std::vector<double>> arrBinsY, THnSparse* h = nullptr);
+  MatrixHandlerNDim(std::vector<std::vector<double>> arrBinsX, std::vector<std::vector<double>> arrBinsY, TH2F* h = nullptr);
+  MatrixHandlerNDim(const MatrixHandlerNDim&) = delete;            // copy ctor
+  MatrixHandlerNDim(MatrixHandlerNDim&&) = delete;                 // move ctor
+  MatrixHandlerNDim& operator=(const MatrixHandlerNDim&) = delete; // copy assignment
+  MatrixHandlerNDim& operator=(MatrixHandlerNDim&&) = delete;      // move assignment
+  virtual ~MatrixHandlerNDim() = default;
+
+  int getBinIndexMesonX(const double val) const;
+  int getBinIndexMesonY(const double val) const;
+  int getBinIndexJetX(const double val) const;
+  int getBinIndexJetY(const double val) const;
+
+  unsigned int getIndex(std::vector<double> vecVal, bool isXAxis);
+
+  double getValueForBinIndexMesonX(const int index) const;
+  double getValueForBinIndexJetX(const int index) const;
+  double getValueForBinIndexMesonY(const int index) const;
+  double getValueForBinIndexJetY(const int index) const;
+
+  void Fill(double valJetX, double valJetY, double valMesonX, double valMesonY, double val = 1);
+  void Fill(std::vector<double> valRec, std::vector<double> valTrue, double val = 1);
+
+  void AddBinContent(double valJetX, double valJetY, double valMesonX, double valMesonY, double val = 1, double err = 1);
+  void AddBinContent(std::vector<double> valRec, std::vector<double> valTrue, double val = 1, double err = 1);
+
+  double GetBinLowEdge(std::vector<unsigned int> vecDim, const std::vector<std::vector<double>> vecND);
+  std::vector<double> MakeAxis1D(const std::vector<std::vector<double>> vecND);
+
+  THnSparseF* GetTHnSparseClone(const char* name = "hSparseResponse_Clone");
+  THnSparseF* GetTHnSparse(const char* name = "");
+
+  TH2F* GetTH2(const char* name = "hSparseResponse_Clone");
+  TH2F* GetResponseMatrix(int binX, int binY, const char* name = "dummy");
+  TH2F* GetResponseMatrix(std::vector<double> vecBins, const char* name = "dummy");
+
+ private:
+  bool useTHNSparese = false;
+  int nBinsJet = 0;
+  std::vector<std::vector<double>> vecBinsX = {};
+  std::vector<std::vector<double>> vecBinsY = {};
+  TH2F* h2d = nullptr;
+  TH1F* h1dJet = nullptr;
+  TH1F* h1dMeson = nullptr;
+  THnSparseF* hSparseResponse = nullptr;
+
+  ClassDef(MatrixHandlerNDim, 1)
 };
 
 #endif

--- a/PWGGA/GammaConvBase/PWGGAGammaConvBaseLinkDef.h
+++ b/PWGGA/GammaConvBase/PWGGAGammaConvBaseLinkDef.h
@@ -29,6 +29,7 @@
 #pragma link C++ class AliCaloTrackMatcher+;
 #pragma link C++ class AliPhotonIsolation+;
 #pragma link C++ class MatrixHandler4D+;
+#pragma link C++ class MatrixHandlerNDim+;
 
 
 // User tasks


### PR DESCRIPTION
- Histograms added to study the meson production as function of jet pt, meson pt, and the radius between jet and meson
- As this needs an analyisis in three dimensions, a six dimensional unfolding matrix is needed. This is realized in a new NDimensional matrix handler
- Defintion of z changed from a simple division of the pts: z = ptMeson/ptJet to the scalar product of jet and meson momentum normalized to the squared lenght of the jet momentum. This allows the definition to be independent of the jet direction. As the Fragmentation should probe the momentum fraction of the meson to the jet, it should be in the reference frame of the jet
- px, py and pz of the true jet were added to the ConvJet task in order to properly calculate z