### PR TITLE
PWG/EMCal: quited unnecessary warning, PWGGA/GammaConv: modified configs for PCM, PCM-EMC & EMC pPb

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.cxx
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.cxx
@@ -131,7 +131,7 @@ AliAnalysisTaskEmcal::AliAnalysisTaskEmcal() :
   fClusterCollArray(),
   fTriggers(0),
   fEMCalTriggerMode(kOverlapWithLowThreshold),
-  fUseNewCentralityEstimation(kFALSE),
+  fUseNewCentralityEstimation(kTRUE),
   fGeneratePythiaInfoObject(kFALSE),
   fUsePtHardBinScaling(kFALSE),
   fUseXsecFromHeader(kFALSE),
@@ -259,7 +259,7 @@ AliAnalysisTaskEmcal::AliAnalysisTaskEmcal(const char *name, Bool_t histo) :
   fClusterCollArray(),
   fTriggers(0),
   fEMCalTriggerMode(kOverlapWithLowThreshold),
-  fUseNewCentralityEstimation(kFALSE),
+  fUseNewCentralityEstimation(kTRUE),
   fGeneratePythiaInfoObject(kFALSE),
   fUsePtHardBinScaling(kFALSE),
   fUseXsecFromHeader(kFALSE),
@@ -1642,7 +1642,7 @@ Bool_t AliAnalysisTaskEmcal::RetrieveEventObjects()
       else if (fCent >= 30 && fCent <   50) fCentBin = 2;
       else if (fCent >= 50 && fCent <= 100) fCentBin = 3;
       else {
-        AliWarning(Form("%s: Negative centrality: %f. Assuming 99", GetName(), fCent));
+        AliWarning(Form("%s: Negative centrality: %f. Assuming 99, cent estimator: %s", GetName(), fCent, fCentEst.Data()));
         fCentBin = fNcentBins-1;
       }
     }
@@ -1656,7 +1656,7 @@ Bool_t AliAnalysisTaskEmcal::RetrieveEventObjects()
         fCentBin = 4;
       }
       else {
-        AliWarning(Form("%s: Negative centrality: %f. Assuming 99", GetName(), fCent));
+        AliWarning(Form("%s: Negative centrality: %f. Assuming 99, cent estimator: %s", GetName(), fCent, fCentEst.Data()));
         fCentBin = fNcentBins-1;
       }
     }

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterizer.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterizer.cxx
@@ -601,8 +601,8 @@ void AliEmcalCorrectionClusterizer::RecPoints2Clusters(TClonesArray *clus)
     c->SetLabel(parentList, parentMult);
     if(parentListDE[0]) {
       c->SetClusterMCEdepFractionFromEdepArray(parentListDE);
-    } else{
-      AliWarning("Could not get deposited energy of parents. Particle might not have parents?");
+    } else {
+      if (mcEnergy > 0.) AliWarning("Could not get deposited energy of parents. Particle might not have parents?");
     }
     
     //

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionTask.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionTask.cxx
@@ -54,7 +54,7 @@ AliEmcalCorrectionTask::AliEmcalCorrectionTask() :
   fMaxCent(-999),
   fNcentBins(4),
   fCentEst("V0M"),
-  fUseNewCentralityEstimation(kFALSE),
+  fUseNewCentralityEstimation(kTRUE),
   fVertex{0},
   fNVertCont(0),
   fBeamType(kNA),
@@ -99,7 +99,7 @@ AliEmcalCorrectionTask::AliEmcalCorrectionTask(const char * name) :
   fMaxCent(-999),
   fNcentBins(4),
   fCentEst("V0M"),
-  fUseNewCentralityEstimation(kFALSE),
+  fUseNewCentralityEstimation(kTRUE),
   fVertex{0},
   fNVertCont(0),
   fBeamType(kNA),
@@ -1251,7 +1251,7 @@ Bool_t AliEmcalCorrectionTask::RetrieveEventObjects()
       else if (fCent >= 30 && fCent <   50) fCentBin = 2;
       else if (fCent >= 50 && fCent <= 100) fCentBin = 3;
       else {
-        AliWarning(Form("Negative centrality: %f. Assuming 99", fCent));
+        AliWarning(Form("%s: Negative centrality: %f. Assuming 99, cent estimator: %s", GetName(), fCent, fCentEst.Data()));
         fCentBin = fNcentBins-1;
       }
     }
@@ -1265,7 +1265,7 @@ Bool_t AliEmcalCorrectionTask::RetrieveEventObjects()
         fCentBin = 4;
       }
       else {
-        AliWarning(Form("Negative centrality: %f. Assuming 99", fCent));
+        AliWarning(Form("%s: Negative centrality: %f. Assuming 99, cent estimator: %s", GetName(), fCent, fCentEst.Data()));
         fCentBin = fNcentBins-1;
       }
     }

--- a/PWGGA/GammaConv/macros/AddTask_GammaCalo_pPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaCalo_pPb.C
@@ -202,36 +202,32 @@ void AddTask_GammaCalo_pPb(
   // EMC +(DMC) clusters pPb 5TeV
   // ===============================================================================================
   if (trainConfig == 1){
-    cuts.AddCutCalo("80010113","411790105f032230000","01631031000000d0"); // 0-100
-    cuts.AddCutCalo("80010113","111110105f032230000","01631031000000d0"); // 0-100
-  } else if (trainConfig == 2){ // unmodified NL
-    cuts.AddCutCalo("80010113","411790105f032230000","01631031000000d0"); // 0-100
-    cuts.AddCutCalo("80010113","111110105f032230000","01631031000000d0"); // 0-100
-  } else if (trainConfig == 3){ // no time cut, TB NL
-    cuts.AddCutCalo("80010113","411793100f032230000","01631031000000d0"); // 0-100
-    cuts.AddCutCalo("80010113","111113100f032230000","01631031000000d0"); // 0-100
-  } else if (trainConfig == 4){
-    cuts.AddCutCalo("80010123","411793105f032230000","01631031000000d0"); // 0-100
-    cuts.AddCutCalo("80010123","111113105f032230000","01631031000000d0"); // 0-100
+    cuts.AddCutCalo("80010113","411790109fe30220000","0s631031000000d0"); // 0-100 MB latest 13TeV cuts E/DMC
+    cuts.AddCutCalo("80010113","411790109fe302v0000","0s631031000000d0"); // 0-100 MB latest 13TeV cuts E/DMC, closed M02(0.7->0.5) cut at high PT
+    cuts.AddCutCalo("80010113","111110109fe30220000","0s631031000000d0"); // 0-100 MB latest 13TeV cuts EMC
+    cuts.AddCutCalo("80010113","111110109fe302v0000","0s631031000000d0"); // 0-100 MB latest 13TeV cuts EMC, closed M02(0.7->0.5) cut at high PT
+  } else if (trainConfig == 2){ // diff MC treatment
+    cuts.AddCutCalo("80010123","411790109fe30220000","0s631031000000d0"); // 0-100 MB latest 13TeV cuts E/DMC
+    cuts.AddCutCalo("80010123","411790109fe302v0000","0s631031000000d0"); // 0-100 MB latest 13TeV cuts E/DMC, closed M02(0.7->0.5) cut at high PT
+    cuts.AddCutCalo("80010123","111110109fe30220000","0s631031000000d0"); // 0-100 MB latest 13TeV cuts EMC
+    cuts.AddCutCalo("80010123","111110109fe302v0000","0s631031000000d0"); // 0-100 MB latest 13TeV cuts EMC, closed M02(0.7->0.5) cut at high PT
+  } else if (trainConfig == 3){
+    cuts.AddCutCalo("80052113","111110109fe30220000","0s631031000000d0"); // 0-100 EMC7 latest 13TeV cuts EMC
+    cuts.AddCutCalo("80085113","111110109fe30220000","0s631031000000d0"); // 0-100 EG2 latest 13TeV cuts EMC
+    cuts.AddCutCalo("80083113","111110109fe30220000","0s631031000000d0"); // 0-100 EG1 latest 13TeV cuts EMC
+  } else if (trainConfig == 4){ // diff MC treatment
+    cuts.AddCutCalo("80052123","111110109fe30220000","0s631031000000d0"); // 0-100 EMC7 latest 13TeV cuts EMC
+    cuts.AddCutCalo("80085123","111110109fe30220000","0s631031000000d0"); // 0-100 EG2 latest 13TeV cuts EMC
+    cuts.AddCutCalo("80083123","111110109fe30220000","0s631031000000d0"); // 0-100 EG1 latest 13TeV cuts EMC
   } else if (trainConfig == 5){
-    cuts.AddCutCalo("80010113","411793105f032230000","01631031000000d0"); // 0-100
-    cuts.AddCutCalo("80010113","411793105f032230000","01631031000000i0"); // 0-100 only pair in same calo
-    cuts.AddCutCalo("80010113","411793105f032230300","01631031000000i0"); // 0-100 remove 1 leg of conv cand Mgg < 0.03
-    cuts.AddCutCalo("80010113","411793105f032230200","01631031000000i0"); // 0-100 remove 1 leg of conv cand Mgg < 0.025
-    cuts.AddCutCalo("80010113","411793105f032230400","01631031000000i0"); // 0-100 remove 1 leg of conv cand Mgg < 0.045
-  } else if (trainConfig == 6){
-    cuts.AddCutCalo("80010113","111113105f032230000","01631031000000d0"); // 0-100
-    cuts.AddCutCalo("80010113","111113105f032230000","01631031000000i0"); // 0-100 only pair in same calo
-    cuts.AddCutCalo("80010113","111113105f032230300","01631031000000i0"); // 0-100 remove 1 leg of conv cand Mgg < 0.03
-    cuts.AddCutCalo("80010113","111113105f032230200","01631031000000i0"); // 0-100 remove 1 leg of conv cand Mgg < 0.025
-    cuts.AddCutCalo("80010113","111113105f032230400","01631031000000i0"); // 0-100 remove 1 leg of conv cand Mgg < 0.035
-  } else if (trainConfig == 7){
-    cuts.AddCutCalo("80010123","111113105f032230000","01631031000000d0"); // 0-100
-    cuts.AddCutCalo("80010123","111113105f032230000","01631031000000i0"); // 0-100 only pair in same calo
-    cuts.AddCutCalo("80010123","111113105f032230300","01631031000000i0"); // 0-100 remove 1 leg of conv cand Mgg < 0.03
-    cuts.AddCutCalo("80010123","111113105f032230200","01631031000000i0"); // 0-100 remove 1 leg of conv cand Mgg < 0.025
-    cuts.AddCutCalo("80010123","111113105f032230400","01631031000000i0"); // 0-100 remove 1 leg of conv cand Mgg < 0.035
-
+    cuts.AddCutCalo("80052113","111110109fe302v0000","0s631031000000d0"); // 0-100 EMC7 latest 13TeV cuts EMC, closed M02(0.7->0.5) cut at high PT
+    cuts.AddCutCalo("80085113","111110109fe302v0000","0s631031000000d0"); // 0-100 EG2 latest 13TeV cuts EMC, closed M02(0.7->0.5) cut at high PT
+    cuts.AddCutCalo("80083113","111110109fe302v0000","0s631031000000d0"); // 0-100 EG1 latest 13TeV cuts EMC, closed M02(0.7->0.5) cut at high PT
+  } else if (trainConfig == 6){ // diff MC treatment
+    cuts.AddCutCalo("80052123","111110109fe302v0000","0s631031000000d0"); // 0-100 EMC7 latest 13TeV cuts EMC, closed M02(0.7->0.5) cut at high PT
+    cuts.AddCutCalo("80085123","111110109fe302v0000","0s631031000000d0"); // 0-100 EG2 latest 13TeV cuts EMC, closed M02(0.7->0.5) cut at high PT
+    cuts.AddCutCalo("80083123","111110109fe302v0000","0s631031000000d0"); // 0-100 EG1 latest 13TeV cuts EMC, closed M02(0.7->0.5) cut at high PT
+    
 
   // CONFIGS for sys MB MCs & JJs
   } else if (trainConfig == 10) { // CALO variations

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_pPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_pPb.C
@@ -122,17 +122,17 @@ void AddTask_GammaConvCalo_pPb(
   for(Int_t i = 0; i<rmaxFacPtHardSetting->GetEntries() ; i++){
     TObjString* tempObjStrPtHardSetting     = (TObjString*) rmaxFacPtHardSetting->At(i);
     TString strTempSetting                  = tempObjStrPtHardSetting->GetString();
-    if(strTempSetting.BeginsWith("MINPTHFAC:")){
+    if(strTempSetting.BeginsWith("MINPTHFAC:") && isMC == 2){
       strTempSetting.Replace(0,10,"");
       minFacPtHard               = strTempSetting.Atof();
       cout << "running with min pT hard jet fraction of: " << minFacPtHard << endl;
       fMinPtHardSet        = kTRUE;
-    } else if(strTempSetting.BeginsWith("MAXPTHFAC:")){
+    } else if(strTempSetting.BeginsWith("MAXPTHFAC:")&& isMC == 2){
       strTempSetting.Replace(0,10,"");
       maxFacPtHard               = strTempSetting.Atof();
       cout << "running with max pT hard jet fraction of: " << maxFacPtHard << endl;
       fMaxPtHardSet        = kTRUE;
-    } else if(strTempSetting.BeginsWith("MAXPTHFACSINGLE:")){
+    } else if(strTempSetting.BeginsWith("MAXPTHFACSINGLE:")&& isMC == 2){
       strTempSetting.Replace(0,16,"");
       maxFacPtHardSingle         = strTempSetting.Atof();
       cout << "running with max single particle pT hard fraction of: " << maxFacPtHardSingle << endl;
@@ -143,19 +143,19 @@ void AddTask_GammaConvCalo_pPb(
         cout << "using MC jet finder for outlier removal" << endl;
         fJetFinderUsage        = kTRUE;
       }
-    } else if(strTempSetting.BeginsWith("PTHFROMFILE:")){
+    } else if(strTempSetting.BeginsWith("PTHFROMFILE:")&& isMC == 2){
       strTempSetting.Replace(0,12,"");
       if(strTempSetting.Atoi()==1){
         cout << "using MC jet finder for outlier removal" << endl;
         fUsePtHardFromFile        = kTRUE;
       }
-    } else if(strTempSetting.BeginsWith("ADDOUTLIERREJ:")){
+    } else if(strTempSetting.BeginsWith("ADDOUTLIERREJ:")&& isMC == 2){
       strTempSetting.Replace(0,14,"");
       if(strTempSetting.Atoi()==1){
         cout << "using path based outlier removal" << endl;
         fUseAddOutlierRej        = kTRUE;
       }
-    } else if(rmaxFacPtHardSetting->GetEntries()==1 && strTempSetting.Atof()>0){
+    } else if(rmaxFacPtHardSetting->GetEntries()==1 && strTempSetting.Atof()>0 && isMC == 2){
       maxFacPtHard               = strTempSetting.Atof();
       cout << "running with max pT hard jet fraction of: " << maxFacPtHard << endl;
       fMaxPtHardSet        = kTRUE;
@@ -178,8 +178,7 @@ void AddTask_GammaConvCalo_pPb(
   TString cutnumberPhoton = photonCutNumberV0Reader.Data();
   TString cutnumberEvent = "80000003";
   AliAnalysisDataContainer *cinput = mgr->GetCommonInputContainer();
-
-    //========= Add V0 Reader to  ANALYSIS manager if not yet existent =====
+  //========= Add V0 Reader to  ANALYSIS manager if not yet existent =====
   TString V0ReaderName        = Form("V0ReaderV1_%s_%s",cutnumberEvent.Data(),cutnumberPhoton.Data());
   AliV0ReaderV1 *fV0ReaderV1  =  NULL;
   if( !(AliV0ReaderV1*)mgr->GetTask(V0ReaderName.Data()) ){
@@ -188,7 +187,6 @@ void AddTask_GammaConvCalo_pPb(
   } else {
     cout << "V0Reader: " << V0ReaderName.Data() << " found!!"<< endl;
   }
-
   //================================================
   //========= Add task to the ANALYSIS manager =====
   //================================================
@@ -203,35 +201,27 @@ void AddTask_GammaConvCalo_pPb(
   task->SetTrackMatcherRunningMode(trackMatcherRunningMode);
   if(trainConfig >= 1520 && trainConfig < 1530) task->SetDoHBTHistoOutput(kTRUE);
 
-  // cluster cuts
+    // cluster cuts
   // 0 "ClusterType",  1 "EtaMin", 2 "EtaMax", 3 "PhiMin", 4 "PhiMax", 5 "DistanceToBadChannel", 6 "Timing", 7 "TrackMatching", 8 "ExoticCell",
   // 9 "MinEnergy", 10 "MinNCells", 11 "MinM02", 12 "MaxM02", 13 "MinMaxM20", 14 "RecConv", 15 "MaximumDispersion", 16 "NLM"
 
   //************************************************ PCM- EDC analysis 5 TeV pPb *********************************************
   if (trainConfig == 1){ // EMC  INT7 run1 & run2
-    cuts.AddCutPCMCalo("80010113","00200009f9730000dge0400000","411790105f032230000","0h63103100000010"); // 0-100% without NL
-    cuts.AddCutPCMCalo("80010113","00200009f9730000dge0400000","111110105f032230000","0h63103100000010"); // 0-100% without NL just EMC
+    cout << "Line: " << __LINE__ << endl;
+    cuts.AddCutPCMCalo("80010113","0dm00009f9730000dge0404000","411790109fe30220000","0r63103100000010"); // 0-100% latest 13TeV cut
+    cuts.AddCutPCMCalo("80010113","0dm00009f9730000dge0404000","111110109fe30220000","0r63103100000010"); // 0-100% latest 13TeV cut    
   } else if (trainConfig == 2){ // EMC  INT7 run1 & run2
-    cuts.AddCutPCMCalo("80010113","00200009f9730000dge0400000","411793105f032230000","0h63103100000010"); // 0-100% PCM NL
-    cuts.AddCutPCMCalo("80010113","00200009f9730000dge0400000","111113105f032230000","0h63103100000010"); // 0-100% PCM NL just EMC
+    cuts.AddCutPCMCalo("80010123","0dm00009f9730000dge0404000","411790109fe30220000","0r63103100000010"); // 0-100% latest 13TeV cut
+    cuts.AddCutPCMCalo("80010123","0dm00009f9730000dge0404000","111110109fe30220000","0r63103100000010"); // 0-100% latest 13TeV cut    
   } else if (trainConfig == 3){ // EMC EMC triggers
-    cuts.AddCutPCMCalo("80052113","00200009f9730000dge0400000","111110105f032230000","0h63103100000010"); // 0-100% without NL just EMC, EMC7
-    cuts.AddCutPCMCalo("80052113","00200009f9730000dge0400000","111113105f032230000","0h63103100000010"); // 0-100% PCM NL just EMC, EMC7
-  } else if (trainConfig == 4){ // EMC EMC triggers
-    cuts.AddCutPCMCalo("80083113","00200009f9730000dge0400000","111110105f032230000","0h63103100000010"); // 0-100% without NL just EMC, EG1
-    cuts.AddCutPCMCalo("80083113","00200009f9730000dge0400000","111113105f032230000","0h63103100000010"); // 0-100% PCM NL just EMC, EG1
-  } else if (trainConfig == 5){ // EMC EMC triggers
-    cuts.AddCutPCMCalo("80085113","00200009f9730000dge0400000","111110105f032230000","0h63103100000010"); // 0-100% without NL just EMC, EG2
-    cuts.AddCutPCMCalo("80085113","00200009f9730000dge0400000","111113105f032230000","0h63103100000010"); // 0-100% PCM NL just EMC, EG2
-  } else if (trainConfig == 6){ // EMC EMC triggers
-    cuts.AddCutPCMCalo("80083123","00200009f9730000dge0400000","111110105f032230000","0h63103100000010"); // 0-100% without NL just EMC, EG1
-    cuts.AddCutPCMCalo("80083123","00200009f9730000dge0400000","111113105f032230000","0h63103100000010"); // 0-100% PCM NL just EMC, EG1
-  } else if (trainConfig == 7){ // EMC EMC triggers
-    cuts.AddCutPCMCalo("80085123","00200009f9730000dge0400000","111110105f032230000","0h63103100000010"); // 0-100% without NL just EMC, EG2
-    cuts.AddCutPCMCalo("80085123","00200009f9730000dge0400000","111113105f032230000","0h63103100000010"); // 0-100% PCM NL just EMC, EG2
-  } else if (trainConfig == 8){ // EMC  INT7 run1 & run2
-    cuts.AddCutPCMCalo("80010123","00200009f9730000dge0400000","411793105f032230000","0h63103100000010"); // 0-100% PCM NL
-    cuts.AddCutPCMCalo("80010123","00200009f9730000dge0400000","111113105f032230000","0h63103100000010"); // 0-100% PCM NL just EMC
+    cout << "Line: " << __LINE__ << endl;
+    cuts.AddCutPCMCalo("80052113","0dm00009f9730000dge0404000","111110109fe30220000","0r63103100000010"); // 0-100% latest 13TeV cut EMC7
+    cuts.AddCutPCMCalo("80085113","0dm00009f9730000dge0404000","111110109fe30220000","0r63103100000010"); // 0-100% latest 13TeV cut EG2
+    cuts.AddCutPCMCalo("80083113","0dm00009f9730000dge0404000","111110109fe30220000","0r63103100000010"); // 0-100% latest 13TeV cut EG1
+  } else if (trainConfig == 4){ // EMC EMC triggers MC rejected
+    cuts.AddCutPCMCalo("80052123","0dm00009f9730000dge0404000","111110109fe30220000","0r63103100000010"); // 0-100% latest 13TeV cut EMC7
+    cuts.AddCutPCMCalo("80085123","0dm00009f9730000dge0404000","111110109fe30220000","0r63103100000010"); // 0-100% latest 13TeV cut EG2
+    cuts.AddCutPCMCalo("80083123","0dm00009f9730000dge0404000","111110109fe30220000","0r63103100000010"); // 0-100% latest 13TeV cut EG1
 
   //************************************************ PCM- EDC analysis 5 TeV pPb INT7 sys *********************************
   } else if (trainConfig == 10) { // PCM variations
@@ -2027,7 +2017,7 @@ void AddTask_GammaConvCalo_pPb(
     if(analysisMesonCuts[i]->DoGammaSwappForBg()) analysisClusterCuts[i]->SetUseEtaPhiMapForBackCand(kTRUE);
     analysisClusterCuts[i]->SetFillCutHistograms("");
   }
-
+  
   task->SetEventCutList(numberOfCuts,EventCutList);
   task->SetConversionCutList(numberOfCuts,ConvCutList);
   task->SetCaloCutList(numberOfCuts,ClusterCutList);

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvV1_pPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvV1_pPb.C
@@ -170,7 +170,7 @@ void AddTask_GammaConvV1_pPb(
   // new standard configurations  MB
   if(trainConfig == 1){
     cuts.AddCutPCM("80010113", "00200009f9730000dge0400000", "0162103500900000"); // new default
-    cuts.AddCutPCM("80010113", "00200009327000008250400000", "0162103500900000"); // new default, no to close
+    cuts.AddCutPCM("80010113", "00200009327000008250400000", "0162103500900000"); // new default, no to close    
   } else if (trainConfig == 2){
     cuts.AddCutPCM("80010113", "00200009f9730000dge0400000", "0162103500000000"); // new default
     cuts.AddCutPCM("80010113", "00200009327000008250400000", "0162103500000000"); // new default, no to close
@@ -180,16 +180,10 @@ void AddTask_GammaConvV1_pPb(
   } else if (trainConfig == 4){
     cuts.AddCutPCM("80010123", "00200009f9730000dge0400000", "0162103500000000"); // new default
     cuts.AddCutPCM("80010123", "00200009327000008250400000", "0162103500000000"); // new default, no to close
-  } else if (trainConfig == 5){ // past-future protection
-    cuts.AddCutPCM("80010213", "00200009f9730000dge0400000", "0162103500900000"); // new default, +-2.225\mus no other interaction
-    cuts.AddCutPCM("80010213", "00200009327000008250400000", "0162103500900000"); // new default, no to close, +-2.225\mus no other interaction
-    cuts.AddCutPCM("80010513", "00200009f9730000dge0400000", "0162103500900000"); // new default, +-1.075\mus no other interaction
-    cuts.AddCutPCM("80010513", "00200009327000008250400000", "0162103500900000"); // new default, no to close, +-1.075\mus no other interaction
-  } else if (trainConfig == 6){ // past-future protection
-    cuts.AddCutPCM("80010213", "00200009f9730000dge0400000", "0162103500000000"); // new default,  +-2.225\mus no other interaction
-    cuts.AddCutPCM("80010213", "00200009327000008250400000", "0162103500000000"); // new default, no to close, +-2.225\mus no other interaction
-    cuts.AddCutPCM("80010513", "00200009f9730000dge0400000", "0162103500000000"); // new default,  +-1.075\mus no other interaction
-    cuts.AddCutPCM("80010513", "00200009327000008250400000", "0162103500000000"); // new default, no to close,  +-1.075\mus no other interaction
+  } else if (trainConfig == 5){ 
+    cuts.AddCutPCM("80010113", "0dm00009f9730000dge0404000", "0162103500000000"); // new default 13TeV
+  } else if (trainConfig == 6){
+    cuts.AddCutPCM("80010123", "0dm00009f9730000dge0404000", "0162103500000000"); // new default 13TeV diff MC treatment
   } else if (trainConfig == 7){
     cuts.AddCutPCM("80010123", "00200009f9730000dge0400000", "0162103500900000"); // new default
     cuts.AddCutPCM("80010123", "00200009327000008250400000", "0162103500900000"); // new default, no to close


### PR DESCRIPTION
PWG/EMCal:

- switched by default to new centrality estimator for all EMCal central tasks
- modified warnings
- quited unnecessary warnings

PWGGA/GammaConv: 

- updated cuts for pPb: PCM, EMC, PCM-EMC to match latest greatest 13TeV cuts