### PR TITLE
PWGGA/GammaConv: Fix for PHOS track matching

### DIFF
--- a/PWGGA/GammaConvBase/AliCaloPhotonCuts.cxx
+++ b/PWGGA/GammaConvBase/AliCaloPhotonCuts.cxx
@@ -216,6 +216,7 @@ AliCaloPhotonCuts::AliCaloPhotonCuts(Int_t isMC, const char *name,const char *ti
   fHistClusterEtavsPhiAfterQA(NULL),
   fHistClusterEtavsPhiAfterQA_onlyTriggered(NULL),
   fHistClusterEtavsPhiBackground(NULL),
+  fHistClusterEtavsPhiMatchedClusters(NULL),
   fHistClusterTimevsEBeforeQA(NULL),
   fHistClusterTimevsEAfterQA(NULL),
   fHistClusterTimevsELowGain(NULL),
@@ -457,6 +458,7 @@ AliCaloPhotonCuts::AliCaloPhotonCuts(const AliCaloPhotonCuts &ref) :
   fHistClusterEtavsPhiAfterQA(NULL),
   fHistClusterEtavsPhiAfterQA_onlyTriggered(NULL),
   fHistClusterEtavsPhiBackground(NULL),
+  fHistClusterEtavsPhiMatchedClusters(NULL),
   fHistClusterTimevsEBeforeQA(NULL),
   fHistClusterTimevsEAfterQA(NULL),
   fHistClusterTimevsELowGain(NULL),
@@ -744,6 +746,12 @@ void AliCaloPhotonCuts::InitCutHistograms(TString name){
         fHistClusterEtavsPhiBackground->GetYaxis()->SetTitle("#eta");
         fHistograms->Add(fHistClusterEtavsPhiBackground);
       }
+      if(fExtendedMatchAndQA >= 3){
+        fHistClusterEtavsPhiMatchedClusters  = new TH2F(Form("EtaPhi_MatchedClusters %s",GetCutNumber().Data()),"EtaPhi_MatchedClusters",nEmcalPhiBins,EmcalPhiBins,nEmcalEtaBins,EmcalEtaBins);
+        fHistClusterEtavsPhiMatchedClusters->GetXaxis()->SetTitle("#varphi (rad)");
+        fHistClusterEtavsPhiMatchedClusters->GetYaxis()->SetTitle("#eta");
+        fHistograms->Add(fHistClusterEtavsPhiMatchedClusters);
+      }
     }
     fHistClusterEtavsPhiAfterQA     = new TH2F(Form("EtaPhi_afterClusterQA %s",GetCutNumber().Data()),"EtaPhi_afterClusterQA",nEmcalPhiBins,EmcalPhiBins,nEmcalEtaBins,EmcalEtaBins);
     fHistClusterEtavsPhiAfterQA->GetXaxis()->SetTitle("#varphi (rad)");
@@ -769,6 +777,12 @@ void AliCaloPhotonCuts::InitCutHistograms(TString name){
         fHistClusterEtavsPhiBackground->GetXaxis()->SetTitle("#varphi (rad)");
         fHistClusterEtavsPhiBackground->GetYaxis()->SetTitle("#eta");
         fHistograms->Add(fHistClusterEtavsPhiBackground);
+      }
+      if(fExtendedMatchAndQA >= 3){
+        fHistClusterEtavsPhiMatchedClusters  = new TH2F(Form("EtaPhi_MatchedClusters %s",GetCutNumber().Data()),"EtaPhi_MatchedClusters",nPhosPhiBins,PhosPhiRange[0],PhosPhiRange[1],nPhosEtaBins,PhosEtaRange[0],PhosEtaRange[1]);
+        fHistClusterEtavsPhiMatchedClusters->GetXaxis()->SetTitle("#varphi (rad)");
+        fHistClusterEtavsPhiMatchedClusters->GetYaxis()->SetTitle("#eta");
+        fHistograms->Add(fHistClusterEtavsPhiMatchedClusters);
       }
     }
     fHistClusterEtavsPhiAfterQA     = new TH2F(Form("EtaPhi_afterClusterQA %s",GetCutNumber().Data()),"EtaPhi_afterClusterQA",nPhosPhiBins,PhosPhiRange[0],PhosPhiRange[1],nPhosEtaBins,PhosEtaRange[0],PhosEtaRange[1]);
@@ -799,6 +813,12 @@ void AliCaloPhotonCuts::InitCutHistograms(TString name){
         fHistClusterEtavsPhiBackground->GetYaxis()->SetTitle("#eta");
         fHistograms->Add(fHistClusterEtavsPhiBackground);
       }
+      if(fExtendedMatchAndQA >= 3){
+        fHistClusterEtavsPhiMatchedClusters  = new TH2F(Form("EtaPhi_MatchedClusters %s",GetCutNumber().Data()),"EtaPhi_MatchedClusters",nDcalPhiBins,4.5,5.7,nDcalEtaBins,-0.66687,0.66465);
+        fHistClusterEtavsPhiMatchedClusters->GetXaxis()->SetTitle("#varphi (rad)");
+        fHistClusterEtavsPhiMatchedClusters->GetYaxis()->SetTitle("#eta");
+        fHistograms->Add(fHistClusterEtavsPhiMatchedClusters);
+      }
     }
     fHistClusterEtavsPhiAfterQA     = new TH2F(Form("EtaPhi_afterClusterQA %s",GetCutNumber().Data()),"EtaPhi_afterClusterQA",nDcalPhiBins,4.5,5.7,nDcalEtaBins,-0.66687,0.66465);
     fHistClusterEtavsPhiAfterQA->GetXaxis()->SetTitle("#varphi (rad)");
@@ -819,6 +839,12 @@ void AliCaloPhotonCuts::InitCutHistograms(TString name){
         fHistClusterEtavsPhiBackground->GetXaxis()->SetTitle("#varphi (rad)");
         fHistClusterEtavsPhiBackground->GetYaxis()->SetTitle("#eta");
         fHistograms->Add(fHistClusterEtavsPhiBackground);
+      }
+      if(fExtendedMatchAndQA >= 3){
+        fHistClusterEtavsPhiMatchedClusters  = new TH2F(Form("EtaPhi_MatchedClusters %s",GetCutNumber().Data()),"EtaPhi_MatchedClusters",462,0,2*TMath::Pi(),110,-0.7,0.7);
+        fHistClusterEtavsPhiMatchedClusters->GetXaxis()->SetTitle("#varphi (rad)");
+        fHistClusterEtavsPhiMatchedClusters->GetYaxis()->SetTitle("#eta");
+        fHistograms->Add(fHistClusterEtavsPhiMatchedClusters);
       }
     }
     fHistClusterEtavsPhiAfterQA     = new TH2F(Form("EtaPhi_afterClusterQA %s",GetCutNumber().Data()),"EtaPhi_afterClusterQA",462,0,2*TMath::Pi(),110,-0.7,0.7);
@@ -841,6 +867,12 @@ void AliCaloPhotonCuts::InitCutHistograms(TString name){
         fHistClusterEtavsPhiBackground->GetYaxis()->SetTitle("#eta");
         fHistograms->Add(fHistClusterEtavsPhiBackground);
       }
+      if(fExtendedMatchAndQA >= 3){
+        fHistClusterEtavsPhiMatchedClusters  = new TH2F(Form("EtaPhi_MatchedClusters %s",GetCutNumber().Data()),"EtaPhi_MatchedClusters",462,0,2*TMath::Pi(),110,-0.7,0.7);
+        fHistClusterEtavsPhiMatchedClusters->GetXaxis()->SetTitle("#varphi (rad)");
+        fHistClusterEtavsPhiMatchedClusters->GetYaxis()->SetTitle("#eta");
+        fHistograms->Add(fHistClusterEtavsPhiMatchedClusters);
+      }
     }
     fHistClusterEtavsPhiAfterQA     = new TH2F(Form("EtaPhi_afterClusterQA %s",GetCutNumber().Data()),"EtaPhi_afterClusterQA",462,0,2*TMath::Pi(),110,-0.7,0.7);
     fHistClusterEtavsPhiAfterQA->GetXaxis()->SetTitle("#varphi (rad)");
@@ -854,6 +886,9 @@ void AliCaloPhotonCuts::InitCutHistograms(TString name){
       fHistClusterEtavsPhiAfterAcc->Sumw2();
       if(fUseEtaPhiMapForBackCand){
         fHistClusterEtavsPhiBackground->Sumw2();
+      }
+      if(fExtendedMatchAndQA >= 3){
+        fHistClusterEtavsPhiMatchedClusters->Sumw2();
       }
     }
     fHistClusterEtavsPhiAfterQA->Sumw2();
@@ -2863,6 +2898,10 @@ Bool_t AliCaloPhotonCuts::ClusterQualityCuts(AliVCluster* cluster, AliVEvent *ev
   if (fVectorMatchedClusterIDs.size()>0 && fUseDistTrackToCluster && fUsePtDepTrackToCluster < 2){
     if( CheckClusterForTrackMatch(cluster) ){
       if(fHistClusterIdentificationCuts)fHistClusterIdentificationCuts->Fill(cutIndex, cluster->E(), weight);//2
+      // Fill eta phi map for matched clusters as QA check
+      if(fExtendedMatchAndQA >= 3){
+        fHistClusterEtavsPhiMatchedClusters->Fill(phiCluster, etaCluster, weight);
+      }
       // TM efficiency histos after TM
       if (fIsMC && isMC && (fExtendedMatchAndQA == 1 || fExtendedMatchAndQA == 3 || fExtendedMatchAndQA == 5)  && !(fIsPureCalo > 0 && cluster->E() < 10.)){ // ignore low energies for merged analysis
         if(IsClusterPi0(event, mcEvent, cluster))

--- a/PWGGA/GammaConvBase/AliCaloPhotonCuts.h
+++ b/PWGGA/GammaConvBase/AliCaloPhotonCuts.h
@@ -612,6 +612,7 @@ class AliCaloPhotonCuts : public AliAnalysisCuts {
     TH2F*     fHistClusterEtavsPhiAfterQA;              // eta-phi-distribution of all after cluster quality cuts
     TH2F*     fHistClusterEtavsPhiAfterQA_onlyTriggered;// eta-phi-distribution of all after cluster quality cuts
     TH2F*     fHistClusterEtavsPhiBackground;           // eta-phi-distribution of all clusters in background calculation
+    TH2F*     fHistClusterEtavsPhiMatchedClusters;      // eta-phi-distribution of all track-matched clusters
     TH2F*     fHistClusterTimevsEBeforeQA;              // Cluster time vs E before cluster quality cuts
     TH2F*     fHistClusterTimevsEAfterQA;               // Cluster time vs E after cluster quality cuts
     TH2F*     fHistClusterTimevsELowGain;               // Cluster time vs E for low gain cluster
@@ -740,7 +741,7 @@ class AliCaloPhotonCuts : public AliAnalysisCuts {
 
   private:
 
-    ClassDef(AliCaloPhotonCuts,126)
+    ClassDef(AliCaloPhotonCuts,127)
 };
 
 #endif

--- a/PWGGA/GammaConvBase/AliCaloTrackMatcher.cxx
+++ b/PWGGA/GammaConvBase/AliCaloTrackMatcher.cxx
@@ -365,14 +365,16 @@ void AliCaloTrackMatcher::ProcessEvent(AliVEvent *event){
       if (fClusterType == 1 || fClusterType == 3 || fClusterType == 4){
         if( TMath::Abs(aodt->GetTrackEtaOnEMCal()) > 0.75 ){FillfHistControlMatches(1.,inTrack->Pt()); continue;}
 
+        double trackPhiEMC = aodt->GetTrackPhiOnEMCal();
+        if(trackPhiEMC < 0) trackPhiEMC+=2*TMath::Pi(); // phi should be between 0 and 2pi
         // conditions for run1
-        if( fClusterType == 1 && nModules < 13 && ( aodt->GetTrackPhiOnEMCal() < 70*TMath::DegToRad() || aodt->GetTrackPhiOnEMCal() > 190*TMath::DegToRad())){FillfHistControlMatches(1.,inTrack->Pt()); continue;}
+        if( fClusterType == 1 && nModules < 13 && ( trackPhiEMC < 70*TMath::DegToRad() || trackPhiEMC > 190*TMath::DegToRad())){FillfHistControlMatches(1.,inTrack->Pt()); continue;}
 
         // conditions for run2
         if( nModules > 12 ){
-          if( fClusterType == 3 && ( aodt->GetTrackPhiOnEMCal() < 250*TMath::DegToRad() || aodt->GetTrackPhiOnEMCal() > 340*TMath::DegToRad()) ){FillfHistControlMatches(1.,inTrack->Pt()); continue;}
-          if( fClusterType == 1 && ( aodt->GetTrackPhiOnEMCal() < 70*TMath::DegToRad() || aodt->GetTrackPhiOnEMCal() > 190*TMath::DegToRad()) ){FillfHistControlMatches(1.,inTrack->Pt()); continue;}
-          if( fClusterType == 4 && ( aodt->GetTrackPhiOnEMCal() < 70*TMath::DegToRad() || aodt->GetTrackPhiOnEMCal() > 190*TMath::DegToRad()) && ( aodt->GetTrackPhiOnEMCal() < 250*TMath::DegToRad() || aodt->GetTrackPhiOnEMCal() > 340*TMath::DegToRad()) ){FillfHistControlMatches(1.,inTrack->Pt()); continue;}
+          if( fClusterType == 3 && ( trackPhiEMC < 250*TMath::DegToRad() || trackPhiEMC > 340*TMath::DegToRad()) ){FillfHistControlMatches(1.,inTrack->Pt()); continue;}
+          if( fClusterType == 1 && ( trackPhiEMC < 70*TMath::DegToRad() || trackPhiEMC > 190*TMath::DegToRad()) ){FillfHistControlMatches(1.,inTrack->Pt()); continue;}
+          if( fClusterType == 4 && ( trackPhiEMC < 70*TMath::DegToRad() || trackPhiEMC > 190*TMath::DegToRad()) && ( trackPhiEMC < 250*TMath::DegToRad() || trackPhiEMC > 340*TMath::DegToRad()) ){FillfHistControlMatches(1.,inTrack->Pt()); continue;}
         }
       }
       trackParam = new AliExternalTrackParam(xyz,pxpypz,cv,aodt->Charge());
@@ -433,7 +435,9 @@ void AliCaloTrackMatcher::ProcessEvent(AliVEvent *event){
           FillfHistControlMatches(3.,inTrack->Pt());
           continue;
         }
-        if (trkPosVec.Phi() < 230*TMath::DegToRad() || trkPosVec.Phi() > 350*TMath::DegToRad() ){
+        double trkPosPhi = trkPosVec.Phi();
+        if(trkPosPhi < 0) trkPosPhi+=2*TMath::Pi(); // to circumvent that phi has negative values
+        if (trkPosPhi < 230*TMath::DegToRad() || trkPosPhi > 350*TMath::DegToRad() ){
           delete trackParam;
           FillfHistControlMatches(3.,inTrack->Pt());
           continue;
@@ -612,25 +616,28 @@ Bool_t AliCaloTrackMatcher::PropagateV0TrackToClusterAndGetMatchingResidual(AliV
         fSecMap_TrID_ClID_AlreadyTried[make_pair(inSecTrack->GetID(),cluster->GetID())] = 1.;
         return kFALSE;
       }
+      double trackPhiEMC = aodt->GetTrackPhiOnEMCal();
+      if(trackPhiEMC < 0) trackPhiEMC+=2*TMath::Pi(); // phi should be between 0 and 2pi
+
       if( nModules < 13 ){
-        if (( aodt->GetTrackPhiOnEMCal() < 60*TMath::DegToRad() || aodt->GetTrackPhiOnEMCal() > 200*TMath::DegToRad())){
+        if (( trackPhiEMC < 60*TMath::DegToRad() || trackPhiEMC > 200*TMath::DegToRad())){
           FillfSecHistControlMatches(1.,inSecTrack->Pt());
           fSecMap_TrID_ClID_AlreadyTried[make_pair(inSecTrack->GetID(),cluster->GetID())] = 1.;
           return kFALSE;
         }
       } else if( nModules > 12 ){
-        if (fClusterType == 3 && ( aodt->GetTrackPhiOnEMCal() < 250*TMath::DegToRad() || aodt->GetTrackPhiOnEMCal() > 340*TMath::DegToRad())){
+        if (fClusterType == 3 && ( trackPhiEMC < 250*TMath::DegToRad() || trackPhiEMC > 340*TMath::DegToRad())){
           FillfSecHistControlMatches(1.,inSecTrack->Pt());
           fSecMap_TrID_ClID_AlreadyTried[make_pair(inSecTrack->GetID(),cluster->GetID())] = 1.;
           return kFALSE;
         }
-        if( fClusterType == 1 && ( aodt->GetTrackPhiOnEMCal() < 60*TMath::DegToRad() || aodt->GetTrackPhiOnEMCal() > 200*TMath::DegToRad())){
+        if( fClusterType == 1 && ( trackPhiEMC < 60*TMath::DegToRad() || trackPhiEMC > 200*TMath::DegToRad())){
           FillfSecHistControlMatches(1.,inSecTrack->Pt());
           fSecMap_TrID_ClID_AlreadyTried[make_pair(inSecTrack->GetID(),cluster->GetID())] = 1.;
           return kFALSE;
         }
-        if( fClusterType == 4 && ( aodt->GetTrackPhiOnEMCal() < 60*TMath::DegToRad() || aodt->GetTrackPhiOnEMCal() > 200*TMath::DegToRad())
-                              && ( aodt->GetTrackPhiOnEMCal() < 250*TMath::DegToRad() || aodt->GetTrackPhiOnEMCal() > 340*TMath::DegToRad()) ){
+        if( fClusterType == 4 && ( trackPhiEMC < 60*TMath::DegToRad() || trackPhiEMC > 200*TMath::DegToRad())
+                              && ( trackPhiEMC < 250*TMath::DegToRad() || trackPhiEMC > 340*TMath::DegToRad()) ){
           FillfSecHistControlMatches(1.,inSecTrack->Pt());
           fSecMap_TrID_ClID_AlreadyTried[make_pair(inSecTrack->GetID(),cluster->GetID())] = 1.;
           return kFALSE;


### PR DESCRIPTION
- Track matching for PHOS in the AliCaloTrackMatcher imlied that phi is between 0 and 2pi. However the TVector3 returns phi in a range from -pi to pi.
- Therefore, phi values below 0 are now increased by 2pi to get the expected range.
- For QA purposes, a 2D hitmap is implemented in AliCaloPhotonCuts to show the position of matched clusters (if QA flag >=3)