### PR TITLE
PWGGA/GammaConv: New phi acceptance cuts for PHOS

### DIFF
--- a/PWGGA/GammaConv/macros/AddTask_GammaCalo_pPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaCalo_pPb.C
@@ -1126,6 +1126,8 @@ void AddTask_GammaCalo_pPb(
     cuts.AddCutCalo("80010123","24466000ha01cc00000","0163103100000010"); // 0-100% without non-lin
     cuts.AddCutCalo("80010123","24466530ha01cc00000","0163103100000010"); // 0-100% non-lin 1
     cuts.AddCutCalo("80010123","24466540ha01cc00000","0163103100000010"); // 0-100% non-lin 2
+  } else if (trainConfig == 526) { 
+    cuts.AddCutCalo("80010113","2444c530ua01cc00000","0163103100000010"); // non-lin 1 and new eta-phi
 
   } else if (trainConfig == 528){ // PHOS INT7, 300MeV
     cuts.AddCutCalo("80010123","24466190sa01cc00000","0163103100000010"); //Int7 no Trigger

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_pPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_pPb.C
@@ -1033,6 +1033,10 @@ void AddTask_GammaConvCalo_pPb(
     cuts.AddCutPCMCalo("80010113","0dm00009f9730000dge0404000","24466530ha01cc00000","0h63103100000010"); // 0-100% with NL 1
   } else if (trainConfig == 1008) { // timing cut effi u, new default
     cuts.AddCutPCMCalo("80010113","0dm00009f9730000dge0404000","24466530ua01cc00000","0h63103100000010"); // 0-100% with NL 1
+
+  } else if (trainConfig == 1009) { // timing cut effi u, new default, new eta-phi
+    cuts.AddCutPCMCalo("80010113","0dm00009f9730000dge0404000","2444c530ua01cc00000","0h63103100000010"); // 0-100% with NL 1
+  
   
   ///PCM-Variation
   } else if (trainConfig == 1010) {

--- a/PWGGA/GammaConvBase/AliCaloPhotonCuts.cxx
+++ b/PWGGA/GammaConvBase/AliCaloPhotonCuts.cxx
@@ -5311,6 +5311,10 @@ Bool_t AliCaloPhotonCuts::SetMaxPhiCut(Int_t maxPhi)
     fMaxPhiCut = 5.59;//PHOS acceptance RUN2
     fReduceTriggeredPhiDueBadDDLs = kTRUE;
     break;
+  case 12:
+    if( !fUsePhiCut ) fUsePhiCut=1;
+    fMaxPhiCut = 5.24;//PHOS acceptance RUN2
+    break;
   default:
     AliError(Form("Max Phi Cut not defined %d",maxPhi));
     return kFALSE;


### PR DESCRIPTION
- for QA studies the outer PHOS modules are excluded, therefore new phi ranges are defined (4.55 - 5.24)

- added TrainConfigs for new cuts