### PR TITLE
Add Common Ancestors for Cascade in FemtoDream

### DIFF
--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliAnalysisTaskOtonXx.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliAnalysisTaskOtonXx.h
@@ -35,12 +35,8 @@ class AliAnalysisTaskOtonXx : public AliAnalysisTaskSE {
   void SetEventCuts(AliFemtoDreamEventCuts *evtCuts) {fEventCuts = evtCuts;};
   void SetTrackCutsKaon(AliFemtoDreamTrackCuts *trkCuts) {fTrackCutsKaon = trkCuts;};
   void SetTrackCutsAntiKaon(AliFemtoDreamTrackCuts *trkCuts) {fTrackCutsAntiKaon = trkCuts;};
-  void SetXiCuts(AliFemtoDreamCascadeCuts* cascCuts) {
-    fCutsXi = cascCuts;
-  }
-  void SetAntiXiCuts(AliFemtoDreamCascadeCuts* cascCuts) {
-    fCutsAntiXi = cascCuts;
-  }
+  void SetXiCuts(AliFemtoDreamCascadeCuts* cascCuts) { fCutsXi = cascCuts; }
+  void SetAntiXiCuts(AliFemtoDreamCascadeCuts* cascCuts) { fCutsAntiXi = cascCuts;}
   void SetCollectionConfig(AliFemtoDreamCollConfig *config) {fConfig = config;};
   void SetRunTaskLightWeight(bool light) {
     fisLightWeight = light;
@@ -147,6 +143,7 @@ class AliAnalysisTaskOtonXx : public AliAnalysisTaskSE {
   Int_t fTKaonPDG[300];
   Int_t fTKaonMotherWeak[300];
   Short_t fTKaonOrigin[300];
+  Int_t fTKaonMotherID[300];
 
   const Int_t MAXXiS = 10;
   Int_t fTnXi;
@@ -180,6 +177,7 @@ class AliAnalysisTaskOtonXx : public AliAnalysisTaskSE {
   Bool_t fTXiTrackSPDtime[10][3];
   Bool_t fTXiTrackITStime[10][3];
   Bool_t fTXiTrackTOFtime[10][3];
+  Int_t fTXiMotherID[10];
 
   // ClassDef 6 ????
   ClassDef(AliAnalysisTaskOtonXx, 6)

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamTrackMCHist.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamTrackMCHist.cxx
@@ -37,6 +37,7 @@ AliFemtoDreamTrackMCHist::AliFemtoDreamTrackMCHist()
       fMCSecKlongDCAXYPtBins(nullptr),
       fMCSecKshortDCAXYPtBins(nullptr),
       fMCSecKchDCAXYPtBins(nullptr),
+      fMCSecpichDCAXYPtBins(nullptr),
       fPtResolution(nullptr),
       fThetaResolution(nullptr),
       fPhiResolution(nullptr) {
@@ -96,6 +97,7 @@ AliFemtoDreamTrackMCHist::AliFemtoDreamTrackMCHist(bool contribSplitting,
       fMCSecKlongDCAXYPtBins(nullptr),
       fMCSecKshortDCAXYPtBins(nullptr),
       fMCSecKchDCAXYPtBins(nullptr),
+      fMCSecpichDCAXYPtBins(nullptr),
       fPtResolution(nullptr),
       fThetaResolution(nullptr),
       fPhiResolution(nullptr) {
@@ -279,6 +281,7 @@ AliFemtoDreamTrackMCHist::AliFemtoDreamTrackMCHist(bool contribSplitting,
     TString MCSecKlcaPtBinName = TString::Format("DCAPtBinningSecKl");
     TString MCSecKsdcaPtBinName = TString::Format("DCAPtBinningSecKs");
     TString MCSecKchdcaPtBinName = TString::Format("DCAPtBinningSecKch");
+    TString MCSecpichdcaPtBinName = TString::Format("DCAPtBinningSecpich");
 
 
     fMCPrimDCAXYPtBins = new TH2F(MCPridcaPtBinName.Data(),
@@ -364,6 +367,14 @@ AliFemtoDreamTrackMCHist::AliFemtoDreamTrackMCHist(bool contribSplitting,
     fMCSecKchDCAXYPtBins->GetXaxis()->SetTitle("p_{T}");
     fMCSecKchDCAXYPtBins->GetYaxis()->SetTitle("dca_{XY}");
     fDCAPlots->Add(fMCSecKchDCAXYPtBins);
+
+    fMCSecpichDCAXYPtBins = new TH2F(MCSecpichdcaPtBinName.Data(),
+                                    MCSecpichdcaPtBinName.Data(), fpTbins,
+                                       fpTmin, fpTmax, 5000, -5, 5);
+    fMCSecpichDCAXYPtBins->GetXaxis()->SetTitle("p_{T}");
+    fMCSecpichDCAXYPtBins->GetYaxis()->SetTitle("dca_{XY}");
+    fDCAPlots->Add(fMCSecpichDCAXYPtBins);
+
   } else {
     fDCAPlots = 0;
     fMCPrimDCAXYPtBins = 0;
@@ -378,6 +389,7 @@ AliFemtoDreamTrackMCHist::AliFemtoDreamTrackMCHist(bool contribSplitting,
     fMCSecKlongDCAXYPtBins = 0;
     fMCSecKshortDCAXYPtBins = 0;
     fMCSecKchDCAXYPtBins = 0;
+    fMCSecpichDCAXYPtBins = 0;
   }
 }
 void AliFemtoDreamTrackMCHist::FillMCDCAXYPtBins(
@@ -408,6 +420,8 @@ void AliFemtoDreamTrackMCHist::FillMCDCAXYPtBins(
       fMCSecKshortDCAXYPtBins->Fill(pT, dcaxy);
     } else if (TMath::Abs(PDGCodeMoth) == 321) {
       fMCSecKchDCAXYPtBins->Fill(pT, dcaxy);
+    } else if (TMath::Abs(PDGCodeMoth) == 211) {
+      fMCSecpichDCAXYPtBins->Fill(pT, dcaxy);
     } else {
       TString ErrHistSP = TString::Format("Feeddown for %d not implemented", PDGCodeMoth);
       AliWarning(ErrHistSP.Data());

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamTrackMCHist.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamTrackMCHist.h
@@ -1,5 +1,5 @@
 /*
- * AliFemtoDreamTrackMCHist.h
+ *fMCSecKchDCAXYPtBins AliFemtoDreamTrackMCHist.h
  *
  *  Created on: Nov 14, 2017
  *      Author: gu74req
@@ -157,6 +157,7 @@ class AliFemtoDreamTrackMCHist {
   TH2F *fMCSecKlongDCAXYPtBins;       //!
   TH2F *fMCSecKshortDCAXYPtBins;      //!
   TH2F *fMCSecKchDCAXYPtBins;         //!
+  TH2F *fMCSecpichDCAXYPtBins;         //!
 
   TH1F *fMCpTPCDist[4];           //!
   TH1F *fMCetaDist[4];            //!


### PR DESCRIPTION
-changes in AliFemtoDreamCascade to fix Common ancestors bug for Cascade
-Fix also annoying warning in MC hists by adding pion to the list of feed-down histograms for DCA (actually this was creating some memory problems when running pions in MC in Femto Dream!)