### PR TITLE
[PWGEM-13] PWGGA/GammaConv: Add EMC cut settings for PbPb

### DIFF
--- a/PWGGA/GammaConv/macros/AddTask_GammaCalo_PbPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaCalo_PbPb.C
@@ -1286,11 +1286,26 @@ void AddTask_GammaCalo_PbPb(
     cuts.AddCutCalo("1138ea13","4117901050e30220000","01331061000000d0"); //
     cuts.AddCutCalo("1358ea13","4117901050e30220000","01331031000000d0"); //
     cuts.AddCutCalo("1598ea13","4117901050e30220000","01331031000000d0"); //
-   } else if (trainConfig == 785){ // EMCAL+DCal clusters - 13 TeV emcal cuts
+   } else if (trainConfig == 785){ // EMCAL+DCal clusters - 13 TeV emcal cuts wo TM
     cuts.AddCutCalo("10130e03","4117901050e30220000","0s631031000000d0"); // 00-10%
     cuts.AddCutCalo("11310e03","4117901050e30220000","0s631031000000d0"); // 10-30%
     cuts.AddCutCalo("13530e03","4117901050e30220000","0s631031000000d0"); // 30-50%
     cuts.AddCutCalo("15910e03","4117901050e30220000","0s631031000000d0"); // 50-90%
+    } else if (trainConfig == 786){ // EMCAL+DCal clusters - 13 TeV emcal cuts with TM
+    cuts.AddCutCalo("10130e03","411790105fe30220000","0s631031000000d0"); // 00-10%
+    cuts.AddCutCalo("11310e03","411790105fe30220000","0s631031000000d0"); // 10-30%
+    cuts.AddCutCalo("13530e03","411790105fe30220000","0s631031000000d0"); // 30-50%
+    cuts.AddCutCalo("15910e03","411790105fe30220000","0s631031000000d0"); // 50-90%
+    } else if (trainConfig == 786){ // EMCAL+DCal clusters - 13 TeV emcal mixed event wo TM
+    cuts.AddCutCalo("10130e03","4117901050e30220000","01631031000000d0"); // 00-10%
+    cuts.AddCutCalo("11310e03","4117901050e30220000","01631031000000d0"); // 10-30%
+    cuts.AddCutCalo("13530e03","4117901050e30220000","01631031000000d0"); // 30-50%
+    cuts.AddCutCalo("15910e03","4117901050e30220000","01631031000000d0"); // 50-90%
+    } else if (trainConfig == 786){ // EMCAL+DCal clusters - 13 TeV emcal mixed event cuts with TM
+    cuts.AddCutCalo("10130e03","411790105fe30220000","01631031000000d0"); // 00-10%
+    cuts.AddCutCalo("11310e03","411790105fe30220000","01631031000000d0"); // 10-30%
+    cuts.AddCutCalo("13530e03","411790105fe30220000","01631031000000d0"); // 30-50%
+    cuts.AddCutCalo("15910e03","411790105fe30220000","01631031000000d0"); // 50-90%
 
   // **********************************************************************************************************
   // ***************************** PHOS       QA configurations PbPb run 2 2018 *******************************


### PR DESCRIPTION
- Add cut setting for rotation background with TM
- Add cut setting for mixed event without TM
- Add cut setting for mixed event with TM

- Without TM is for the usage of the cell track matcher and with track matching for when the cell track matcher is disabled
- Goals:
	- Comaprison of rotation background with template fits and mixed event background
	- Comparison of TM and Cell TM performance and agreement between data and MC