### PR TITLE
PWGGA/GammaConv: Meson-Jet correlation: flag to set pi0 unstable

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskMesonJetCorrelation.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskMesonJetCorrelation.h
@@ -89,6 +89,7 @@ class AliAnalysisTaskMesonJetCorrelation : public AliAnalysisTaskSE
   // void IsTrueParticle(AliAODConversionMother* Pi0Candidate, AliAODConversionPhoton* TrueGammaCandidate0, AliAODConversionPhoton* TrueGammaCandidate1, Bool_t matched);
   bool CheckAcceptance(AliAODMCParticle* gamma0, AliAODMCParticle* gamma1);
   bool IsParticleFromPartonFrag(AliAODMCParticle* particle, int idParton);
+  void UnselectStablePi0(AliAODMCParticle* part); // Rleabel Pi0, eta etc. tounstable in case they were labeled stable by the jet framework
 
   // Jet functions
   void ProcessJets();
@@ -120,6 +121,7 @@ class AliAnalysisTaskMesonJetCorrelation : public AliAnalysisTaskSE
   void SetFillMesonDCATree(bool tmp) { fFillDCATree = tmp; }
   void SetDoUseCentralEvtSelection(bool tmp) { fUseCentralEventSelection = tmp; }
   void SetUsePtForCalcZ(bool tmp) { fUsePtForZCalc = tmp; }
+  void SetForcePi0Unstable(bool tmp) { fUnsetStablePi0 = tmp; }
 
   void SetEventCutList(int nCuts,
                        TList* CutArray)
@@ -226,6 +228,7 @@ class AliAnalysisTaskMesonJetCorrelation : public AliAnalysisTaskSE
   bool fFillDCATree;                                    // flag if DCA tree should be filled or not
   bool fUseCentralEventSelection;                       // flag if central event selection (AliEventSelection.cxx) should be used
   bool fUsePtForZCalc;                                  // flag if z = pt_meson/pt_jet or if its z = (P_{meson}*P_{jet})/|P_{Jet}^{2}|
+  bool fUnsetStablePi0;                                 // flag to decide if pi0 need to be reset to Unstable particles
   //-------------------------------
   // conversions
   //-------------------------------
@@ -485,7 +488,7 @@ class AliAnalysisTaskMesonJetCorrelation : public AliAnalysisTaskSE
   AliAnalysisTaskMesonJetCorrelation(const AliAnalysisTaskMesonJetCorrelation&);            // Prevent copy-construction
   AliAnalysisTaskMesonJetCorrelation& operator=(const AliAnalysisTaskMesonJetCorrelation&); // Prevent assignment
 
-  ClassDef(AliAnalysisTaskMesonJetCorrelation, 14);
+  ClassDef(AliAnalysisTaskMesonJetCorrelation, 15);
 };
 
 #endif

--- a/PWGGA/GammaConv/macros/AddTask_MesonJetCorr_Calo.C
+++ b/PWGGA/GammaConv/macros/AddTask_MesonJetCorr_Calo.C
@@ -50,6 +50,7 @@ void AddTask_MesonJetCorr_Calo(
   // special settings
   Bool_t enableSortingMCLabels = kTRUE, // enable sorting for MC cluster labels
   bool useCentralEvtSelection = true,
+  bool setPi0Unstable = false,
   // subwagon config
   TString additionalTrainConfig = "0" // additional counter for trainconfig
 
@@ -223,6 +224,44 @@ void AddTask_MesonJetCorr_Calo(
     cuts.AddCutCalo("0009b103", "411790109fe30230000", "2s631034000000d0"); // Jet-high trigg in-jet, pi0 mass: 0.1-0.15, rotation back
 
 
+  //---------------------------------------
+  // Cut variations for standard cut (2)
+  //---------------------------------------
+
+  //--------  INT7 Meson cut variations
+  } else if (trainConfig == 100) { // 
+    cuts.AddCutCalo("00010103", "411790009fe30230000", "2s631034000000d0"); // NL var. etc which is handled in correction framework
+  } else if (trainConfig == 101) { // background variation
+    cuts.AddCutCalo("00010103", "411790009fe30230000", "21631034000000d0"); // jet mixing back
+  } else if (trainConfig == 102) { // alpha cut variation
+    cuts.AddCutCalo("00010103", "411790009fe30230000", "21631054000000d0"); // alpha cut 0-0.75
+    cuts.AddCutCalo("00010103", "411790009fe30230000", "21631084000000d0"); // alpha cut 0-0.65
+  } else if (trainConfig == 103) { // opening angle var.
+    cuts.AddCutCalo("00010103", "411790009fe30230000", "2s631034000000b0"); // INT7 Op. Ang. var 1 cell dist + 0.0152
+    cuts.AddCutCalo("00010103", "411790009fe30230000", "2s631034000000g0"); // INT7 Op. Ang. var 1 cell dist + 0.0202
+    cuts.AddCutCalo("00010103", "411790009fe30230000", "2s631034000000a0"); // INT7 Op. Ang. var 1 cell dist + 0
+
+
+  } else if (trainConfig == 105) { // M02 variation (std M02 = 0.5)
+    cuts.AddCutCalo("00010103", "411790009fe30240000", "2s631034000000d0"); // M02 = 0.4
+    cuts.AddCutCalo("00010103", "411790009fe30220000", "2s631034000000d0"); // M02 = 0.7
+    cuts.AddCutCalo("00010103", "411790009fe30210000", "2s631034000000d0"); // M02 = 1.0
+  } else if (trainConfig == 106) { // TM variations for mesons
+    cuts.AddCutCalo("00010103", "4117900090e30230000", "2s631034000000d0"); // INT7 no TM
+    cuts.AddCutCalo("00010103", "411790009ee30230000", "2s631034000000d0"); // TM var EoverP 2.00
+    cuts.AddCutCalo("00010103", "411790009ge30230000", "2s631034000000d0"); // TM var EoverP 1.5
+    cuts.AddCutCalo("00010103", "4117900097e30230000", "2s631034000000d0"); // No E/p
+    cuts.AddCutCalo("00010103", "411790009le30230000", "2s631034000000d0"); // std + sec TM
+    cuts.AddCutCalo("00010103", "411790009ne30230000", "2s631034000000d0"); // INT7 TM var, Eta (0.035, 0.010, 2.5); Phi (0.085, 0.015, 2.)
+  } else if (trainConfig == 107) { // cluster time
+    cuts.AddCutCalo("00010103", "411790005fe30230000", "2s631034000000d0"); // -50 - 50 ns
+    cuts.AddCutCalo("00010103", "411790006fe30230000", "2s631034000000d0"); // -30 - 35 ns
+    cuts.AddCutCalo("00010103", "41179000afe30230000", "2s631034000000d0"); // -12.5 - 13 ns
+  } else if (trainConfig == 108) { // NCell
+    cuts.AddCutCalo("00010103", "411790009fe3r230000", "2s631034000000d0"); // INT7 EDC pi0 tagging for gamma clus, Gaussian Fit
+    cuts.AddCutCalo("00010103", "411790009fe3n230000", "2s631034000000d0"); // INT7 PCMEDC pi0 tagging for gamma clus, Gaussian Fit
+    cuts.AddCutCalo("00010103", "411790009fe3m230000", "2s631034000000d0"); // INT7 PCMEDC pi0 tagging for all clus, Gaussian Fit
+    cuts.AddCutCalo("00010103", "411790009fe3l230000", "2s631034000000d0"); // INT7 PCMEDC pi0 tagging for gamma clus, pol2 fit
    
     //---------------------------------------
     // configs for eta meson pp 13 TeV
@@ -346,6 +385,7 @@ void AddTask_MesonJetCorr_Calo(
                                          //   task->SetDoClusterQA(enableQAClusterTask);  //Attention new switch small for Cluster QA
   task->SetUseTHnSparseForResponse(enableTHnSparse);
   task->SetDoUseCentralEvtSelection(useCentralEvtSelection);
+  task->SetForcePi0Unstable(setPi0Unstable);
 
   //connect containers
   TString nameContainer = Form("MesonJetCorrelation_Calo_%i_%i%s%s", meson, trainConfig, corrTaskSetting.EqualTo("") == true ? "" : Form("_%s", corrTaskSetting.Data()), nameJetFinder.EqualTo("") == true ? "" : Form("_%s", nameJetFinder.Data()) );

--- a/PWGGA/GammaConv/macros/AddTask_MesonJetCorr_Conv.C
+++ b/PWGGA/GammaConv/macros/AddTask_MesonJetCorr_Conv.C
@@ -52,6 +52,7 @@ void AddTask_MesonJetCorr_Conv(
   Bool_t enableChargedPrimary = kFALSE,
   bool doFillMesonDCATree = false, // swith to enable filling the meson DCA tree for pile-up estimation
   bool useCentralEvtSelection = true,
+  bool
   // subwagon config
   TString additionalTrainConfig = "0" // additional counter for trainconfig + special settings
 )
@@ -322,6 +323,8 @@ void AddTask_MesonJetCorr_Conv(
   if(enableMatBudWeightsPi0) task->SetDoMaterialBudgetWeightingOfGammasForTrueMesons(true);
   if(doFillMesonDCATree) task->SetFillMesonDCATree(true);
   task->SetDoUseCentralEvtSelection(useCentralEvtSelection);
+  task->SetForcePi0Unstable(setPi0Unstable);
+  bool setPi0Unstable = false,
 
   //connect containers
   TString nameContainer = Form("MesonJetCorrelation_Conv_%i_%i%s", meson, trainConfig, nameJetFinder.EqualTo("") == true ? "" : Form("_%s", nameJetFinder.Data()) );

--- a/PWGGA/GammaConv/macros/AddTask_MesonJetCorr_ConvCalo.C
+++ b/PWGGA/GammaConv/macros/AddTask_MesonJetCorr_ConvCalo.C
@@ -60,6 +60,7 @@ void AddTask_MesonJetCorr_ConvCalo(
   Double_t smearParConst = 0.,           // conv photon smearing params
   Bool_t doPrimaryTrackMatching = kTRUE, // enable basic track matching for all primary tracks to cluster
   bool useCentralEvtSelection = true,
+  bool setPi0Unstable = false,
   // subwagon config
   TString additionalTrainConfig = "0" // additional counter for trainconfig
 )
@@ -402,6 +403,8 @@ void AddTask_MesonJetCorr_ConvCalo(
                                          //   task->SetDoClusterQA(enableQAClusterTask);  //Attention new switch small for Cluster QA
   task->SetUseTHnSparseForResponse(enableTHnSparse);
   task->SetDoUseCentralEvtSelection(useCentralEvtSelection);
+  task->SetForcePi0Unstable(setPi0Unstable);
+
   //connect containers
   TString nameContainer = Form("MesonJetCorrelation_ConvCalo_%i_%i%s%s", meson, trainConfig, corrTaskSetting.EqualTo("") == true ? "" : Form("_%s", corrTaskSetting.Data()), nameJetFinder.EqualTo("") == true ? "" : Form("_%s", nameJetFinder.Data()) );
   AliAnalysisDataContainer* coutput = mgr->CreateContainer(nameContainer, TList::Class(), AliAnalysisManager::kOutputContainer, Form("MesonJetCorrelation_ConvCalo_%i_%i.root", meson, trainConfig));

--- a/PWGGA/GammaConvBase/AliResponseMatrixHelper.cxx
+++ b/PWGGA/GammaConvBase/AliResponseMatrixHelper.cxx
@@ -373,6 +373,25 @@ MatrixHandlerNDim::MatrixHandlerNDim(std::vector<std::vector<double>> arrBinsX, 
 
 
 //____________________________________________________________________________________________________________________________
+MatrixHandlerNDim::MatrixHandlerNDim(std::vector<std::vector<double>> arrX, std::vector<std::vector<double>> arrY, THnSparse* h)
+{
+  vecBinsX = arrX;
+  vecBinsY = arrY;
+  useTHNSparese = true;
+  hSparseResponse = (THnSparseF*)h->Clone();
+}
+
+//____________________________________________________________________________________________________________________________
+MatrixHandlerNDim::MatrixHandlerNDim(std::vector<std::vector<double>> arrX, std::vector<std::vector<double>> arrY, TH2F* h)
+{
+  vecBinsX = arrX;
+  vecBinsY = arrY;
+  useTHNSparese = false;
+  h2d = (TH2F*)h->Clone();
+}
+
+
+//____________________________________________________________________________________________________________________________
 std::vector<double> MatrixHandlerNDim::MakeAxis1D(const std::vector<std::vector<double>> vecND){
   const unsigned int dim = vecND.size();
 
@@ -440,6 +459,42 @@ double MatrixHandlerNDim::GetBinLowEdge(std::vector<unsigned int> vecDim, const 
 }
 
 //____________________________________________________________________________________________________________________________
+std::vector<double> MatrixHandlerNDim::getValueForBinIndex(const unsigned int index, bool isXAxis){
+  std::vector<std::vector<double>> vecBins = isXAxis == true ? vecBinsX : vecBinsY;
+  const unsigned int dim = vecBins.size();
+
+  std::vector<unsigned int> vecDim(dim, 0);
+
+  unsigned int nBins = 1;
+  for(const auto & v : vecBins){
+      nBins*=(v.size()-1);
+  }
+
+  for(unsigned int i = 0; i < nBins; ++i){
+    if(i == index) break;
+    for(int d = dim-1; d >= 0; --d){
+      if(vecDim[d] == vecBins[d].size()-2){
+          vecDim[d] = 0;
+          continue;
+      }
+      if(vecDim[d] < vecBins[d].size()-2) {
+          vecDim[d]++;
+          break;
+      }            
+    }
+  }
+
+  // get the values
+  std::vector<double> val(dim, 0);
+  for(unsigned int i = 0; i < vecBins.size(); ++i){
+    val[i] = vecBins[i][vecDim[i]] + 0.000001;
+  }
+
+  return val;
+
+}
+
+//____________________________________________________________________________________________________________________________
 unsigned int MatrixHandlerNDim::getIndex(std::vector<double> vecVal, bool isXAxis){
   std::vector<std::vector<double>> vecBins = isXAxis == true ? vecBinsX : vecBinsY;
   const unsigned int dim = vecBins.size();
@@ -497,6 +552,30 @@ void MatrixHandlerNDim::Fill(std::vector<double> vecValX, std::vector<double> ve
 }
 
 //____________________________________________________________________________________________________________________________
+void MatrixHandlerNDim::AddBinContent(std::vector<double> vecValX, std::vector<double> vecValY, double val, double err)
+{
+  int indexX = getIndex(vecValX, true);
+  
+  int indexY = getIndex(vecValY, false);
+  
+
+  if (useTHNSparese) {
+    std::array<double, 2> arrFill;
+    arrFill[0] = indexX + 0.5;
+    arrFill[1] = indexY + 0.5;
+    hSparseResponse->Fill(arrFill.data(), val);
+  } else {
+    std::array<int, 2> arrFill;
+    arrFill[0] = indexX;
+    arrFill[1] = indexY;
+    double currentBinCont = h2d->GetBinContent(arrFill[0], arrFill[1]);
+    double currentBinErr = h2d->GetBinError(arrFill[0], arrFill[1]);
+    h2d->SetBinContent(arrFill[0], arrFill[1], val + currentBinCont);
+    h2d->SetBinError(arrFill[0], arrFill[1], std::sqrt(err * err + currentBinErr * currentBinErr));
+  }
+}
+
+//____________________________________________________________________________________________________________________________
 TH2F* MatrixHandlerNDim::GetTH2(const char* name)
 {
   if (useTHNSparese) {
@@ -534,6 +613,7 @@ TH2F* MatrixHandlerNDim::GetTH2(const char* name)
   }
 }
 
+//____________________________________________________________________________________________________________________________
 TH2F* MatrixHandlerNDim::GetResponseMatrix(std::vector<double> binsX, std::vector<double> binsY, const char* name){
   
   TH2F* hResponse = new TH2F(name, name, vecBinsX.back().size()-1, vecBinsX.back().data(), vecBinsY.back().size()-1, vecBinsY.back().data());
@@ -546,7 +626,7 @@ TH2F* MatrixHandlerNDim::GetResponseMatrix(std::vector<double> binsX, std::vecto
   for(unsigned x = 0; x < vecBinsX.back().size()-1; ++x){
     for(unsigned y = 0; y < vecBinsY.back().size()-1; ++y){
       if(h2d){
-        hResponse->SetBinContent(x+1, y+1, h2d->GetBinContent(indexX + x + 1, indexY + y + 1));
+        hResponse->SetBinContent(x+1, y+1, h2d->GetBinContent(indexX + static_cast<int>(x) + 1, indexY + static_cast<int>(y) + 1));
       } else {
         int tmp[2] = {static_cast<int>(indexX + x + 1), static_cast<int>(indexY + y + 1)};
         hResponse->SetBinContent(x+1, y+1, hSparseResponse->GetBinContent(tmp));
@@ -555,6 +635,116 @@ TH2F* MatrixHandlerNDim::GetResponseMatrix(std::vector<double> binsX, std::vecto
   }
   return hResponse;
 }
+
+// if index -1 is passed, this is considered to be the one taken for the axis
+//____________________________________________________________________________________________________________________________
+TH2F* MatrixHandlerNDim::GetResponseMatrix(std::vector<int> binsX, std::vector<int> binsY, const char* name){
+  
+  if(vecBinsX.size() != binsX.size() || vecBinsY.size() != binsY.size()){
+    printf("MatrixHandlerNDim::GetResponseMatrix  The given indeces cannot be correct \n");
+    return nullptr;
+  }
+
+  std::array<std::vector<double>, 2> arrBinning;
+  for(unsigned int i = 0; i < binsX.size(); ++i){
+    if(binsX[i] < 0){
+      if(arrBinning[0].size() == 0) arrBinning[0] = vecBinsX[i];
+      else arrBinning[1] = vecBinsX[i];
+    }
+  }
+  for(unsigned int i = 0; i < binsY.size(); ++i){
+    if(binsY[i] < 0){
+      if(arrBinning[0].size() == 0) arrBinning[0] = vecBinsY[i];
+      else arrBinning[1] = vecBinsY[i];
+    }
+  }
+
+  const unsigned int dimX = vecBinsX.size();
+  std::vector<unsigned int> vecDimX(dimX, 0);
+  const unsigned int dimY = vecBinsY.size();
+  std::vector<unsigned int> vecDimY(dimY, 0);
+
+  unsigned int nBinsX = 1;
+  for(const auto & v : vecBinsX){
+      nBinsX*=(v.size()-1);
+  }
+
+  unsigned int nBinsY = 1;
+  for(const auto & v : vecBinsY){
+      nBinsY*=(v.size()-1);
+  }
+  printf("nBinsY %d\n", nBinsY );
+
+  printf("name %s\n", name);
+  TH2F* hResponse = new TH2F(name, name, arrBinning[0].size()-1, arrBinning[0].data(), arrBinning[1].size()-1, arrBinning[1].data());
+  
+  TH2F* hResponse_org = GetTH2();
+
+  for(unsigned x = 0; x < nBinsX; ++x){
+
+    std::vector<double> valX = getValueForBinIndex(x, true);
+
+    bool acceptBinX = true;
+    for(unsigned int i = 0; i < valX.size(); ++i){
+      if(binsX[i] < 0){
+        continue;
+      } else if(valX[i] < vecBinsX[i][binsX[i]] || valX[i] > vecBinsX[i][binsX[i] + 1]){ // which bin??
+        acceptBinX = false;
+      }
+    }
+
+    for(unsigned y = 0; y < nBinsY; ++y){
+
+      std::vector<double> valY = getValueForBinIndex(y, false);
+
+      bool acceptBinY = true;
+      for(unsigned int i = 0; i < valY.size(); ++i){
+        // if(i==0){
+        //   printf(" %f < valY[i] %f < %f\n", vecBinsY[i][binsY[i]], valY[i], vecBinsY[i][binsY[i]+1]);
+        // }
+        if(binsY[i] < 0){
+          continue;
+        } else if(valY[i] < vecBinsY[i][binsY[i]] || valY[i] > vecBinsY[i][binsY[i] + 1]){
+          acceptBinY = false;
+        }
+      }
+
+      // if(acceptBinY) printf("accept y bin\n");
+
+      if(acceptBinX && acceptBinY){
+        printf("all accepted\n");
+        std::array<double, 2> val = {-1e12, -1e12};
+        for(unsigned int i = 0; i < binsX.size(); ++i){
+          if(binsX[i] < 0){
+            if(val[0]  == -1e12){
+              val[0] = valX[i];
+            } else {
+              val[1] = valX[i];
+            }
+          }
+        }
+
+        for(unsigned int i = 0; i < binsY.size(); ++i){
+          if(binsY[i] < 0){
+            if(val[0]  == -1e12){
+              val[0] = valY[i];
+            } else {
+              val[1] = valY[i];
+            }
+          }
+        }
+        printf("val %f,   %f --> %f\n", val[0], val[1], hResponse_org->GetBinContent(x, y));   
+        hResponse->SetBinContent(hResponse->GetXaxis()->FindBin(val[0]), hResponse->GetYaxis()->FindBin(val[1]), hResponse_org->GetBinContent(x+1, y+1));
+        hResponse->SetBinError(hResponse->GetXaxis()->FindBin(val[0]), hResponse->GetYaxis()->FindBin(val[1]), hResponse_org->GetBinError(x+1, y+1));  
+      
+      }
+      
+    }
+  }
+
+  return hResponse;
+}
+
 
 //____________________________________________________________________________________________________________________________
 THnSparseF* MatrixHandlerNDim::GetTHnSparseClone(const char* name)

--- a/PWGGA/GammaConvBase/AliResponseMatrixHelper.h
+++ b/PWGGA/GammaConvBase/AliResponseMatrixHelper.h
@@ -87,8 +87,8 @@ class MatrixHandlerNDim
  public:
   MatrixHandlerNDim() = default;
   MatrixHandlerNDim(std::vector<std::vector<double>> arrBinsX, std::vector<std::vector<double>> arrBinsY, bool useTHN = false);
-  MatrixHandlerNDim(std::vector<std::vector<double>> arrBinsX, std::vector<std::vector<double>> arrBinsY, THnSparse* h = nullptr);
-  MatrixHandlerNDim(std::vector<std::vector<double>> arrBinsX, std::vector<std::vector<double>> arrBinsY, TH2F* h = nullptr);
+  MatrixHandlerNDim(std::vector<std::vector<double>> arrX, std::vector<std::vector<double>> arrY, THnSparse* h = nullptr);
+  MatrixHandlerNDim(std::vector<std::vector<double>> arrX, std::vector<std::vector<double>> arrY, TH2F* h = nullptr);
   MatrixHandlerNDim(const MatrixHandlerNDim&) = delete;            // copy ctor
   MatrixHandlerNDim(MatrixHandlerNDim&&) = delete;                 // move ctor
   MatrixHandlerNDim& operator=(const MatrixHandlerNDim&) = delete; // copy assignment
@@ -102,10 +102,14 @@ class MatrixHandlerNDim
 
   unsigned int getIndex(std::vector<double> vecVal, bool isXAxis);
 
-  double getValueForBinIndexMesonX(const int index) const;
-  double getValueForBinIndexJetX(const int index) const;
-  double getValueForBinIndexMesonY(const int index) const;
-  double getValueForBinIndexJetY(const int index) const;
+  // double getValueForBinIndexMesonX(const int index) const;
+  // double getValueForBinIndexJetX(const int index) const;
+  // double getValueForBinIndexMesonY(const int index) const;
+  // double getValueForBinIndexJetY(const int index) const;
+
+  TH2F* GetResponseMatrix(std::vector<int> binsX, std::vector<int> binsY, const char* name);
+
+  std::vector<double> getValueForBinIndex(const unsigned int index, bool isXAxis);
 
   void Fill(double valJetX, double valJetY, double valMesonX, double valMesonY, double val = 1);
   void Fill(std::vector<double> valRec, std::vector<double> valTrue, double val = 1);


### PR DESCRIPTION
- For QA studies, the effect on the fragmentation function setting the pi0 as stable or unstable (so reconstructing the photons or the mesons directly). For this, the pi0s are set to stable in the jet tasks. To revert this change in the meson task, a new function is implemented that can be switched on.
- Fix in the binning of the resolution hists
- Some further optimizations for the NDimensional response matrix (still WIP)