### PR TITLE
PWGGA/GammaConv: Change for jet task to handle different jet container

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskConvJet.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskConvJet.cxx
@@ -137,7 +137,7 @@ void AliAnalysisTaskConvJet::DoJetLoop()
     TString JetName = jetCont->GetTitle();
     TObjArray* arr = JetName.Tokenize("__");
     TObjString* testObjString = (TObjString*)arr->At(2);
-    if (testObjString->GetString() != "mcparticles") {
+    if (!(static_cast<TString>(testObjString->GetString())).Contains("mcparticles")) {
       UInt_t count = 0;
       fNJets = 0;
       fVectorJetPt.clear();


### PR DESCRIPTION
- for MC, the jet task could only handle the mcparticles particle container. If one wants to use multiple particle container (for example setting the pi0 stable in one of them), this could not be handled by the conv jet task. Now, the string has only to contain the mcparticle name but can be mcparticleStablePi0 etc.