### PR TITLE
Optimized AliAnalysisTaskEHCorrel for Pb-Pb collisions for systematics

### DIFF
--- a/PWGHF/hfe/AliAnalysisTaskEHCorrel.h
+++ b/PWGHF/hfe/AliAnalysisTaskEHCorrel.h
@@ -1,3 +1,4 @@
+
 #ifndef AliAnalysisTaskEHCorrel_h
 #define AliAnalysisTaskEHCorrel_h
 
@@ -9,6 +10,7 @@
 //                                                                    //
 //  Author: Deepa Thomas (University of Texas at Austin)              //
 //          Ravindra Singh (IIT Indore)                               //
+//          Amanda Flores (University of Texas at Austin)             //
 //                                                                    //
 ////////////////////////////////////////////////////////////////////////
 
@@ -118,6 +120,10 @@ class AliAnalysisTaskEHCorrel : public AliAnalysisTaskSE {
     void    IsPASS2weight(Bool_t pPbpass2weight) {fpPbPASS2weight = pPbpass2weight;};
     void    IsMC(Bool_t isMC) {fIsMC = isMC;};
 
+    void    IsClustersOn(Bool_t fSwitch) {fEMCalClusOn = fSwitch;};
+    void    IsHadInfoOn(Bool_t fSwitch) {fHadronInfoOn = fSwitch;};
+    void    IsTracksOn(Bool_t fSwitch) {fTracksOn = fSwitch;};
+
     void    SwitchFillEHCorrel(Bool_t fSwitch){fFillEHCorrel = fSwitch;};
     void    SetNDeltaPhiBins(Int_t nbins){fNDelPhiBins = nbins;};
 
@@ -209,6 +215,9 @@ class AliAnalysisTaskEHCorrel : public AliAnalysisTaskSE {
     TClonesArray        *fMCarray;//!
     AliAODMCHeader      *fMCHeader;//!
     Bool_t              fIsMC;// Is MC
+    Bool_t              fEMCalClusOn;//
+    Bool_t              fHadronInfoOn;//
+    Bool_t              fTracksOn;//
     Bool_t              fApplyElectronEffi;//
     Double_t            fEffi;//!
     Double_t            fWeight;//!
@@ -228,6 +237,7 @@ class AliAnalysisTaskEHCorrel : public AliAnalysisTaskSE {
     Int_t               fNpureMC;//! N of particles from main generator (Hijing/Pythia)
     Int_t               fNembMCpi0; //! N > fNembMCpi0 = particles from pi0 generator
     Int_t               fNembMCeta; //! N > fNembMCeta = particles from eta generator
+    Int_t               fNembMCpileup; //! N > fNembMCpileup = PileupNoGenTrig Cocktail Header
     
     TF1                 *fFuncPtDepEta;//!
     TF1                 *fFuncPtDepPhi;//!

--- a/PWGHF/hfe/macros/AddTaskEHCorrel.C
+++ b/PWGHF/hfe/macros/AddTaskEHCorrel.C
@@ -14,7 +14,8 @@ AliAnalysisTask *AddTaskEHCorrel(TString ContNameExt = "", Bool_t isPbPb=kFALSE,
     Int_t AddPileUpCut=kFALSE, Int_t hadCutCase=2,  Bool_t FillEHCorrel=kTRUE,
     Bool_t  CalcHadronTrackEffi=kFALSE, Bool_t CalculateNonHFEEffi=kFALSE, Bool_t CalPi0EtaWeight=kFALSE,
     Bool_t applyEleEffi=kFALSE, Int_t nBins=32, Bool_t isMC=kFALSE, Bool_t removePileUpMCGen=kFALSE, Bool_t pPbpass2weight=kTRUE,
-    Bool_t IsPbPb2018 = kFALSE)
+    Bool_t IsPbPb2018 = kFALSE, 
+    Bool_t ClusOn = kFALSE, Bool_t HadInfoOn = kFALSE, Bool_t TracksOn = kFALSE)
 {
   //get the current analysis manager
   AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
@@ -44,7 +45,7 @@ AliAnalysisTask *AddTaskEHCorrel(TString ContNameExt = "", Bool_t isPbPb=kFALSE,
     
   Int_t PhysSel = AliVEvent::kINT7;
 
-  if(PhysSel == AliVEvent::kINT7){
+  if(!IsPbPb2018 && PhysSel == AliVEvent::kINT7){
     AliAnalysisTaskEHCorrel *taskHFEeh = new AliAnalysisTaskEHCorrel("eh");
     mgr->AddTask(taskHFEeh);
     taskHFEeh->SelectCollisionCandidates(AliVEvent::kINT7);
@@ -126,8 +127,8 @@ AliAnalysisTask *AddTaskEHCorrel(TString ContNameExt = "", Bool_t isPbPb=kFALSE,
         //Centrality trigger used in 2018
         AliAnalysisTaskEHCorrel *taskHFEehCent = new AliAnalysisTaskEHCorrel("ehCent");
         mgr->AddTask(taskHFEehCent);
-        if(centMin == 0) taskHFEehCent->SelectCollisionCandidates(AliVEvent::kCentral);
-        if(centMin == 30) taskHFEehCent->SelectCollisionCandidates(AliVEvent::kSemiCentral);
+        if(centMin == 0 || PhysSel == AliVEvent::kINT7) taskHFEehCent->SelectCollisionCandidates(AliVEvent::kCentral);
+        if(centMin == 30 || PhysSel == AliVEvent::kINT7) taskHFEehCent->SelectCollisionCandidates(AliVEvent::kSemiCentral);
         taskHFEehCent->IsPbPb(isPbPb);
         taskHFEehCent->Ispp(ispp);
         taskHFEehCent->IsPASS2weight(pPbpass2weight);


### PR DESCRIPTION
Optimized AliAnalysisTaskEHCorrel task for Pb-Pb systematic studies; also edited task to accommodate LHC18q,r pass3 HFe Monte Carlo list. Edited AddTaskEHCorrel to include INT7 and CentTriggered events for Pb-Pb.