### PR TITLE
Fixed issue with switching EMCal clusters, tracks, and had info

### DIFF
--- a/PWGHF/hfe/macros/AddTaskEHCorrel.C
+++ b/PWGHF/hfe/macros/AddTaskEHCorrel.C
@@ -85,6 +85,9 @@ AliAnalysisTask *AddTaskEHCorrel(TString ContNameExt = "", Bool_t isPbPb=kFALSE,
     taskHFEeh->SwitchHadTrackEffi(CalcHadronTrackEffi);
     taskHFEeh->SwitchFillEHCorrel(FillEHCorrel);
     taskHFEeh->SetWeightCal(CalPi0EtaWeight);
+    taskHFEeh->IsClustersOn(ClusOn);
+    taskHFEeh->IsHadInfoOn(HadInfoOn);
+    taskHFEeh->IsTracksOn(TracksOn);
     taskHFEeh->SetNonHFEEffi(CalculateNonHFEEffi);
     taskHFEeh->SetNDeltaPhiBins(nBins);
     taskHFEeh->IsMC(isMC);
@@ -165,6 +168,9 @@ AliAnalysisTask *AddTaskEHCorrel(TString ContNameExt = "", Bool_t isPbPb=kFALSE,
         taskHFEehCent->SwitchHadTrackEffi(CalcHadronTrackEffi);
         taskHFEehCent->SwitchFillEHCorrel(FillEHCorrel);
         taskHFEehCent->SetWeightCal(CalPi0EtaWeight);
+        taskHFEehCent->IsClustersOn(ClusOn);
+        taskHFEehCent->IsHadInfoOn(HadInfoOn);
+        taskHFEehCent->IsTracksOn(TracksOn);
         taskHFEehCent->SetNonHFEEffi(CalculateNonHFEEffi);
         taskHFEehCent->SetNDeltaPhiBins(nBins);
         taskHFEehCent->IsMC(isMC);


### PR DESCRIPTION
Needed to include these functions in AddTask macro to switch on and off EMCal clusters, tracks, and had info for systematic runs