### PR TITLE
PWGGA/GammaConv: Add additional option for mixed back

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskConvJet.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskConvJet.cxx
@@ -61,6 +61,7 @@ AliAnalysisTaskConvJet::AliAnalysisTaskConvJet() : AliAnalysisTaskEmcalJet(),
                                                    fTrueVectorJetEta(0),
                                                    fTrueVectorJetPhi(0),
                                                    fTrueVectorJetR(0),
+                                                   fTrueVectorJetNPart(0),
                                                    fTrueVectorJetParton(0),
                                                    fTrueVectorJetPartonPt(0),
                                                    fTrueVectorJetPartonPx(0),
@@ -88,6 +89,7 @@ AliAnalysisTaskConvJet::AliAnalysisTaskConvJet(const char* name) : AliAnalysisTa
                                                                    fTrueVectorJetEta(0),
                                                                    fTrueVectorJetPhi(0),
                                                                    fTrueVectorJetR(0),
+                                                                   fTrueVectorJetNPart(0),
                                                                    fTrueVectorJetParton(0),
                                                                    fTrueVectorJetPartonPt(0),
                                                                    fTrueVectorJetPartonPx(0),
@@ -177,6 +179,7 @@ void AliAnalysisTaskConvJet::DoJetLoop()
       fTrueVectorJetEta.clear();
       fTrueVectorJetPhi.clear();
       fTrueVectorJetR.clear();
+      fTrueVectorJetNPart.clear();
       for (auto const& jet : jetCont->accepted()) {
         if (!jet)
           continue;
@@ -188,6 +191,7 @@ void AliAnalysisTaskConvJet::DoJetLoop()
         fTrueVectorJetEta.push_back(jet->Eta());
         fTrueVectorJetPhi.push_back(jet->Phi());
         fTrueVectorJetR.push_back(jet->Area());
+        fTrueVectorJetNPart.push_back(jet->N());
       }
       fTrueNJets = count;
     }

--- a/PWGGA/GammaConv/AliAnalysisTaskConvJet.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskConvJet.h
@@ -58,6 +58,7 @@ class AliAnalysisTaskConvJet : public AliAnalysisTaskEmcalJet
   std::vector<Double_t> GetTrueVectorJetEta() { return fTrueVectorJetEta; }
   std::vector<Double_t> GetTrueVectorJetPhi() { return fTrueVectorJetPhi; }
   std::vector<Double_t> GetTrueVectorJetArea() { return fTrueVectorJetR; }
+  std::vector<Double_t> GetTrueVectorJetNPart() { return fTrueVectorJetNPart; }
 
   std::vector<int> GetTrueVectorJetParton() { return fTrueVectorJetParton; }
   std::vector<double> GetTrueVectorJetPartonPt() { return fTrueVectorJetPartonPt; }
@@ -105,6 +106,7 @@ class AliAnalysisTaskConvJet : public AliAnalysisTaskEmcalJet
   std::vector<Double_t> fTrueVectorJetEta; // Vector for the eta of the true jets
   std::vector<Double_t> fTrueVectorJetPhi; // Vector for the phi of the true jets
   std::vector<Double_t> fTrueVectorJetR;   // Vector for the radius of the true jets
+  std::vector<Double_t> fTrueVectorJetNPart; // Vector for the number of particles contributing to this true jet
 
   std::vector<int> fTrueVectorJetParton;      // vector containing the mc stack id from the leading parton ("seed of the jet")
   std::vector<double> fTrueVectorJetPartonPt; // vector containing the pt of the leading parton ("seed of the jet")
@@ -117,7 +119,7 @@ class AliAnalysisTaskConvJet : public AliAnalysisTaskEmcalJet
   AliAnalysisTaskConvJet& operator=(const AliAnalysisTaskConvJet&);
 
   /// \cond CLASSIMP
-  ClassDef(AliAnalysisTaskConvJet, 14);
+  ClassDef(AliAnalysisTaskConvJet, 15);
   /// \endcond
 };
 #endif

--- a/PWGGA/GammaConv/AliAnalysisTaskMesonJetCorrelation.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskMesonJetCorrelation.cxx
@@ -86,6 +86,8 @@ ClassImp(AliAnalysisTaskMesonJetCorrelation)
                                                                              fUseCentralEventSelection(true),
                                                                              fUsePtForZCalc(false),
                                                                              fUnsetStablePi0(false),
+                                                                             fUseMixedBackAdd(false),
+                                                                             fDoRadiusDep(false),
                                                                              // aod relabeling
                                                                              fMCEventPos(nullptr),
                                                                              fMCEventNeg(nullptr),
@@ -120,6 +122,7 @@ ClassImp(AliAnalysisTaskMesonJetCorrelation)
                                                                              fTrueVectorJetPz({}),
                                                                              fTrueVectorJetEta({}),
                                                                              fTrueVectorJetPhi({}),
+                                                                             fTrueVectorJetNPart({}),
                                                                              fTrueVectorJetPartonID({}),
                                                                              fTrueVectorJetPartonPt({}),
                                                                              fTrueVectorJetPartonPx({}),
@@ -136,6 +139,8 @@ ClassImp(AliAnalysisTaskMesonJetCorrelation)
                                                                              fRespMatrixHandlerMesonInvMassVsZ({}),
                                                                              fRespMatrixHandlerMesonBackInvMassVsZ({}),
                                                                              fRespMatrixHandlerMesonBackInvMassVsPt({}),
+                                                                             fRespMatrixHandlerMesonBackAddInvMassVsZ({}),
+                                                                             fRespMatrixHandlerMesonBackAddInvMassVsPt({}),
                                                                              fRespMatrixHandlerMesonInvMassPerpCone({}),
                                                                              fRespMatrixHandlerMesonInvMassVsZPerpCone({}),
                                                                              fRespMatrixHandlerMesonPtRadius({}),
@@ -192,6 +197,7 @@ ClassImp(AliAnalysisTaskMesonJetCorrelation)
                                                                              fHistoNEFVsPtJet({}),
                                                                              fHistoNchVsPtJet({}),
                                                                              fHistoNclusVsPtJet({}),
+                                                                             fHistoNPartInTrueJetVsJetPt({}),
                                                                              // true meon histograms
                                                                              fRespMatrixHandlerTrueMesonInvMassVsPt({}),
                                                                              fRespMatrixHandlerTrueMesonInvMassVsZ({}),
@@ -337,6 +343,8 @@ AliAnalysisTaskMesonJetCorrelation::AliAnalysisTaskMesonJetCorrelation(const cha
                                                                                            fUseCentralEventSelection(true),
                                                                                            fUsePtForZCalc(false),
                                                                                            fUnsetStablePi0(false),
+                                                                                           fUseMixedBackAdd(false),
+                                                                                           fDoRadiusDep(false),
                                                                                            // aod relabeling
                                                                                            fMCEventPos(nullptr),
                                                                                            fMCEventNeg(nullptr),
@@ -371,6 +379,7 @@ AliAnalysisTaskMesonJetCorrelation::AliAnalysisTaskMesonJetCorrelation(const cha
                                                                                            fTrueVectorJetPz({}),
                                                                                            fTrueVectorJetEta({}),
                                                                                            fTrueVectorJetPhi({}),
+                                                                                           fTrueVectorJetNPart({}),
                                                                                            fTrueVectorJetPartonID({}),
                                                                                            fTrueVectorJetPartonPt({}),
                                                                                            fTrueVectorJetPartonPx({}),
@@ -387,6 +396,8 @@ AliAnalysisTaskMesonJetCorrelation::AliAnalysisTaskMesonJetCorrelation(const cha
                                                                                            fRespMatrixHandlerMesonInvMassVsZ({}),
                                                                                            fRespMatrixHandlerMesonBackInvMassVsZ({}),
                                                                                            fRespMatrixHandlerMesonBackInvMassVsPt({}),
+                                                                                           fRespMatrixHandlerMesonBackAddInvMassVsZ({}),
+                                                                                           fRespMatrixHandlerMesonBackAddInvMassVsPt({}),
                                                                                            fRespMatrixHandlerMesonInvMassPerpCone({}),
                                                                                            fRespMatrixHandlerMesonInvMassVsZPerpCone({}),
                                                                                            fRespMatrixHandlerMesonPtRadius({}),
@@ -443,6 +454,7 @@ AliAnalysisTaskMesonJetCorrelation::AliAnalysisTaskMesonJetCorrelation(const cha
                                                                                            fHistoNEFVsPtJet({}),
                                                                                            fHistoNchVsPtJet({}),
                                                                                            fHistoNclusVsPtJet({}),
+                                                                                           fHistoNPartInTrueJetVsJetPt({}),
                                                                                            // true meon histograms
                                                                                            fRespMatrixHandlerTrueMesonInvMassVsPt({}),
                                                                                            fRespMatrixHandlerTrueMesonInvMassVsZ({}),
@@ -675,8 +687,10 @@ void AliAnalysisTaskMesonJetCorrelation::UserCreateOutputObjects()
     fHistoMCPartonPtVsFrag.resize(fnCuts);
     fHistoMCJetPtVsFragTrueParton.resize(fnCuts);
     fHistoMCPartonPtVsFragTrueParton.resize(fnCuts);
-    fHistoMCJetPtVsMesonPtVsRadius.resize(fnCuts);
-    fHistoMCJetPtVsMesonPtVsRadiusInAcc.resize(fnCuts);
+    if(fDoRadiusDep){
+      fHistoMCJetPtVsMesonPtVsRadius.resize(fnCuts);
+      fHistoMCJetPtVsMesonPtVsRadiusInAcc.resize(fnCuts);
+    }
   }
 
   //----------------------
@@ -713,6 +727,7 @@ void AliAnalysisTaskMesonJetCorrelation::UserCreateOutputObjects()
     fHistoTruevsRecJetPt.resize(fnCuts);
     if(!fDoLightOutput){
       fHistoTruevsRecJetPtForTrueJets.resize(fnCuts);
+      fHistoNPartInTrueJetVsJetPt.resize(fnCuts);
     }
     fHistoTrueJetPtVsPartonPt.resize(fnCuts);
     fHistoMatchedPtJet.resize(fnCuts);
@@ -738,9 +753,11 @@ void AliAnalysisTaskMesonJetCorrelation::UserCreateOutputObjects()
     fRespMatrixHandlerTrueOtherMesonInvMassVsZ.resize(fnCuts);
     fRespMatrixHandlerTrueSecondaryMesonInvMassVsPt.resize(fnCuts);
     fRespMatrixHandlerTrueSecondaryMesonInvMassVsZ.resize(fnCuts);
-    fRespMatrixHandlerTrueMesonPtRadius.resize(fnCuts);
-    fRespMatrixHandlerTrueMesonTruePtRadius.resize(fnCuts);
-    fRespMatrixHandlerTrueSecondaryMesonPtRadius.resize(fnCuts);
+    if(fDoRadiusDep){
+      fRespMatrixHandlerTrueMesonPtRadius.resize(fnCuts);
+      fRespMatrixHandlerTrueMesonTruePtRadius.resize(fnCuts);
+      fRespMatrixHandlerTrueSecondaryMesonPtRadius.resize(fnCuts);
+    }
     if(fDoMesonQA > 0){
       fHistoTrueMesonInvMassVsTruePt.resize(fnCuts);
       fHistoTruePrimaryMesonInvMassPt.resize(fnCuts);
@@ -793,12 +810,18 @@ void AliAnalysisTaskMesonJetCorrelation::UserCreateOutputObjects()
   fRespMatrixHandlerMesonInvMass.resize(fnCuts);
   fRespMatrixHandlerMesonBackInvMassVsZ.resize(fnCuts);
   fRespMatrixHandlerMesonBackInvMassVsPt.resize(fnCuts);
+  if(fUseMixedBackAdd){
+    fRespMatrixHandlerMesonBackAddInvMassVsZ.resize(fnCuts);
+    fRespMatrixHandlerMesonBackAddInvMassVsPt.resize(fnCuts);
+  }
   // perpendicular cone
   fRespMatrixHandlerMesonInvMassVsZPerpCone.resize(fnCuts);
   fRespMatrixHandlerMesonInvMassPerpCone.resize(fnCuts);
   // vs. radius and pt
-  fRespMatrixHandlerMesonPtInvMassRadius.resize(fnCuts);
-  fRespMatrixHandlerMesonBackPtInvMassRadius.resize(fnCuts);
+  if(fDoRadiusDep){
+    fRespMatrixHandlerMesonPtInvMassRadius.resize(fnCuts);
+    fRespMatrixHandlerMesonBackPtInvMassRadius.resize(fnCuts);
+  }
   if (fIsMC) {
     fRespMatrixHandlerMesonPt.resize(fnCuts);
     fRespMatrixHandlerFrag.resize(fnCuts);
@@ -806,8 +829,10 @@ void AliAnalysisTaskMesonJetCorrelation::UserCreateOutputObjects()
       fRespMatrixHandlerFragTrueJets.resize(fnCuts);
     }
     // vs radius and pt
-    fRespMatrixHandlerMesonPtRadius.resize(fnCuts);
-    fRespMatrixHandlerMesonPtTrueRadius.resize(fnCuts);
+    if(fDoRadiusDep){
+      fRespMatrixHandlerMesonPtRadius.resize(fnCuts);
+      fRespMatrixHandlerMesonPtTrueRadius.resize(fnCuts);
+    }
   }
 
   if(fIsConv && fFillDCATree){
@@ -1162,17 +1187,19 @@ void AliAnalysisTaskMesonJetCorrelation::UserCreateOutputObjects()
       fHistoMCPartonPtVsFragTrueParton[iCut]->SetYTitle("p_{T, parton, jet} (GeV/c)");
       fMCList[iCut]->Add(fHistoMCPartonPtVsFragTrueParton[iCut]);
 
-      fHistoMCJetPtVsMesonPtVsRadius[iCut] = new TH3F("MC_PtMeson_PtJet_Radius", "MC_PtMeson_PtJet_Radius", fVecBinsMesonPtCoarse.size() - 1, fVecBinsMesonPtCoarse.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data(), fVecBinsMesonJetRadius.size()-1, fVecBinsMesonJetRadius.data());
-      fHistoMCJetPtVsMesonPtVsRadius[iCut]->SetXTitle("p_{T, meson}");
-      fHistoMCJetPtVsMesonPtVsRadius[iCut]->SetYTitle("p_{T, jet}");
-      fHistoMCJetPtVsMesonPtVsRadius[iCut]->SetZTitle("radius");
-      fMCList[iCut]->Add(fHistoMCJetPtVsMesonPtVsRadius[iCut]);
+      if(fDoRadiusDep){
+        fHistoMCJetPtVsMesonPtVsRadius[iCut] = new TH3F("MC_PtMeson_PtJet_Radius", "MC_PtMeson_PtJet_Radius", fVecBinsMesonPtCoarse.size() - 1, fVecBinsMesonPtCoarse.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data(), fVecBinsMesonJetRadius.size()-1, fVecBinsMesonJetRadius.data());
+        fHistoMCJetPtVsMesonPtVsRadius[iCut]->SetXTitle("p_{T, meson}");
+        fHistoMCJetPtVsMesonPtVsRadius[iCut]->SetYTitle("p_{T, jet}");
+        fHistoMCJetPtVsMesonPtVsRadius[iCut]->SetZTitle("radius");
+        fMCList[iCut]->Add(fHistoMCJetPtVsMesonPtVsRadius[iCut]);
 
-      fHistoMCJetPtVsMesonPtVsRadiusInAcc[iCut] = new TH3F("MC_PtMeson_PtJet_Radius_InAcc", "MC_PtMeson_PtJet_Radius_InAcc", fVecBinsMesonPtCoarse.size() - 1, fVecBinsMesonPtCoarse.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data(), fVecBinsMesonJetRadius.size()-1, fVecBinsMesonJetRadius.data());
-      fHistoMCJetPtVsMesonPtVsRadiusInAcc[iCut]->SetXTitle("p_{T, meson}");
-      fHistoMCJetPtVsMesonPtVsRadiusInAcc[iCut]->SetYTitle("p_{T, jet}");
-      fHistoMCJetPtVsMesonPtVsRadiusInAcc[iCut]->SetZTitle("radius");
-      fMCList[iCut]->Add(fHistoMCJetPtVsMesonPtVsRadiusInAcc[iCut]);
+        fHistoMCJetPtVsMesonPtVsRadiusInAcc[iCut] = new TH3F("MC_PtMeson_PtJet_Radius_InAcc", "MC_PtMeson_PtJet_Radius_InAcc", fVecBinsMesonPtCoarse.size() - 1, fVecBinsMesonPtCoarse.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data(), fVecBinsMesonJetRadius.size()-1, fVecBinsMesonJetRadius.data());
+        fHistoMCJetPtVsMesonPtVsRadiusInAcc[iCut]->SetXTitle("p_{T, meson}");
+        fHistoMCJetPtVsMesonPtVsRadiusInAcc[iCut]->SetYTitle("p_{T, jet}");
+        fHistoMCJetPtVsMesonPtVsRadiusInAcc[iCut]->SetZTitle("radius");
+        fMCList[iCut]->Add(fHistoMCJetPtVsMesonPtVsRadiusInAcc[iCut]);
+      }
 
     } // end MC generated histos
 
@@ -1217,6 +1244,8 @@ void AliAnalysisTaskMesonJetCorrelation::UserCreateOutputObjects()
       if(!fDoLightOutput){
         fHistoTruevsRecJetPtForTrueJets[iCut] = new TH2F("True_JetPt_vs_Rec_JetPt_ForTrueJets", "True_JetPt_vs_Rec_JetPt_ForTrueJets", fVecBinsJetPt.size() - 1, fVecBinsJetPt.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
         fTrueJetList[iCut]->Add(fHistoTruevsRecJetPtForTrueJets[iCut]);
+        fHistoNPartInTrueJetVsJetPt[iCut] = new TH2F("NparticlesInTrueJetVsJetPt", "NparticlesInTrueJetVsJetPt", 25, vecEquidistFromMinus05.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
+        fTrueJetList[iCut]->Add(fHistoNPartInTrueJetVsJetPt[iCut]);
       }
       fHistoTrueJetPtVsPartonPt[iCut] = new TH2F("True_JetPt_vs_Parton_Pt", "True_JetPt_vs_Parton_Pt", fVecBinsJetPt.size() - 1, fVecBinsJetPt.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
       fTrueJetList[iCut]->Add(fHistoTrueJetPtVsPartonPt[iCut]);
@@ -1298,27 +1327,28 @@ void AliAnalysisTaskMesonJetCorrelation::UserCreateOutputObjects()
         fTrueList[iCut]->Add(fRespMatrixHandlerTrueSecondaryMesonInvMassVsZ[iCut]->GetTH2("ESD_TrueSecondaryMother_InvMass_Z_JetPt"));
 
       // inv. mass vs. radius
-      std::vector<std::vector<double>> vecXAxisRadius = {fVecBinsMesonInvMass, fVecBinsMesonPtCoarse, fVecBinsMesonJetRadius};
-      std::vector<std::vector<double>> vecYAxisRadius = {fVecBinsJetPt, {0, 1}, {0, 1}};
+      if(fDoRadiusDep){
+        std::vector<std::vector<double>> vecXAxisRadius = {fVecBinsMesonInvMass, fVecBinsMesonPtCoarse, fVecBinsMesonJetRadius};
+        std::vector<std::vector<double>> vecYAxisRadius = {fVecBinsJetPt, {0, 1}, {0, 1}};
 
-      fRespMatrixHandlerTrueMesonPtRadius[iCut] = new MatrixHandlerNDim(vecXAxisRadius, vecYAxisRadius, fUseThNForResponse);
-      if (fUseThNForResponse)
-        fTrueList[iCut]->Add(fRespMatrixHandlerTrueMesonPtRadius[iCut]->GetTHnSparse("ESD_TrueMother_InvMass_Pt_JetPt_Radius"));
-      else
-        fTrueList[iCut]->Add(fRespMatrixHandlerTrueMesonPtRadius[iCut]->GetTH2("ESD_TrueMother_InvMass_Pt_JetPt_Radius"));
+        fRespMatrixHandlerTrueMesonPtRadius[iCut] = new MatrixHandlerNDim(vecXAxisRadius, vecYAxisRadius, fUseThNForResponse);
+        if (fUseThNForResponse)
+          fTrueList[iCut]->Add(fRespMatrixHandlerTrueMesonPtRadius[iCut]->GetTHnSparse("ESD_TrueMother_InvMass_Pt_JetPt_Radius"));
+        else
+          fTrueList[iCut]->Add(fRespMatrixHandlerTrueMesonPtRadius[iCut]->GetTH2("ESD_TrueMother_InvMass_Pt_JetPt_Radius"));
 
-      fRespMatrixHandlerTrueMesonTruePtRadius[iCut] = new MatrixHandlerNDim(vecXAxisRadius, vecYAxisRadius, fUseThNForResponse);
-      if (fUseThNForResponse)
-        fTrueList[iCut]->Add(fRespMatrixHandlerTrueMesonTruePtRadius[iCut]->GetTHnSparse("ESD_TrueMother_InvMass_TruePt_JetPt_Radius"));
-      else
-        fTrueList[iCut]->Add(fRespMatrixHandlerTrueMesonTruePtRadius[iCut]->GetTH2("ESD_TrueMother_InvMass_TruePt_JetPt_Radius"));
+        fRespMatrixHandlerTrueMesonTruePtRadius[iCut] = new MatrixHandlerNDim(vecXAxisRadius, vecYAxisRadius, fUseThNForResponse);
+        if (fUseThNForResponse)
+          fTrueList[iCut]->Add(fRespMatrixHandlerTrueMesonTruePtRadius[iCut]->GetTHnSparse("ESD_TrueMother_InvMass_TruePt_JetPt_Radius"));
+        else
+          fTrueList[iCut]->Add(fRespMatrixHandlerTrueMesonTruePtRadius[iCut]->GetTH2("ESD_TrueMother_InvMass_TruePt_JetPt_Radius"));
 
-      fRespMatrixHandlerTrueSecondaryMesonPtRadius[iCut] = new MatrixHandlerNDim(vecXAxisRadius, vecYAxisRadius, fUseThNForResponse);
-      if (fUseThNForResponse)
-        fTrueList[iCut]->Add(fRespMatrixHandlerTrueSecondaryMesonPtRadius[iCut]->GetTHnSparse("ESD_TrueSecondaryMother_InvMass_Pt_JetPt_Radius"));
-      else
-        fTrueList[iCut]->Add(fRespMatrixHandlerTrueSecondaryMesonPtRadius[iCut]->GetTH2("ESD_TrueSecondaryMother_InvMass_Pt_JetPt_Radius"));
-
+        fRespMatrixHandlerTrueSecondaryMesonPtRadius[iCut] = new MatrixHandlerNDim(vecXAxisRadius, vecYAxisRadius, fUseThNForResponse);
+        if (fUseThNForResponse)
+          fTrueList[iCut]->Add(fRespMatrixHandlerTrueSecondaryMesonPtRadius[iCut]->GetTHnSparse("ESD_TrueSecondaryMother_InvMass_Pt_JetPt_Radius"));
+        else
+          fTrueList[iCut]->Add(fRespMatrixHandlerTrueSecondaryMesonPtRadius[iCut]->GetTH2("ESD_TrueSecondaryMother_InvMass_Pt_JetPt_Radius"));
+      }
 
       if(fDoMesonQA > 0){
         fHistoTrueMesonInvMassVsTruePt[iCut] = new TH2F("ESD_TrueMother_InvMass_TruePt", "ESD_TrueMother_InvMass_TruePt", fVecBinsMesonInvMass.size() - 1, fVecBinsMesonInvMass.data(), fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data());
@@ -1464,6 +1494,22 @@ void AliAnalysisTaskMesonJetCorrelation::UserCreateOutputObjects()
     else
       fESDList[iCut]->Add(fRespMatrixHandlerMesonBackInvMassVsPt[iCut]->GetTH2("InvMassVsPt_Background_JetPt"));
 
+    // only for additional mixed background
+    if( fUseMixedBackAdd ){
+      fRespMatrixHandlerMesonBackAddInvMassVsZ[iCut] = new MatrixHandler4D(fVecBinsMesonInvMass, fVecBinsFragment, fVecBinsJetPt, {0, 1}, fUseThNForResponse);
+      if (fUseThNForResponse)
+        fESDList[iCut]->Add(fRespMatrixHandlerMesonBackAddInvMassVsZ[iCut]->GetTHnSparse("InvMassVsZ_Background_Add_JetPt"));
+      else
+        fESDList[iCut]->Add(fRespMatrixHandlerMesonBackAddInvMassVsZ[iCut]->GetTH2("InvMassVsZ_Background_Add_JetPt"));
+
+      fRespMatrixHandlerMesonBackAddInvMassVsPt[iCut] = new MatrixHandler4D(fVecBinsMesonInvMass, fVecBinsMesonPt, fVecBinsJetPt, {0, 1}, fUseThNForResponse);
+      if (fUseThNForResponse)
+        fESDList[iCut]->Add(fRespMatrixHandlerMesonBackAddInvMassVsPt[iCut]->GetTHnSparse("InvMassVsPt_Background_Add_JetPt"));
+      else
+        fESDList[iCut]->Add(fRespMatrixHandlerMesonBackAddInvMassVsPt[iCut]->GetTH2("InvMassVsPt_Background_Add_JetPt"));
+
+    }
+
     // perpendicular cone
     fRespMatrixHandlerMesonInvMassVsZPerpCone[iCut] = new MatrixHandler4D(fVecBinsMesonInvMass, fVecBinsFragment, fVecBinsJetPt, {0, 1}, fUseThNForResponse);
     if (fUseThNForResponse)
@@ -1477,19 +1523,21 @@ void AliAnalysisTaskMesonJetCorrelation::UserCreateOutputObjects()
     else
       fESDList[iCut]->Add(fRespMatrixHandlerMesonInvMassPerpCone[iCut]->GetTH2("InvMassVsPt_JetPt_PerpCone"));
 
-    std::vector<std::vector<double>> vecXAxisInvMassPtRadius = {fVecBinsMesonInvMass, fVecBinsMesonPtCoarse, fVecBinsMesonJetRadius};
-    std::vector<std::vector<double>> vecYAxisJetPt = {fVecBinsJetPt, {0, 1}, {0, 1}};
-    fRespMatrixHandlerMesonPtInvMassRadius[iCut] = new MatrixHandlerNDim(vecXAxisInvMassPtRadius, vecYAxisJetPt, fUseThNForResponse);
-    if (fUseThNForResponse)
-      fESDList[iCut]->Add(fRespMatrixHandlerMesonPtInvMassRadius[iCut]->GetTHnSparse("InvMassVsPtVsR_JetPt"));
-    else
-      fESDList[iCut]->Add(fRespMatrixHandlerMesonPtInvMassRadius[iCut]->GetTH2("InvMassVsPtVsR_JetPt"));
+    if(fDoRadiusDep){
+      std::vector<std::vector<double>> vecXAxisInvMassPtRadius = {fVecBinsMesonInvMass, fVecBinsMesonPtCoarse, fVecBinsMesonJetRadius};
+      std::vector<std::vector<double>> vecYAxisJetPt = {fVecBinsJetPt, {0, 1}, {0, 1}};
+      fRespMatrixHandlerMesonPtInvMassRadius[iCut] = new MatrixHandlerNDim(vecXAxisInvMassPtRadius, vecYAxisJetPt, fUseThNForResponse);
+      if (fUseThNForResponse)
+        fESDList[iCut]->Add(fRespMatrixHandlerMesonPtInvMassRadius[iCut]->GetTHnSparse("InvMassVsPtVsR_JetPt"));
+      else
+        fESDList[iCut]->Add(fRespMatrixHandlerMesonPtInvMassRadius[iCut]->GetTH2("InvMassVsPtVsR_JetPt"));
 
-    fRespMatrixHandlerMesonBackPtInvMassRadius[iCut] = new MatrixHandlerNDim(vecXAxisInvMassPtRadius, vecYAxisJetPt, fUseThNForResponse);
-    if (fUseThNForResponse)
-      fESDList[iCut]->Add(fRespMatrixHandlerMesonBackPtInvMassRadius[iCut]->GetTHnSparse("InvMassVsPtVsR_Background_JetPt"));
-    else
-      fESDList[iCut]->Add(fRespMatrixHandlerMesonBackPtInvMassRadius[iCut]->GetTH2("InvMassVsPtVsR_Background_JetPt"));
+      fRespMatrixHandlerMesonBackPtInvMassRadius[iCut] = new MatrixHandlerNDim(vecXAxisInvMassPtRadius, vecYAxisJetPt, fUseThNForResponse);
+      if (fUseThNForResponse)
+        fESDList[iCut]->Add(fRespMatrixHandlerMesonBackPtInvMassRadius[iCut]->GetTHnSparse("InvMassVsPtVsR_Background_JetPt"));
+      else
+        fESDList[iCut]->Add(fRespMatrixHandlerMesonBackPtInvMassRadius[iCut]->GetTH2("InvMassVsPtVsR_Background_JetPt"));
+    }
 
     //-----------------------------------------------//
     // ----------------- MC related ---------------- //
@@ -1515,18 +1563,20 @@ void AliAnalysisTaskMesonJetCorrelation::UserCreateOutputObjects()
           fTrueList[iCut]->Add(fRespMatrixHandlerFragTrueJets[iCut]->GetTH2("Frag_JetPt_TrueVsRec_ForTrueJets"));
       }
       
-      std::vector<std::vector<double>> vecXAxisRadius = {fVecBinsJetPt, fVecBinsMesonJetRadius, fVecBinsMesonPtCoarse};
-      fRespMatrixHandlerMesonPtRadius[iCut] = new MatrixHandlerNDim(vecXAxisRadius, vecXAxisRadius, fUseThNForResponse);
-      if (fUseThNForResponse)
-        fTrueList[iCut]->Add(fRespMatrixHandlerMesonPtRadius[iCut]->GetTHnSparse("JetPt_Radius_MesonPt_TrueVsRec"));
-      else
-        fTrueList[iCut]->Add(fRespMatrixHandlerMesonPtRadius[iCut]->GetTH2("JetPt_Radius_MesonPt_TrueVsRec"));
+      if(fDoRadiusDep){
+        std::vector<std::vector<double>> vecXAxisRadius = {fVecBinsJetPt, fVecBinsMesonJetRadius, fVecBinsMesonPtCoarse};
+        fRespMatrixHandlerMesonPtRadius[iCut] = new MatrixHandlerNDim(vecXAxisRadius, vecXAxisRadius, fUseThNForResponse);
+        if (fUseThNForResponse)
+          fTrueList[iCut]->Add(fRespMatrixHandlerMesonPtRadius[iCut]->GetTHnSparse("JetPt_Radius_MesonPt_TrueVsRec"));
+        else
+          fTrueList[iCut]->Add(fRespMatrixHandlerMesonPtRadius[iCut]->GetTH2("JetPt_Radius_MesonPt_TrueVsRec"));
 
-      fRespMatrixHandlerMesonPtTrueRadius[iCut] = new MatrixHandlerNDim(vecXAxisRadius, vecXAxisRadius, fUseThNForResponse);
-      if (fUseThNForResponse)
-        fTrueList[iCut]->Add(fRespMatrixHandlerMesonPtTrueRadius[iCut]->GetTHnSparse("MesonPt_JetPt_TrueRadius_TrueVsRec"));
-      else
-        fTrueList[iCut]->Add(fRespMatrixHandlerMesonPtTrueRadius[iCut]->GetTH2("MesonPt_JetPt_TrueRadius_TrueVsRec"));
+        fRespMatrixHandlerMesonPtTrueRadius[iCut] = new MatrixHandlerNDim(vecXAxisRadius, vecXAxisRadius, fUseThNForResponse);
+        if (fUseThNForResponse)
+          fTrueList[iCut]->Add(fRespMatrixHandlerMesonPtTrueRadius[iCut]->GetTHnSparse("MesonPt_JetPt_TrueRadius_TrueVsRec"));
+        else
+          fTrueList[iCut]->Add(fRespMatrixHandlerMesonPtTrueRadius[iCut]->GetTH2("MesonPt_JetPt_TrueRadius_TrueVsRec"));
+      }
     } // end MC related
     
     if(fUseCentralEventSelection){
@@ -1802,6 +1852,7 @@ void AliAnalysisTaskMesonJetCorrelation::InitJets()
     fTrueVectorJetPt = fConvJetReader->GetTrueVectorJetPt();
     fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta();
     fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi();
+    fTrueVectorJetNPart = fConvJetReader->GetTrueVectorJetNPart();
     fTrueVectorJetPartonID = fConvJetReader->GetTrueVectorJetParton();
     fTrueVectorJetPartonPt = fConvJetReader->GetTrueVectorJetPartonPt();
     fTrueVectorJetPartonPx = fConvJetReader->GetTrueVectorJetPartonPx();
@@ -1883,6 +1934,9 @@ void AliAnalysisTaskMesonJetCorrelation::ProcessJets()
   if (fIsMC) {
     for (int i = 0; i < fConvJetReader->GetTrueNJets(); i++) {
       fHistoTruePtJet[fiCut]->Fill(fTrueVectorJetPt.at(i), fWeightJetJetMC);
+      if(!fDoLightOutput){
+        fHistoNPartInTrueJetVsJetPt[fiCut]->Fill(fTrueVectorJetNPart.at(i), fTrueVectorJetPt.at(i));
+      }
 
       // lambda to find the index of the rec. jet corresponding to the true jet
       auto findResults = std::find_if(std::begin(MapRecJetsTrueJets), std::end(MapRecJetsTrueJets), [&](const std::pair<int, int>& pair) {
@@ -2523,9 +2577,11 @@ void AliAnalysisTaskMesonJetCorrelation::FillMesonHistograms(AliAODConversionPho
       // Fill the inv. mass histograms for all jet pTs
       fRespMatrixHandlerMesonInvMass[fiCut]->Fill(ptJet, 0.5, pi0cand->M(), pi0cand->Pt(), fWeightJetJetMC*weightMatBudget);
 
-      std::vector<double> vecFillInvMassPtR = {pi0cand->M(), pi0cand->Pt(), RJetPi0Cand};
-      std::vector<double> vecFillJetPt = {ptJet, 0.5, 0.5};
-      fRespMatrixHandlerMesonPtInvMassRadius[fiCut]->Fill(vecFillInvMassPtR, vecFillJetPt, fWeightJetJetMC*weightMatBudget);
+      if(fDoRadiusDep){
+        std::vector<double> vecFillInvMassPtR = {pi0cand->M(), pi0cand->Pt(), RJetPi0Cand};
+        std::vector<double> vecFillJetPt = {ptJet, 0.5, 0.5};
+        fRespMatrixHandlerMesonPtInvMassRadius[fiCut]->Fill(vecFillInvMassPtR, vecFillJetPt, fWeightJetJetMC*weightMatBudget);
+      }
 
       // Fill Z histograms
       float z = GetFrag(pi0cand, matchedJet, false);
@@ -2706,7 +2762,8 @@ void AliAnalysisTaskMesonJetCorrelation::CalculateBackground()
   // cout << "CalculateBackground" << endl;
   if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->DoGammaSwappForBg()) {
     CalculateBackgroundSwapp();
-  } else {
+  } 
+  if( (fUseMixedBackAdd && ((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->DoGammaSwappForBg()) || !((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->DoGammaSwappForBg()){
     CalculateBackgroundMix();
   }
 }
@@ -2731,7 +2788,7 @@ void AliAnalysisTaskMesonJetCorrelation::CalculateBackgroundMix()
 
             if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelected(backgroundCandidate.get(), false, ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift(), cellID, ((AliAODConversionPhoton*)currentEventGamma)->GetLeadingCellID())) {
               // Fill histograms here
-              FillInvMassBackHistograms(backgroundCandidate.get());
+              FillInvMassBackHistograms(backgroundCandidate.get(), false);
             }
           }
         }
@@ -2752,7 +2809,7 @@ void AliAnalysisTaskMesonJetCorrelation::CalculateBackgroundMix()
 
             if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelected(backgroundCandidate.get(), false, ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift(), cellID, -1)) {
               // Fill histograms here
-              FillInvMassBackHistograms(backgroundCandidate.get());
+              FillInvMassBackHistograms(backgroundCandidate.get(), false);
             }
           }
         }
@@ -2772,7 +2829,7 @@ void AliAnalysisTaskMesonJetCorrelation::CalculateBackgroundMix()
 
             if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelected(backgroundCandidate.get(), false, ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift(), -1, -1)) {
               // Fill histograms here
-              FillInvMassBackHistograms(backgroundCandidate.get());
+              FillInvMassBackHistograms(backgroundCandidate.get(), false);
             }
           }
         }
@@ -2825,7 +2882,7 @@ void AliAnalysisTaskMesonJetCorrelation::CalculateBackgroundSwapp()
             if (!(((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->CheckDistanceToBadChannelSwapping(cellIDRotatedPhoton[iSwapped], fInputEvent, ((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->GetDistanceToBorderForBg())) && swappedGammas[iSwapped]->P() > ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetMinClusterEnergy()) {
               if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelected(backgroundCandidate.get(), false, ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift(), cellIDRotatedPhoton[iSwapped], ((AliAODConversionPhoton*)currentEventGoodV0Temp3)->GetLeadingCellID())) {
                 // Fill histograms here
-                FillInvMassBackHistograms(backgroundCandidate.get());
+                FillInvMassBackHistograms(backgroundCandidate.get(), true);
               }
             }
           }
@@ -2859,7 +2916,7 @@ void AliAnalysisTaskMesonJetCorrelation::CalculateBackgroundSwapp()
 
               if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelected(backgroundCandidate.get(), false, ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift(), -1, ((AliAODConversionPhoton*)currentEventGoodV0Temp3)->GetLeadingCellID())) {
                 // Fill histograms here
-                FillInvMassBackHistograms(backgroundCandidate.get());
+                FillInvMassBackHistograms(backgroundCandidate.get(), true);
               }
             }
           }
@@ -2876,7 +2933,7 @@ void AliAnalysisTaskMesonJetCorrelation::CalculateBackgroundSwapp()
               if (!(((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->CheckDistanceToBadChannelSwapping(cellIDRotatedPhoton, fInputEvent, ((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->GetDistanceToBorderForBg())) && swappedGammas[0]->P() > ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetMinClusterEnergy()) {
                 if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelected(backgroundCandidate.get(), false, ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift(), cellIDRotatedPhoton, -1)) {
                   // Fill histograms here
-                  FillInvMassBackHistograms(backgroundCandidate.get());
+                  FillInvMassBackHistograms(backgroundCandidate.get(), true);
                 }
               }
             }
@@ -2911,7 +2968,7 @@ void AliAnalysisTaskMesonJetCorrelation::CalculateBackgroundSwapp()
             if (swappedGammas[iSwapped]->Eta() < ((AliConversionPhotonCuts*)fConvCutArray->At(fiCut))->GetEtaCut()) {
               if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelected(backgroundCandidate.get(), false, ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift(), -1, -1)) {
                 // Fill histograms here
-                FillInvMassBackHistograms(backgroundCandidate.get());
+                FillInvMassBackHistograms(backgroundCandidate.get(), true);
               }
             }
           }
@@ -2924,7 +2981,7 @@ void AliAnalysisTaskMesonJetCorrelation::CalculateBackgroundSwapp()
 //__________________________________________________________________________
 /// \brief function to fill all histograms related to the meson background (estimated with rotation, mixed evt etc.)
 /// \param backgroundCandidate particle reconstructed from two photons containing the mass, pT etc.
-void AliAnalysisTaskMesonJetCorrelation::FillInvMassBackHistograms(AliAODConversionMother* backgroundCandidate)
+void AliAnalysisTaskMesonJetCorrelation::FillInvMassBackHistograms(AliAODConversionMother* backgroundCandidate, const bool isRotBack)
 {
 
   int matchedJet = -1;
@@ -2933,19 +2990,32 @@ void AliAnalysisTaskMesonJetCorrelation::FillInvMassBackHistograms(AliAODConvers
     return;
   }
 
-  //_______ Standard Inv Mass vs. pT background histo _______________
-  fHistoInvMassVsPtBack[fiCut]->Fill(backgroundCandidate->M(), backgroundCandidate->Pt(), fWeightJetJetMC);
 
-  //_______ Fill Inv Mass vs. Z for purity correction _______________
+  //_______ Calculate z and get jet pt _______________
   float ptJet = (matchedJet < 0) ? 0 : fVectorJetPt[matchedJet];
   float z = GetFrag(backgroundCandidate, matchedJet, false);
-  fRespMatrixHandlerMesonBackInvMassVsPt[fiCut]->Fill(ptJet, 0.5, backgroundCandidate->M(), backgroundCandidate->Pt(), fWeightJetJetMC); // Inv Mass vs. meson Pt in Jet Pt_rec bins. Needed to subtract background in the Pt-distribution
-  fRespMatrixHandlerMesonBackInvMassVsZ[fiCut]->Fill(ptJet, 0.5, backgroundCandidate->M(), z, fWeightJetJetMC);                          // Inv Mass vs. Z in Jet Pt_rec bins. Needed to subtract background in the Z-distribution
+  
 
-  // Fill as function of radius
+  // For filling as function of radius
   std::vector<double> vecFillInvMassPtR = {backgroundCandidate->M(), backgroundCandidate->Pt(), RJetPi0Cand};
   std::vector<double> vecFillJetPt = {ptJet, 0.5, 0.5};
-  fRespMatrixHandlerMesonBackPtInvMassRadius[fiCut]->Fill(vecFillInvMassPtR, vecFillJetPt, fWeightJetJetMC);
+
+  // Here, a special case is filled in case of both rotation and mixed background are used
+  if(!isRotBack && fUseMixedBackAdd){
+    fRespMatrixHandlerMesonBackAddInvMassVsPt[fiCut]->Fill(ptJet, 0.5, backgroundCandidate->M(), backgroundCandidate->Pt(), fWeightJetJetMC); // Inv Mass vs. meson Pt in Jet Pt_rec bins. Needed to subtract background in the Pt-distribution
+    fRespMatrixHandlerMesonBackAddInvMassVsZ[fiCut]->Fill(ptJet, 0.5, backgroundCandidate->M(), z, fWeightJetJetMC);                          // Inv Mass vs. Z in Jet Pt_rec bins. Needed to subtract background in the Z-distribution
+    // if(fDoRadiusDep){
+    //   fRespMatrixHandlerMesonBackAddPtInvMassRadius[fiCut]->Fill(vecFillInvMassPtR, vecFillJetPt, fWeightJetJetMC);
+    // }
+  } else {
+    fRespMatrixHandlerMesonBackInvMassVsPt[fiCut]->Fill(ptJet, 0.5, backgroundCandidate->M(), backgroundCandidate->Pt(), fWeightJetJetMC); // Inv Mass vs. meson Pt in Jet Pt_rec bins. Needed to subtract background in the Pt-distribution
+    fRespMatrixHandlerMesonBackInvMassVsZ[fiCut]->Fill(ptJet, 0.5, backgroundCandidate->M(), z, fWeightJetJetMC);                          // Inv Mass vs. Z in Jet Pt_rec bins. Needed to subtract background in the Z-distribution
+    if(fDoRadiusDep){
+      fRespMatrixHandlerMesonBackPtInvMassRadius[fiCut]->Fill(vecFillInvMassPtR, vecFillJetPt, fWeightJetJetMC);
+    }
+    //_______ Standard Inv Mass vs. pT background histo _______________
+    fHistoInvMassVsPtBack[fiCut]->Fill(backgroundCandidate->M(), backgroundCandidate->Pt(), fWeightJetJetMC);
+  }
 
 }
 
@@ -3232,7 +3302,9 @@ void AliAnalysisTaskMesonJetCorrelation::ProcessAODMCParticles(int isCurrentEven
             fHistoMCPartonPtVsFrag[fiCut]->Fill(z_parton, fTrueVectorJetPartonPt[matchedJet], weighted * fWeightJetJetMC);
 
             // FIll radius vs. jet pt vs meson pt histogram
-            fHistoMCJetPtVsMesonPtVsRadius[fiCut]->Fill(particle->Pt(), fTrueVectorJetPt[matchedJet], RJetPi0Cand, weighted * fWeightJetJetMC);
+            if(fDoRadiusDep){
+              fHistoMCJetPtVsMesonPtVsRadius[fiCut]->Fill(particle->Pt(), fTrueVectorJetPt[matchedJet], RJetPi0Cand, weighted * fWeightJetJetMC);
+            }
 
             if (IsParticleFromPartonFrag(particle, fTrueVectorJetPartonID[matchedJet])) {
               fHistoMCJetPtVsFragTrueParton[fiCut]->Fill(z_jet, fTrueVectorJetPt[matchedJet], weighted * fWeightJetJetMC);
@@ -3251,7 +3323,9 @@ void AliAnalysisTaskMesonJetCorrelation::ProcessAODMCParticles(int isCurrentEven
                 fHistoMCMesonInAccPt[fiCut]->Fill(particle->Pt(), weighted * fWeightJetJetMC); // MC Pi0 with gamma in acc
                 fHistoMCJetPtVsFragInAcc[fiCut]->Fill(z_jet, fTrueVectorJetPt[matchedJet], weighted * fWeightJetJetMC);
                 fHistoMCJetPtVsMesonPtInAcc[fiCut]->Fill(particle->Pt(), fTrueVectorJetPt[matchedJet], weighted * fWeightJetJetMC);
-                fHistoMCJetPtVsMesonPtVsRadiusInAcc[fiCut]->Fill(particle->Pt(), fTrueVectorJetPt[matchedJet], RJetPi0Cand, weighted * fWeightJetJetMC);
+                if(fDoRadiusDep){
+                  fHistoMCJetPtVsMesonPtVsRadiusInAcc[fiCut]->Fill(particle->Pt(), fTrueVectorJetPt[matchedJet], RJetPi0Cand, weighted * fWeightJetJetMC);
+                }
                 if (isCurrentEventSelected == 1)
                   fHistoMCMesonInAccPtNotTriggered[fiCut]->Fill(particle->Pt(), weighted * fWeightJetJetMC); // MC Pi0 with gamma in acc for not triggered events
                 if (fIsMC > 1)
@@ -3542,13 +3616,15 @@ bool AliAnalysisTaskMesonJetCorrelation::ProcessTrueMesonCandidatesAOD(AliAODCon
   fRespMatrixHandlerTrueMesonInvMassVsZ[fiCut]->Fill(jetPtRec, 0.5, Pi0Candidate->M(), z_rec, fWeightJetJetMC*weightMatBudget);
 
   // fill as function of radius
-  std::vector<double> vecFillRecInvMass = {mesonMassRec, mesonPtRec, RJetPi0Cand};
-  std::vector<double> vecFillJetPt = {jetPtRec, 0.5, 0.5};
-  fRespMatrixHandlerTrueMesonPtRadius[fiCut]->Fill(vecFillRecInvMass, vecFillJetPt,  fWeightJetJetMC*weightMatBudget);
-
-  std::vector<double> vecFillRecInvMassTrue = {mesonMassRec, mesonPtTrue, RJetPi0CandTrue};
-  std::vector<double> vecFillJetPtTrue = {jetPtTrue, 0.5, 0.5};
-  fRespMatrixHandlerTrueMesonTruePtRadius[fiCut]->Fill(vecFillRecInvMassTrue, vecFillJetPtTrue,  fWeightJetJetMC*weightMatBudget);
+  if(fDoRadiusDep){
+    std::vector<double> vecFillRecInvMass = {mesonMassRec, mesonPtRec, RJetPi0Cand};
+    std::vector<double> vecFillJetPt = {jetPtRec, 0.5, 0.5};
+    fRespMatrixHandlerTrueMesonPtRadius[fiCut]->Fill(vecFillRecInvMass, vecFillJetPt,  fWeightJetJetMC*weightMatBudget);
+    
+    std::vector<double> vecFillRecInvMassTrue = {mesonMassRec, mesonPtTrue, RJetPi0CandTrue};
+    std::vector<double> vecFillJetPtTrue = {jetPtTrue, 0.5, 0.5};
+    fRespMatrixHandlerTrueMesonTruePtRadius[fiCut]->Fill(vecFillRecInvMassTrue, vecFillJetPtTrue,  fWeightJetJetMC*weightMatBudget);
+  }
 
   if(fDoMesonQA > 0){
     fHistoTrueMesonInvMassVsTruePt[fiCut]->Fill(Pi0Candidate->M(), trueMesonCand->Pt(), fWeightJetJetMC*weightMatBudget);
@@ -3589,11 +3665,13 @@ bool AliAnalysisTaskMesonJetCorrelation::ProcessTrueMesonCandidatesAOD(AliAODCon
     // fill 4d response matrix
     fRespMatrixHandlerMesonPt[fiCut]->Fill(jetPtRec, jetPtTrue, mesonPtRec, mesonPtTrue, fWeightJetJetMC*weightMatBudget);
 
-    std::vector<double> vecFillRec = {jetPtRec, RJetPi0Cand, mesonPtRec};
-    std::vector<double> vecFillTrue = {jetPtTrue, RJetPi0Cand, mesonPtTrue};
-    std::vector<double> vecFillTrueRadius = {jetPtTrue, RJetPi0CandTrue, mesonPtTrue};
-    fRespMatrixHandlerMesonPtRadius[fiCut]->Fill(vecFillRec, vecFillTrue,  fWeightJetJetMC*weightMatBudget);
-    fRespMatrixHandlerMesonPtTrueRadius[fiCut]->Fill(vecFillRec, vecFillTrueRadius,  fWeightJetJetMC*weightMatBudget);
+    if(fDoRadiusDep){
+      std::vector<double> vecFillRec = {jetPtRec, RJetPi0Cand, mesonPtRec};
+      std::vector<double> vecFillTrue = {jetPtTrue, RJetPi0Cand, mesonPtTrue};
+      std::vector<double> vecFillTrueRadius = {jetPtTrue, RJetPi0CandTrue, mesonPtTrue};
+      fRespMatrixHandlerMesonPtRadius[fiCut]->Fill(vecFillRec, vecFillTrue,  fWeightJetJetMC*weightMatBudget);
+      fRespMatrixHandlerMesonPtTrueRadius[fiCut]->Fill(vecFillRec, vecFillTrueRadius,  fWeightJetJetMC*weightMatBudget);
+    }
 
 
   } else { // fill all secondary mesons
@@ -3609,12 +3687,16 @@ bool AliAnalysisTaskMesonJetCorrelation::ProcessTrueMesonCandidatesAOD(AliAODCon
     fRespMatrixHandlerTrueSecondaryMesonInvMassVsPt[fiCut]->Fill(jetPtRec, 0.5, Pi0Candidate->M(), Pi0Candidate->Pt(), fWeightJetJetMC*weightMatBudget);
     fRespMatrixHandlerTrueSecondaryMesonInvMassVsZ[fiCut]->Fill(jetPtRec, 0.5, Pi0Candidate->M(), z_rec, fWeightJetJetMC*weightMatBudget);
 
-    // Fill as function of radius
-    fRespMatrixHandlerTrueSecondaryMesonPtRadius[fiCut]->Fill(vecFillRecInvMass, vecFillJetPt,  fWeightJetJetMC*weightMatBudget);
+    if(fDoRadiusDep){
+      // Fill as function of radius
+      std::vector<double> vecFillRecInvMass = {mesonMassRec, mesonPtRec, RJetPi0Cand};
+      std::vector<double> vecFillJetPt = {jetPtRec, 0.5, 0.5};
+      fRespMatrixHandlerTrueSecondaryMesonPtRadius[fiCut]->Fill(vecFillRecInvMass, vecFillJetPt,  fWeightJetJetMC*weightMatBudget);
 
-    std::vector<double> vecFillRec = {jetPtRec, mesonPtRec, RJetPi0Cand};
-    std::vector<double> vecFillDummy = {0.5, 0.5, 0.5};
-    fRespMatrixHandlerTrueSecondaryMesonPtRadius[fiCut]->Fill(vecFillRec, vecFillDummy,  fWeightJetJetMC*weightMatBudget);
+      std::vector<double> vecFillRec = {jetPtRec, mesonPtRec, RJetPi0Cand};
+      std::vector<double> vecFillDummy = {0.5, 0.5, 0.5};
+      fRespMatrixHandlerTrueSecondaryMesonPtRadius[fiCut]->Fill(vecFillRec, vecFillDummy,  fWeightJetJetMC*weightMatBudget);
+    }
     
   }
   return true;

--- a/PWGGA/GammaConv/AliAnalysisTaskMesonJetCorrelation.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskMesonJetCorrelation.h
@@ -48,6 +48,7 @@
 
 class AliAnalysisTaskMesonJetCorrelation : public AliAnalysisTaskSE
 {
+  
  public:
   AliAnalysisTaskMesonJetCorrelation();
   AliAnalysisTaskMesonJetCorrelation(const char* name);
@@ -66,7 +67,7 @@ class AliAnalysisTaskMesonJetCorrelation : public AliAnalysisTaskSE
   void CalculateBackgroundSwapp();
   void CalculateBackgroundMix();
   void UpdateEventMixData();
-  void FillInvMassBackHistograms(AliAODConversionMother* backgroundCandidate);
+  void FillInvMassBackHistograms(AliAODConversionMother* backgroundCandidate, const bool isRotBack = true);
   std::array<std::unique_ptr<AliAODConversionPhoton>, 2> GetGammasSwapped(AliAODConversionPhoton* currentEventGoodV0Temp1, AliAODConversionPhoton* currentEventGoodV0Temp2);
   void FillMesonHistograms(AliAODConversionPhoton* gamma0, AliAODConversionPhoton* gamma1, int firstGammaIndex, int secondGammaIndex);
   void ProcessTrueBackgroundCandidatesAOD(AliAODConversionMother* Pi0Candidate, AliAODConversionPhoton* TrueGammaCandidate0, AliAODConversionPhoton* TrueGammaCandidate1, const int matchedJet, const float RJetPi0Cand);
@@ -122,6 +123,8 @@ class AliAnalysisTaskMesonJetCorrelation : public AliAnalysisTaskSE
   void SetDoUseCentralEvtSelection(bool tmp) { fUseCentralEventSelection = tmp; }
   void SetUsePtForCalcZ(bool tmp) { fUsePtForZCalc = tmp; }
   void SetForcePi0Unstable(bool tmp) { fUnsetStablePi0 = tmp; }
+  void SetUseMixedBackAdd(bool tmp) { fUseMixedBackAdd = tmp; }
+  void SetDoRadiusDependence(bool tmp) { fDoRadiusDep = tmp; }
 
   void SetEventCutList(int nCuts,
                        TList* CutArray)
@@ -229,6 +232,8 @@ class AliAnalysisTaskMesonJetCorrelation : public AliAnalysisTaskSE
   bool fUseCentralEventSelection;                       // flag if central event selection (AliEventSelection.cxx) should be used
   bool fUsePtForZCalc;                                  // flag if z = pt_meson/pt_jet or if its z = (P_{meson}*P_{jet})/|P_{Jet}^{2}|
   bool fUnsetStablePi0;                                 // flag to decide if pi0 need to be reset to Unstable particles
+  bool fUseMixedBackAdd;                                // flag to enable a histogram for the mixed jet background in addition to the rotation background. This is to save memory and CPU (As otherwise a completely new wagon would be needed)
+  bool fDoRadiusDep;                                    // flag to enable radius dependent histograms
   //-------------------------------
   // conversions
   //-------------------------------
@@ -274,6 +279,7 @@ class AliAnalysisTaskMesonJetCorrelation : public AliAnalysisTaskSE
   vector<double> fTrueVectorJetPz;       //! Vector of True JetPz
   vector<double> fTrueVectorJetEta;      //! Vector of True JetEta
   vector<double> fTrueVectorJetPhi;      //! Vector of True JetPhi
+  vector<double> fTrueVectorJetNPart;    //! Vector of True number of particles in jet
   vector<int> fTrueVectorJetPartonID;    //! Vector of parton id matched to true jet
   vector<double> fTrueVectorJetPartonPt; //! Vector of parton pt matched to true jet
   vector<double> fTrueVectorJetPartonPx; //! Vector of parton pt matched to true jet
@@ -295,6 +301,8 @@ class AliAnalysisTaskMesonJetCorrelation : public AliAnalysisTaskSE
   std::vector<MatrixHandler4D*> fRespMatrixHandlerMesonInvMassVsZ;         //! Response matrix for meson inv. mass and meson z for each jet pt true vs. rec. bin
   std::vector<MatrixHandler4D*> fRespMatrixHandlerMesonBackInvMassVsZ;     //! Response matrix for meson inv. mass and meson z for background candidates (mixed evt/rotation) for each jet pt true vs. rec. bin
   std::vector<MatrixHandler4D*> fRespMatrixHandlerMesonBackInvMassVsPt;    //! Response matrix for meson inv. mass and meson pT for background candidates (mixed evt/rotation) for each jet pt true vs. rec. bin
+  std::vector<MatrixHandler4D*> fRespMatrixHandlerMesonBackAddInvMassVsZ;  //! Response matrix for meson inv. mass and meson z for background candidates (mixed evt) for each jet pt true vs. rec. bin
+  std::vector<MatrixHandler4D*> fRespMatrixHandlerMesonBackAddInvMassVsPt; //! Response matrix for meson inv. mass and meson pT for background candidates (mixed evt) for each jet pt true vs. rec. bin
   std::vector<MatrixHandler4D*> fRespMatrixHandlerMesonInvMassPerpCone;    //! Same as fRespMatrixHandlerMesonInvMass but in perpendicular cone
   std::vector<MatrixHandler4D*> fRespMatrixHandlerMesonInvMassVsZPerpCone; //! Same as fRespMatrixHandlerMesonInvMassVsZ but in perpendicular cone
 
@@ -381,6 +389,7 @@ class AliAnalysisTaskMesonJetCorrelation : public AliAnalysisTaskSE
   std::vector<TH2F*> fHistoNEFVsPtJet;                //! vector of histos with pt of jets vs neutral energy fraction
   std::vector<TH2F*> fHistoNchVsPtJet;                //! vector of histos with pt of jets vs number of charged tracks in jet
   std::vector<TH2F*> fHistoNclusVsPtJet;              //! vector of histos with pt of jets vs neutral clusters in jet
+  std::vector<TH2F*> fHistoNPartInTrueJetVsJetPt;     //! vector of histos with pt jet vs number of true jet particles
   
   //-------------------------------
   // True meson histograms
@@ -489,7 +498,7 @@ class AliAnalysisTaskMesonJetCorrelation : public AliAnalysisTaskSE
   AliAnalysisTaskMesonJetCorrelation(const AliAnalysisTaskMesonJetCorrelation&);            // Prevent copy-construction
   AliAnalysisTaskMesonJetCorrelation& operator=(const AliAnalysisTaskMesonJetCorrelation&); // Prevent assignment
 
-  ClassDef(AliAnalysisTaskMesonJetCorrelation, 15);
+  ClassDef(AliAnalysisTaskMesonJetCorrelation, 16);
 };
 
 #endif

--- a/PWGGA/GammaConv/macros/AddTask_MesonJetCorr_Calo.C
+++ b/PWGGA/GammaConv/macros/AddTask_MesonJetCorr_Calo.C
@@ -51,6 +51,8 @@ void AddTask_MesonJetCorr_Calo(
   Bool_t enableSortingMCLabels = kTRUE, // enable sorting for MC cluster labels
   bool useCentralEvtSelection = true,
   bool setPi0Unstable = false,
+  bool enableAddBackground = false,
+  bool enableRadiusDep = false,
   // subwagon config
   TString additionalTrainConfig = "0" // additional counter for trainconfig
 
@@ -386,6 +388,8 @@ void AddTask_MesonJetCorr_Calo(
   task->SetUseTHnSparseForResponse(enableTHnSparse);
   task->SetDoUseCentralEvtSelection(useCentralEvtSelection);
   task->SetForcePi0Unstable(setPi0Unstable);
+  task->SetUseMixedBackAdd(enableAddBackground);
+  task->SetDoRadiusDependence(enableRadiusDep);
 
   //connect containers
   TString nameContainer = Form("MesonJetCorrelation_Calo_%i_%i%s%s", meson, trainConfig, corrTaskSetting.EqualTo("") == true ? "" : Form("_%s", corrTaskSetting.Data()), nameJetFinder.EqualTo("") == true ? "" : Form("_%s", nameJetFinder.Data()) );

--- a/PWGGA/GammaConv/macros/AddTask_MesonJetCorr_Conv.C
+++ b/PWGGA/GammaConv/macros/AddTask_MesonJetCorr_Conv.C
@@ -50,9 +50,11 @@ void AddTask_MesonJetCorr_Conv(
   Bool_t enableElecDeDxPostCalibration = kFALSE,
   // special settings
   Bool_t enableChargedPrimary = kFALSE,
-  bool doFillMesonDCATree = false, // swith to enable filling the meson DCA tree for pile-up estimation
+  bool doFillMesonDCATree = false, // switch to enable filling the meson DCA tree for pile-up estimation
   bool useCentralEvtSelection = true,
   bool setPi0Unstable = false,
+  bool enableAddBackground = false,
+  bool enableRadiusDep = false,
   // subwagon config
   TString additionalTrainConfig = "0" // additional counter for trainconfig + special settings
 )
@@ -324,6 +326,8 @@ void AddTask_MesonJetCorr_Conv(
   if(doFillMesonDCATree) task->SetFillMesonDCATree(true);
   task->SetDoUseCentralEvtSelection(useCentralEvtSelection);
   task->SetForcePi0Unstable(setPi0Unstable);
+  task->SetUseMixedBackAdd(enableAddBackground);
+  task->SetDoRadiusDependence(enableRadiusDep);
 
   //connect containers
   TString nameContainer = Form("MesonJetCorrelation_Conv_%i_%i%s", meson, trainConfig, nameJetFinder.EqualTo("") == true ? "" : Form("_%s", nameJetFinder.Data()) );

--- a/PWGGA/GammaConv/macros/AddTask_MesonJetCorr_ConvCalo.C
+++ b/PWGGA/GammaConv/macros/AddTask_MesonJetCorr_ConvCalo.C
@@ -61,6 +61,8 @@ void AddTask_MesonJetCorr_ConvCalo(
   Bool_t doPrimaryTrackMatching = kTRUE, // enable basic track matching for all primary tracks to cluster
   bool useCentralEvtSelection = true,
   bool setPi0Unstable = false,
+  bool enableAddBackground = false,
+  bool enableRadiusDep = false,
   // subwagon config
   TString additionalTrainConfig = "0" // additional counter for trainconfig
 )
@@ -404,6 +406,8 @@ void AddTask_MesonJetCorr_ConvCalo(
   task->SetUseTHnSparseForResponse(enableTHnSparse);
   task->SetDoUseCentralEvtSelection(useCentralEvtSelection);
   task->SetForcePi0Unstable(setPi0Unstable);
+  task->SetUseMixedBackAdd(enableAddBackground);
+  task->SetDoRadiusDependence(enableRadiusDep);
 
   //connect containers
   TString nameContainer = Form("MesonJetCorrelation_ConvCalo_%i_%i%s%s", meson, trainConfig, corrTaskSetting.EqualTo("") == true ? "" : Form("_%s", corrTaskSetting.Data()), nameJetFinder.EqualTo("") == true ? "" : Form("_%s", nameJetFinder.Data()) );


### PR DESCRIPTION
- To better compare the mixed jet backgrund and the rotation background, an option is added where both background histograms are available in the same train (This saves CPU and memory in case one wants to compare them)
- Added QA flag for radius dependency studies
- Added new true jet histogram to monitor the number of particles of a true jet