### PR TITLE
PWG/EMCAL: Add option for cell scale for run1 w/wo TRD

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.h
+++ b/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.h
@@ -173,11 +173,10 @@ public:
   void     SetNonLinearityThreshold(Int_t threshold)     { fNonLinearThreshold = threshold ; } //only for Alexie's non linearity correction
   Int_t    GetNonLinearityThreshold()              const { return fNonLinearThreshold      ; }
   void     SetUseTowerShaperNonlinarityCorrection(Bool_t doCorr)     { fUseShaperNonlin = doCorr ; }
-  void     SetUseDetermineLowGain(Bool_t doCorr)     { fUseDetermineLowGain = doCorr ; }
-  void     SetUseTowerAdditionalScaleCorrection(Bool_t doCorr)       { fUseAdditionalScale = doCorr;}
-  void     SetUseTowerAdditionalScaleCorrectionEtaDep(Bool_t doCorr) { fUseAdditionalScaleEtaDep = doCorr;}
-  void     SetTowerAdditionalScaleCorrection(Int_t i, Float_t val)   { if(i < 3 && i >= 0) fAdditionalScaleSM[i] = val;
-                                                                       else AliInfo(Form("fAdditionalScaleSM index %d larger than 3 or negative, do nothing\n",i));}
+  void     SetUseDetermineLowGain(Bool_t doCorr)                     { fUseDetermineLowGain = doCorr ; }
+  void     SetUseTowerAdditionalScaleCorrection(Int_t doCorr)        { fUseAdditionalScale = doCorr;}
+  void     SetTowerAdditionalScaleCorrection(Int_t i, Float_t val)   { if(i < 4 && i >= 0) fAdditionalScaleSM[i] = val;
+                                                                       else AliInfo(Form("fAdditionalScaleSM index %d larger than 4 or negative, do nothing\n",i));}
 
   //-----------------------------------------------------
   // MC clusters energy smearing
@@ -638,9 +637,8 @@ private:
   Bool_t     fUseShaperNonlin;           ///< Shaper non linearity correction for towers
   Bool_t     fUseDetermineLowGain;       ///< If set on true, wether a cell is low gain or high gain is not taken from cell info but calculated directly from cell ADC value
   AliEMCALCalibData* fCalibData;         ///< EMCAL calib data
-  Bool_t     fUseAdditionalScale;        ///< Switch for additional scale on cell level. 
-  Bool_t     fUseAdditionalScaleEtaDep;  ///< Switch for eta-dependent (with and without TRD support structure) scale on cell level. Should not be used for standard Analyses
-  Float_t    fAdditionalScaleSM[3];      ///< Value for additional scale on cell level. 
+  Int_t     fUseAdditionalScale;         ///< Switch for additional scale on cell level: 1 = default (Scales for Full, 2/3 and 1/3 SM), 2 = diff. scales for regions behind TRD support, 3 = Run1 scales behind SM with TRD in front and without, 4 = Same as 3 but additionally values for with and without TRD support structures
+  Float_t    fAdditionalScaleSM[4];      ///< Value for additional scale on cell level. 
 
   // Energy smearing for MC
   Bool_t     fSmearClusterEnergy;        ///< Smear cluster energy, to be done only for simulated data to match real data
@@ -759,7 +757,7 @@ private:
   Bool_t     fMCGenerToAcceptForTrack;   ///<  Activate the removal of tracks entering the track matching that come from a particular generator
 
   /// \cond CLASSIMP
-  ClassDef(AliEMCALRecoUtils, 44) ;
+  ClassDef(AliEMCALRecoUtils, 45) ;
   /// \endcond
 
 };

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEnergy.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEnergy.cxx
@@ -31,13 +31,13 @@ AliEmcalCorrectionCellEnergy::AliEmcalCorrectionCellEnergy() :
   ,fDisableTempCalib(0)
   ,fUseShaperCorrection(0)
   ,fUseDetermineLowGain(0)
-  ,fUseAdditionalScale(kFALSE)
-  ,fUseAdditionalScaleEtaDep(kFALSE)
-  ,fAdditionalScaleSM(0)
+  ,fUseAdditionalScale(0)
+  ,fAdditionalScaleMode(1)
+  ,fAdditionalScaleSM({})
   ,fCustomRecalibFilePath("")
   ,fLoad1DRecalibFactors(0)
 {
-  for(unsigned int i = 0; i < 3; ++i){
+  for(unsigned int i = 0; i < 4; ++i){
     fAdditionalScaleSM.push_back(1); // set default values to 1
   }
 
@@ -74,12 +74,12 @@ Bool_t AliEmcalCorrectionCellEnergy::Initialize()
   // check the YAML configuration if custom determination of LG/HG is requested (default is false)
   GetProperty("enableLGDetermination",fUseDetermineLowGain);
 
-  // check the YAML configuration if an additional cell correction scale is requested (default is 1 -> no scale shift)
+  // check the YAML configuration if an additional cell correction scale is requested
   GetProperty("enableAdditionalScale",fUseAdditionalScale);
-
-  // check the YAML configuration if an additional cell correction scale is requested (default is 1 -> no scale shift)
-  GetProperty("enableAdditionalScaleEtaDep",fUseAdditionalScaleEtaDep);
   
+  // check the YAML configuration which version of the additional scale should be used (default is 1)
+  GetProperty("additionalScaleMode", fAdditionalScaleMode);
+
   // check the YAML configuration for values for additional scale (default is 1 for each SM category )
   GetProperty("additionalScaleValuesSM",fAdditionalScaleSM);
 
@@ -543,12 +543,8 @@ Bool_t AliEmcalCorrectionCellEnergy::CheckIfRunChanged()
 
   if(fUseAdditionalScale)
   {
-    fRecoUtils->SetUseTowerAdditionalScaleCorrection(kTRUE);
-    if(fUseAdditionalScaleEtaDep)
-    {
-      fRecoUtils->SetUseTowerAdditionalScaleCorrectionEtaDep(kTRUE);
-    }
-    for(int i = 0; i < 3; ++i){
+    fRecoUtils->SetUseTowerAdditionalScaleCorrection(fAdditionalScaleMode);
+    for(int i = 0; i < 4; ++i){
       fRecoUtils->SetTowerAdditionalScaleCorrection(i, fAdditionalScaleSM[i]);
     }
   }

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEnergy.h
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEnergy.h
@@ -49,8 +49,8 @@ private:
   Bool_t                 fDisableTempCalib;          ///< Off by default, disables temp calibration totally
   Bool_t                 fUseShaperCorrection;       ///< Off by default the correction for the shaper nonlinearity
   Bool_t                 fUseDetermineLowGain;       ///< Instead of using cell info, determine if cell is LG or HG from ADC values
-  Bool_t                 fUseAdditionalScale;        ///< Eenables an energy scale shift on cell level
-  Bool_t                 fUseAdditionalScaleEtaDep;  ///< Off by default, enables an energy scale shift on cell level for cells behing TRD suport. Highly experimental!
+  Bool_t                 fUseAdditionalScale;        ///< Enables an energy scale shift on cell level. 
+  Int_t                  fAdditionalScaleMode;       ///< Mode for the additional scale: 1 = default (Scales for Full, 2/3 and 1/3 SM), 2 = diff. scales for regions behind TRD support, 3 = Run1 scales behind SM with TRD in front and without, 4 = Same as 3 but additionally values for with and without TRD support structures
   std::vector<Float_t>   fAdditionalScaleSM;         ///< values for additionalScale shift for 3 different types of SM: Full, 2/3 and 1/3
   TString                fCustomRecalibFilePath;     ///< Empty string by default the path to the OADB file of the custom energy recalibration
   Bool_t                 fLoad1DRecalibFactors;      ///< Flag to load 1D energy recalibration factors
@@ -62,7 +62,7 @@ private:
   static RegisterCorrectionComponent<AliEmcalCorrectionCellEnergy> reg;
 
   /// \cond CLASSIMP
-  ClassDef(AliEmcalCorrectionCellEnergy, 11); // EMCal cell energy correction component
+  ClassDef(AliEmcalCorrectionCellEnergy, 12); // EMCal cell energy correction component
   /// \endcond
 };
 

--- a/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
+++ b/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
@@ -73,7 +73,7 @@ CellEnergy:                                         # Cell Energy correction com
     customRecalibFilePath: ""                       # Full path including .root file for custom recalibration object
     load1DRecalibFactors: false                     # Flag to load a 1D energy recalibration histogram
     enableAdditionalScale: false                    # Set an additional energy scale shift on cell level.
-    enableAdditionalScaleEtaDep: false              # Set an additional energy scale shift on cell with an eta dependence (behind trd support and not behind TRD support). HIGHLY EXPERIMENTAL and should not be used for standard analyses!
+    additionalScaleMode: 1                          # Set the mode for the additional scale: 1 = default (Scales for Full, 2/3 and 1/3 SM), 2 = diff. scales for regions behind TRD support, 3 = Run1 scales behind SM with TRD in front and without, 4 = Same as 3 but additionally values for with and without TRD support structures
     additionalScaleValuesSM: [1.0, 1.0, 1.0]        # Set values for additional scale on cell level for Full SM, 2/3 SM, and 1/3 SM
     cellsNames:                                     # Names of the cells input objects which should be attached to the correction
         - defaultCells                              # This object is defined above in the cells section of the input objects


### PR DESCRIPTION
- For run1, TRD modules with/witout TRD modules in front might need to be treated differently, as they have more/less material in front and as such more/less conversions etc.
- Instead of just having the eta dependent scale activated for run2, a total of 4 options for the cell scale is available now: 1 = default (Scales for Full, 2/3 and 1/3 SM), 2 = diff. scales for regions behind TRD support, 3 = Run1 scales behind SM with TRD in front and without, 4 = Same as 3 but additionally values for with and without TRD support structures
- These options can be set in the yaml file via fAdditionalScaleMode
- In order not to break existing analyses, the variable fUseAdditionalScale still has to be setto true if one wants to use a cell scale (and the variable has to stay a bool as its not evaluated to 1 if one sets it to true)