### PR TITLE
PWGGA/GammaConv: Add processing for true jets for not triggered events

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskMesonJetCorrelation.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskMesonJetCorrelation.h
@@ -93,7 +93,7 @@ class AliAnalysisTaskMesonJetCorrelation : public AliAnalysisTaskSE
   void UnselectStablePi0(AliAODMCParticle* part); // Rleabel Pi0, eta etc. tounstable in case they were labeled stable by the jet framework
 
   // Jet functions
-  void ProcessJets();
+  void ProcessJets(int isCurrentEventSelected = 0);
   void InitJets();
 
   // Helper functions
@@ -384,6 +384,7 @@ class AliAnalysisTaskMesonJetCorrelation : public AliAnalysisTaskSE
   std::vector<TH1F*> fHistoMatchedPtJet;              //! vector of histos with pt of jets for jets that got matched with a true jet
   std::vector<TH1F*> fHistoUnMatchedPtJet;            //! vector of histos with pt of jets for jets that did not get matched with a true jet
   std::vector<TH1F*> fHistoTruePtJet;                 //! vector of histos with pt of true jets
+  std::vector<TH1F*> fHistoTruePtJetNotTriggered;     //! vector of histos with pt of true jets for events that did not trigger
   std::vector<TH1F*> fHistoTrueMatchedPtJet;          //! vector of histos with pt of true jets that are matched to a rec jet
   std::vector<TH1F*> fHistoTrueUnMatchedPtJet;        //! vector of histos with pt of jets that are not matched to a rec jet
   std::vector<TH2F*> fHistoNEFVsPtJet;                //! vector of histos with pt of jets vs neutral energy fraction
@@ -498,7 +499,7 @@ class AliAnalysisTaskMesonJetCorrelation : public AliAnalysisTaskSE
   AliAnalysisTaskMesonJetCorrelation(const AliAnalysisTaskMesonJetCorrelation&);            // Prevent copy-construction
   AliAnalysisTaskMesonJetCorrelation& operator=(const AliAnalysisTaskMesonJetCorrelation&); // Prevent assignment
 
-  ClassDef(AliAnalysisTaskMesonJetCorrelation, 16);
+  ClassDef(AliAnalysisTaskMesonJetCorrelation, 17);
 };
 
 #endif


### PR DESCRIPTION
- For events which are not triggered, the generator information still has to be processed to get the trigger efficiency correct
- Add histogram for jet pt for MC gen. jets for events that are not triggered