### PR TITLE
PWGGA/GammaConv: Add outlier rejection for Herwig JJ MC

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskMesonJetCorrelation.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskMesonJetCorrelation.cxx
@@ -2103,23 +2103,6 @@ void AliAnalysisTaskMesonJetCorrelation::UserExec(Option_t*)
     if(fLocalDebugFlag) {printf("InitJets\n");}
     InitJets();
 
-    // Additional outlier rejection for herwig
-    // CHeck if a MC true jet has more than 1.5 times the pt hard of the collision
-    if(fIsMC>1){
-      AliGenEventHeader * eventHeader = fMCEvent->GenEventHeader();
-      TString eventHeaderName     = eventHeader->ClassName();
-      if(eventHeaderName.EqualTo("AliGenHepMCEventHeader")) {
-        float ptHard = dynamic_cast<AliGenHepMCEventHeader*>(eventHeader)->pthard();
-        for(const auto & jetPt : fTrueVectorJetPt){
-          if(jetPt > ptHard*1.5){
-            fHistoNEvents[iCut]->Fill(10, fWeightJetJetMC);
-            fHistoNEventsWOWeight[iCut]->Fill(10);
-            continue;
-          }
-        }
-      }
-    }
-
     // reset double counting vector
     fMesonDoubleCount.clear();
 

--- a/PWGGA/GammaConvBase/AliConvEventCuts.cxx
+++ b/PWGGA/GammaConvBase/AliConvEventCuts.cxx
@@ -3840,11 +3840,10 @@ Bool_t AliConvEventCuts::IsJetJetMCEventAccepted(AliMCEvent *mcEvent, Double_t& 
           for(Long_t i = 0; i < mcEvent->GetNumberOfPrimaries(); i++) {
             AliMCParticle* particle = (AliMCParticle*) mcEvent->GetTrack(i);
             if (!particle) continue;
-            // if (TMath::Abs(particle->GetPdgCode()) == 111 || TMath::Abs(particle->GetPdgCode()) == 221){
-                if (particle->Pt() > fMaxFacPtHardSingleParticle*ptHard && TMath::Abs(particle->PdgCode()) > 21){
-                  eventAccepted= kFALSE;
-                }
-            // }
+            if (particle->Pt() > fMaxFacPtHardSingleParticle*ptHard && TMath::Abs(particle->PdgCode()) > 21){
+              eventAccepted= kFALSE;
+              break;
+            }
           }
         }
 
@@ -4458,6 +4457,17 @@ Bool_t AliConvEventCuts::IsJetJetMCEventAccepted(AliMCEvent *mcEvent, Double_t& 
 
         // int pthardbin = -1;
         float ptHard = dynamic_cast<AliGenHepMCEventHeader*>(gh)->pthard();
+        
+        if (mcEvent){
+          for(Long_t i = 0; i < mcEvent->GetNumberOfPrimaries(); i++) {
+            AliMCParticle* particle = (AliMCParticle*) mcEvent->GetTrack(i);
+            if (!particle) continue;
+            if (particle->Pt() > fMaxFacPtHardSingleParticle*ptHard && TMath::Abs(particle->PdgCode()) > 21){
+              eventAccepted= kFALSE;
+              break;
+            }
+          }
+        }
 
         if ( fPeriodEnum == kLHC17HERJJ ) {
           double ptHardBinRanges[21]    = { 5,  7,  9, 12, 16,
@@ -4544,11 +4554,10 @@ Bool_t AliConvEventCuts::IsJetJetMCEventAccepted(AliMCEvent *mcEvent, Double_t& 
         for(Long_t i = 0; i < mcEvent->GetNumberOfPrimaries(); i++) {
           AliMCParticle* particle = (AliMCParticle*) mcEvent->GetTrack(i);
           if (!particle) continue;
-          // if (TMath::Abs(particle->GetPdgCode()) == 111 || TMath::Abs(particle->GetPdgCode()) == 221){
-              if (particle->Pt() > fMaxFacPtHardSingleParticle*ptHard && TMath::Abs(particle->PdgCode()) > 21){
-                eventAccepted= kFALSE;
-              }
-          // }
+          if (particle->Pt() > fMaxFacPtHardSingleParticle*ptHard && TMath::Abs(particle->PdgCode()) > 21){
+            eventAccepted= kFALSE;
+            break;
+          }
         }
       }
       Int_t pthardbin = -1;
@@ -5317,6 +5326,16 @@ Bool_t AliConvEventCuts::IsJetJetMCEventAccepted(AliMCEvent *mcEvent, Double_t& 
     } else if(eventAccepted && isHerwig){
       // int pthardbin = -1;
       float ptHard = dynamic_cast<AliGenHepMCEventHeader*>(eventHeader)->pthard();
+
+      for(Long_t i = 0; i < mcEvent->GetNumberOfPrimaries(); i++) {
+          AliMCParticle* particle = (AliMCParticle*) mcEvent->GetTrack(i);
+          if (!particle) continue;
+          if (particle->Pt() > fMaxFacPtHardSingleParticle*ptHard && TMath::Abs(particle->PdgCode()) > 21){
+            eventAccepted= kFALSE;
+            break;
+          }
+        }
+        
       if ( fPeriodEnum == kLHC17HERJJ ) {
         double ptHardBinRanges[21]    = { 5,  7,  9, 12, 16,
                                           21, 28, 36, 45, 57,


### PR DESCRIPTION
- In same way as for Pythia, check if a particle has more than x-times the momentum of the current generator pt hard of the event
- Add breaks in loop over mc-particles when event is rejected to save some cpu time