### PR TITLE
PWGGA/GammaConv: Write all high pt photons to tree

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskConversionQA.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskConversionQA.h
@@ -45,10 +45,15 @@ class AliAnalysisTaskConversionQA : public AliAnalysisTaskSE{
                                                                                           }
 
     void FillType                           ( Double_t fillTree,
-                                              Bool_t fillHistorams)                       {
-                                                                                            ffillTree = fillTree                ;
-                                                                                            ffillHistograms = fillHistorams     ;
-                                                                                          }
+                                              Double_t treeHighPt,
+                                              Bool_t fillHistorams){
+        ffillTree = fillTree                ;
+        fTreeHighPt = treeHighPt            ;
+        ffillHistograms = fillHistorams     ;
+        printf("AliAnalysisTaskConversionQA:: ffillTree = %.2f, fTreeHighPt = %.2f\n", 
+            ffillTree, 
+            fTreeHighPt);
+    }
     void SetIsMC                            ( Bool_t isMC )                               { fIsMC = isMC                        ; }
 
   private:
@@ -81,6 +86,7 @@ class AliAnalysisTaskConversionQA : public AliAnalysisTaskSE{
     TTree*                      fTreeQA;                    //
     Bool_t                      fIsHeavyIon;                //
     Double_t                    ffillTree;                  //
+    Double_t                    fTreeHighPt;                // up to this pt write only a fraction 1/fFillTree to the tree, above write all photons to the tree
     Bool_t                      ffillHistograms;            //
     TList*                      fOutputList;                //
     TList*                      fESDList;                   //
@@ -135,7 +141,7 @@ class AliAnalysisTaskConversionQA : public AliAnalysisTaskSE{
     Int_t*                      fMCStackPos;                //[fnGammaCandidates]
     Int_t*                      fMCStackNeg;                //[fnGammaCandidates]
     
-    ClassDef(AliAnalysisTaskConversionQA, 11);
+    ClassDef(AliAnalysisTaskConversionQA, 12);
 };
 
 #endif

--- a/PWGGA/GammaConv/macros/AddTask_PhotonQA.C
+++ b/PWGGA/GammaConv/macros/AddTask_PhotonQA.C
@@ -6,6 +6,7 @@ void AddTask_PhotonQA(
   Int_t     IsHeavyIon                    = 0,
   Bool_t    kHistograms                   = kTRUE,
   Double_t  kTree                         = 1.0,  // 0. / 0 / kFALSE for no, 1. / 1 / kTRUE for yes,  x > 1.0 will use only 1/x of the event statistics for the tree
+  Double_t  kTreeHighPt                   = 100., // effective only for kTree >1. up to this pt write a fraction 1/kTree to the tree, above write all photons to the tree
   TString   V0ReaderCutNumberAODBranch    = "0000000060084001001500000",
   Bool_t    runBasicQAWithStandardOutput  = kTRUE,
   Bool_t    doEtaShiftV0Reader            = kFALSE,
@@ -71,7 +72,7 @@ void AddTask_PhotonQA(
   AliAnalysisTaskConversionQA *fQA = new AliAnalysisTaskConversionQA(Form("%s_%s_QA",TaskEventCutnumber.Data(),TaskPhotonCutnumber.Data()));
   fQA->SetEventCuts(analysisEventCuts,IsHeavyIon);
   fQA->SetConversionCuts(analysisCuts,IsHeavyIon);
-  fQA->FillType(kTree,kHistograms);
+  fQA->FillType(kTree,kTreeHighPt,kHistograms);
   fQA->SetIsMC(isMC);
   fQA->SetV0ReaderName(V0ReaderName);
   mgr->AddTask(fQA);


### PR DESCRIPTION
For low pt photons only a fraction as it used to be. Boarder between high and low pt can be modified.