### PR TITLE
[PWGEM-13] Add secondary cell energy subtraction for cell track matcher

### DIFF
--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellTrackMatcherAndMIPSubtraction.h
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellTrackMatcherAndMIPSubtraction.h
@@ -38,6 +38,7 @@ class AliEmcalCorrectionCellTrackMatcherAndMIPSubtraction : public AliEmcalCorre
 protected:
 
   Bool_t        IsTrackInEmcalAcceptance(AliVTrack* part, Double_t edges=0.9) const;
+  Bool_t        FindAndSubtractNextCell(Int_t absID, AliVTrack* track, double restEnergy) const;
 
   Double_t               fEmipData;            ///< Energy of MIP used to subtract from cell, in case of data
   Double_t               fEmipMC;              ///< Energy of MIP used to subtract from cell, in case of MC
@@ -45,6 +46,7 @@ protected:
   Bool_t                 fDoPropagation;      ///< Bool to switch propagation on/off
   Bool_t                 fDoMatchPrimaryOnly; ///< Bool to switch if secndaries/conversions (r>fMaxDistToVtxPrim cm) will be matched
   Double_t               fMaxDistToVtxPrim;   ///< Maximum DCA in XY direction for a track to be counted as primary
+  Bool_t                 fSubtractMultiple;   ///< Bool to switch if more than one cell should get the energy subtracted if the MIP energy is larger than the cell energy
 
   //#if !(defined(__CINT__) || defined(__MAKECINT__))
   // Handle mapping between index and containers
@@ -67,7 +69,7 @@ protected:
   static RegisterCorrectionComponent<AliEmcalCorrectionCellTrackMatcherAndMIPSubtraction> reg;
 
   /// \cond CLASSIMP
-  ClassDef(AliEmcalCorrectionCellTrackMatcherAndMIPSubtraction, 4); // EMCal cell track matcher
+  ClassDef(AliEmcalCorrectionCellTrackMatcherAndMIPSubtraction, 5); // EMCal cell track matcher
   /// \endcond
 };
 

--- a/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
+++ b/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
@@ -347,6 +347,7 @@ CellTrackMatcherAndMIPSubtraction:                  # Cell energy shift correcti
     DoPropagation: false                            # Whether track propagation should be performed. In case of AODs its not recommended to enable it
     MatchOnlyPrimaries: false                       # Whether only primary tracks (r < MaxDistToVtxPrimcm) should be matched. Needed as clusters from conversion electrons should be track matched
     MaxDistToVtxPrim: 5                             # Maximum DCA in XY for which a track is considered primary
+    SubtractMultiple: false                         # Subtract rest MIP energy from next cell if first cell has less energy than the MIP energy
     cellsNames:                                     # Names of the cells input objects which should be attached to the correction
         - defaultCells                              # This object is defined above in the cells section of the input objects
     trackContainersNames:                           # Names of the track input objects which should be attached to the correection

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.cxx
@@ -890,6 +890,7 @@ void AliAnalysisTaskGammaCalo::UserCreateOutputObjects(){
   }
 
   // set common binning in pT for mesons and photons
+  double epsilon              = 1.e-6;
   Float_t binWidthPt          = 0.1;
   Int_t nBinsPt               = 250;
   Float_t minPt               = 0;
@@ -901,9 +902,12 @@ void AliAnalysisTaskGammaCalo::UserCreateOutputObjects(){
   Float_t maxClusterPt        = 50;
   Int_t nBinsMinv             = 800;
   Float_t maxMinv             = 0.8;
+  float minRes                = -1.f;
+  float maxRes                = +5.f; 
   Double_t *arrPtBinning      = new Double_t[1200];
   Double_t *arrQAPtBinning    = new Double_t[1200];
   Double_t *arrClusPtBinning  = new Double_t[1200];
+  std::vector<double> arrResBinning;
   if( fDoPi0Only ){
     nBinsMinv                 = 150;
     maxMinv                  = 0.3;
@@ -945,6 +949,7 @@ void AliAnalysisTaskGammaCalo::UserCreateOutputObjects(){
       else if(i<310) arrClusPtBinning[i]      = 70.+2.5*(i-298);
       else arrClusPtBinning[i]                = maxClusterPt;
     }
+
   } else if ( ((AliConvEventCuts*)fV0Reader->GetEventCuts())->GetEnergyEnum() == AliConvEventCuts::k13TeV ||
               ((AliConvEventCuts*)fV0Reader->GetEventCuts())->GetEnergyEnum() == AliConvEventCuts::k13TeVLowB ){
     if( fDoPi0Only ){
@@ -1090,6 +1095,21 @@ void AliAnalysisTaskGammaCalo::UserCreateOutputObjects(){
       else arrQAPtBinning[i]                  = maxQAPt;
     }
   }
+
+  // if (fDoClusterQA > 0 && !fDoLightOutput){
+    double valRes = minRes;
+    for (int i = 0; i < 1000; ++i) {
+      arrResBinning.push_back(valRes);
+      if (valRes < -0.5 - epsilon)
+        valRes += 0.05;
+      else if (valRes < 0.5 - epsilon)
+        valRes += 0.01;
+      else if (valRes < maxRes - epsilon)
+        valRes += 0.05;
+      else
+        break;
+    }
+  // }
 
   // Create histograms
   if(fOutputContainer != NULL){
@@ -2642,11 +2662,11 @@ void AliAnalysisTaskGammaCalo::UserCreateOutputObjects(){
         fHistoTrueClusEMNonLeadingPt[iCut]          = new TH1F("TrueClusEMNonLeading_Pt", "TrueClusEMNonLeading_Pt", nBinsClusterPt, arrClusPtBinning);
         fHistoTrueClusEMNonLeadingPt[iCut]->SetXTitle("#it{p}_{T} (GeV/#it{c})");
         fTrueList[iCut]->Add(fHistoTrueClusEMNonLeadingPt[iCut]);
-        fHistoTrueClusGammaEResPt[iCut]          = new TH2F("TrueClusGammaERes_Pt", "TrueClusGammaERes_Pt", nBinsClusterPt, arrClusPtBinning, 100, -5., +5.);
+        fHistoTrueClusGammaEResPt[iCut]          = new TH2F("TrueClusGammaERes_Pt", "TrueClusGammaERes_Pt", nBinsClusterPt, arrClusPtBinning, arrResBinning.size()-1, arrResBinning.data());
         fHistoTrueClusGammaEResPt[iCut]->SetXTitle("#it{p}_{T} (GeV/#it{c})");
         fHistoTrueClusGammaEResPt[iCut]->SetYTitle("(#it{E}_{rec}-#it{E}_{true})/#it{E}_{true}");
         fTrueList[iCut]->Add(fHistoTrueClusGammaEResPt[iCut]);
-        fHistoTrueClusPhotonGammaEResPt[iCut]          = new TH2F("TrueClusPhotonGammaERes_Pt", "TrueClusPhotonGammaERes_Pt", nBinsClusterPt, arrClusPtBinning, 100, -5., +5.);
+        fHistoTrueClusPhotonGammaEResPt[iCut]          = new TH2F("TrueClusPhotonGammaERes_Pt", "TrueClusPhotonGammaERes_Pt", nBinsClusterPt, arrClusPtBinning, arrResBinning.size()-1, arrResBinning.data());
         fHistoTrueClusPhotonGammaEResPt[iCut]->SetXTitle("#it{p}_{T} (GeV/#it{c})");
         fHistoTrueClusPhotonGammaEResPt[iCut]->SetYTitle("(#it{E}_{rec}-#it{E}_{true})/#it{E}_{true}");
         fTrueList[iCut]->Add(fHistoTrueClusPhotonGammaEResPt[iCut]);


### PR DESCRIPTION
- In the cell track matcher there is now the option `SubtractMultiple` which can be enabled. If this is enabled and a cell has less energy than the MIP energy of the matched particlethen a cell next to this one will be searched to subtract the remaining energy from this cell. The search direction is only in phi and prefers the direction the track is pointing. If this cell has no energy take the other one, if both have no energy than nothing will be done.

- Changed binning for the resolution histogram added in the PR #22452