### PR TITLE
PWGGA/GammaConv: Add acceptance check for jets

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskConvJet.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskConvJet.cxx
@@ -66,7 +66,9 @@ AliAnalysisTaskConvJet::AliAnalysisTaskConvJet() : AliAnalysisTaskEmcalJet(),
                                                    fTrueVectorJetPartonPt(0),
                                                    fTrueVectorJetPartonPx(0),
                                                    fTrueVectorJetPartonPy(0),
-                                                   fTrueVectorJetPartonPz(0)
+                                                   fTrueVectorJetPartonPz(0),
+                                                   fAccType(0),
+                                                   fAccTypeMC(0)
 {
 }
 
@@ -94,7 +96,9 @@ AliAnalysisTaskConvJet::AliAnalysisTaskConvJet(const char* name) : AliAnalysisTa
                                                                    fTrueVectorJetPartonPt(0),
                                                                    fTrueVectorJetPartonPx(0),
                                                                    fTrueVectorJetPartonPy(0),
-                                                                   fTrueVectorJetPartonPz(0)
+                                                                   fTrueVectorJetPartonPz(0),
+                                                                   fAccType(0),
+                                                                   fAccTypeMC(0)
 {
   SetMakeGeneralHistograms(kTRUE);
 }
@@ -140,6 +144,7 @@ void AliAnalysisTaskConvJet::DoJetLoop()
     TObjArray* arr = JetName.Tokenize("__");
     TObjString* testObjString = (TObjString*)arr->At(2);
     if (!(static_cast<TString>(testObjString->GetString())).Contains("mcparticles")) {
+      fAccType = jetCont->GetAcceptanceType();
       UInt_t count = 0;
       fNJets = 0;
       fVectorJetPt.clear();
@@ -170,6 +175,7 @@ void AliAnalysisTaskConvJet::DoJetLoop()
       }
       fNJets = count;
     } else {
+      fAccTypeMC = jetCont->GetAcceptanceType();
       UInt_t count = 0;
       fTrueNJets = 0;
       fTrueVectorJetPt.clear();

--- a/PWGGA/GammaConv/AliAnalysisTaskConvJet.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskConvJet.h
@@ -65,6 +65,9 @@ class AliAnalysisTaskConvJet : public AliAnalysisTaskEmcalJet
   std::vector<double> GetTrueVectorJetPartonPx() { return fTrueVectorJetPartonPx; }
   std::vector<double> GetTrueVectorJetPartonPy() { return fTrueVectorJetPartonPy; }
   std::vector<double> GetTrueVectorJetPartonPz() { return fTrueVectorJetPartonPz; }
+  
+  UInt_t GetAcceptanceType() { return fAccType; }
+  UInt_t GetAcceptanceTypeMC() { return fAccTypeMC; }
 
   Double_t Get_Jet_Radius()
   {
@@ -114,12 +117,15 @@ class AliAnalysisTaskConvJet : public AliAnalysisTaskEmcalJet
   std::vector<double> fTrueVectorJetPartonPy; // vector containing the pt of the leading parton ("seed of the jet")
   std::vector<double> fTrueVectorJetPartonPz; // vector containing the pt of the leading parton ("seed of the jet")
 
+  UInt_t fAccType;
+  UInt_t fAccTypeMC;
+
  private:
   AliAnalysisTaskConvJet(const AliAnalysisTaskConvJet&);
   AliAnalysisTaskConvJet& operator=(const AliAnalysisTaskConvJet&);
 
   /// \cond CLASSIMP
-  ClassDef(AliAnalysisTaskConvJet, 15);
+  ClassDef(AliAnalysisTaskConvJet, 16);
   /// \endcond
 };
 #endif

--- a/PWGGA/GammaConv/AliAnalysisTaskMesonJetCorrelation.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskMesonJetCorrelation.h
@@ -97,6 +97,9 @@ class AliAnalysisTaskMesonJetCorrelation : public AliAnalysisTaskSE
   // Jet functions
   void ProcessJets(int isCurrentEventSelected = 0);
   void InitJets();
+  bool IsJetInAcc(unsigned int accType, double r, double eta, double phi);
+  bool IsInEMCalAcc(double r, double eta, double phi);
+  bool IsInDCalAcc(double r, double eta, double phi);
 
   // Helper functions
   void MakeBinning();
@@ -386,6 +389,7 @@ class AliAnalysisTaskMesonJetCorrelation : public AliAnalysisTaskSE
   std::vector<TH1F*> fHistoMatchedPtJet;              //! vector of histos with pt of jets for jets that got matched with a true jet
   std::vector<TH1F*> fHistoUnMatchedPtJet;            //! vector of histos with pt of jets for jets that did not get matched with a true jet
   std::vector<TH1F*> fHistoTruePtJet;                 //! vector of histos with pt of true jets
+  std::vector<TH1F*> fHistoTruePtJetInAcc;            //! vector of histos with pt of true jets for generated jets in rec. acceptance
   std::vector<TH1F*> fHistoTruePtJetNotTriggered;     //! vector of histos with pt of true jets for events that did not trigger
   std::vector<TH1F*> fHistoTrueMatchedPtJet;          //! vector of histos with pt of true jets that are matched to a rec jet
   std::vector<TH1F*> fHistoTrueUnMatchedPtJet;        //! vector of histos with pt of jets that are not matched to a rec jet
@@ -506,7 +510,7 @@ class AliAnalysisTaskMesonJetCorrelation : public AliAnalysisTaskSE
   AliAnalysisTaskMesonJetCorrelation(const AliAnalysisTaskMesonJetCorrelation&);            // Prevent copy-construction
   AliAnalysisTaskMesonJetCorrelation& operator=(const AliAnalysisTaskMesonJetCorrelation&); // Prevent assignment
 
-  ClassDef(AliAnalysisTaskMesonJetCorrelation, 18);
+  ClassDef(AliAnalysisTaskMesonJetCorrelation, 19);
 };
 
 #endif


### PR DESCRIPTION
- Fill histograms wit pt of true jet but only for true jets in the acceptance of reconstructed jets. This is to plot the acceptance and finding efficiency seperatly