### PR TITLE
PWGGA/GammaConv: MesonsInJets add cuts for different acceptance

### DIFF
--- a/PWGGA/GammaConv/macros/AddTask_MesonJetCorr_Calo.C
+++ b/PWGGA/GammaConv/macros/AddTask_MesonJetCorr_Calo.C
@@ -199,6 +199,21 @@ void AddTask_MesonJetCorr_Calo(
   } else if (trainConfig == 7) {
     cuts.AddCutCalo("0009b103", "411790009fe30230000", "2s631034000000d0"); // Jet-high trigg in-jet, pi0 mass: 0.1-0.15, rotation back
 
+  // EJ1 and EJ2 only EMCal triggers
+  } else if (trainConfig == 8) {
+    cuts.AddCutCalo("00095103", "411790009fe30230000", "2s631034000000d0"); // Jet-low trigg in-jet, pi0 mass: 0.1-0.15, rotation back
+  } else if (trainConfig == 9) {
+    cuts.AddCutCalo("00093103", "411790009fe30230000", "2s631034000000d0"); // Jet-high trigg in-jet, pi0 mass: 0.1-0.15, rotation back
+
+  // configs with Mesons only in EMCal, EMCal triggers only
+  } else if (trainConfig == 10) {
+    cuts.AddCutCalo("00010103", "111110009fe30230000", "2s631034000000d0"); // in-jet, pi0 mass: 0.1-0.15, rotation back
+  } else if (trainConfig == 11) {
+    cuts.AddCutCalo("00095103", "111110009fe30230000", "2s631034000000d0"); // Jet-low trigg in-jet, pi0 mass: 0.1-0.15, rotation back
+  } else if (trainConfig == 12) {
+    cuts.AddCutCalo("00093103", "111110009fe30230000", "2s631034000000d0"); // Jet-high trigg in-jet, pi0 mass: 0.1-0.15, rotation back
+
+
   } else if (trainConfig == 14) { // same as 4 but with mixed jet back
     cuts.AddCutCalo("0008e103", "411790009fe30230000", "21631034000000d0"); // EG2 in-jet, pi0 mass: 0.1-0.15, mixed jet back
   } else if (trainConfig == 15) {// same as 5 but with mixed jet back
@@ -227,6 +242,27 @@ void AddTask_MesonJetCorr_Calo(
     cuts.AddCutCalo("0009c103", "411790109fe30230000", "2s631034000000d0"); // Jet-low trigg in-jet, pi0 mass: 0.1-0.15, rotation back
   } else if (trainConfig == 27) {
     cuts.AddCutCalo("0009b103", "411790109fe30230000", "2s631034000000d0"); // Jet-high trigg in-jet, pi0 mass: 0.1-0.15, rotation back
+
+
+  // configs with eta < 0.5
+  } else if (trainConfig == 30) {
+    cuts.AddCutCalo("00010103", "411790009fe30230000", "2s634034000000d0"); // in-jet, pi0 mass: 0.1-0.15, rotation back
+  } else if (trainConfig == 31) {
+    cuts.AddCutCalo("0009c103", "411790009fe30230000", "2s634034000000d0"); // Jet-low trigg in-jet, pi0 mass: 0.1-0.15, rotation back
+  } else if (trainConfig == 32) {
+    cuts.AddCutCalo("0009b103", "411790009fe30230000", "2s634034000000d0"); // Jet-high trigg in-jet, pi0 mass: 0.1-0.15, rotation back
+
+  // configs with eta < 0.5, only EMCal triggers (not DCal)
+  } else if (trainConfig == 33) {
+    cuts.AddCutCalo("00095103", "411790009fe30230000", "2s634034000000d0"); // Jet-low trigg in-jet, pi0 mass: 0.1-0.15, rotation back
+  } else if (trainConfig == 34) {
+    cuts.AddCutCalo("00093103", "411790009fe30230000", "2s634034000000d0"); // Jet-high trigg in-jet, pi0 mass: 0.1-0.15, rotation back
+
+  // configs with eta < 0.5, only EMCal triggers (not DCal), Mesons only with EMCal
+  } else if (trainConfig == 35) {
+    cuts.AddCutCalo("00095103", "111110009fe30230000", "2s634034000000d0"); // Jet-low trigg in-jet, pi0 mass: 0.1-0.15, rotation back
+  } else if (trainConfig == 36) {
+    cuts.AddCutCalo("00093103", "111110009fe30230000", "2s634034000000d0"); // Jet-high trigg in-jet, pi0 mass: 0.1-0.15, rotation back
 
 
   //---------------------------------------

--- a/PWGGA/GammaConv/macros/AddTask_MesonJetCorr_Conv.C
+++ b/PWGGA/GammaConv/macros/AddTask_MesonJetCorr_Conv.C
@@ -214,6 +214,11 @@ void AddTask_MesonJetCorr_Conv(
     cuts.AddCutPCM("00010103", "0dm00009f97300003ge0404000", "2s52103500000000"); // qT max 0.05 1D
     cuts.AddCutPCM("00010103", "0dm00009f97300002ge0404000", "2s52103500000000"); // qT max 0.06 2D
     cuts.AddCutPCM("00010103", "0dm00009f97300009ge0404000", "2s52103500000000"); // qT max 0.03 2D
+
+
+  // configs with eta < 0.5
+  } else if (trainConfig == 30) {
+    cuts.AddCutPCM("00010103", "0dm00009f9730000dge0404000", "2s52403500000000"); // in-Jet mass cut around pi0: 0.1-0.15, rotation back
   
 
   //--- Systamtic variations for INT7 trigger

--- a/PWGGA/GammaConv/macros/AddTask_MesonJetCorr_ConvCalo.C
+++ b/PWGGA/GammaConv/macros/AddTask_MesonJetCorr_ConvCalo.C
@@ -209,6 +209,20 @@ void AddTask_MesonJetCorr_ConvCalo(
   } else if (trainConfig == 7) {
     cuts.AddCutPCMCalo("0009b103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2s63103400000010"); // Jet high trigg in-Jet, mass cut pi0: 0.1-0.15, rotation back
 
+  // EJ1 and EJ2 only EMCal triggers
+  } else if (trainConfig == 8) {
+    cuts.AddCutPCMCalo("00095103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2s631034000000d0"); // Jet-low trigg in-jet, pi0 mass: 0.1-0.15, rotation back
+  } else if (trainConfig == 9) {
+    cuts.AddCutPCMCalo("00093103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2s631034000000d0"); // Jet-high trigg in-jet, pi0 mass: 0.1-0.15, rotation back
+
+  // configs with Mesons only in EMCal, EMCal triggers only
+  } else if (trainConfig == 10) {
+    cuts.AddCutPCMCalo("00010103", "0dm00009f9730000dge0404000", "111110009fe30230000", "2s631034000000d0"); // in-jet, pi0 mass: 0.1-0.15, rotation back
+  } else if (trainConfig == 11) {
+    cuts.AddCutPCMCalo("00095103", "0dm00009f9730000dge0404000", "111110009fe30230000", "2s631034000000d0"); // Jet-low trigg in-jet, pi0 mass: 0.1-0.15, rotation back
+  } else if (trainConfig == 12) {
+    cuts.AddCutPCMCalo("00093103", "0dm00009f9730000dge0404000", "111110009fe30230000", "2s631034000000d0"); // Jet-high trigg in-jet, pi0 mass: 0.1-0.15, rotation back
+
   } else if (trainConfig == 14) { // same as 4 but with jet mixing back
     cuts.AddCutPCMCalo("0008e103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2163103400000010"); // EG2 in-Jet, mass cut pi0: 0.1-0.15, mixed jet back
   } else if (trainConfig == 15) { // same as 5 but with jet mixing back
@@ -240,6 +254,26 @@ void AddTask_MesonJetCorr_ConvCalo(
   } else if (trainConfig == 27) {
     cuts.AddCutPCMCalo("0009b103", "0dm00009f9730000dge0404000", "411790109fe30230000", "2s63103400000010"); // Jet high trigg in-Jet, mass cut pi0: 0.1-0.15, rotation back
 
+
+   // configs with eta < 0.5
+  } else if (trainConfig == 30) {
+    cuts.AddCutPCMCalo("00010103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2s634034000000d0"); // in-jet, pi0 mass: 0.1-0.15, rotation back
+  } else if (trainConfig == 31) {
+    cuts.AddCutPCMCalo("0009c103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2s634034000000d0"); // Jet-low trigg in-jet, pi0 mass: 0.1-0.15, rotation back
+  } else if (trainConfig == 32) {
+    cuts.AddCutPCMCalo("0009b103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2s634034000000d0"); // Jet-high trigg in-jet, pi0 mass: 0.1-0.15, rotation back
+
+  // configs with eta < 0.5, only EMCal triggers (not DCal)
+  } else if (trainConfig == 33) {
+    cuts.AddCutPCMCalo("00095103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2s634034000000d0"); // Jet-low trigg in-jet, pi0 mass: 0.1-0.15, rotation back
+  } else if (trainConfig == 34) {
+    cuts.AddCutPCMCalo("00093103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2s634034000000d0"); // Jet-high trigg in-jet, pi0 mass: 0.1-0.15, rotation back
+
+  // configs with eta < 0.5, only EMCal triggers (not DCal), Mesons only with EMCal
+  } else if (trainConfig == 35) {
+    cuts.AddCutPCMCalo("00095103", "0dm00009f9730000dge0404000", "111110009fe30230000", "2s634034000000d0"); // Jet-low trigg in-jet, pi0 mass: 0.1-0.15, rotation back
+  } else if (trainConfig == 36) {
+    cuts.AddCutPCMCalo("00093103", "0dm00009f9730000dge0404000", "111110009fe30230000", "2s634034000000d0"); // Jet-high trigg in-jet, pi0 mass: 0.1-0.15, rotation back
 
 
 

--- a/PWGGA/GammaConvBase/AliResponseMatrixHelper.cxx
+++ b/PWGGA/GammaConvBase/AliResponseMatrixHelper.cxx
@@ -329,6 +329,80 @@ TH2F* MatrixHandler4D::GetResponseMatrix(int binX, int binY, const char* name)
   return hMesonResp;
 }
 
+//____________________________________________________________________________________________________________________________
+void MatrixHandler4D::WeightResponseMatrix(TF1* funcMeson, TF1* funcJet)
+{
+
+  for(unsigned int jx = 0; jx < vecBinsJetX.size()-1; ++jx){
+    for(unsigned int jy = 0; jy < vecBinsJetY.size()-1; ++jy){
+      for(unsigned int mx = 0; mx < vecBinsMesonX.size()-1; ++mx){
+        for(unsigned int my = 0; my < vecBinsMesonY.size()-1; ++my){
+          const double valJet = 0.5*(vecBinsJetY[jy] + vecBinsJetY[jy+1]);
+          const double valMeson = 0.5*(vecBinsMesonY[my] + vecBinsMesonY[my+1]);
+          const double weightMeson = (funcMeson == nullptr) ? 1 : funcMeson->Eval(valMeson);
+          const double weightJet = (funcJet == nullptr) ? 1 : funcJet->Eval(valJet);
+          const double weight = weightMeson*weightJet;
+          
+          if (useTHNSparese) {
+            std::array<double, 2> arrFill;
+            arrFill[0] = jx * (vecBinsMesonX.size() - 1) + mx + 1 - 0.5; // -0.5 due to the fact that this is not the bin but the bin center
+            arrFill[1] = jy * (vecBinsMesonY.size() - 1) + my + 1 - 0.5;
+            const double val = hSparseResponse->GetBinContent(hSparseResponse->GetBin(arrFill.data()));
+            const double err = hSparseResponse->GetBinError(hSparseResponse->GetBin(arrFill.data()));
+            hSparseResponse->SetBinContent(hSparseResponse->GetBin(arrFill.data()), val*weight);
+            hSparseResponse->SetBinError(hSparseResponse->GetBin(arrFill.data()), err*weight);
+          } else {
+            std::array<int, 2> arrFill;
+            arrFill[0] = jx * (vecBinsMesonX.size() - 1) + mx + 1;
+            arrFill[1] = jy * (vecBinsMesonY.size() - 1) + my + 1;
+            const double val = h2d->GetBinContent(arrFill[0], arrFill[1]);
+            const double err = h2d->GetBinError(arrFill[0], arrFill[1]);
+            h2d->SetBinContent(arrFill[0], arrFill[1], val*weight);
+            h2d->SetBinError(arrFill[0], arrFill[1], err*weight);
+          }
+        }
+      }
+    }
+  }
+}
+
+//____________________________________________________________________________________________________________________________
+void MatrixHandler4D::WeightResponseMatrix(TF2* func)
+{
+
+  for(unsigned int jx = 0; jx < vecBinsJetX.size()-1; ++jx){
+    for(unsigned int jy = 0; jy < vecBinsJetY.size()-1; ++jy){
+      for(unsigned int mx = 0; mx < vecBinsMesonX.size()-1; ++mx){
+        for(unsigned int my = 0; my < vecBinsMesonY.size()-1; ++my){
+          const double valJet = 0.5*(vecBinsJetY[jy] + vecBinsJetY[jy+1]);
+          const double valMeson = 0.5*(vecBinsMesonY[my] + vecBinsMesonY[my+1]);
+          const double weight = func->Eval(valJet, valMeson);
+          
+          if (useTHNSparese) {
+            std::array<double, 2> arrFill;
+            arrFill[0] = jx * (vecBinsMesonX.size() - 1) + mx + 1 - 0.5; // -0.5 due to the fact that this is not the bin but the bin center
+            arrFill[1] = jy * (vecBinsMesonY.size() - 1) + my + 1 - 0.5;
+            const double val = hSparseResponse->GetBinContent(hSparseResponse->GetBin(arrFill.data()));
+            const double err = hSparseResponse->GetBinError(hSparseResponse->GetBin(arrFill.data()));
+            hSparseResponse->SetBinContent(hSparseResponse->GetBin(arrFill.data()), val*weight);
+            hSparseResponse->SetBinError(hSparseResponse->GetBin(arrFill.data()), err*weight);
+            
+          } else {
+            std::array<int, 2> arrFill;
+            arrFill[0] = jx * (vecBinsMesonX.size() - 1) + mx + 1;
+            arrFill[1] = jy * (vecBinsMesonY.size() - 1) + my + 1;
+            const double val = h2d->GetBinContent(arrFill[0], arrFill[1]);
+            const double err = h2d->GetBinError(arrFill[0], arrFill[1]);
+            h2d->SetBinContent(arrFill[0], arrFill[1], val*weight);
+            h2d->SetBinError(arrFill[0], arrFill[1], err*weight);
+          }
+            
+        }
+      }
+    }
+  }
+}
+
 
 
 

--- a/PWGGA/GammaConvBase/AliResponseMatrixHelper.h
+++ b/PWGGA/GammaConvBase/AliResponseMatrixHelper.h
@@ -27,6 +27,8 @@
 #include <vector>
 #include "TH1.h"
 #include "TH2.h"
+#include "TF1.h"
+#include "TF2.h"
 #include "THnSparse.h"
 
 class MatrixHandler4D
@@ -64,6 +66,9 @@ class MatrixHandler4D
   TH2F* GetTH2(const char* name = "hSparseResponse_Clone");
   TH2F* GetResponseMatrix(int binX, int binY, const char* name = "dummy");
 
+  void WeightResponseMatrix(TF1* funcMeson = nullptr, TF1* funcJet = nullptr);
+  void WeightResponseMatrix(TF2* func);
+
  private:
   bool useTHNSparese = false;
   int nBinsJet = 0;
@@ -76,7 +81,7 @@ class MatrixHandler4D
   TH1F* h1dMeson = nullptr;
   THnSparseF* hSparseResponse = nullptr;
 
-  ClassDef(MatrixHandler4D, 3)
+  ClassDef(MatrixHandler4D, 4)
 };
 
 


### PR DESCRIPTION
- Add cuts for: Mesons in eta<0.5 (for TPC fid acceptance
- Add cuts for EMCal fiducial acceptane with only the emcal trigger
- Add cuts with only the EMCal for mesons (excluding DCal))

- Add functionality to weight the response matrix according to a function (needed for unfolding studies)