### PR TITLE
PWGGA/GammaConv: Add mode to run only pt or z inside jets

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskMesonJetCorrelation.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskMesonJetCorrelation.cxx
@@ -88,6 +88,8 @@ ClassImp(AliAnalysisTaskMesonJetCorrelation)
                                                                              fUnsetStablePi0(false),
                                                                              fUseMixedBackAdd(false),
                                                                              fDoRadiusDep(false),
+                                                                             fDoAnalysisPt(true),
+                                                                             fDoAnalysisZ(true),
                                                                              // aod relabeling
                                                                              fMCEventPos(nullptr),
                                                                              fMCEventNeg(nullptr),
@@ -351,6 +353,8 @@ AliAnalysisTaskMesonJetCorrelation::AliAnalysisTaskMesonJetCorrelation(const cha
                                                                                            fUnsetStablePi0(false),
                                                                                            fUseMixedBackAdd(false),
                                                                                            fDoRadiusDep(false),
+                                                                                           fDoAnalysisPt(true),
+                                                                                           fDoAnalysisZ(true),
                                                                                            // aod relabeling
                                                                                            fMCEventPos(nullptr),
                                                                                            fMCEventNeg(nullptr),
@@ -688,17 +692,21 @@ void AliAnalysisTaskMesonJetCorrelation::UserCreateOutputObjects()
     fHistoMCSecMesonSource.resize(fnCuts);
     fHistoMCSecMesonInAccPtvsSource.resize(fnCuts);
 
-    fHistoMCJetPtVsMesonPt.resize(fnCuts);
-    fHistoMCJetPtVsMesonPtInAcc.resize(fnCuts);
-    fHistoMCJetPtVsFrag.resize(fnCuts);
-    fHistoMCJetPtVsFragInAcc.resize(fnCuts);
-    fHistoMCJetPtVsFrag_Sec.resize(fnCuts);
-    fHistoMCRecJetPtVsFrag.resize(fnCuts);
-    fHistoMCRecJetPtVsMesonPt.resize(fnCuts);
-    fHistoMCJetPtVsMesonPt_Sec.resize(fnCuts);
-    fHistoMCPartonPtVsFrag.resize(fnCuts);
-    fHistoMCJetPtVsFragTrueParton.resize(fnCuts);
-    fHistoMCPartonPtVsFragTrueParton.resize(fnCuts);
+    if(fDoAnalysisPt){
+      fHistoMCJetPtVsMesonPt.resize(fnCuts);
+      fHistoMCJetPtVsMesonPtInAcc.resize(fnCuts);
+      fHistoMCRecJetPtVsMesonPt.resize(fnCuts);
+      fHistoMCJetPtVsMesonPt_Sec.resize(fnCuts);
+    }
+    if(fDoAnalysisZ){
+      fHistoMCJetPtVsFrag.resize(fnCuts);
+      fHistoMCJetPtVsFragInAcc.resize(fnCuts);
+      fHistoMCJetPtVsFrag_Sec.resize(fnCuts);
+      fHistoMCRecJetPtVsFrag.resize(fnCuts);
+      fHistoMCPartonPtVsFrag.resize(fnCuts);
+      fHistoMCJetPtVsFragTrueParton.resize(fnCuts);
+      fHistoMCPartonPtVsFragTrueParton.resize(fnCuts);
+    }
     if(fDoRadiusDep){
       fHistoMCJetPtVsMesonPtVsRadius.resize(fnCuts);
       fHistoMCJetPtVsMesonPtVsRadiusInAcc.resize(fnCuts);
@@ -752,104 +760,112 @@ void AliAnalysisTaskMesonJetCorrelation::UserCreateOutputObjects()
   }
 
   //----------------------
-  // inv mass histograms
+  // pT dep histos
   //----------------------
-  fHistoInvMassVsPt.resize(fnCuts);
-  fHistoInvMassVsPt_Incl.resize(fnCuts);
+  if(fDoAnalysisPt){
+    fHistoInvMassVsPt.resize(fnCuts);
+    fHistoInvMassVsPt_Incl.resize(fnCuts);
 
-  fHistoInvMassVsPtMassCut.resize(fnCuts);
-  fHistoInvMassVsPtMassCutSB.resize(fnCuts);
+      // perpendicular cone
+    fHistoInvMassVsPtPerpCone.resize(fnCuts);
 
-  if (fIsMC) {
-    fRespMatrixHandlerTrueMesonInvMassVsPt.resize(fnCuts);
-    fRespMatrixHandlerTrueMesonInvMassVsZ.resize(fnCuts);
-    fRespMatrixHandlerTrueOtherMesonInvMassVsPt.resize(fnCuts);
-    fRespMatrixHandlerTrueOtherMesonInvMassVsZ.resize(fnCuts);
-    fRespMatrixHandlerTrueSecondaryMesonInvMassVsPt.resize(fnCuts);
-    fRespMatrixHandlerTrueSecondaryMesonInvMassVsZ.resize(fnCuts);
+    // inv mass background
+    fHistoInvMassVsPtBack.resize(fnCuts);
+
+    fHistoInvMassVsPtMassCut.resize(fnCuts);
+    fHistoInvMassVsPtMassCutSB.resize(fnCuts);
+
+
+    fRespMatrixHandlerMesonInvMass.resize(fnCuts);
+    fRespMatrixHandlerMesonBackInvMassVsPt.resize(fnCuts);
+    if(fUseMixedBackAdd){
+      fRespMatrixHandlerMesonBackAddInvMassVsPt.resize(fnCuts);
+    }
+    // perpendicular cone
+    fRespMatrixHandlerMesonInvMassPerpCone.resize(fnCuts);
+
     if(fDoRadiusDep){
-      fRespMatrixHandlerTrueMesonPtRadius.resize(fnCuts);
-      fRespMatrixHandlerTrueMesonTruePtRadius.resize(fnCuts);
-      fRespMatrixHandlerTrueSecondaryMesonPtRadius.resize(fnCuts);
+      fRespMatrixHandlerMesonPtInvMassRadius.resize(fnCuts);
+      fRespMatrixHandlerMesonBackPtInvMassRadius.resize(fnCuts);
+      fRespMatrixHandlerMesonPtRadius.resize(fnCuts);
+      fRespMatrixHandlerMesonPtTrueRadius.resize(fnCuts);
     }
-    if(fDoMesonQA > 0){
-      fHistoTrueMesonInvMassVsTruePt.resize(fnCuts);
-      fHistoTruePrimaryMesonInvMassPt.resize(fnCuts);
-      fHistoTrueSecondaryMesonInvMassPt.resize(fnCuts);
-    }
-
-    fHistoTrueMesonJetPtVsTruePt.resize(fnCuts);
-    fHistoTrueMesonJetPtVsTrueZ.resize(fnCuts);
-
-    fHistoTrueMesonJetPtVsRecPt.resize(fnCuts);
-    fHistoTrueMesonJetPtVsRecZ.resize(fnCuts);
-
-    if(fDoMesonQA>0){
-      fHistoTrueSecMesonJetPtVsRecPt.resize(fnCuts);
-      fHistoTrueSecMesonJetPtVsRecZ.resize(fnCuts);
-
-      fHistoTrueMesonInTrueJet_JetPtVsTruePt.resize(fnCuts);
-      fHistoTrueMesonInTrueJet_JetPtVsTrueZ.resize(fnCuts);
-    }
-
-    fRespMatrixHandlerTrueMesonInvMassVsPtDoubleCount.resize(fnCuts);
-    fRespMatrixHandlerTrueMesonInvMassVsZDoubleCount.resize(fnCuts);
-
-    if (fDoMesonQA) {
-      fHistoMesonResponse.resize(fnCuts);
-      fHistoMesonResolutionJetPt.resize(fnCuts);
-      fHistoTrueMesonBothDaughtersInJet.resize(fnCuts);
-      fHistoTrueMesonOneDaughtersInJet.resize(fnCuts);
-      fHistoTrueMesonNoDaughtersInJet.resize(fnCuts);
-      fHistoTrueMesonDaughtersInOtherJet.resize(fnCuts);
-    }
-
   }
-
-
-  // perpendicular cone
-  fHistoInvMassVsPtPerpCone.resize(fnCuts);
-
-  // inv mass background
-  fHistoInvMassVsPtBack.resize(fnCuts);
 
   //----------------------
   // fragmentation histos
   //----------------------
-  fHistoJetPtVsFrag.resize(fnCuts);
+  if(fDoAnalysisZ){
+    fHistoJetPtVsFrag.resize(fnCuts);
 
-  // perpendicular cone
-  fHistoJetPtVsFragPerpCone.resize(fnCuts);
+    // perpendicular cone
+    fHistoJetPtVsFragPerpCone.resize(fnCuts);
 
-  //----------------------
-  // response matrix
-  //----------------------
-  fRespMatrixHandlerMesonInvMassVsZ.resize(fnCuts);
-  fRespMatrixHandlerMesonInvMass.resize(fnCuts);
-  fRespMatrixHandlerMesonBackInvMassVsZ.resize(fnCuts);
-  fRespMatrixHandlerMesonBackInvMassVsPt.resize(fnCuts);
-  if(fUseMixedBackAdd){
-    fRespMatrixHandlerMesonBackAddInvMassVsZ.resize(fnCuts);
-    fRespMatrixHandlerMesonBackAddInvMassVsPt.resize(fnCuts);
-  }
-  // perpendicular cone
-  fRespMatrixHandlerMesonInvMassVsZPerpCone.resize(fnCuts);
-  fRespMatrixHandlerMesonInvMassPerpCone.resize(fnCuts);
-  // vs. radius and pt
-  if(fDoRadiusDep){
-    fRespMatrixHandlerMesonPtInvMassRadius.resize(fnCuts);
-    fRespMatrixHandlerMesonBackPtInvMassRadius.resize(fnCuts);
-  }
-  if (fIsMC) {
-    fRespMatrixHandlerMesonPt.resize(fnCuts);
-    fRespMatrixHandlerFrag.resize(fnCuts);
-    if(!fDoLightOutput) {
-      fRespMatrixHandlerFragTrueJets.resize(fnCuts);
+    fRespMatrixHandlerMesonInvMassVsZ.resize(fnCuts);
+    fRespMatrixHandlerMesonBackInvMassVsZ.resize(fnCuts);
+    if(fUseMixedBackAdd){
+      fRespMatrixHandlerMesonBackAddInvMassVsZ.resize(fnCuts);
     }
-    // vs radius and pt
-    if(fDoRadiusDep){
-      fRespMatrixHandlerMesonPtRadius.resize(fnCuts);
-      fRespMatrixHandlerMesonPtTrueRadius.resize(fnCuts);
+    // perpendicular cone
+    fRespMatrixHandlerMesonInvMassVsZPerpCone.resize(fnCuts);
+  }
+
+
+  if (fIsMC) {
+    if(fDoAnalysisPt){
+      fRespMatrixHandlerTrueMesonInvMassVsPt.resize(fnCuts);
+      fRespMatrixHandlerTrueOtherMesonInvMassVsPt.resize(fnCuts);
+      fRespMatrixHandlerTrueSecondaryMesonInvMassVsPt.resize(fnCuts);
+
+      fHistoTrueMesonJetPtVsTruePt.resize(fnCuts);
+      fHistoTrueMesonJetPtVsRecPt.resize(fnCuts);
+
+      fRespMatrixHandlerMesonPt.resize(fnCuts);
+
+      if(fDoMesonQA > 0){
+        fHistoTrueMesonInvMassVsTruePt.resize(fnCuts);
+        fHistoTruePrimaryMesonInvMassPt.resize(fnCuts);
+        fHistoTrueSecondaryMesonInvMassPt.resize(fnCuts);
+
+        fHistoTrueSecMesonJetPtVsRecPt.resize(fnCuts);
+        fHistoTrueMesonInTrueJet_JetPtVsTruePt.resize(fnCuts);
+
+        fRespMatrixHandlerTrueMesonInvMassVsPtDoubleCount.resize(fnCuts);
+        
+        fHistoMesonResponse.resize(fnCuts);
+        fHistoMesonResolutionJetPt.resize(fnCuts);
+        fHistoTrueMesonBothDaughtersInJet.resize(fnCuts);
+        fHistoTrueMesonOneDaughtersInJet.resize(fnCuts);
+        fHistoTrueMesonNoDaughtersInJet.resize(fnCuts);
+        fHistoTrueMesonDaughtersInOtherJet.resize(fnCuts);
+      }
+
+      if(fDoRadiusDep){
+        fRespMatrixHandlerTrueMesonPtRadius.resize(fnCuts);
+        fRespMatrixHandlerTrueMesonTruePtRadius.resize(fnCuts);
+        fRespMatrixHandlerTrueSecondaryMesonPtRadius.resize(fnCuts);
+      }
+    }
+    if(fDoAnalysisZ){
+      fRespMatrixHandlerTrueMesonInvMassVsZ.resize(fnCuts);
+      fRespMatrixHandlerTrueOtherMesonInvMassVsZ.resize(fnCuts);
+      fRespMatrixHandlerTrueSecondaryMesonInvMassVsZ.resize(fnCuts);
+
+      fHistoTrueMesonJetPtVsTrueZ.resize(fnCuts);
+      fHistoTrueMesonJetPtVsRecZ.resize(fnCuts);
+
+      fRespMatrixHandlerFrag.resize(fnCuts);
+
+
+      if(!fDoLightOutput) {
+        fRespMatrixHandlerFragTrueJets.resize(fnCuts);
+      }
+
+      if(fDoMesonQA > 0){
+        fRespMatrixHandlerTrueMesonInvMassVsZDoubleCount.resize(fnCuts);
+        fHistoTrueSecMesonJetPtVsRecZ.resize(fnCuts);
+        fHistoTrueMesonInTrueJet_JetPtVsTrueZ.resize(fnCuts);
+      }
     }
   }
 
@@ -1149,61 +1165,65 @@ void AliAnalysisTaskMesonJetCorrelation::UserCreateOutputObjects()
       fMCList[iCut]->Add(fHistoMCSecMesonInAccPtvsSource[iCut]);
 
       // jet pt vs meson pt
-      fHistoMCJetPtVsMesonPt[iCut] = new TH2F("MC_MesonPt_JetPt", "MC_MesonPt_JetPt", fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
-      fHistoMCJetPtVsMesonPt[iCut]->SetXTitle("p_{T, meson} (true)");
-      fHistoMCJetPtVsMesonPt[iCut]->SetYTitle("p_{T, true, Jet} (GeV/c)");
-      fMCList[iCut]->Add(fHistoMCJetPtVsMesonPt[iCut]);
+      if(fDoAnalysisPt){
+        fHistoMCJetPtVsMesonPt[iCut] = new TH2F("MC_MesonPt_JetPt", "MC_MesonPt_JetPt", fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
+        fHistoMCJetPtVsMesonPt[iCut]->SetXTitle("p_{T, meson} (true)");
+        fHistoMCJetPtVsMesonPt[iCut]->SetYTitle("p_{T, true, Jet} (GeV/c)");
+        fMCList[iCut]->Add(fHistoMCJetPtVsMesonPt[iCut]);
 
-      fHistoMCJetPtVsMesonPtInAcc[iCut] = new TH2F("MC_MesonPt_JetPt_InAcc", "MC_MesonPt_JetPt_InAcc", fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
-      fHistoMCJetPtVsMesonPtInAcc[iCut]->SetXTitle("p_{T, meson} (true)");
-      fHistoMCJetPtVsMesonPtInAcc[iCut]->SetYTitle("p_{T, true, Jet} (GeV/c)");
-      fMCList[iCut]->Add(fHistoMCJetPtVsMesonPtInAcc[iCut]);
+        fHistoMCJetPtVsMesonPtInAcc[iCut] = new TH2F("MC_MesonPt_JetPt_InAcc", "MC_MesonPt_JetPt_InAcc", fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
+        fHistoMCJetPtVsMesonPtInAcc[iCut]->SetXTitle("p_{T, meson} (true)");
+        fHistoMCJetPtVsMesonPtInAcc[iCut]->SetYTitle("p_{T, true, Jet} (GeV/c)");
+        fMCList[iCut]->Add(fHistoMCJetPtVsMesonPtInAcc[iCut]);
 
-      fHistoMCRecJetPtVsMesonPt[iCut] = new TH2F("MC_MesonPt_JetPt_InRecJet", "MC_MesonPt_JetPt_InRecJet", fVecBinsFragment.size() - 1, fVecBinsFragment.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
-      fHistoMCRecJetPtVsMesonPt[iCut]->SetXTitle("z (true)");
-      fHistoMCRecJetPtVsMesonPt[iCut]->SetYTitle("p_{T, true, rec. Jet} (GeV/c)");
-      fMCList[iCut]->Add(fHistoMCRecJetPtVsMesonPt[iCut]);
+        fHistoMCRecJetPtVsMesonPt[iCut] = new TH2F("MC_MesonPt_JetPt_InRecJet", "MC_MesonPt_JetPt_InRecJet", fVecBinsFragment.size() - 1, fVecBinsFragment.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
+        fHistoMCRecJetPtVsMesonPt[iCut]->SetXTitle("z (true)");
+        fHistoMCRecJetPtVsMesonPt[iCut]->SetYTitle("p_{T, true, rec. Jet} (GeV/c)");
+        fMCList[iCut]->Add(fHistoMCRecJetPtVsMesonPt[iCut]);
+
+        fHistoMCJetPtVsMesonPt_Sec[iCut] = new TH2F("MC_Sec_MesonPt_JetPt", "MC_Sec_MesonPt_JetPt", fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
+        fHistoMCJetPtVsMesonPt_Sec[iCut]->SetXTitle("p_{T, true} (true)");
+        fHistoMCJetPtVsMesonPt_Sec[iCut]->SetYTitle("p_{T, true, Jet} (GeV/c)");
+        fMCList[iCut]->Add(fHistoMCJetPtVsMesonPt_Sec[iCut]);
+      }
 
       // jet pt vs fragmentation z
-      fHistoMCJetPtVsFrag[iCut] = new TH2F("MC_Frag_JetPt", "MC_Frag_JetPt", fVecBinsFragment.size() - 1, fVecBinsFragment.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
-      fHistoMCJetPtVsFrag[iCut]->SetXTitle("z (true)");
-      fHistoMCJetPtVsFrag[iCut]->SetYTitle("p_{T, true, Jet} (GeV/c)");
-      fMCList[iCut]->Add(fHistoMCJetPtVsFrag[iCut]);
+      if(fDoAnalysisZ){
+        fHistoMCJetPtVsFrag[iCut] = new TH2F("MC_Frag_JetPt", "MC_Frag_JetPt", fVecBinsFragment.size() - 1, fVecBinsFragment.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
+        fHistoMCJetPtVsFrag[iCut]->SetXTitle("z (true)");
+        fHistoMCJetPtVsFrag[iCut]->SetYTitle("p_{T, true, Jet} (GeV/c)");
+        fMCList[iCut]->Add(fHistoMCJetPtVsFrag[iCut]);
 
-      fHistoMCJetPtVsFragInAcc[iCut] = new TH2F("MC_Frag_JetPt_InAcc", "MC_Frag_JetPt_InAcc", fVecBinsFragment.size() - 1, fVecBinsFragment.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
-      fHistoMCJetPtVsFragInAcc[iCut]->SetXTitle("z (true)");
-      fHistoMCJetPtVsFragInAcc[iCut]->SetYTitle("p_{T, true, Jet} (GeV/c)");
-      fMCList[iCut]->Add(fHistoMCJetPtVsFragInAcc[iCut]);
+        fHistoMCJetPtVsFragInAcc[iCut] = new TH2F("MC_Frag_JetPt_InAcc", "MC_Frag_JetPt_InAcc", fVecBinsFragment.size() - 1, fVecBinsFragment.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
+        fHistoMCJetPtVsFragInAcc[iCut]->SetXTitle("z (true)");
+        fHistoMCJetPtVsFragInAcc[iCut]->SetYTitle("p_{T, true, Jet} (GeV/c)");
+        fMCList[iCut]->Add(fHistoMCJetPtVsFragInAcc[iCut]);
 
-      fHistoMCJetPtVsFrag_Sec[iCut] = new TH2F("MC_Sec_Frag_JetPt", "MC_Sec_Frag_JetPt", fVecBinsFragment.size() - 1, fVecBinsFragment.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
-      fHistoMCJetPtVsFrag_Sec[iCut]->SetXTitle("z (true)");
-      fHistoMCJetPtVsFrag_Sec[iCut]->SetYTitle("p_{T, true, Jet} (GeV/c)");
-      fMCList[iCut]->Add(fHistoMCJetPtVsFrag_Sec[iCut]);
+        fHistoMCJetPtVsFrag_Sec[iCut] = new TH2F("MC_Sec_Frag_JetPt", "MC_Sec_Frag_JetPt", fVecBinsFragment.size() - 1, fVecBinsFragment.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
+        fHistoMCJetPtVsFrag_Sec[iCut]->SetXTitle("z (true)");
+        fHistoMCJetPtVsFrag_Sec[iCut]->SetYTitle("p_{T, true, Jet} (GeV/c)");
+        fMCList[iCut]->Add(fHistoMCJetPtVsFrag_Sec[iCut]);
 
-      fHistoMCRecJetPtVsFrag[iCut] = new TH2F("MC_Frag_JetPt_InRecJet", "MC_Frag_JetPt_InRecJet", fVecBinsFragment.size() - 1, fVecBinsFragment.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
-      fHistoMCRecJetPtVsFrag[iCut]->SetXTitle("z (true)");
-      fHistoMCRecJetPtVsFrag[iCut]->SetYTitle("p_{T, true, rec. Jet} (GeV/c)");
-      fMCList[iCut]->Add(fHistoMCRecJetPtVsFrag[iCut]);
+        fHistoMCRecJetPtVsFrag[iCut] = new TH2F("MC_Frag_JetPt_InRecJet", "MC_Frag_JetPt_InRecJet", fVecBinsFragment.size() - 1, fVecBinsFragment.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
+        fHistoMCRecJetPtVsFrag[iCut]->SetXTitle("z (true)");
+        fHistoMCRecJetPtVsFrag[iCut]->SetYTitle("p_{T, true, rec. Jet} (GeV/c)");
+        fMCList[iCut]->Add(fHistoMCRecJetPtVsFrag[iCut]);
+      
+        fHistoMCPartonPtVsFrag[iCut] = new TH2F("MC_Frag_PartonPt", "MC_Frag_PartonPt", fVecBinsFragment.size() - 1, fVecBinsFragment.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
+        fHistoMCPartonPtVsFrag[iCut]->SetXTitle("z (true)");
+        fHistoMCPartonPtVsFrag[iCut]->SetYTitle("p_{T, parton, jet} (GeV/c)");
+        fMCList[iCut]->Add(fHistoMCPartonPtVsFrag[iCut]);
 
-      fHistoMCJetPtVsMesonPt_Sec[iCut] = new TH2F("MC_Sec_MesonPt_JetPt", "MC_Sec_MesonPt_JetPt", fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
-      fHistoMCJetPtVsMesonPt_Sec[iCut]->SetXTitle("p_{T, true} (true)");
-      fHistoMCJetPtVsMesonPt_Sec[iCut]->SetYTitle("p_{T, true, Jet} (GeV/c)");
-      fMCList[iCut]->Add(fHistoMCJetPtVsMesonPt_Sec[iCut]);
+        fHistoMCJetPtVsFragTrueParton[iCut] = new TH2F("MC_Frag_JetPt_TrueParton", "MC_Frag_JetPt_TrueParton", fVecBinsFragment.size() - 1, fVecBinsFragment.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
+        fHistoMCJetPtVsFragTrueParton[iCut]->SetXTitle("z (true)");
+        fHistoMCJetPtVsFragTrueParton[iCut]->SetYTitle("p_{T, true, Jet} (GeV/c)");
+        fMCList[iCut]->Add(fHistoMCJetPtVsFragTrueParton[iCut]);
 
-      fHistoMCPartonPtVsFrag[iCut] = new TH2F("MC_Frag_PartonPt", "MC_Frag_PartonPt", fVecBinsFragment.size() - 1, fVecBinsFragment.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
-      fHistoMCPartonPtVsFrag[iCut]->SetXTitle("z (true)");
-      fHistoMCPartonPtVsFrag[iCut]->SetYTitle("p_{T, parton, jet} (GeV/c)");
-      fMCList[iCut]->Add(fHistoMCPartonPtVsFrag[iCut]);
-
-      fHistoMCJetPtVsFragTrueParton[iCut] = new TH2F("MC_Frag_JetPt_TrueParton", "MC_Frag_JetPt_TrueParton", fVecBinsFragment.size() - 1, fVecBinsFragment.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
-      fHistoMCJetPtVsFragTrueParton[iCut]->SetXTitle("z (true)");
-      fHistoMCJetPtVsFragTrueParton[iCut]->SetYTitle("p_{T, true, Jet} (GeV/c)");
-      fMCList[iCut]->Add(fHistoMCJetPtVsFragTrueParton[iCut]);
-
-      fHistoMCPartonPtVsFragTrueParton[iCut] = new TH2F("MC_Frag_PartonPt_TrueParton", "MC_Frag_PartonPt_TrueParton", fVecBinsFragment.size() - 1, fVecBinsFragment.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
-      fHistoMCPartonPtVsFragTrueParton[iCut]->SetXTitle("z (true)");
-      fHistoMCPartonPtVsFragTrueParton[iCut]->SetYTitle("p_{T, parton, jet} (GeV/c)");
-      fMCList[iCut]->Add(fHistoMCPartonPtVsFragTrueParton[iCut]);
+        fHistoMCPartonPtVsFragTrueParton[iCut] = new TH2F("MC_Frag_PartonPt_TrueParton", "MC_Frag_PartonPt_TrueParton", fVecBinsFragment.size() - 1, fVecBinsFragment.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
+        fHistoMCPartonPtVsFragTrueParton[iCut]->SetXTitle("z (true)");
+        fHistoMCPartonPtVsFragTrueParton[iCut]->SetYTitle("p_{T, parton, jet} (GeV/c)");
+        fMCList[iCut]->Add(fHistoMCPartonPtVsFragTrueParton[iCut]);
+      }
 
       if(fDoRadiusDep){
         fHistoMCJetPtVsMesonPtVsRadius[iCut] = new TH3F("MC_PtMeson_PtJet_Radius", "MC_PtMeson_PtJet_Radius", fVecBinsMesonPtCoarse.size() - 1, fVecBinsMesonPtCoarse.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data(), fVecBinsMesonJetRadius.size()-1, fVecBinsMesonJetRadius.data());
@@ -1295,58 +1315,52 @@ void AliAnalysisTaskMesonJetCorrelation::UserCreateOutputObjects()
       fJetList[iCut]->Add(fHistoNclusVsPtJet[iCut]);
     }
 
-    // inv mass histograms
-    fHistoInvMassVsPt[iCut] = new TH2F("ESD_Mother_InvMass_Pt", "ESD_Mother_InvMass_Pt", fVecBinsMesonInvMass.size() - 1, fVecBinsMesonInvMass.data(), fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data());
-    fHistoInvMassVsPt[iCut]->SetXTitle("M_{#gamma#gamma} (GeV/c^{2})");
-    fHistoInvMassVsPt[iCut]->SetYTitle("p_{T} (GeV/c)");
-    fESDList[iCut]->Add(fHistoInvMassVsPt[iCut]);
-
-    // in perpendicular cone
-
-    fHistoInvMassVsPtPerpCone[iCut] = new TH2F("ESD_Mother_InvMass_Pt_PerpCone", "ESD_Mother_InvMass_Pt_PerpCone", fVecBinsMesonInvMass.size() - 1, fVecBinsMesonInvMass.data(), fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data());
-    fHistoInvMassVsPtPerpCone[iCut]->SetXTitle("M_{#gamma#gamma} (GeV/c^{2})");
-    fHistoInvMassVsPtPerpCone[iCut]->SetYTitle("p_{T} (GeV/c)");
-    fESDList[iCut]->Add(fHistoInvMassVsPtPerpCone[iCut]);
 
     if (fIsMC) {
-      // true mesons inv mass vs pT
-      fRespMatrixHandlerTrueMesonInvMassVsPt[iCut] = new MatrixHandler4D(fVecBinsMesonInvMass, fVecBinsMesonPt, fVecBinsJetPt, {0, 1}, fUseThNForResponse);
-      if (fUseThNForResponse)
-        fTrueList[iCut]->Add(fRespMatrixHandlerTrueMesonInvMassVsPt[iCut]->GetTHnSparse("ESD_TrueMother_InvMass_Pt_JetPt"));
-      else
-        fTrueList[iCut]->Add(fRespMatrixHandlerTrueMesonInvMassVsPt[iCut]->GetTH2("ESD_TrueMother_InvMass_Pt_JetPt"));
+      if(fDoAnalysisPt){
+        // true mesons inv mass vs pT
+        fRespMatrixHandlerTrueMesonInvMassVsPt[iCut] = new MatrixHandler4D(fVecBinsMesonInvMass, fVecBinsMesonPt, fVecBinsJetPt, {0, 1}, fUseThNForResponse);
+        if (fUseThNForResponse)
+          fTrueList[iCut]->Add(fRespMatrixHandlerTrueMesonInvMassVsPt[iCut]->GetTHnSparse("ESD_TrueMother_InvMass_Pt_JetPt"));
+        else
+          fTrueList[iCut]->Add(fRespMatrixHandlerTrueMesonInvMassVsPt[iCut]->GetTH2("ESD_TrueMother_InvMass_Pt_JetPt"));
 
-      fRespMatrixHandlerTrueMesonInvMassVsZ[iCut] = new MatrixHandler4D(fVecBinsMesonInvMass, fVecBinsFragment, fVecBinsJetPt, {0, 1}, fUseThNForResponse);
-      if (fUseThNForResponse)
-        fTrueList[iCut]->Add(fRespMatrixHandlerTrueMesonInvMassVsZ[iCut]->GetTHnSparse("ESD_TrueMother_InvMass_Z_JetPt"));
-      else
-        fTrueList[iCut]->Add(fRespMatrixHandlerTrueMesonInvMassVsZ[iCut]->GetTH2("ESD_TrueMother_InvMass_Z_JetPt"));
+        // true other mesons inv mass vs pT
+        fRespMatrixHandlerTrueOtherMesonInvMassVsPt[iCut] = new MatrixHandler4D(fVecBinsMesonInvMass, fVecBinsMesonPt, fVecBinsJetPt, {0, 1}, fUseThNForResponse);
+        if (fUseThNForResponse)
+          fTrueList[iCut]->Add(fRespMatrixHandlerTrueOtherMesonInvMassVsPt[iCut]->GetTHnSparse("ESD_TrueOtherMother_InvMass_Pt_JetPt"));
+        else
+          fTrueList[iCut]->Add(fRespMatrixHandlerTrueOtherMesonInvMassVsPt[iCut]->GetTH2("ESD_TrueOtherMother_InvMass_Pt_JetPt"));
 
-      // true other mesons inv mass vs pT
-      fRespMatrixHandlerTrueOtherMesonInvMassVsPt[iCut] = new MatrixHandler4D(fVecBinsMesonInvMass, fVecBinsMesonPt, fVecBinsJetPt, {0, 1}, fUseThNForResponse);
-      if (fUseThNForResponse)
-        fTrueList[iCut]->Add(fRespMatrixHandlerTrueOtherMesonInvMassVsPt[iCut]->GetTHnSparse("ESD_TrueOtherMother_InvMass_Pt_JetPt"));
-      else
-        fTrueList[iCut]->Add(fRespMatrixHandlerTrueOtherMesonInvMassVsPt[iCut]->GetTH2("ESD_TrueOtherMother_InvMass_Pt_JetPt"));
+        // secondary mesons inv mass vs pT
+        fRespMatrixHandlerTrueSecondaryMesonInvMassVsPt[iCut] = new MatrixHandler4D(fVecBinsMesonInvMass, fVecBinsMesonPt, fVecBinsJetPt, {0, 1}, fUseThNForResponse);
+        if (fUseThNForResponse)
+          fTrueList[iCut]->Add(fRespMatrixHandlerTrueSecondaryMesonInvMassVsPt[iCut]->GetTHnSparse("ESD_TrueSecondaryMother_InvMass_Pt_JetPt"));
+        else
+          fTrueList[iCut]->Add(fRespMatrixHandlerTrueSecondaryMesonInvMassVsPt[iCut]->GetTH2("ESD_TrueSecondaryMother_InvMass_Pt_JetPt"));
 
-      fRespMatrixHandlerTrueOtherMesonInvMassVsZ[iCut] = new MatrixHandler4D(fVecBinsMesonInvMass, fVecBinsFragment, fVecBinsJetPt, {0, 1}, fUseThNForResponse);
-      if (fUseThNForResponse)
-        fTrueList[iCut]->Add(fRespMatrixHandlerTrueOtherMesonInvMassVsZ[iCut]->GetTHnSparse("ESD_TrueOtherMother_InvMass_Z_JetPt"));
-      else
-        fTrueList[iCut]->Add(fRespMatrixHandlerTrueOtherMesonInvMassVsZ[iCut]->GetTH2("ESD_TrueOtherMother_InvMass_Z_JetPt"));
+      }
+      if(fDoAnalysisZ){
+        fRespMatrixHandlerTrueMesonInvMassVsZ[iCut] = new MatrixHandler4D(fVecBinsMesonInvMass, fVecBinsFragment, fVecBinsJetPt, {0, 1}, fUseThNForResponse);
+        if (fUseThNForResponse)
+          fTrueList[iCut]->Add(fRespMatrixHandlerTrueMesonInvMassVsZ[iCut]->GetTHnSparse("ESD_TrueMother_InvMass_Z_JetPt"));
+        else
+          fTrueList[iCut]->Add(fRespMatrixHandlerTrueMesonInvMassVsZ[iCut]->GetTH2("ESD_TrueMother_InvMass_Z_JetPt"));
 
-      // secondary mesons inv mass vs pT
-      fRespMatrixHandlerTrueSecondaryMesonInvMassVsPt[iCut] = new MatrixHandler4D(fVecBinsMesonInvMass, fVecBinsMesonPt, fVecBinsJetPt, {0, 1}, fUseThNForResponse);
-      if (fUseThNForResponse)
-        fTrueList[iCut]->Add(fRespMatrixHandlerTrueSecondaryMesonInvMassVsPt[iCut]->GetTHnSparse("ESD_TrueSecondaryMother_InvMass_Pt_JetPt"));
-      else
-        fTrueList[iCut]->Add(fRespMatrixHandlerTrueSecondaryMesonInvMassVsPt[iCut]->GetTH2("ESD_TrueSecondaryMother_InvMass_Pt_JetPt"));
+        
+        fRespMatrixHandlerTrueOtherMesonInvMassVsZ[iCut] = new MatrixHandler4D(fVecBinsMesonInvMass, fVecBinsFragment, fVecBinsJetPt, {0, 1}, fUseThNForResponse);
+        if (fUseThNForResponse)
+          fTrueList[iCut]->Add(fRespMatrixHandlerTrueOtherMesonInvMassVsZ[iCut]->GetTHnSparse("ESD_TrueOtherMother_InvMass_Z_JetPt"));
+        else
+          fTrueList[iCut]->Add(fRespMatrixHandlerTrueOtherMesonInvMassVsZ[iCut]->GetTH2("ESD_TrueOtherMother_InvMass_Z_JetPt"));
 
-      fRespMatrixHandlerTrueSecondaryMesonInvMassVsZ[iCut] = new MatrixHandler4D(fVecBinsMesonInvMass, fVecBinsFragment, fVecBinsJetPt, {0, 1}, fUseThNForResponse);
-      if (fUseThNForResponse)
-        fTrueList[iCut]->Add(fRespMatrixHandlerTrueSecondaryMesonInvMassVsZ[iCut]->GetTHnSparse("ESD_TrueSecondaryMother_InvMass_Z_JetPt"));
-      else
-        fTrueList[iCut]->Add(fRespMatrixHandlerTrueSecondaryMesonInvMassVsZ[iCut]->GetTH2("ESD_TrueSecondaryMother_InvMass_Z_JetPt"));
+        
+        fRespMatrixHandlerTrueSecondaryMesonInvMassVsZ[iCut] = new MatrixHandler4D(fVecBinsMesonInvMass, fVecBinsFragment, fVecBinsJetPt, {0, 1}, fUseThNForResponse);
+        if (fUseThNForResponse)
+          fTrueList[iCut]->Add(fRespMatrixHandlerTrueSecondaryMesonInvMassVsZ[iCut]->GetTHnSparse("ESD_TrueSecondaryMother_InvMass_Z_JetPt"));
+        else
+          fTrueList[iCut]->Add(fRespMatrixHandlerTrueSecondaryMesonInvMassVsZ[iCut]->GetTH2("ESD_TrueSecondaryMother_InvMass_Z_JetPt"));
+      }
 
       // inv. mass vs. radius
       if(fDoRadiusDep){
@@ -1372,198 +1386,229 @@ void AliAnalysisTaskMesonJetCorrelation::UserCreateOutputObjects()
           fTrueList[iCut]->Add(fRespMatrixHandlerTrueSecondaryMesonPtRadius[iCut]->GetTH2("ESD_TrueSecondaryMother_InvMass_Pt_JetPt_Radius"));
       }
 
-      if(fDoMesonQA > 0){
-        fHistoTrueMesonInvMassVsTruePt[iCut] = new TH2F("ESD_TrueMother_InvMass_TruePt", "ESD_TrueMother_InvMass_TruePt", fVecBinsMesonInvMass.size() - 1, fVecBinsMesonInvMass.data(), fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data());
-        fHistoTrueMesonInvMassVsTruePt[iCut]->SetXTitle("M_{#gamma#gamma} (GeV/c^{2})");
-        fHistoTrueMesonInvMassVsTruePt[iCut]->SetYTitle("p_{T} (GeV/c)");
-        fTrueList[iCut]->Add(fHistoTrueMesonInvMassVsTruePt[iCut]);
+      if(fDoAnalysisPt){
+        if(fDoMesonQA > 0){
+          fHistoTrueMesonInvMassVsTruePt[iCut] = new TH2F("ESD_TrueMother_InvMass_TruePt", "ESD_TrueMother_InvMass_TruePt", fVecBinsMesonInvMass.size() - 1, fVecBinsMesonInvMass.data(), fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data());
+          fHistoTrueMesonInvMassVsTruePt[iCut]->SetXTitle("M_{#gamma#gamma} (GeV/c^{2})");
+          fHistoTrueMesonInvMassVsTruePt[iCut]->SetYTitle("p_{T} (GeV/c)");
+          fTrueList[iCut]->Add(fHistoTrueMesonInvMassVsTruePt[iCut]);
 
-        fHistoTruePrimaryMesonInvMassPt[iCut] = new TH2F("ESD_TruePrimaryMother_InvMass_Pt", "ESD_TruePrimaryMother_InvMass_Pt", fVecBinsMesonInvMass.size() - 1, fVecBinsMesonInvMass.data(), fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data());
-        fHistoTruePrimaryMesonInvMassPt[iCut]->SetXTitle("M_{#gamma#gamma} (GeV/c^{2})");
-        fHistoTruePrimaryMesonInvMassPt[iCut]->SetYTitle("p_{T} (GeV/c)");
-        fTrueList[iCut]->Add(fHistoTruePrimaryMesonInvMassPt[iCut]);
+          fHistoTruePrimaryMesonInvMassPt[iCut] = new TH2F("ESD_TruePrimaryMother_InvMass_Pt", "ESD_TruePrimaryMother_InvMass_Pt", fVecBinsMesonInvMass.size() - 1, fVecBinsMesonInvMass.data(), fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data());
+          fHistoTruePrimaryMesonInvMassPt[iCut]->SetXTitle("M_{#gamma#gamma} (GeV/c^{2})");
+          fHistoTruePrimaryMesonInvMassPt[iCut]->SetYTitle("p_{T} (GeV/c)");
+          fTrueList[iCut]->Add(fHistoTruePrimaryMesonInvMassPt[iCut]);
 
-        fHistoTrueSecondaryMesonInvMassPt[iCut] = new TH2F("ESD_TrueSecondaryMother_InvMass_Pt", "ESD_TrueSecondaryMother_InvMass_Pt", fVecBinsMesonInvMass.size() - 1, fVecBinsMesonInvMass.data(), fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data());
-        fHistoTrueSecondaryMesonInvMassPt[iCut]->SetXTitle("M_{#gamma#gamma} (GeV/c^{2})");
-        fHistoTrueSecondaryMesonInvMassPt[iCut]->SetYTitle("p_{T} (GeV/c)");
-        fTrueList[iCut]->Add(fHistoTrueSecondaryMesonInvMassPt[iCut]);
-      }
-
-      fHistoTrueMesonJetPtVsTruePt[iCut] = new TH2F("ESD_TrueMeson_TruePt_JetPt", "ESD_TrueMeson_TruePt_JetPt", fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
-      fHistoTrueMesonJetPtVsTruePt[iCut]->SetXTitle("meson p_{T} (GeV/c)");
-      fHistoTrueMesonJetPtVsTruePt[iCut]->SetYTitle("Jet p_{T} (GeV/c)");
-      fTrueList[iCut]->Add(fHistoTrueMesonJetPtVsTruePt[iCut]);
-
-      fHistoTrueMesonJetPtVsTrueZ[iCut] = new TH2F("ESD_TrueMeson_TrueFrag_JetPt", "ESD_TrueMeson_TrueFrag_JetPt", fVecBinsFragment.size() - 1, fVecBinsFragment.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
-      fHistoTrueMesonJetPtVsTrueZ[iCut]->SetXTitle("Z");
-      fHistoTrueMesonJetPtVsTrueZ[iCut]->SetYTitle("Jet p_{T} (GeV/c)");
-      fTrueList[iCut]->Add(fHistoTrueMesonJetPtVsTrueZ[iCut]);
-
-      fHistoTrueMesonJetPtVsRecPt[iCut] = new TH2F("ESD_TrueMeson_RecPt_JetPt", "ESD_TrueMeson_RecPt_JetPt", fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
-      fHistoTrueMesonJetPtVsRecPt[iCut]->SetXTitle("meson p_{T} (GeV/c)");
-      fHistoTrueMesonJetPtVsRecPt[iCut]->SetYTitle("Jet p_{T} (GeV/c)");
-      fTrueList[iCut]->Add(fHistoTrueMesonJetPtVsRecPt[iCut]);
-
-      fHistoTrueMesonJetPtVsRecZ[iCut] = new TH2F("ESD_TrueMeson_RecFrag_JetPt", "ESD_TrueMeson_RecFrag_JetPt", fVecBinsFragment.size() - 1, fVecBinsFragment.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
-      fHistoTrueMesonJetPtVsRecZ[iCut]->SetXTitle("Z");
-      fHistoTrueMesonJetPtVsRecZ[iCut]->SetYTitle("Jet p_{T} (GeV/c)");
-      fTrueList[iCut]->Add(fHistoTrueMesonJetPtVsRecZ[iCut]);
-
-      if(fDoMesonQA > 0){
-        fHistoTrueSecMesonJetPtVsRecPt[iCut] = new TH2F("ESD_TrueSecMeson_RecPt_JetPt", "ESD_TrueSecMeson_RecPt_JetPt", fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
-        fHistoTrueSecMesonJetPtVsRecPt[iCut]->SetXTitle("Pt");
-        fHistoTrueSecMesonJetPtVsRecPt[iCut]->SetYTitle("Jet p_{T} (GeV/c)");
-        fTrueList[iCut]->Add(fHistoTrueSecMesonJetPtVsRecPt[iCut]);
-
-        fHistoTrueSecMesonJetPtVsRecZ[iCut] = new TH2F("ESD_TrueSecMeson_RecFrag_JetPt", "ESD_TrueMeson_RecFrag_JetPt", fVecBinsFragment.size() - 1, fVecBinsFragment.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
-        fHistoTrueSecMesonJetPtVsRecZ[iCut]->SetXTitle("Z");
-        fHistoTrueSecMesonJetPtVsRecZ[iCut]->SetYTitle("Jet p_{T} (GeV/c)");
-        fTrueList[iCut]->Add(fHistoTrueSecMesonJetPtVsRecZ[iCut]);
-
-        fHistoTrueMesonInTrueJet_JetPtVsTruePt[iCut] = new TH2F("ESD_TrueMeson_InTrueJets_TruePt_JetPt", "ESD_TrueMeson_InTrueJets_TruePt_JetPt", fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
-        fHistoTrueMesonInTrueJet_JetPtVsTruePt[iCut]->SetXTitle("meson p_{T} (GeV/c)");
-        fHistoTrueMesonInTrueJet_JetPtVsTruePt[iCut]->SetYTitle("Jet p_{T} (GeV/c)");
-        fTrueList[iCut]->Add(fHistoTrueMesonInTrueJet_JetPtVsTruePt[iCut]);
-
-        fHistoTrueMesonInTrueJet_JetPtVsTrueZ[iCut] = new TH2F("ESD_TrueMeson_InTrueJets_TrueFrag_JetPt", "ESD_TrueMeson_InTrueJets_TrueFrag_JetPt", fVecBinsFragment.size() - 1, fVecBinsFragment.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
-        fHistoTrueMesonInTrueJet_JetPtVsTrueZ[iCut]->SetXTitle("meson z_{T}");
-        fHistoTrueMesonInTrueJet_JetPtVsTrueZ[iCut]->SetYTitle("Jet p_{T} (GeV/c)");
-        fTrueList[iCut]->Add(fHistoTrueMesonInTrueJet_JetPtVsTrueZ[iCut]);
-
-        fRespMatrixHandlerTrueMesonInvMassVsPtDoubleCount[iCut] = new MatrixHandler4D(fVecBinsMesonInvMass, fVecBinsMesonPt, fVecBinsJetPt, {0, 1}, fUseThNForResponse);
-        if (fUseThNForResponse)
-          fTrueList[iCut]->Add(fRespMatrixHandlerTrueMesonInvMassVsPtDoubleCount[iCut]->GetTHnSparse("ESD_TrueMother_InvMass_Pt_JetPt_DoubleCount"));
-        else
-          fTrueList[iCut]->Add(fRespMatrixHandlerTrueMesonInvMassVsPtDoubleCount[iCut]->GetTH2("ESD_TrueMother_InvMass_Pt_JetPt_DoubleCount"));
-
-        fRespMatrixHandlerTrueMesonInvMassVsZDoubleCount[iCut] = new MatrixHandler4D(fVecBinsMesonInvMass, fVecBinsFragment, fVecBinsJetPt, {0, 1}, fUseThNForResponse);
-        if (fUseThNForResponse)
-          fTrueList[iCut]->Add(fRespMatrixHandlerTrueMesonInvMassVsZDoubleCount[iCut]->GetTHnSparse("ESD_TrueMother_InvMass_Z_JetPt_DoubleCount"));
-        else
-          fTrueList[iCut]->Add(fRespMatrixHandlerTrueMesonInvMassVsZDoubleCount[iCut]->GetTH2("ESD_TrueMother_InvMass_Z_JetPt_DoubleCount"));
-
-        fHistoMesonResponse[iCut] = new TH2F("ESD_TrueMeson_RecPt_TruePt", "ESD_TrueMeson_RecPt_TruePt", fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data(), fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data());
-        fHistoMesonResponse[iCut]->SetXTitle("p_{T, rec} (GeV/c)");
-        fHistoMesonResponse[iCut]->SetYTitle("p_{T, true} (GeV/c)");
-        fTrueList[iCut]->Add(fHistoMesonResponse[iCut]);
-
-        std::vector<double> vecResol;
-        for(int i = 0; i < 100; ++i){
-          vecResol.push_back(0.02*i - 1);
+          fHistoTrueSecondaryMesonInvMassPt[iCut] = new TH2F("ESD_TrueSecondaryMother_InvMass_Pt", "ESD_TrueSecondaryMother_InvMass_Pt", fVecBinsMesonInvMass.size() - 1, fVecBinsMesonInvMass.data(), fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data());
+          fHistoTrueSecondaryMesonInvMassPt[iCut]->SetXTitle("M_{#gamma#gamma} (GeV/c^{2})");
+          fHistoTrueSecondaryMesonInvMassPt[iCut]->SetYTitle("p_{T} (GeV/c)");
+          fTrueList[iCut]->Add(fHistoTrueSecondaryMesonInvMassPt[iCut]);
         }
-        fHistoMesonResolutionJetPt[iCut] = new TH3F("ESD_MesonResolution_JetPt", "ESD_MesonResolution_JetPt", fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data(), vecResol.size()-1, vecResol.data(), fVecBinsJetPt.size()-1, fVecBinsJetPt.data());
-        fHistoMesonResolutionJetPt[iCut]->SetXTitle("p_{T, meson, rec} (GeV/c)");
-        fHistoMesonResolutionJetPt[iCut]->SetYTitle("(p_{T, rec} - p_{T, true})/p_{T, rec} (GeV/c)");
-        fHistoMesonResolutionJetPt[iCut]->SetZTitle("p_{T, jet} (GeV/c)");
-        fTrueList[iCut]->Add(fHistoMesonResolutionJetPt[iCut]);
+      }
 
-        fHistoTrueMesonBothDaughtersInJet[iCut] = new TH2F("ESD_TrueMesonsRecJets_BothGammaInJet", "ESD_TrueMesonsRecJets_BothGammaInJet", fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
-        fHistoTrueMesonBothDaughtersInJet[iCut]->SetXTitle("p_{T, meson} (GeV/c)");
-        fHistoTrueMesonBothDaughtersInJet[iCut]->SetYTitle("p_{T, jet} (GeV/c)");
-        fTrueList[iCut]->Add(fHistoTrueMesonBothDaughtersInJet[iCut]);
+      if(fDoAnalysisPt){
+        fHistoTrueMesonJetPtVsTruePt[iCut] = new TH2F("ESD_TrueMeson_TruePt_JetPt", "ESD_TrueMeson_TruePt_JetPt", fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
+        fHistoTrueMesonJetPtVsTruePt[iCut]->SetXTitle("meson p_{T} (GeV/c)");
+        fHistoTrueMesonJetPtVsTruePt[iCut]->SetYTitle("Jet p_{T} (GeV/c)");
+        fTrueList[iCut]->Add(fHistoTrueMesonJetPtVsTruePt[iCut]);
 
-        fHistoTrueMesonOneDaughtersInJet[iCut] = new TH2F("ESD_TrueMesonsRecJets_OneGammaInJet", "ESD_TrueMesonsRecJets_OneGammaInJet", fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
-        fHistoTrueMesonOneDaughtersInJet[iCut]->SetXTitle("p_{T, meson} (GeV/c)");
-        fHistoTrueMesonOneDaughtersInJet[iCut]->SetYTitle("p_{T, jet} (GeV/c)");
-        fTrueList[iCut]->Add(fHistoTrueMesonOneDaughtersInJet[iCut]);
+        fHistoTrueMesonJetPtVsRecPt[iCut] = new TH2F("ESD_TrueMeson_RecPt_JetPt", "ESD_TrueMeson_RecPt_JetPt", fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
+        fHistoTrueMesonJetPtVsRecPt[iCut]->SetXTitle("meson p_{T} (GeV/c)");
+        fHistoTrueMesonJetPtVsRecPt[iCut]->SetYTitle("Jet p_{T} (GeV/c)");
+        fTrueList[iCut]->Add(fHistoTrueMesonJetPtVsRecPt[iCut]);
 
-        fHistoTrueMesonNoDaughtersInJet[iCut] = new TH2F("ESD_TrueMesonsRecJets_NoGammaInJet", "ESD_TrueMesonsRecJets_NoGammaInJet", fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
-        fHistoTrueMesonNoDaughtersInJet[iCut]->SetXTitle("p_{T, meson} (GeV/c)");
-        fHistoTrueMesonNoDaughtersInJet[iCut]->SetYTitle("p_{T, jet} (GeV/c)");
-        fTrueList[iCut]->Add(fHistoTrueMesonNoDaughtersInJet[iCut]);
+        if(fDoMesonQA > 0){
+          fHistoTrueSecMesonJetPtVsRecPt[iCut] = new TH2F("ESD_TrueSecMeson_RecPt_JetPt", "ESD_TrueSecMeson_RecPt_JetPt", fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
+          fHistoTrueSecMesonJetPtVsRecPt[iCut]->SetXTitle("Pt");
+          fHistoTrueSecMesonJetPtVsRecPt[iCut]->SetYTitle("Jet p_{T} (GeV/c)");
+          fTrueList[iCut]->Add(fHistoTrueSecMesonJetPtVsRecPt[iCut]);
 
-        fHistoTrueMesonDaughtersInOtherJet[iCut] = new TH2F("ESD_TrueMesonsRecJets_GammaInOtherJet", "ESD_TrueMesonsRecJets_GammaInOtherJet", fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
-        fHistoTrueMesonDaughtersInOtherJet[iCut]->SetXTitle("p_{T, meson} (GeV/c)");
-        fHistoTrueMesonDaughtersInOtherJet[iCut]->SetYTitle("p_{T, jet} (GeV/c)");
-        fTrueList[iCut]->Add(fHistoTrueMesonDaughtersInOtherJet[iCut]);
+          fHistoTrueMesonInTrueJet_JetPtVsTruePt[iCut] = new TH2F("ESD_TrueMeson_InTrueJets_TruePt_JetPt", "ESD_TrueMeson_InTrueJets_TruePt_JetPt", fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
+          fHistoTrueMesonInTrueJet_JetPtVsTruePt[iCut]->SetXTitle("meson p_{T} (GeV/c)");
+          fHistoTrueMesonInTrueJet_JetPtVsTruePt[iCut]->SetYTitle("Jet p_{T} (GeV/c)");
+          fTrueList[iCut]->Add(fHistoTrueMesonInTrueJet_JetPtVsTruePt[iCut]);
+
+          fRespMatrixHandlerTrueMesonInvMassVsPtDoubleCount[iCut] = new MatrixHandler4D(fVecBinsMesonInvMass, fVecBinsMesonPt, fVecBinsJetPt, {0, 1}, fUseThNForResponse);
+          if (fUseThNForResponse)
+            fTrueList[iCut]->Add(fRespMatrixHandlerTrueMesonInvMassVsPtDoubleCount[iCut]->GetTHnSparse("ESD_TrueMother_InvMass_Pt_JetPt_DoubleCount"));
+          else
+            fTrueList[iCut]->Add(fRespMatrixHandlerTrueMesonInvMassVsPtDoubleCount[iCut]->GetTH2("ESD_TrueMother_InvMass_Pt_JetPt_DoubleCount"));
+
+          fHistoMesonResponse[iCut] = new TH2F("ESD_TrueMeson_RecPt_TruePt", "ESD_TrueMeson_RecPt_TruePt", fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data(), fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data());
+          fHistoMesonResponse[iCut]->SetXTitle("p_{T, rec} (GeV/c)");
+          fHistoMesonResponse[iCut]->SetYTitle("p_{T, true} (GeV/c)");
+          fTrueList[iCut]->Add(fHistoMesonResponse[iCut]);
+
+          std::vector<double> vecResol;
+          for(int i = 0; i < 100; ++i){
+            vecResol.push_back(0.02*i - 1);
+          }
+          fHistoMesonResolutionJetPt[iCut] = new TH3F("ESD_MesonResolution_JetPt", "ESD_MesonResolution_JetPt", fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data(), vecResol.size()-1, vecResol.data(), fVecBinsJetPt.size()-1, fVecBinsJetPt.data());
+          fHistoMesonResolutionJetPt[iCut]->SetXTitle("p_{T, meson, rec} (GeV/c)");
+          fHistoMesonResolutionJetPt[iCut]->SetYTitle("(p_{T, rec} - p_{T, true})/p_{T, rec} (GeV/c)");
+          fHistoMesonResolutionJetPt[iCut]->SetZTitle("p_{T, jet} (GeV/c)");
+          fTrueList[iCut]->Add(fHistoMesonResolutionJetPt[iCut]);
+
+          fHistoTrueMesonBothDaughtersInJet[iCut] = new TH2F("ESD_TrueMesonsRecJets_BothGammaInJet", "ESD_TrueMesonsRecJets_BothGammaInJet", fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
+          fHistoTrueMesonBothDaughtersInJet[iCut]->SetXTitle("p_{T, meson} (GeV/c)");
+          fHistoTrueMesonBothDaughtersInJet[iCut]->SetYTitle("p_{T, jet} (GeV/c)");
+          fTrueList[iCut]->Add(fHistoTrueMesonBothDaughtersInJet[iCut]);
+
+          fHistoTrueMesonOneDaughtersInJet[iCut] = new TH2F("ESD_TrueMesonsRecJets_OneGammaInJet", "ESD_TrueMesonsRecJets_OneGammaInJet", fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
+          fHistoTrueMesonOneDaughtersInJet[iCut]->SetXTitle("p_{T, meson} (GeV/c)");
+          fHistoTrueMesonOneDaughtersInJet[iCut]->SetYTitle("p_{T, jet} (GeV/c)");
+          fTrueList[iCut]->Add(fHistoTrueMesonOneDaughtersInJet[iCut]);
+
+          fHistoTrueMesonNoDaughtersInJet[iCut] = new TH2F("ESD_TrueMesonsRecJets_NoGammaInJet", "ESD_TrueMesonsRecJets_NoGammaInJet", fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
+          fHistoTrueMesonNoDaughtersInJet[iCut]->SetXTitle("p_{T, meson} (GeV/c)");
+          fHistoTrueMesonNoDaughtersInJet[iCut]->SetYTitle("p_{T, jet} (GeV/c)");
+          fTrueList[iCut]->Add(fHistoTrueMesonNoDaughtersInJet[iCut]);
+
+          fHistoTrueMesonDaughtersInOtherJet[iCut] = new TH2F("ESD_TrueMesonsRecJets_GammaInOtherJet", "ESD_TrueMesonsRecJets_GammaInOtherJet", fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
+          fHistoTrueMesonDaughtersInOtherJet[iCut]->SetXTitle("p_{T, meson} (GeV/c)");
+          fHistoTrueMesonDaughtersInOtherJet[iCut]->SetYTitle("p_{T, jet} (GeV/c)");
+          fTrueList[iCut]->Add(fHistoTrueMesonDaughtersInOtherJet[iCut]);
+        }
+      }
+
+      if(fDoAnalysisZ){
+        fHistoTrueMesonJetPtVsTrueZ[iCut] = new TH2F("ESD_TrueMeson_TrueFrag_JetPt", "ESD_TrueMeson_TrueFrag_JetPt", fVecBinsFragment.size() - 1, fVecBinsFragment.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
+        fHistoTrueMesonJetPtVsTrueZ[iCut]->SetXTitle("Z");
+        fHistoTrueMesonJetPtVsTrueZ[iCut]->SetYTitle("Jet p_{T} (GeV/c)");
+        fTrueList[iCut]->Add(fHistoTrueMesonJetPtVsTrueZ[iCut]);
+ 
+        fHistoTrueMesonJetPtVsRecZ[iCut] = new TH2F("ESD_TrueMeson_RecFrag_JetPt", "ESD_TrueMeson_RecFrag_JetPt", fVecBinsFragment.size() - 1, fVecBinsFragment.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
+        fHistoTrueMesonJetPtVsRecZ[iCut]->SetXTitle("Z");
+        fHistoTrueMesonJetPtVsRecZ[iCut]->SetYTitle("Jet p_{T} (GeV/c)");
+        fTrueList[iCut]->Add(fHistoTrueMesonJetPtVsRecZ[iCut]);
+      
+        if(fDoMesonQA > 0){        
+          fHistoTrueSecMesonJetPtVsRecZ[iCut] = new TH2F("ESD_TrueSecMeson_RecFrag_JetPt", "ESD_TrueMeson_RecFrag_JetPt", fVecBinsFragment.size() - 1, fVecBinsFragment.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
+          fHistoTrueSecMesonJetPtVsRecZ[iCut]->SetXTitle("Z");
+          fHistoTrueSecMesonJetPtVsRecZ[iCut]->SetYTitle("Jet p_{T} (GeV/c)");
+          fTrueList[iCut]->Add(fHistoTrueSecMesonJetPtVsRecZ[iCut]);
+
+          fHistoTrueMesonInTrueJet_JetPtVsTrueZ[iCut] = new TH2F("ESD_TrueMeson_InTrueJets_TrueFrag_JetPt", "ESD_TrueMeson_InTrueJets_TrueFrag_JetPt", fVecBinsFragment.size() - 1, fVecBinsFragment.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
+          fHistoTrueMesonInTrueJet_JetPtVsTrueZ[iCut]->SetXTitle("meson z_{T}");
+          fHistoTrueMesonInTrueJet_JetPtVsTrueZ[iCut]->SetYTitle("Jet p_{T} (GeV/c)");
+          fTrueList[iCut]->Add(fHistoTrueMesonInTrueJet_JetPtVsTrueZ[iCut]);
+
+          fRespMatrixHandlerTrueMesonInvMassVsZDoubleCount[iCut] = new MatrixHandler4D(fVecBinsMesonInvMass, fVecBinsFragment, fVecBinsJetPt, {0, 1}, fUseThNForResponse);
+          if (fUseThNForResponse)
+            fTrueList[iCut]->Add(fRespMatrixHandlerTrueMesonInvMassVsZDoubleCount[iCut]->GetTHnSparse("ESD_TrueMother_InvMass_Z_JetPt_DoubleCount"));
+          else
+            fTrueList[iCut]->Add(fRespMatrixHandlerTrueMesonInvMassVsZDoubleCount[iCut]->GetTH2("ESD_TrueMother_InvMass_Z_JetPt_DoubleCount"));
+        }
+      
       }
     }
 
-    if (fDoMesonQA > 0) {
-      fHistoInvMassVsPt_Incl[iCut] = new TH2F("ESD_Mother_InvMass_Pt_Incl", "ESD_Mother_InvMass_Pt_Incl", fVecBinsMesonInvMass.size() - 1, fVecBinsMesonInvMass.data(), fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data());
-      fHistoInvMassVsPt_Incl[iCut]->SetXTitle("M_{#gamma#gamma} (GeV/c^{2})");
-      fHistoInvMassVsPt_Incl[iCut]->SetYTitle("p_{T} (GeV/c)");
-      fESDList[iCut]->Add(fHistoInvMassVsPt_Incl[iCut]);
+    if(fDoAnalysisPt){
 
-      fHistoInvMassVsPtMassCut[iCut] = new TH2F("ESD_Mother_InvMass_Pt_MassCut", "ESD_Mother_InvMass_Pt_MassCut", fVecBinsMesonInvMass.size() - 1, fVecBinsMesonInvMass.data(), fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data());
-      fHistoInvMassVsPtMassCut[iCut]->SetXTitle("M_{#gamma#gamma} (GeV/c^{2})");
-      fHistoInvMassVsPtMassCut[iCut]->SetYTitle("p_{T} (GeV/c)");
-      fESDList[iCut]->Add(fHistoInvMassVsPtMassCut[iCut]);
+      // inv mass histograms
+      fHistoInvMassVsPt[iCut] = new TH2F("ESD_Mother_InvMass_Pt", "ESD_Mother_InvMass_Pt", fVecBinsMesonInvMass.size() - 1, fVecBinsMesonInvMass.data(), fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data());
+      fHistoInvMassVsPt[iCut]->SetXTitle("M_{#gamma#gamma} (GeV/c^{2})");
+      fHistoInvMassVsPt[iCut]->SetYTitle("p_{T} (GeV/c)");
+      fESDList[iCut]->Add(fHistoInvMassVsPt[iCut]);
 
-      fHistoInvMassVsPtMassCutSB[iCut] = new TH2F("ESD_Mother_InvMass_Pt_MassCutSB", "ESD_Mother_InvMass_Pt_MassCutSB", fVecBinsMesonInvMass.size() - 1, fVecBinsMesonInvMass.data(), fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data());
-      fHistoInvMassVsPtMassCutSB[iCut]->SetXTitle("M_{#gamma#gamma} (GeV/c^{2})");
-      fHistoInvMassVsPtMassCutSB[iCut]->SetYTitle("p_{T} (GeV/c)");
-      fESDList[iCut]->Add(fHistoInvMassVsPtMassCutSB[iCut]);
+      fHistoInvMassVsPtBack[iCut] = new TH2F("ESD_Back_InvMass_Pt", "ESD_Back_InvMass_Pt", fVecBinsMesonInvMass.size() - 1, fVecBinsMesonInvMass.data(), fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data());
+      fHistoInvMassVsPtBack[iCut]->SetXTitle("M_{#gamma#gamma} (GeV/c^{2})");
+      fHistoInvMassVsPtBack[iCut]->SetYTitle("p_{T} (GeV/c)");
+      fESDList[iCut]->Add(fHistoInvMassVsPtBack[iCut]);
+
+      // in perpendicular cone
+      fHistoInvMassVsPtPerpCone[iCut] = new TH2F("ESD_Mother_InvMass_Pt_PerpCone", "ESD_Mother_InvMass_Pt_PerpCone", fVecBinsMesonInvMass.size() - 1, fVecBinsMesonInvMass.data(), fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data());
+      fHistoInvMassVsPtPerpCone[iCut]->SetXTitle("M_{#gamma#gamma} (GeV/c^{2})");
+      fHistoInvMassVsPtPerpCone[iCut]->SetYTitle("p_{T} (GeV/c)");
+      fESDList[iCut]->Add(fHistoInvMassVsPtPerpCone[iCut]);
+
+      fRespMatrixHandlerMesonInvMass[iCut] = new MatrixHandler4D(fVecBinsMesonInvMass, fVecBinsMesonPt, fVecBinsJetPt, fVecBinsJetPt, fUseThNForResponse);
+      if (fUseThNForResponse)
+        fESDList[iCut]->Add(fRespMatrixHandlerMesonInvMass[iCut]->GetTHnSparse("InvMassVsPt_JetPt"));
+      else
+        fESDList[iCut]->Add(fRespMatrixHandlerMesonInvMass[iCut]->GetTH2("InvMassVsPt_JetPt"));
+      
+      fRespMatrixHandlerMesonBackInvMassVsPt[iCut] = new MatrixHandler4D(fVecBinsMesonInvMass, fVecBinsMesonPt, fVecBinsJetPt, {0, 1}, fUseThNForResponse);
+      if (fUseThNForResponse)
+        fESDList[iCut]->Add(fRespMatrixHandlerMesonBackInvMassVsPt[iCut]->GetTHnSparse("InvMassVsPt_Background_JetPt"));
+      else
+        fESDList[iCut]->Add(fRespMatrixHandlerMesonBackInvMassVsPt[iCut]->GetTH2("InvMassVsPt_Background_JetPt"));
+
+      // only for additional mixed background
+      if( fUseMixedBackAdd ){
+        fRespMatrixHandlerMesonBackAddInvMassVsPt[iCut] = new MatrixHandler4D(fVecBinsMesonInvMass, fVecBinsMesonPt, fVecBinsJetPt, {0, 1}, fUseThNForResponse);
+        if (fUseThNForResponse)
+          fESDList[iCut]->Add(fRespMatrixHandlerMesonBackAddInvMassVsPt[iCut]->GetTHnSparse("InvMassVsPt_Background_Add_JetPt"));
+        else
+          fESDList[iCut]->Add(fRespMatrixHandlerMesonBackAddInvMassVsPt[iCut]->GetTH2("InvMassVsPt_Background_Add_JetPt"));
+      }
+
+      fRespMatrixHandlerMesonInvMassPerpCone[iCut] = new MatrixHandler4D(fVecBinsMesonInvMass, fVecBinsMesonPt, fVecBinsJetPt, {0, 1}, fUseThNForResponse);
+      if (fUseThNForResponse)
+        fESDList[iCut]->Add(fRespMatrixHandlerMesonInvMassPerpCone[iCut]->GetTHnSparse("InvMassVsPt_JetPt_PerpCone"));
+      else
+        fESDList[iCut]->Add(fRespMatrixHandlerMesonInvMassPerpCone[iCut]->GetTH2("InvMassVsPt_JetPt_PerpCone"));
+
+
+      if (fDoMesonQA > 0) {
+        fHistoInvMassVsPt_Incl[iCut] = new TH2F("ESD_Mother_InvMass_Pt_Incl", "ESD_Mother_InvMass_Pt_Incl", fVecBinsMesonInvMass.size() - 1, fVecBinsMesonInvMass.data(), fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data());
+        fHistoInvMassVsPt_Incl[iCut]->SetXTitle("M_{#gamma#gamma} (GeV/c^{2})");
+        fHistoInvMassVsPt_Incl[iCut]->SetYTitle("p_{T} (GeV/c)");
+        fESDList[iCut]->Add(fHistoInvMassVsPt_Incl[iCut]);
+
+        fHistoInvMassVsPtMassCut[iCut] = new TH2F("ESD_Mother_InvMass_Pt_MassCut", "ESD_Mother_InvMass_Pt_MassCut", fVecBinsMesonInvMass.size() - 1, fVecBinsMesonInvMass.data(), fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data());
+        fHistoInvMassVsPtMassCut[iCut]->SetXTitle("M_{#gamma#gamma} (GeV/c^{2})");
+        fHistoInvMassVsPtMassCut[iCut]->SetYTitle("p_{T} (GeV/c)");
+        fESDList[iCut]->Add(fHistoInvMassVsPtMassCut[iCut]);
+
+        fHistoInvMassVsPtMassCutSB[iCut] = new TH2F("ESD_Mother_InvMass_Pt_MassCutSB", "ESD_Mother_InvMass_Pt_MassCutSB", fVecBinsMesonInvMass.size() - 1, fVecBinsMesonInvMass.data(), fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data());
+        fHistoInvMassVsPtMassCutSB[iCut]->SetXTitle("M_{#gamma#gamma} (GeV/c^{2})");
+        fHistoInvMassVsPtMassCutSB[iCut]->SetYTitle("p_{T} (GeV/c)");
+        fESDList[iCut]->Add(fHistoInvMassVsPtMassCutSB[iCut]);
+      }
     }
 
-    fHistoInvMassVsPtBack[iCut] = new TH2F("ESD_Back_InvMass_Pt", "ESD_Back_InvMass_Pt", fVecBinsMesonInvMass.size() - 1, fVecBinsMesonInvMass.data(), fVecBinsMesonPt.size() - 1, fVecBinsMesonPt.data());
-    fHistoInvMassVsPtBack[iCut]->SetXTitle("M_{#gamma#gamma} (GeV/c^{2})");
-    fHistoInvMassVsPtBack[iCut]->SetYTitle("p_{T} (GeV/c)");
-    fESDList[iCut]->Add(fHistoInvMassVsPtBack[iCut]);
 
-    fHistoJetPtVsFrag[iCut] = new TH2F("ESD_Frag_JetPt", "ESD_Frag_JetPt", fVecBinsFragment.size() - 1, fVecBinsFragment.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
-    fHistoJetPtVsFrag[iCut]->SetXTitle("z");
-    fHistoJetPtVsFrag[iCut]->SetYTitle("p_{T, Jet} (GeV/c)");
-    fESDList[iCut]->Add(fHistoJetPtVsFrag[iCut]);
+    if(fDoAnalysisZ){
+      fHistoJetPtVsFrag[iCut] = new TH2F("ESD_Frag_JetPt", "ESD_Frag_JetPt", fVecBinsFragment.size() - 1, fVecBinsFragment.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
+      fHistoJetPtVsFrag[iCut]->SetXTitle("z");
+      fHistoJetPtVsFrag[iCut]->SetYTitle("p_{T, Jet} (GeV/c)");
+      fESDList[iCut]->Add(fHistoJetPtVsFrag[iCut]);
 
-    // perpendicular cone
-    fHistoJetPtVsFragPerpCone[iCut] = new TH2F("ESD_Frag_JetPt_PerpCone", "ESD_Frag_JetPt_PerpCone", fVecBinsFragment.size() - 1, fVecBinsFragment.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
-    fHistoJetPtVsFragPerpCone[iCut]->SetXTitle("z");
-    fHistoJetPtVsFragPerpCone[iCut]->SetYTitle("p_{T, Jet} (GeV/c)");
-    fESDList[iCut]->Add(fHistoJetPtVsFragPerpCone[iCut]);
+      // perpendicular cone
+      fHistoJetPtVsFragPerpCone[iCut] = new TH2F("ESD_Frag_JetPt_PerpCone", "ESD_Frag_JetPt_PerpCone", fVecBinsFragment.size() - 1, fVecBinsFragment.data(), fVecBinsJetPt.size() - 1, fVecBinsJetPt.data());
+      fHistoJetPtVsFragPerpCone[iCut]->SetXTitle("z");
+      fHistoJetPtVsFragPerpCone[iCut]->SetYTitle("p_{T, Jet} (GeV/c)");
+      fESDList[iCut]->Add(fHistoJetPtVsFragPerpCone[iCut]);
 
-    fRespMatrixHandlerMesonInvMass[iCut] = new MatrixHandler4D(fVecBinsMesonInvMass, fVecBinsMesonPt, fVecBinsJetPt, fVecBinsJetPt, fUseThNForResponse);
-    if (fUseThNForResponse)
-      fESDList[iCut]->Add(fRespMatrixHandlerMesonInvMass[iCut]->GetTHnSparse("InvMassVsPt_JetPt"));
-    else
-      fESDList[iCut]->Add(fRespMatrixHandlerMesonInvMass[iCut]->GetTH2("InvMassVsPt_JetPt"));
-
-    fRespMatrixHandlerMesonInvMassVsZ[iCut] = new MatrixHandler4D(fVecBinsMesonInvMass, fVecBinsFragment, fVecBinsJetPt, {0, 1}, fUseThNForResponse);
-    if (fUseThNForResponse)
-      fESDList[iCut]->Add(fRespMatrixHandlerMesonInvMassVsZ[iCut]->GetTHnSparse("InvMassVsZ_JetPt"));
-    else
-      fESDList[iCut]->Add(fRespMatrixHandlerMesonInvMassVsZ[iCut]->GetTH2("InvMassVsZ_JetPt"));
-
-    fRespMatrixHandlerMesonBackInvMassVsZ[iCut] = new MatrixHandler4D(fVecBinsMesonInvMass, fVecBinsFragment, fVecBinsJetPt, {0, 1}, fUseThNForResponse);
-    if (fUseThNForResponse)
-      fESDList[iCut]->Add(fRespMatrixHandlerMesonBackInvMassVsZ[iCut]->GetTHnSparse("InvMassVsZ_Background_JetPt"));
-    else
-      fESDList[iCut]->Add(fRespMatrixHandlerMesonBackInvMassVsZ[iCut]->GetTH2("InvMassVsZ_Background_JetPt"));
-
-    fRespMatrixHandlerMesonBackInvMassVsPt[iCut] = new MatrixHandler4D(fVecBinsMesonInvMass, fVecBinsMesonPt, fVecBinsJetPt, {0, 1}, fUseThNForResponse);
-    if (fUseThNForResponse)
-      fESDList[iCut]->Add(fRespMatrixHandlerMesonBackInvMassVsPt[iCut]->GetTHnSparse("InvMassVsPt_Background_JetPt"));
-    else
-      fESDList[iCut]->Add(fRespMatrixHandlerMesonBackInvMassVsPt[iCut]->GetTH2("InvMassVsPt_Background_JetPt"));
-
-    // only for additional mixed background
-    if( fUseMixedBackAdd ){
-      fRespMatrixHandlerMesonBackAddInvMassVsZ[iCut] = new MatrixHandler4D(fVecBinsMesonInvMass, fVecBinsFragment, fVecBinsJetPt, {0, 1}, fUseThNForResponse);
+      fRespMatrixHandlerMesonInvMassVsZ[iCut] = new MatrixHandler4D(fVecBinsMesonInvMass, fVecBinsFragment, fVecBinsJetPt, {0, 1}, fUseThNForResponse);
       if (fUseThNForResponse)
-        fESDList[iCut]->Add(fRespMatrixHandlerMesonBackAddInvMassVsZ[iCut]->GetTHnSparse("InvMassVsZ_Background_Add_JetPt"));
+        fESDList[iCut]->Add(fRespMatrixHandlerMesonInvMassVsZ[iCut]->GetTHnSparse("InvMassVsZ_JetPt"));
       else
-        fESDList[iCut]->Add(fRespMatrixHandlerMesonBackAddInvMassVsZ[iCut]->GetTH2("InvMassVsZ_Background_Add_JetPt"));
+        fESDList[iCut]->Add(fRespMatrixHandlerMesonInvMassVsZ[iCut]->GetTH2("InvMassVsZ_JetPt"));
 
-      fRespMatrixHandlerMesonBackAddInvMassVsPt[iCut] = new MatrixHandler4D(fVecBinsMesonInvMass, fVecBinsMesonPt, fVecBinsJetPt, {0, 1}, fUseThNForResponse);
+      fRespMatrixHandlerMesonBackInvMassVsZ[iCut] = new MatrixHandler4D(fVecBinsMesonInvMass, fVecBinsFragment, fVecBinsJetPt, {0, 1}, fUseThNForResponse);
       if (fUseThNForResponse)
-        fESDList[iCut]->Add(fRespMatrixHandlerMesonBackAddInvMassVsPt[iCut]->GetTHnSparse("InvMassVsPt_Background_Add_JetPt"));
+        fESDList[iCut]->Add(fRespMatrixHandlerMesonBackInvMassVsZ[iCut]->GetTHnSparse("InvMassVsZ_Background_JetPt"));
       else
-        fESDList[iCut]->Add(fRespMatrixHandlerMesonBackAddInvMassVsPt[iCut]->GetTH2("InvMassVsPt_Background_Add_JetPt"));
+        fESDList[iCut]->Add(fRespMatrixHandlerMesonBackInvMassVsZ[iCut]->GetTH2("InvMassVsZ_Background_JetPt"));
 
+      // only for additional mixed background
+      if( fUseMixedBackAdd ){
+        fRespMatrixHandlerMesonBackAddInvMassVsZ[iCut] = new MatrixHandler4D(fVecBinsMesonInvMass, fVecBinsFragment, fVecBinsJetPt, {0, 1}, fUseThNForResponse);
+        if (fUseThNForResponse)
+          fESDList[iCut]->Add(fRespMatrixHandlerMesonBackAddInvMassVsZ[iCut]->GetTHnSparse("InvMassVsZ_Background_Add_JetPt"));
+        else
+          fESDList[iCut]->Add(fRespMatrixHandlerMesonBackAddInvMassVsZ[iCut]->GetTH2("InvMassVsZ_Background_Add_JetPt"));
+      }
+
+      // perpendicular cone
+      fRespMatrixHandlerMesonInvMassVsZPerpCone[iCut] = new MatrixHandler4D(fVecBinsMesonInvMass, fVecBinsFragment, fVecBinsJetPt, {0, 1}, fUseThNForResponse);
+      if (fUseThNForResponse)
+        fESDList[iCut]->Add(fRespMatrixHandlerMesonInvMassVsZPerpCone[iCut]->GetTHnSparse("InvMassVsZ_JetPt_PerpCone"));
+      else
+        fESDList[iCut]->Add(fRespMatrixHandlerMesonInvMassVsZPerpCone[iCut]->GetTH2("InvMassVsZ_JetPt_PerpCone"));
+    
     }
-
-    // perpendicular cone
-    fRespMatrixHandlerMesonInvMassVsZPerpCone[iCut] = new MatrixHandler4D(fVecBinsMesonInvMass, fVecBinsFragment, fVecBinsJetPt, {0, 1}, fUseThNForResponse);
-    if (fUseThNForResponse)
-      fESDList[iCut]->Add(fRespMatrixHandlerMesonInvMassVsZPerpCone[iCut]->GetTHnSparse("InvMassVsZ_JetPt_PerpCone"));
-    else
-      fESDList[iCut]->Add(fRespMatrixHandlerMesonInvMassVsZPerpCone[iCut]->GetTH2("InvMassVsZ_JetPt_PerpCone"));
-
-    fRespMatrixHandlerMesonInvMassPerpCone[iCut] = new MatrixHandler4D(fVecBinsMesonInvMass, fVecBinsMesonPt, fVecBinsJetPt, {0, 1}, fUseThNForResponse);
-    if (fUseThNForResponse)
-      fESDList[iCut]->Add(fRespMatrixHandlerMesonInvMassPerpCone[iCut]->GetTHnSparse("InvMassVsPt_JetPt_PerpCone"));
-    else
-      fESDList[iCut]->Add(fRespMatrixHandlerMesonInvMassPerpCone[iCut]->GetTH2("InvMassVsPt_JetPt_PerpCone"));
 
     if(fDoRadiusDep){
       std::vector<std::vector<double>> vecXAxisInvMassPtRadius = {fVecBinsMesonInvMass, fVecBinsMesonPtCoarse, fVecBinsMesonJetRadius};
@@ -1585,24 +1630,27 @@ void AliAnalysisTaskMesonJetCorrelation::UserCreateOutputObjects()
     // ----------------- MC related ---------------- //
     //-----------------------------------------------//
     if (fIsMC) {
-      fRespMatrixHandlerMesonPt[iCut] = new MatrixHandler4D(fVecBinsMesonPt, fVecBinsMesonPt, fVecBinsJetPt, fVecBinsJetPt, fUseThNForResponse);
-      if (fUseThNForResponse)
-        fTrueList[iCut]->Add(fRespMatrixHandlerMesonPt[iCut]->GetTHnSparse("MesonPt_JetPt_TrueVsRec"));
-      else
-        fTrueList[iCut]->Add(fRespMatrixHandlerMesonPt[iCut]->GetTH2("MesonPt_JetPt_TrueVsRec"));
-
-      fRespMatrixHandlerFrag[iCut] = new MatrixHandler4D(fVecBinsFragment, fVecBinsFragment, fVecBinsJetPt, fVecBinsJetPt, fUseThNForResponse);
-      if (fUseThNForResponse)
-        fTrueList[iCut]->Add(fRespMatrixHandlerFrag[iCut]->GetTHnSparse("Frag_JetPt_TrueVsRec"));
-      else
-        fTrueList[iCut]->Add(fRespMatrixHandlerFrag[iCut]->GetTH2("Frag_JetPt_TrueVsRec"));
-
-      if(!fDoLightOutput){
-        fRespMatrixHandlerFragTrueJets[iCut] = new MatrixHandler4D(fVecBinsFragment, fVecBinsFragment, fVecBinsJetPt, fVecBinsJetPt, fUseThNForResponse);
+      if(fDoAnalysisPt){
+        fRespMatrixHandlerMesonPt[iCut] = new MatrixHandler4D(fVecBinsMesonPt, fVecBinsMesonPt, fVecBinsJetPt, fVecBinsJetPt, fUseThNForResponse);
         if (fUseThNForResponse)
-          fTrueList[iCut]->Add(fRespMatrixHandlerFragTrueJets[iCut]->GetTHnSparse("Frag_JetPt_TrueVsRec_ForTrueJets"));
+          fTrueList[iCut]->Add(fRespMatrixHandlerMesonPt[iCut]->GetTHnSparse("MesonPt_JetPt_TrueVsRec"));
         else
-          fTrueList[iCut]->Add(fRespMatrixHandlerFragTrueJets[iCut]->GetTH2("Frag_JetPt_TrueVsRec_ForTrueJets"));
+          fTrueList[iCut]->Add(fRespMatrixHandlerMesonPt[iCut]->GetTH2("MesonPt_JetPt_TrueVsRec"));
+      }
+      if(fDoAnalysisZ){
+        fRespMatrixHandlerFrag[iCut] = new MatrixHandler4D(fVecBinsFragment, fVecBinsFragment, fVecBinsJetPt, fVecBinsJetPt, fUseThNForResponse);
+        if (fUseThNForResponse)
+          fTrueList[iCut]->Add(fRespMatrixHandlerFrag[iCut]->GetTHnSparse("Frag_JetPt_TrueVsRec"));
+        else
+          fTrueList[iCut]->Add(fRespMatrixHandlerFrag[iCut]->GetTH2("Frag_JetPt_TrueVsRec"));
+      
+        if(!fDoLightOutput){
+          fRespMatrixHandlerFragTrueJets[iCut] = new MatrixHandler4D(fVecBinsFragment, fVecBinsFragment, fVecBinsJetPt, fVecBinsJetPt, fUseThNForResponse);
+          if (fUseThNForResponse)
+            fTrueList[iCut]->Add(fRespMatrixHandlerFragTrueJets[iCut]->GetTHnSparse("Frag_JetPt_TrueVsRec_ForTrueJets"));
+          else
+            fTrueList[iCut]->Add(fRespMatrixHandlerFragTrueJets[iCut]->GetTH2("Frag_JetPt_TrueVsRec_ForTrueJets"));
+        }
       }
       
       if(fDoRadiusDep){
@@ -1620,7 +1668,7 @@ void AliAnalysisTaskMesonJetCorrelation::UserCreateOutputObjects()
           fTrueList[iCut]->Add(fRespMatrixHandlerMesonPtTrueRadius[iCut]->GetTH2("MesonPt_JetPt_TrueRadius_TrueVsRec"));
       }
     } // end MC related
-    
+
     if(fUseCentralEventSelection){
       fAliEventCuts.AddQAplotsToList(fESDList[iCut]);
     }
@@ -1794,14 +1842,14 @@ void AliAnalysisTaskMesonJetCorrelation::MakeBinning()
   double valJetPt = 0;
   for (int i = 0; i < 1000; ++i) {
     fVecBinsJetPt.push_back(valJetPt);
-    if (valJetPt < 20.0 - epsilon)
+    if (valJetPt < 5.0 - epsilon)
+      valJetPt += 2.5;
+    else if (valJetPt < 20.0 - epsilon)
       valJetPt += 5;
     else if (valJetPt < 100 - epsilon)
       valJetPt += 10;
     else if (valJetPt < 200 - epsilon)
       valJetPt += 25;
-    else if (valJetPt < 300 - epsilon)
-      valJetPt += 50;
     else if (valJetPt < 500 - epsilon)
       valJetPt += 100;
     else
@@ -2717,8 +2765,10 @@ void AliAnalysisTaskMesonJetCorrelation::FillMesonHistograms(AliAODConversionPho
         weightMatBudget = vecWeightsMatWeightsGammas[firstGammaIndex];
       }
     }
-    if (fDoMesonQA > 0) {
-      fHistoInvMassVsPt_Incl[fiCut]->Fill(pi0cand->M(), pi0cand->Pt(), fWeightJetJetMC*weightMatBudget);
+    if(fDoAnalysisPt){
+      if (fDoMesonQA > 0) {
+        fHistoInvMassVsPt_Incl[fiCut]->Fill(pi0cand->M(), pi0cand->Pt(), fWeightJetJetMC*weightMatBudget);
+      }
     }
     double RJetPi0Cand = 0;
     int matchedJet = -1;
@@ -2728,11 +2778,13 @@ void AliAnalysisTaskMesonJetCorrelation::FillMesonHistograms(AliAODConversionPho
         ptJet = fVectorJetPt[matchedJet];
       }
 
-      // Fill Inv Mass Histograms
-      fHistoInvMassVsPt[fiCut]->Fill(pi0cand->M(), pi0cand->Pt(), fWeightJetJetMC*weightMatBudget);
+      if(fDoAnalysisPt){
+        // Fill Inv Mass Histograms
+        fHistoInvMassVsPt[fiCut]->Fill(pi0cand->M(), pi0cand->Pt(), fWeightJetJetMC*weightMatBudget);
 
-      // Fill the inv. mass histograms for all jet pTs
-      fRespMatrixHandlerMesonInvMass[fiCut]->Fill(ptJet, 0.5, pi0cand->M(), pi0cand->Pt(), fWeightJetJetMC*weightMatBudget);
+        // Fill the inv. mass histograms for all jet pTs
+        fRespMatrixHandlerMesonInvMass[fiCut]->Fill(ptJet, 0.5, pi0cand->M(), pi0cand->Pt(), fWeightJetJetMC*weightMatBudget);
+      }
 
       if(fDoRadiusDep){
         std::vector<double> vecFillInvMassPtR = {pi0cand->M(), pi0cand->Pt(), RJetPi0Cand};
@@ -2742,12 +2794,14 @@ void AliAnalysisTaskMesonJetCorrelation::FillMesonHistograms(AliAODConversionPho
 
       // Fill Z histograms
       float z = GetFrag(pi0cand, matchedJet, false);
+      if(fDoAnalysisZ){
+        fRespMatrixHandlerMesonInvMassVsZ[fiCut]->Fill(ptJet, 0.5, pi0cand->M(), z, fWeightJetJetMC*weightMatBudget);     // Inv Mass vs. Z in Jet Pt_rec bins. Needed to subtract background in the Z-distribution
+      }
 
-      fRespMatrixHandlerMesonInvMassVsZ[fiCut]->Fill(ptJet, 0.5, pi0cand->M(), z, fWeightJetJetMC*weightMatBudget);     // Inv Mass vs. Z in Jet Pt_rec bins. Needed to subtract background in the Z-distribution
       if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelectedByMassCut(pi0cand, 0)) { // nominal mass range
-        fHistoJetPtVsFrag[fiCut]->Fill(z, ptJet, fWeightJetJetMC*weightMatBudget);
+        if(fDoAnalysisZ){fHistoJetPtVsFrag[fiCut]->Fill(z, ptJet, fWeightJetJetMC*weightMatBudget);}
         if (fDoMesonQA > 0) {
-          fHistoInvMassVsPtMassCut[fiCut]->Fill(pi0cand->M(), pi0cand->Pt(), fWeightJetJetMC*weightMatBudget);
+          if(fDoAnalysisPt){fHistoInvMassVsPtMassCut[fiCut]->Fill(pi0cand->M(), pi0cand->Pt(), fWeightJetJetMC*weightMatBudget);}
         }
       }
 
@@ -2767,18 +2821,23 @@ void AliAnalysisTaskMesonJetCorrelation::FillMesonHistograms(AliAODConversionPho
     double RJetPi0CandPerp = 0;
     int matchedJetPerp = -1;
     if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->IsParticleInJet(fVectorJetEta, fVectorJetPhiPerp, fConvJetReader->Get_Jet_Radius(), pi0cand->Eta(), pi0cand->Phi(), matchedJetPerp, RJetPi0CandPerp)) {
+      
+      if(fDoAnalysisPt){
+        fHistoInvMassVsPtPerpCone[fiCut]->Fill(pi0cand->M(), pi0cand->Pt(), fWeightJetJetMC*weightMatBudget);
+        // Fill the inv. mass histograms for all jet pTs
+        fRespMatrixHandlerMesonInvMassPerpCone[fiCut]->Fill(ptJet, 0.5, pi0cand->M(), pi0cand->Pt(), fWeightJetJetMC*weightMatBudget);
+      }
 
-      fHistoInvMassVsPtPerpCone[fiCut]->Fill(pi0cand->M(), pi0cand->Pt(), fWeightJetJetMC*weightMatBudget);
-
-      // Fill the inv. mass histograms for all jet pTs
-      fRespMatrixHandlerMesonInvMassPerpCone[fiCut]->Fill(ptJet, 0.5, pi0cand->M(), pi0cand->Pt(), fWeightJetJetMC*weightMatBudget);
+      
 
       // Fill Z histograms
-      float z = GetFrag(pi0cand, matchedJet, false);
+      if(fDoAnalysisZ){
+        float z = GetFrag(pi0cand, matchedJet, false);
+        fRespMatrixHandlerMesonInvMassVsZPerpCone[fiCut]->Fill(ptJet, 0.5, pi0cand->M(), z, fWeightJetJetMC*weightMatBudget); // Inv Mass vs. Z in Jet Pt_rec bins. Needed to subtract background in the Z-distribution
 
-      fRespMatrixHandlerMesonInvMassVsZPerpCone[fiCut]->Fill(ptJet, 0.5, pi0cand->M(), z, fWeightJetJetMC*weightMatBudget); // Inv Mass vs. Z in Jet Pt_rec bins. Needed to subtract background in the Z-distribution
-      if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelectedByMassCut(pi0cand, 0)) {     // nominal mass range
-        fHistoJetPtVsFragPerpCone[fiCut]->Fill(z, ptJet, fWeightJetJetMC*weightMatBudget);
+        if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelectedByMassCut(pi0cand, 0)) {     // nominal mass range
+          fHistoJetPtVsFragPerpCone[fiCut]->Fill(z, ptJet, fWeightJetJetMC*weightMatBudget);
+        }
       }
 
     } // end isInJet in perpendicular direction
@@ -3160,19 +3219,21 @@ void AliAnalysisTaskMesonJetCorrelation::FillInvMassBackHistograms(AliAODConvers
 
   // Here, a special case is filled in case of both rotation and mixed background are used
   if(!isRotBack && fUseMixedBackAdd){
-    fRespMatrixHandlerMesonBackAddInvMassVsPt[fiCut]->Fill(ptJet, 0.5, backgroundCandidate->M(), backgroundCandidate->Pt(), fWeightJetJetMC); // Inv Mass vs. meson Pt in Jet Pt_rec bins. Needed to subtract background in the Pt-distribution
-    fRespMatrixHandlerMesonBackAddInvMassVsZ[fiCut]->Fill(ptJet, 0.5, backgroundCandidate->M(), z, fWeightJetJetMC);                          // Inv Mass vs. Z in Jet Pt_rec bins. Needed to subtract background in the Z-distribution
+    if(fDoAnalysisPt){ fRespMatrixHandlerMesonBackAddInvMassVsPt[fiCut]->Fill(ptJet, 0.5, backgroundCandidate->M(), backgroundCandidate->Pt(), fWeightJetJetMC);} // Inv Mass vs. meson Pt in Jet Pt_rec bins. Needed to subtract background in the Pt-distribution
+    if(fDoAnalysisZ){ fRespMatrixHandlerMesonBackAddInvMassVsZ[fiCut]->Fill(ptJet, 0.5, backgroundCandidate->M(), z, fWeightJetJetMC);}                          // Inv Mass vs. Z in Jet Pt_rec bins. Needed to subtract background in the Z-distribution
     // if(fDoRadiusDep){
     //   fRespMatrixHandlerMesonBackAddPtInvMassRadius[fiCut]->Fill(vecFillInvMassPtR, vecFillJetPt, fWeightJetJetMC);
     // }
   } else {
-    fRespMatrixHandlerMesonBackInvMassVsPt[fiCut]->Fill(ptJet, 0.5, backgroundCandidate->M(), backgroundCandidate->Pt(), fWeightJetJetMC); // Inv Mass vs. meson Pt in Jet Pt_rec bins. Needed to subtract background in the Pt-distribution
-    fRespMatrixHandlerMesonBackInvMassVsZ[fiCut]->Fill(ptJet, 0.5, backgroundCandidate->M(), z, fWeightJetJetMC);                          // Inv Mass vs. Z in Jet Pt_rec bins. Needed to subtract background in the Z-distribution
+    if(fDoAnalysisPt){fRespMatrixHandlerMesonBackInvMassVsPt[fiCut]->Fill(ptJet, 0.5, backgroundCandidate->M(), backgroundCandidate->Pt(), fWeightJetJetMC);} // Inv Mass vs. meson Pt in Jet Pt_rec bins. Needed to subtract background in the Pt-distribution
+    if(fDoAnalysisZ){fRespMatrixHandlerMesonBackInvMassVsZ[fiCut]->Fill(ptJet, 0.5, backgroundCandidate->M(), z, fWeightJetJetMC);}                          // Inv Mass vs. Z in Jet Pt_rec bins. Needed to subtract background in the Z-distribution
     if(fDoRadiusDep){
       fRespMatrixHandlerMesonBackPtInvMassRadius[fiCut]->Fill(vecFillInvMassPtR, vecFillJetPt, fWeightJetJetMC);
     }
     //_______ Standard Inv Mass vs. pT background histo _______________
-    fHistoInvMassVsPtBack[fiCut]->Fill(backgroundCandidate->M(), backgroundCandidate->Pt(), fWeightJetJetMC);
+    if(fDoAnalysisPt){
+      fHistoInvMassVsPtBack[fiCut]->Fill(backgroundCandidate->M(), backgroundCandidate->Pt(), fWeightJetJetMC);
+    }
   }
 
 }
@@ -3437,13 +3498,15 @@ void AliAnalysisTaskMesonJetCorrelation::ProcessAODMCParticles(int isCurrentEven
           // }
 
           if (matchedJet >= 0) {
-            if (isCurrentEventSelected == 1)
+            if (isCurrentEventSelected == 1){
               fHistoMCMesonPtNotTriggered[fiCut]->Fill(particle->Pt(), weighted * fWeightJetJetMC); // All MC Pi0 in not triggered collisions
-            else if (isCurrentEventSelected == 2)
+            } else if (isCurrentEventSelected == 2){
               fHistoMCMesonPtNoVertex[fiCut]->Fill(particle->Pt(), weighted * fWeightJetJetMC); // All MC Pi0 in not triggered collisions
+            }
             fHistoMCMesonPt[fiCut]->Fill(particle->Pt(), weighted * fWeightJetJetMC);
-            if (fIsMC > 1)
+            if (fIsMC > 1){
               fHistoMCMesonWOEvtWeightPt[fiCut]->Fill(particle->Pt());
+            }
           }
 
           //------------------------
@@ -3452,35 +3515,44 @@ void AliAnalysisTaskMesonJetCorrelation::ProcessAODMCParticles(int isCurrentEven
           float z_jet = -1;
           float z_parton = -1;
           if (matchedJet >= 0) {
-            z_jet = GetFrag(particle, matchedJet, 1);
-            z_parton = GetFrag(particle, matchedJet, 2);
 
-            fHistoMCJetPtVsFrag[fiCut]->Fill(z_jet, fTrueVectorJetPt[matchedJet], weighted * fWeightJetJetMC);
-            fHistoMCJetPtVsMesonPt[fiCut]->Fill(particle->Pt(), fTrueVectorJetPt[matchedJet], weighted * fWeightJetJetMC);
-            fHistoMCPartonPtVsFrag[fiCut]->Fill(z_parton, fTrueVectorJetPartonPt[matchedJet], weighted * fWeightJetJetMC);
+            if(fDoAnalysisPt){
+              fHistoMCJetPtVsMesonPt[fiCut]->Fill(particle->Pt(), fTrueVectorJetPt[matchedJet], weighted * fWeightJetJetMC);
+            }
+            if(fDoAnalysisZ){
+              z_jet = GetFrag(particle, matchedJet, 1);
+              z_parton = GetFrag(particle, matchedJet, 2);
+              fHistoMCJetPtVsFrag[fiCut]->Fill(z_jet, fTrueVectorJetPt[matchedJet], weighted * fWeightJetJetMC); 
+              fHistoMCPartonPtVsFrag[fiCut]->Fill(z_parton, fTrueVectorJetPartonPt[matchedJet], weighted * fWeightJetJetMC);
+              if (IsParticleFromPartonFrag(particle, fTrueVectorJetPartonID[matchedJet])) {
+                fHistoMCJetPtVsFragTrueParton[fiCut]->Fill(z_jet, fTrueVectorJetPt[matchedJet], weighted * fWeightJetJetMC);
+                fHistoMCPartonPtVsFragTrueParton[fiCut]->Fill(z_parton, fTrueVectorJetPartonPt[matchedJet], weighted * fWeightJetJetMC);
+              }
+            }
 
-            // FIll radius vs. jet pt vs meson pt histogram
+            // Fill radius vs. jet pt vs meson pt histogram
             if(fDoRadiusDep){
               fHistoMCJetPtVsMesonPtVsRadius[fiCut]->Fill(particle->Pt(), fTrueVectorJetPt[matchedJet], RJetPi0Cand, weighted * fWeightJetJetMC);
             }
-
-            if (IsParticleFromPartonFrag(particle, fTrueVectorJetPartonID[matchedJet])) {
-              fHistoMCJetPtVsFragTrueParton[fiCut]->Fill(z_jet, fTrueVectorJetPt[matchedJet], weighted * fWeightJetJetMC);
-              fHistoMCPartonPtVsFragTrueParton[fiCut]->Fill(z_parton, fTrueVectorJetPartonPt[matchedJet], weighted * fWeightJetJetMC);
-            }
+            
           }
           // inside rec. jet but fill true jet quantities
           if (matchedRecJet >= 0 && matchedJet >= 0) {
-            fHistoMCRecJetPtVsFrag[fiCut]->Fill(z_jet, fTrueVectorJetPt[matchedJet], weighted * fWeightJetJetMC);
-            fHistoMCRecJetPtVsMesonPt[fiCut]->Fill(particle->Pt(), fTrueVectorJetPt[matchedJet], weighted * fWeightJetJetMC);
+            if(fDoAnalysisZ){fHistoMCRecJetPtVsFrag[fiCut]->Fill(z_jet, fTrueVectorJetPt[matchedJet], weighted * fWeightJetJetMC);}
+            if(fDoAnalysisPt){fHistoMCRecJetPtVsMesonPt[fiCut]->Fill(particle->Pt(), fTrueVectorJetPt[matchedJet], weighted * fWeightJetJetMC);}
           }
           // Check the acceptance for both gammas
           if (MCParticleIsSelected(daughter0, daughter1, false)) {
             if (CheckAcceptance(daughter0, daughter1)) {
               if (matchedJet >= 0) {
-                fHistoMCMesonInAccPt[fiCut]->Fill(particle->Pt(), weighted * fWeightJetJetMC); // MC Pi0 with gamma in acc
-                fHistoMCJetPtVsFragInAcc[fiCut]->Fill(z_jet, fTrueVectorJetPt[matchedJet], weighted * fWeightJetJetMC);
-                fHistoMCJetPtVsMesonPtInAcc[fiCut]->Fill(particle->Pt(), fTrueVectorJetPt[matchedJet], weighted * fWeightJetJetMC);
+                if(fDoAnalysisPt){
+                  fHistoMCMesonInAccPt[fiCut]->Fill(particle->Pt(), weighted * fWeightJetJetMC); // MC Pi0 with gamma in acc
+                  fHistoMCJetPtVsMesonPtInAcc[fiCut]->Fill(particle->Pt(), fTrueVectorJetPt[matchedJet], weighted * fWeightJetJetMC);
+                }
+                if(fDoAnalysisZ){
+                  fHistoMCJetPtVsFragInAcc[fiCut]->Fill(z_jet, fTrueVectorJetPt[matchedJet], weighted * fWeightJetJetMC);
+                }
+                
                 if(fDoRadiusDep){
                   fHistoMCJetPtVsMesonPtVsRadiusInAcc[fiCut]->Fill(particle->Pt(), fTrueVectorJetPt[matchedJet], RJetPi0Cand, weighted * fWeightJetJetMC);
                 }
@@ -3516,14 +3588,19 @@ void AliAnalysisTaskMesonJetCorrelation::ProcessAODMCParticles(int isCurrentEven
           // Fill histograms for meson fragmentation
           //------------------------
           if (matchedJet >= 0) {
-            float z_jet = GetFrag(particle, matchedJet, 1);
-            fHistoMCJetPtVsFrag_Sec[fiCut]->Fill(z_jet, fTrueVectorJetPt[matchedJet], fWeightJetJetMC);
-            fHistoMCJetPtVsMesonPt_Sec[fiCut]->Fill(particle->Pt(), fTrueVectorJetPt[matchedJet], fWeightJetJetMC);
+            if(fDoAnalysisZ){
+              float z_jet = GetFrag(particle, matchedJet, 1);
+              fHistoMCJetPtVsFrag_Sec[fiCut]->Fill(z_jet, fTrueVectorJetPt[matchedJet], fWeightJetJetMC);
+            }
+            if(fDoAnalysisPt){
+              fHistoMCJetPtVsMesonPt_Sec[fiCut]->Fill(particle->Pt(), fTrueVectorJetPt[matchedJet], fWeightJetJetMC);
+            }
           }
-
-          if (MCParticleIsSelected(daughter0, daughter1, false)) {
-            if (CheckAcceptance(daughter0, daughter1)) {
-              fHistoMCSecMesonInAccPtvsSource[fiCut]->Fill(particle->Pt(), source, fWeightJetJetMC); // All MC Pi0
+          if(fDoAnalysisPt){
+            if (MCParticleIsSelected(daughter0, daughter1, false)) {
+              if (CheckAcceptance(daughter0, daughter1)) {
+                fHistoMCSecMesonInAccPtvsSource[fiCut]->Fill(particle->Pt(), source, fWeightJetJetMC); // All MC Pi0
+              }
             }
           }
         }
@@ -3761,8 +3838,8 @@ bool AliAnalysisTaskMesonJetCorrelation::ProcessTrueMesonCandidatesAOD(AliAODCon
 
   // fill all other mesons (eta and eta prime in case pi0 is selected etc.)
   if (isTrueOtherParticle) {
-    fRespMatrixHandlerTrueOtherMesonInvMassVsPt[fiCut]->Fill(jetPtRec, 0.5, Pi0Candidate->M(), z_rec, fWeightJetJetMC*weightMatBudget);
-    fRespMatrixHandlerTrueOtherMesonInvMassVsZ[fiCut]->Fill(jetPtRec, 0.5, Pi0Candidate->M(), z_rec, fWeightJetJetMC*weightMatBudget);
+    if(fDoAnalysisPt){ fRespMatrixHandlerTrueOtherMesonInvMassVsPt[fiCut]->Fill(jetPtRec, 0.5, Pi0Candidate->M(), Pi0Candidate->Pt(), fWeightJetJetMC*weightMatBudget); }
+    if(fDoAnalysisZ){ fRespMatrixHandlerTrueOtherMesonInvMassVsZ[fiCut]->Fill(jetPtRec, 0.5, Pi0Candidate->M(), z_rec, fWeightJetJetMC*weightMatBudget); }
     return false;
   }
 
@@ -3770,8 +3847,12 @@ bool AliAnalysisTaskMesonJetCorrelation::ProcessTrueMesonCandidatesAOD(AliAODCon
     return false;
 
   // fill all true mesons (primary + secondaries)
-  fRespMatrixHandlerTrueMesonInvMassVsPt[fiCut]->Fill(jetPtRec, 0.5, Pi0Candidate->M(), Pi0Candidate->Pt(), fWeightJetJetMC*weightMatBudget);
-  fRespMatrixHandlerTrueMesonInvMassVsZ[fiCut]->Fill(jetPtRec, 0.5, Pi0Candidate->M(), z_rec, fWeightJetJetMC*weightMatBudget);
+  if(fDoAnalysisPt){
+    fRespMatrixHandlerTrueMesonInvMassVsPt[fiCut]->Fill(jetPtRec, 0.5, Pi0Candidate->M(), Pi0Candidate->Pt(), fWeightJetJetMC*weightMatBudget);
+  }
+  if(fDoAnalysisZ){
+    fRespMatrixHandlerTrueMesonInvMassVsZ[fiCut]->Fill(jetPtRec, 0.5, Pi0Candidate->M(), z_rec, fWeightJetJetMC*weightMatBudget);
+  }
 
   // fill as function of radius
   if(fDoRadiusDep){
@@ -3785,34 +3866,42 @@ bool AliAnalysisTaskMesonJetCorrelation::ProcessTrueMesonCandidatesAOD(AliAODCon
   }
 
   if(fDoMesonQA > 0){
-    fHistoTrueMesonInvMassVsTruePt[fiCut]->Fill(Pi0Candidate->M(), trueMesonCand->Pt(), fWeightJetJetMC*weightMatBudget);
+    if(fDoAnalysisPt){
+      fHistoTrueMesonInvMassVsTruePt[fiCut]->Fill(Pi0Candidate->M(), trueMesonCand->Pt(), fWeightJetJetMC*weightMatBudget);
+    }
 
     if (std::find(fMesonDoubleCount.begin(), fMesonDoubleCount.end(), gamma0MotherLabel) != fMesonDoubleCount.end()) {
-      fRespMatrixHandlerTrueMesonInvMassVsPtDoubleCount[fiCut]->Fill(jetPtRec, 0.5, Pi0Candidate->M(), Pi0Candidate->Pt(), fWeightJetJetMC*weightMatBudget);
-      fRespMatrixHandlerTrueMesonInvMassVsZDoubleCount[fiCut]->Fill(jetPtRec, 0.5, Pi0Candidate->M(), z_rec, fWeightJetJetMC*weightMatBudget);
+      if(fDoAnalysisPt){
+        fRespMatrixHandlerTrueMesonInvMassVsPtDoubleCount[fiCut]->Fill(jetPtRec, 0.5, Pi0Candidate->M(), Pi0Candidate->Pt(), fWeightJetJetMC*weightMatBudget);
+      }
+      if(fDoAnalysisZ){
+        fRespMatrixHandlerTrueMesonInvMassVsZDoubleCount[fiCut]->Fill(jetPtRec, 0.5, Pi0Candidate->M(), z_rec, fWeightJetJetMC*weightMatBudget);
+      }
     } else {
       fMesonDoubleCount.push_back(gamma0MotherLabel);
     }
 
-    // Check if decay gammas are inside jet cone
-    int gammasInJet = 0;
-    int matchedJetGamma0, matchedJetGamma1 = 0;
-    double RJetPi0CandGamma = 0;
-    if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->IsParticleInJet(fVectorJetEta, fVectorJetPhi, fConvJetReader->Get_Jet_Radius(), TrueGammaCandidate0->Eta(), TrueGammaCandidate0->Phi(), matchedJetGamma0, RJetPi0CandGamma)) {
-      gammasInJet++;
-    }
-    if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->IsParticleInJet(fVectorJetEta, fVectorJetPhi, fConvJetReader->Get_Jet_Radius(), TrueGammaCandidate1->Eta(), TrueGammaCandidate1->Phi(), matchedJetGamma1, RJetPi0CandGamma)) {
-      gammasInJet++;
-    }
-    if(gammasInJet == 0){
-      fHistoTrueMesonNoDaughtersInJet[fiCut]->Fill(mesonPtRec, jetPtRec);
-    } else if(gammasInJet == 1){
-      fHistoTrueMesonOneDaughtersInJet[fiCut]->Fill(mesonPtRec, jetPtRec);
-    } else {
-      fHistoTrueMesonBothDaughtersInJet[fiCut]->Fill(mesonPtRec, jetPtRec);
+    if(fDoAnalysisPt){
+      // Check if decay gammas are inside jet cone
+      int gammasInJet = 0;
+      int matchedJetGamma0, matchedJetGamma1 = 0;
+      double RJetPi0CandGamma = 0;
+      if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->IsParticleInJet(fVectorJetEta, fVectorJetPhi, fConvJetReader->Get_Jet_Radius(), TrueGammaCandidate0->Eta(), TrueGammaCandidate0->Phi(), matchedJetGamma0, RJetPi0CandGamma)) {
+        gammasInJet++;
+      }
+      if (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->IsParticleInJet(fVectorJetEta, fVectorJetPhi, fConvJetReader->Get_Jet_Radius(), TrueGammaCandidate1->Eta(), TrueGammaCandidate1->Phi(), matchedJetGamma1, RJetPi0CandGamma)) {
+        gammasInJet++;
+      }
+      if(gammasInJet == 0){
+        fHistoTrueMesonNoDaughtersInJet[fiCut]->Fill(mesonPtRec, jetPtRec);
+      } else if(gammasInJet == 1){
+        fHistoTrueMesonOneDaughtersInJet[fiCut]->Fill(mesonPtRec, jetPtRec);
+      } else {
+        fHistoTrueMesonBothDaughtersInJet[fiCut]->Fill(mesonPtRec, jetPtRec);
 
-      if(matchedJetGamma0 != matchedJet || matchedJetGamma1 != matchedJet){
-        fHistoTrueMesonDaughtersInOtherJet[fiCut]->Fill(mesonPtRec, jetPtRec);
+        if(matchedJetGamma0 != matchedJet || matchedJetGamma1 != matchedJet){
+          fHistoTrueMesonDaughtersInOtherJet[fiCut]->Fill(mesonPtRec, jetPtRec);
+        }
       }
     }
     
@@ -3822,29 +3911,32 @@ bool AliAnalysisTaskMesonJetCorrelation::ProcessTrueMesonCandidatesAOD(AliAODCon
   bool isPrimary = ((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsConversionPrimaryAOD(fInputEvent, static_cast<AliAODMCParticle*>(fAODMCTrackArray->At(gamma0MotherLabel)), mcProdVtxX, mcProdVtxY, mcProdVtxZ);
 
   if (isPrimary) {
-    if (fDoMesonQA) {
-      fHistoTruePrimaryMesonInvMassPt[fiCut]->Fill(mesonMassRec, mesonPtRec, fWeightJetJetMC*weightMatBudget);
-     // meson response matrix (no Jet included here). Only use that for x-checks as the response is probably jet pt dependent
-      fHistoMesonResponse[fiCut]->Fill(mesonPtRec, mesonPtTrue, fWeightJetJetMC*weightMatBudget);
-      fHistoMesonResolutionJetPt[fiCut]->Fill(mesonPtRec, (mesonPtRec- mesonPtTrue)/mesonPtRec, jetPtRec);
+    if(fDoAnalysisPt){
+      if (fDoMesonQA) {
+        fHistoTruePrimaryMesonInvMassPt[fiCut]->Fill(mesonMassRec, mesonPtRec, fWeightJetJetMC*weightMatBudget);
+      // meson response matrix (no Jet included here). Only use that for x-checks as the response is probably jet pt dependent
+        fHistoMesonResponse[fiCut]->Fill(mesonPtRec, mesonPtTrue, fWeightJetJetMC*weightMatBudget);
+        fHistoMesonResolutionJetPt[fiCut]->Fill(mesonPtRec, (mesonPtRec- mesonPtTrue)/mesonPtRec, jetPtRec);
+      }
     }
 
-    fHistoTrueMesonJetPtVsTrueZ[fiCut]->Fill(z_true, jetPtTrue, fWeightJetJetMC*weightMatBudget);
-    fHistoTrueMesonJetPtVsTruePt[fiCut]->Fill(trueMesonCand->Pt(), jetPtTrue, fWeightJetJetMC*weightMatBudget);
-
-    fHistoTrueMesonJetPtVsRecZ[fiCut]->Fill(z_rec, jetPtRec, fWeightJetJetMC*weightMatBudget);
-    fHistoTrueMesonJetPtVsRecPt[fiCut]->Fill(Pi0Candidate->Pt(), jetPtRec, fWeightJetJetMC*weightMatBudget);
-
-    fRespMatrixHandlerFrag[fiCut]->Fill(jetPtRec, jetPtTrue, z_rec, z_true, fWeightJetJetMC*weightMatBudget);
-    // response matrix filled with only true jet information. 
-    if(!fDoLightOutput){
-      fRespMatrixHandlerFragTrueJets[fiCut]->Fill(jetPtRec, jetPtTrue, z_rec_trueJet, z_true, fWeightJetJetMC*weightMatBudget);
+    if(fDoAnalysisPt){
+      fHistoTrueMesonJetPtVsTruePt[fiCut]->Fill(trueMesonCand->Pt(), jetPtTrue, fWeightJetJetMC*weightMatBudget);
+      fHistoTrueMesonJetPtVsRecPt[fiCut]->Fill(Pi0Candidate->Pt(), jetPtRec, fWeightJetJetMC*weightMatBudget);
+      fRespMatrixHandlerMesonInvMass[fiCut]->Fill(jetPtRec, jetPtTrue, Pi0Candidate->M(), Pi0Candidate->Pt(), fWeightJetJetMC*weightMatBudget);
+      // fill 4d response matrix
+      fRespMatrixHandlerMesonPt[fiCut]->Fill(jetPtRec, jetPtTrue, mesonPtRec, mesonPtTrue, fWeightJetJetMC*weightMatBudget);
     }
-
-    fRespMatrixHandlerMesonInvMass[fiCut]->Fill(jetPtRec, jetPtTrue, Pi0Candidate->M(), Pi0Candidate->Pt(), fWeightJetJetMC*weightMatBudget);
-
-    // fill 4d response matrix
-    fRespMatrixHandlerMesonPt[fiCut]->Fill(jetPtRec, jetPtTrue, mesonPtRec, mesonPtTrue, fWeightJetJetMC*weightMatBudget);
+    if(fDoAnalysisZ){
+      fHistoTrueMesonJetPtVsTrueZ[fiCut]->Fill(z_true, jetPtTrue, fWeightJetJetMC*weightMatBudget);
+      fHistoTrueMesonJetPtVsRecZ[fiCut]->Fill(z_rec, jetPtRec, fWeightJetJetMC*weightMatBudget);
+      // fill 4d response matrix
+      fRespMatrixHandlerFrag[fiCut]->Fill(jetPtRec, jetPtTrue, z_rec, z_true, fWeightJetJetMC*weightMatBudget);
+      // response matrix filled with only true jet information. 
+      if(!fDoLightOutput){
+        fRespMatrixHandlerFragTrueJets[fiCut]->Fill(jetPtRec, jetPtTrue, z_rec_trueJet, z_true, fWeightJetJetMC*weightMatBudget);
+      }
+    }  
 
     if(fDoRadiusDep){
       std::vector<double> vecFillRec = {jetPtRec, RJetPi0Cand, mesonPtRec};
@@ -3858,15 +3950,18 @@ bool AliAnalysisTaskMesonJetCorrelation::ProcessTrueMesonCandidatesAOD(AliAODCon
   } else { // fill all secondary mesons
 
     if(fDoMesonQA>0){
-      fHistoTrueSecMesonJetPtVsRecZ[fiCut]->Fill(z_rec, jetPtRec, fWeightJetJetMC*weightMatBudget);
-      fHistoTrueSecMesonJetPtVsRecPt[fiCut]->Fill(Pi0Candidate->Pt(), jetPtRec, fWeightJetJetMC*weightMatBudget);
+      if(fDoAnalysisZ){fHistoTrueSecMesonJetPtVsRecZ[fiCut]->Fill(z_rec, jetPtRec, fWeightJetJetMC*weightMatBudget);}
+      if(fDoAnalysisPt){fHistoTrueSecMesonJetPtVsRecPt[fiCut]->Fill(Pi0Candidate->Pt(), jetPtRec, fWeightJetJetMC*weightMatBudget);}
     }
-
-    if(fDoMesonQA > 0){
-      fHistoTrueSecondaryMesonInvMassPt[fiCut]->Fill(Pi0Candidate->M(), mesonPtRec, fWeightJetJetMC*weightMatBudget);
+    if(fDoAnalysisPt){
+      if(fDoMesonQA > 0){
+        fHistoTrueSecondaryMesonInvMassPt[fiCut]->Fill(Pi0Candidate->M(), mesonPtRec, fWeightJetJetMC*weightMatBudget);
+      }
+      fRespMatrixHandlerTrueSecondaryMesonInvMassVsPt[fiCut]->Fill(jetPtRec, 0.5, Pi0Candidate->M(), Pi0Candidate->Pt(), fWeightJetJetMC*weightMatBudget);
     }
-    fRespMatrixHandlerTrueSecondaryMesonInvMassVsPt[fiCut]->Fill(jetPtRec, 0.5, Pi0Candidate->M(), Pi0Candidate->Pt(), fWeightJetJetMC*weightMatBudget);
-    fRespMatrixHandlerTrueSecondaryMesonInvMassVsZ[fiCut]->Fill(jetPtRec, 0.5, Pi0Candidate->M(), z_rec, fWeightJetJetMC*weightMatBudget);
+    if(fDoAnalysisZ){
+      fRespMatrixHandlerTrueSecondaryMesonInvMassVsZ[fiCut]->Fill(jetPtRec, 0.5, Pi0Candidate->M(), z_rec, fWeightJetJetMC*weightMatBudget);
+    }
 
     if(fDoRadiusDep){
       // Fill as function of radius
@@ -3924,8 +4019,8 @@ void AliAnalysisTaskMesonJetCorrelation::ProcessTrueMesonCandidatesInTrueJetsAOD
   float z_true = GetFrag(trueMesonCand, matchedJet, true);
 
   if(fDoMesonQA>0){
-    fHistoTrueMesonInTrueJet_JetPtVsTrueZ[fiCut]->Fill(z_true, jetPtTrue, fWeightJetJetMC*weightMatBudget);
-    fHistoTrueMesonInTrueJet_JetPtVsTruePt[fiCut]->Fill(mesonPtTrue, jetPtTrue, fWeightJetJetMC*weightMatBudget);
+    if(fDoAnalysisZ){fHistoTrueMesonInTrueJet_JetPtVsTrueZ[fiCut]->Fill(z_true, jetPtTrue, fWeightJetJetMC*weightMatBudget);}
+    if(fDoAnalysisPt){fHistoTrueMesonInTrueJet_JetPtVsTruePt[fiCut]->Fill(mesonPtTrue, jetPtTrue, fWeightJetJetMC*weightMatBudget);}
   }
 }
 

--- a/PWGGA/GammaConv/AliAnalysisTaskMesonJetCorrelation.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskMesonJetCorrelation.h
@@ -130,6 +130,14 @@ class AliAnalysisTaskMesonJetCorrelation : public AliAnalysisTaskSE
   void SetForcePi0Unstable(bool tmp) { fUnsetStablePi0 = tmp; }
   void SetUseMixedBackAdd(bool tmp) { fUseMixedBackAdd = tmp; }
   void SetDoRadiusDependence(bool tmp) { fDoRadiusDep = tmp; }
+  void SetMesonZPt(int tmp)
+  {
+    if(tmp == 1){
+      fDoAnalysisZ = false;
+    } else if(tmp == 2){
+      fDoAnalysisPt = false;
+    }
+  }
 
   void SetEventCutList(int nCuts,
                        TList* CutArray)
@@ -239,6 +247,8 @@ class AliAnalysisTaskMesonJetCorrelation : public AliAnalysisTaskSE
   bool fUnsetStablePi0;                                 // flag to decide if pi0 need to be reset to Unstable particles
   bool fUseMixedBackAdd;                                // flag to enable a histogram for the mixed jet background in addition to the rotation background. This is to save memory and CPU (As otherwise a completely new wagon would be needed)
   bool fDoRadiusDep;                                    // flag to enable radius dependent histograms
+  bool fDoAnalysisPt;                                   // flag to enable filling of pt dependent histograms
+  bool fDoAnalysisZ;                                    // flag to enable filling of z dependent histograms
   //-------------------------------
   // conversions
   //-------------------------------
@@ -510,7 +520,7 @@ class AliAnalysisTaskMesonJetCorrelation : public AliAnalysisTaskSE
   AliAnalysisTaskMesonJetCorrelation(const AliAnalysisTaskMesonJetCorrelation&);            // Prevent copy-construction
   AliAnalysisTaskMesonJetCorrelation& operator=(const AliAnalysisTaskMesonJetCorrelation&); // Prevent assignment
 
-  ClassDef(AliAnalysisTaskMesonJetCorrelation, 19);
+  ClassDef(AliAnalysisTaskMesonJetCorrelation, 20);
 };
 
 #endif

--- a/PWGGA/GammaConv/macros/AddTask_MesonJetCorr_Calo.C
+++ b/PWGGA/GammaConv/macros/AddTask_MesonJetCorr_Calo.C
@@ -53,6 +53,7 @@ void AddTask_MesonJetCorr_Calo(
   bool setPi0Unstable = false,
   bool enableAddBackground = false,
   bool enableRadiusDep = false,
+  int runOnlyZPt = 0,           // if 0, bot pt and z histograms will be filled, if 1, pt histograms will be filled, if 2, only z histograms will be filled
   // subwagon config
   TString additionalTrainConfig = "0" // additional counter for trainconfig
 
@@ -195,23 +196,23 @@ void AddTask_MesonJetCorr_Calo(
   } else if (trainConfig == 5) {
     cuts.AddCutCalo("0008d103", "411790009fe30230000", "2s631034000000d0"); // EG1 in-jet, pi0 mass: 0.1-0.15, rotation back
   } else if (trainConfig == 6) {
-    cuts.AddCutCalo("0009c103", "411790009fe30230000", "2s631034000000d0"); // Jet-low trigg in-jet, pi0 mass: 0.1-0.15, rotation back
+    cuts.AddCutCalo("000fc103", "411790009fe30230000", "2s631034000000d0"); // Jet-low trigg in-jet, pi0 mass: 0.1-0.15, rotation back
   } else if (trainConfig == 7) {
-    cuts.AddCutCalo("0009b103", "411790009fe30230000", "2s631034000000d0"); // Jet-high trigg in-jet, pi0 mass: 0.1-0.15, rotation back
+    cuts.AddCutCalo("000fb103", "411790009fe30230000", "2s631034000000d0"); // Jet-high trigg in-jet, pi0 mass: 0.1-0.15, rotation back
 
   // EJ1 and EJ2 only EMCal triggers
   } else if (trainConfig == 8) {
-    cuts.AddCutCalo("00095103", "411790009fe30230000", "2s631034000000d0"); // Jet-low trigg in-jet, pi0 mass: 0.1-0.15, rotation back
+    cuts.AddCutCalo("000f5103", "411790009fe30230000", "2s631034000000d0"); // Jet-low trigg in-jet, pi0 mass: 0.1-0.15, rotation back
   } else if (trainConfig == 9) {
-    cuts.AddCutCalo("00093103", "411790009fe30230000", "2s631034000000d0"); // Jet-high trigg in-jet, pi0 mass: 0.1-0.15, rotation back
+    cuts.AddCutCalo("000f3103", "411790009fe30230000", "2s631034000000d0"); // Jet-high trigg in-jet, pi0 mass: 0.1-0.15, rotation back
 
   // configs with Mesons only in EMCal, EMCal triggers only
   } else if (trainConfig == 10) {
     cuts.AddCutCalo("00010103", "111110009fe30230000", "2s631034000000d0"); // in-jet, pi0 mass: 0.1-0.15, rotation back
   } else if (trainConfig == 11) {
-    cuts.AddCutCalo("00095103", "111110009fe30230000", "2s631034000000d0"); // Jet-low trigg in-jet, pi0 mass: 0.1-0.15, rotation back
+    cuts.AddCutCalo("000f5103", "111110009fe30230000", "2s631034000000d0"); // Jet-low trigg in-jet, pi0 mass: 0.1-0.15, rotation back
   } else if (trainConfig == 12) {
-    cuts.AddCutCalo("00093103", "111110009fe30230000", "2s631034000000d0"); // Jet-high trigg in-jet, pi0 mass: 0.1-0.15, rotation back
+    cuts.AddCutCalo("000f3103", "111110009fe30230000", "2s631034000000d0"); // Jet-high trigg in-jet, pi0 mass: 0.1-0.15, rotation back
 
 
   } else if (trainConfig == 14) { // same as 4 but with mixed jet back
@@ -219,15 +220,15 @@ void AddTask_MesonJetCorr_Calo(
   } else if (trainConfig == 15) {// same as 5 but with mixed jet back
     cuts.AddCutCalo("0008d103", "411790009fe30230000", "21631034000000d0"); // EG1 in-jet, pi0 mass: 0.1-0.15, mixed jet back
   } else if (trainConfig == 16) {// same as 6 but with mixed jet back
-    cuts.AddCutCalo("0009c103", "411790009fe30230000", "21631034000000d0"); // Jet-low trigg in-jet, pi0 mass: 0.1-0.15, mixed jet back
+    cuts.AddCutCalo("000fc103", "411790009fe30230000", "21631034000000d0"); // Jet-low trigg in-jet, pi0 mass: 0.1-0.15, mixed jet back
   } else if (trainConfig == 17) {// same as 7 but with mixed jet back
-    cuts.AddCutCalo("0009b103", "411790009fe30230000", "21631034000000d0"); // Jet-high trigg in-jet, pi0 mass: 0.1-0.15, mixed jet back
+    cuts.AddCutCalo("000fb103", "411790009fe30230000", "21631034000000d0"); // Jet-high trigg in-jet, pi0 mass: 0.1-0.15, mixed jet back
 
   } else if (trainConfig == 20) {
     cuts.AddCutCalo("00010103", "411790009fe30230000", "es631034000000d0"); // decay daughters also inside jet
   } else if (trainConfig == 21) {
-    cuts.AddCutCalo("0009c103", "411790009fe30230000", "es631034000000d0"); // decay daughters also inside jet
-    cuts.AddCutCalo("0009b103", "411790009fe30230000", "es631034000000d0"); // decay daughters also inside jet
+    cuts.AddCutCalo("000fc103", "411790009fe30230000", "es631034000000d0"); // decay daughters also inside jet
+    cuts.AddCutCalo("000fb103", "411790009fe30230000", "es631034000000d0"); // decay daughters also inside jet
 
   // configs with NonLinearity 
   } else if (trainConfig == 22) {
@@ -239,30 +240,30 @@ void AddTask_MesonJetCorr_Calo(
   } else if (trainConfig == 25) {
     cuts.AddCutCalo("0008d103", "411790109fe30230000", "2s631034000000d0"); // EG1 in-jet, pi0 mass: 0.1-0.15, rotation back
   } else if (trainConfig == 26) {
-    cuts.AddCutCalo("0009c103", "411790109fe30230000", "2s631034000000d0"); // Jet-low trigg in-jet, pi0 mass: 0.1-0.15, rotation back
+    cuts.AddCutCalo("000fc103", "411790109fe30230000", "2s631034000000d0"); // Jet-low trigg in-jet, pi0 mass: 0.1-0.15, rotation back
   } else if (trainConfig == 27) {
-    cuts.AddCutCalo("0009b103", "411790109fe30230000", "2s631034000000d0"); // Jet-high trigg in-jet, pi0 mass: 0.1-0.15, rotation back
+    cuts.AddCutCalo("000fb103", "411790109fe30230000", "2s631034000000d0"); // Jet-high trigg in-jet, pi0 mass: 0.1-0.15, rotation back
 
 
   // configs with eta < 0.5
   } else if (trainConfig == 30) {
     cuts.AddCutCalo("00010103", "411790009fe30230000", "2s634034000000d0"); // in-jet, pi0 mass: 0.1-0.15, rotation back
   } else if (trainConfig == 31) {
-    cuts.AddCutCalo("0009c103", "411790009fe30230000", "2s634034000000d0"); // Jet-low trigg in-jet, pi0 mass: 0.1-0.15, rotation back
+    cuts.AddCutCalo("000fc103", "411790009fe30230000", "2s634034000000d0"); // Jet-low trigg in-jet, pi0 mass: 0.1-0.15, rotation back
   } else if (trainConfig == 32) {
-    cuts.AddCutCalo("0009b103", "411790009fe30230000", "2s634034000000d0"); // Jet-high trigg in-jet, pi0 mass: 0.1-0.15, rotation back
+    cuts.AddCutCalo("000fb103", "411790009fe30230000", "2s634034000000d0"); // Jet-high trigg in-jet, pi0 mass: 0.1-0.15, rotation back
 
   // configs with eta < 0.5, only EMCal triggers (not DCal)
   } else if (trainConfig == 33) {
-    cuts.AddCutCalo("00095103", "411790009fe30230000", "2s634034000000d0"); // Jet-low trigg in-jet, pi0 mass: 0.1-0.15, rotation back
+    cuts.AddCutCalo("000f5103", "411790009fe30230000", "2s634034000000d0"); // Jet-low trigg in-jet, pi0 mass: 0.1-0.15, rotation back
   } else if (trainConfig == 34) {
-    cuts.AddCutCalo("00093103", "411790009fe30230000", "2s634034000000d0"); // Jet-high trigg in-jet, pi0 mass: 0.1-0.15, rotation back
+    cuts.AddCutCalo("000f3103", "411790009fe30230000", "2s634034000000d0"); // Jet-high trigg in-jet, pi0 mass: 0.1-0.15, rotation back
 
   // configs with eta < 0.5, only EMCal triggers (not DCal), Mesons only with EMCal
   } else if (trainConfig == 35) {
-    cuts.AddCutCalo("00095103", "111110009fe30230000", "2s634034000000d0"); // Jet-low trigg in-jet, pi0 mass: 0.1-0.15, rotation back
+    cuts.AddCutCalo("000f5103", "111110009fe30230000", "2s634034000000d0"); // Jet-low trigg in-jet, pi0 mass: 0.1-0.15, rotation back
   } else if (trainConfig == 36) {
-    cuts.AddCutCalo("00093103", "111110009fe30230000", "2s634034000000d0"); // Jet-high trigg in-jet, pi0 mass: 0.1-0.15, rotation back
+    cuts.AddCutCalo("000f3103", "111110009fe30230000", "2s634034000000d0"); // Jet-high trigg in-jet, pi0 mass: 0.1-0.15, rotation back
 
 
   //---------------------------------------
@@ -316,89 +317,89 @@ void AddTask_MesonJetCorr_Calo(
 
     //--------  EJ2 Meson cut variations
   } else if (trainConfig == 130) { // 
-    cuts.AddCutCalo("0009c103", "411790009fe30230000", "2s631034000000d0"); // NL var. etc which is handled in correction framework
+    cuts.AddCutCalo("000fc103", "411790009fe30230000", "2s631034000000d0"); // NL var. etc which is handled in correction framework
   } else if (trainConfig == 131) { // background variation
-    cuts.AddCutCalo("0009c103", "411790009fe30230000", "21631034000000d0"); // jet mixing back
+    cuts.AddCutCalo("000fc103", "411790009fe30230000", "21631034000000d0"); // jet mixing back
   } else if (trainConfig == 132) { // alpha cut variation
-    cuts.AddCutCalo("0009c103", "411790009fe30230000", "2s631054000000d0"); // alpha cut 0-0.75
-    cuts.AddCutCalo("0009c103", "411790009fe30230000", "2s631084000000d0"); // alpha cut 0-0.65
+    cuts.AddCutCalo("000fc103", "411790009fe30230000", "2s631054000000d0"); // alpha cut 0-0.75
+    cuts.AddCutCalo("000fc103", "411790009fe30230000", "2s631084000000d0"); // alpha cut 0-0.65
   } else if (trainConfig == 133) { // opening angle var.
-    cuts.AddCutCalo("0009c103", "411790009fe30230000", "2s631034000000b0"); // INT7 Op. Ang. var 1 cell dist + 0.0152
-    cuts.AddCutCalo("0009c103", "411790009fe30230000", "2s631034000000g0"); // INT7 Op. Ang. var 1 cell dist + 0.0202
-    cuts.AddCutCalo("0009c103", "411790009fe30230000", "2s631034000000a0"); // INT7 Op. Ang. var 1 cell dist + 0
+    cuts.AddCutCalo("000fc103", "411790009fe30230000", "2s631034000000b0"); // INT7 Op. Ang. var 1 cell dist + 0.0152
+    cuts.AddCutCalo("000fc103", "411790009fe30230000", "2s631034000000g0"); // INT7 Op. Ang. var 1 cell dist + 0.0202
+    cuts.AddCutCalo("000fc103", "411790009fe30230000", "2s631034000000a0"); // INT7 Op. Ang. var 1 cell dist + 0
 
 
   } else if (trainConfig == 135) { // M02 variation (std M02 = 0.5)
-    cuts.AddCutCalo("0009c103", "411790009fe30240000", "2s631034000000d0"); // M02 = 0.4
-    cuts.AddCutCalo("0009c103", "411790009fe30220000", "2s631034000000d0"); // M02 = 0.7
-    cuts.AddCutCalo("0009c103", "411790009fe30210000", "2s631034000000d0"); // M02 = 1.0
-    cuts.AddCutCalo("0009c103", "411790009fe302v0000", "2s631034000000d0"); // 0.5 < M02 < 0.7
+    cuts.AddCutCalo("000fc103", "411790009fe30240000", "2s631034000000d0"); // M02 = 0.4
+    cuts.AddCutCalo("000fc103", "411790009fe30220000", "2s631034000000d0"); // M02 = 0.7
+    cuts.AddCutCalo("000fc103", "411790009fe30210000", "2s631034000000d0"); // M02 = 1.0
+    cuts.AddCutCalo("000fc103", "411790009fe302v0000", "2s631034000000d0"); // 0.5 < M02 < 0.7
   } else if (trainConfig == 136) { // TM variations for mesons
-    cuts.AddCutCalo("0009c103", "4117900090e30230000", "2s631034000000d0"); // INT7 no TM
-    cuts.AddCutCalo("0009c103", "411790009ee30230000", "2s631034000000d0"); // TM var EoverP 2.00
-    cuts.AddCutCalo("0009c103", "411790009ge30230000", "2s631034000000d0"); // TM var EoverP 1.5
-    cuts.AddCutCalo("0009c103", "4117900097e30230000", "2s631034000000d0"); // No E/p
-    cuts.AddCutCalo("0009c103", "411790009le30230000", "2s631034000000d0"); // std + sec TM
-    cuts.AddCutCalo("0009c103", "411790009ne30230000", "2s631034000000d0"); // INT7 TM var, Eta (0.035, 0.010, 2.5); Phi (0.085, 0.015, 2.)
+    cuts.AddCutCalo("000fc103", "4117900090e30230000", "2s631034000000d0"); // INT7 no TM
+    cuts.AddCutCalo("000fc103", "411790009ee30230000", "2s631034000000d0"); // TM var EoverP 2.00
+    cuts.AddCutCalo("000fc103", "411790009ge30230000", "2s631034000000d0"); // TM var EoverP 1.5
+    cuts.AddCutCalo("000fc103", "4117900097e30230000", "2s631034000000d0"); // No E/p
+    cuts.AddCutCalo("000fc103", "411790009le30230000", "2s631034000000d0"); // std + sec TM
+    cuts.AddCutCalo("000fc103", "411790009ne30230000", "2s631034000000d0"); // INT7 TM var, Eta (0.035, 0.010, 2.5); Phi (0.085, 0.015, 2.)
   } else if (trainConfig == 137) { // cluster time
-    cuts.AddCutCalo("0009c103", "411790005fe30230000", "2s631034000000d0"); // -50 - 50 ns
-    cuts.AddCutCalo("0009c103", "411790006fe30230000", "2s631034000000d0"); // -30 - 35 ns
-    cuts.AddCutCalo("0009c103", "41179000afe30230000", "2s631034000000d0"); // -12.5 - 13 ns
+    cuts.AddCutCalo("000fc103", "411790005fe30230000", "2s631034000000d0"); // -50 - 50 ns
+    cuts.AddCutCalo("000fc103", "411790006fe30230000", "2s631034000000d0"); // -30 - 35 ns
+    cuts.AddCutCalo("000fc103", "41179000afe30230000", "2s631034000000d0"); // -12.5 - 13 ns
   } else if (trainConfig == 138) { // NCell
-    cuts.AddCutCalo("0009c103", "411790009fe3r230000", "2s631034000000d0"); // INT7 EDC pi0 tagging for gamma clus, Gaussian Fit
-    cuts.AddCutCalo("0009c103", "411790009fe3n230000", "2s631034000000d0"); // INT7 PCMEDC pi0 tagging for gamma clus, Gaussian Fit
-    cuts.AddCutCalo("0009c103", "411790009fe3m230000", "2s631034000000d0"); // INT7 PCMEDC pi0 tagging for all clus, Gaussian Fit
-    cuts.AddCutCalo("0009c103", "411790009fe3l230000", "2s631034000000d0"); // INT7 PCMEDC pi0 tagging for gamma clus, pol2 fit
+    cuts.AddCutCalo("000fc103", "411790009fe3r230000", "2s631034000000d0"); // INT7 EDC pi0 tagging for gamma clus, Gaussian Fit
+    cuts.AddCutCalo("000fc103", "411790009fe3n230000", "2s631034000000d0"); // INT7 PCMEDC pi0 tagging for gamma clus, Gaussian Fit
+    cuts.AddCutCalo("000fc103", "411790009fe3m230000", "2s631034000000d0"); // INT7 PCMEDC pi0 tagging for all clus, Gaussian Fit
+    cuts.AddCutCalo("000fc103", "411790009fe3l230000", "2s631034000000d0"); // INT7 PCMEDC pi0 tagging for gamma clus, pol2 fit
   } else if (trainConfig == 139) { // min energy
-    cuts.AddCutCalo("0009c103", "411790009fe10230000", "2s631034000000d0"); // INT7, minE = 0.5
-    cuts.AddCutCalo("0009c103", "411790009fe20230000", "2s631034000000d0"); // INT7, minE = 0.6
-    cuts.AddCutCalo("0009c103", "411790009fe40230000", "2s631034000000d0"); // INT7, minE = 0.8
+    cuts.AddCutCalo("000fc103", "411790009fe10230000", "2s631034000000d0"); // INT7, minE = 0.5
+    cuts.AddCutCalo("000fc103", "411790009fe20230000", "2s631034000000d0"); // INT7, minE = 0.6
+    cuts.AddCutCalo("000fc103", "411790009fe40230000", "2s631034000000d0"); // INT7, minE = 0.8
   } else if (trainConfig == 140) { // Exotics
-    cuts.AddCutCalo("0009c103", "411790009f030230000", "2s631034000000d0"); // no exotics
-    cuts.AddCutCalo("0009c103", "411790009fb30230000", "2s631034000000d0"); // F+ < 0.95
+    cuts.AddCutCalo("000fc103", "411790009f030230000", "2s631034000000d0"); // no exotics
+    cuts.AddCutCalo("000fc103", "411790009fb30230000", "2s631034000000d0"); // F+ < 0.95
 
   //--------  EJ1 Meson cut variations
   } else if (trainConfig == 160) { // 
-    cuts.AddCutCalo("0009b103", "411790009fe30230000", "2s631034000000d0"); // NL var. etc which is handled in correction framework
+    cuts.AddCutCalo("000fb103", "411790009fe30230000", "2s631034000000d0"); // NL var. etc which is handled in correction framework
   } else if (trainConfig == 161) { // background variation
-    cuts.AddCutCalo("0009b103", "411790009fe30230000", "21631034000000d0"); // jet mixing back
+    cuts.AddCutCalo("000fb103", "411790009fe30230000", "21631034000000d0"); // jet mixing back
   } else if (trainConfig == 162) { // alpha cut variation
-    cuts.AddCutCalo("0009b103", "411790009fe30230000", "2s631054000000d0"); // alpha cut 0-0.75
-    cuts.AddCutCalo("0009b103", "411790009fe30230000", "2s631084000000d0"); // alpha cut 0-0.65
+    cuts.AddCutCalo("000fb103", "411790009fe30230000", "2s631054000000d0"); // alpha cut 0-0.75
+    cuts.AddCutCalo("000fb103", "411790009fe30230000", "2s631084000000d0"); // alpha cut 0-0.65
   } else if (trainConfig == 163) { // opening angle var.
-    cuts.AddCutCalo("0009b103", "411790009fe30230000", "2s631034000000b0"); // INT7 Op. Ang. var 1 cell dist + 0.0152
-    cuts.AddCutCalo("0009b103", "411790009fe30230000", "2s631034000000g0"); // INT7 Op. Ang. var 1 cell dist + 0.0202
-    cuts.AddCutCalo("0009b103", "411790009fe30230000", "2s631034000000a0"); // INT7 Op. Ang. var 1 cell dist + 0
+    cuts.AddCutCalo("000fb103", "411790009fe30230000", "2s631034000000b0"); // INT7 Op. Ang. var 1 cell dist + 0.0152
+    cuts.AddCutCalo("000fb103", "411790009fe30230000", "2s631034000000g0"); // INT7 Op. Ang. var 1 cell dist + 0.0202
+    cuts.AddCutCalo("000fb103", "411790009fe30230000", "2s631034000000a0"); // INT7 Op. Ang. var 1 cell dist + 0
 
 
   } else if (trainConfig == 165) { // M02 variation (std M02 = 0.5)
-    cuts.AddCutCalo("0009b103", "411790009fe30240000", "2s631034000000d0"); // M02 = 0.4
-    cuts.AddCutCalo("0009b103", "411790009fe30220000", "2s631034000000d0"); // M02 = 0.7
-    cuts.AddCutCalo("0009b103", "411790009fe30210000", "2s631034000000d0"); // M02 = 1.0
-    cuts.AddCutCalo("0009b103", "411790009fe302v0000", "2s631034000000d0"); // 0.5 < M02 < 0.7
+    cuts.AddCutCalo("000fb103", "411790009fe30240000", "2s631034000000d0"); // M02 = 0.4
+    cuts.AddCutCalo("000fb103", "411790009fe30220000", "2s631034000000d0"); // M02 = 0.7
+    cuts.AddCutCalo("000fb103", "411790009fe30210000", "2s631034000000d0"); // M02 = 1.0
+    cuts.AddCutCalo("000fb103", "411790009fe302v0000", "2s631034000000d0"); // 0.5 < M02 < 0.7
   } else if (trainConfig == 166) { // TM variations for mesons
-    cuts.AddCutCalo("0009b103", "4117900090e30230000", "2s631034000000d0"); // INT7 no TM
-    cuts.AddCutCalo("0009b103", "411790009ee30230000", "2s631034000000d0"); // TM var EoverP 2.00
-    cuts.AddCutCalo("0009b103", "411790009ge30230000", "2s631034000000d0"); // TM var EoverP 1.5
-    cuts.AddCutCalo("0009b103", "4117900097e30230000", "2s631034000000d0"); // No E/p
-    cuts.AddCutCalo("0009b103", "411790009le30230000", "2s631034000000d0"); // std + sec TM
-    cuts.AddCutCalo("0009b103", "411790009ne30230000", "2s631034000000d0"); // INT7 TM var, Eta (0.035, 0.010, 2.5); Phi (0.085, 0.015, 2.)
+    cuts.AddCutCalo("000fb103", "4117900090e30230000", "2s631034000000d0"); // INT7 no TM
+    cuts.AddCutCalo("000fb103", "411790009ee30230000", "2s631034000000d0"); // TM var EoverP 2.00
+    cuts.AddCutCalo("000fb103", "411790009ge30230000", "2s631034000000d0"); // TM var EoverP 1.5
+    cuts.AddCutCalo("000fb103", "4117900097e30230000", "2s631034000000d0"); // No E/p
+    cuts.AddCutCalo("000fb103", "411790009le30230000", "2s631034000000d0"); // std + sec TM
+    cuts.AddCutCalo("000fb103", "411790009ne30230000", "2s631034000000d0"); // INT7 TM var, Eta (0.035, 0.010, 2.5); Phi (0.085, 0.015, 2.)
   } else if (trainConfig == 167) { // cluster time
-    cuts.AddCutCalo("0009b103", "411790005fe30230000", "2s631034000000d0"); // -50 - 50 ns
-    cuts.AddCutCalo("0009b103", "411790006fe30230000", "2s631034000000d0"); // -30 - 35 ns
-    cuts.AddCutCalo("0009b103", "41179000afe30230000", "2s631034000000d0"); // -12.5 - 13 ns
+    cuts.AddCutCalo("000fb103", "411790005fe30230000", "2s631034000000d0"); // -50 - 50 ns
+    cuts.AddCutCalo("000fb103", "411790006fe30230000", "2s631034000000d0"); // -30 - 35 ns
+    cuts.AddCutCalo("000fb103", "41179000afe30230000", "2s631034000000d0"); // -12.5 - 13 ns
   } else if (trainConfig == 168) { // NCell
-    cuts.AddCutCalo("0009b103", "411790009fe3r230000", "2s631034000000d0"); // INT7 EDC pi0 tagging for gamma clus, Gaussian Fit
-    cuts.AddCutCalo("0009b103", "411790009fe3n230000", "2s631034000000d0"); // INT7 PCMEDC pi0 tagging for gamma clus, Gaussian Fit
-    cuts.AddCutCalo("0009b103", "411790009fe3m230000", "2s631034000000d0"); // INT7 PCMEDC pi0 tagging for all clus, Gaussian Fit
-    cuts.AddCutCalo("0009b103", "411790009fe3l230000", "2s631034000000d0"); // INT7 PCMEDC pi0 tagging for gamma clus, pol2 fit
+    cuts.AddCutCalo("000fb103", "411790009fe3r230000", "2s631034000000d0"); // INT7 EDC pi0 tagging for gamma clus, Gaussian Fit
+    cuts.AddCutCalo("000fb103", "411790009fe3n230000", "2s631034000000d0"); // INT7 PCMEDC pi0 tagging for gamma clus, Gaussian Fit
+    cuts.AddCutCalo("000fb103", "411790009fe3m230000", "2s631034000000d0"); // INT7 PCMEDC pi0 tagging for all clus, Gaussian Fit
+    cuts.AddCutCalo("000fb103", "411790009fe3l230000", "2s631034000000d0"); // INT7 PCMEDC pi0 tagging for gamma clus, pol2 fit
   } else if (trainConfig == 169) { // min energy
-    cuts.AddCutCalo("0009b103", "411790009fe10230000", "2s631034000000d0"); // INT7, minE = 0.5
-    cuts.AddCutCalo("0009b103", "411790009fe20230000", "2s631034000000d0"); // INT7, minE = 0.6
-    cuts.AddCutCalo("0009b103", "411790009fe40230000", "2s631034000000d0"); // INT7, minE = 0.8
+    cuts.AddCutCalo("000fb103", "411790009fe10230000", "2s631034000000d0"); // INT7, minE = 0.5
+    cuts.AddCutCalo("000fb103", "411790009fe20230000", "2s631034000000d0"); // INT7, minE = 0.6
+    cuts.AddCutCalo("000fb103", "411790009fe40230000", "2s631034000000d0"); // INT7, minE = 0.8
   } else if (trainConfig == 170) { // Exotics
-    cuts.AddCutCalo("0009b103", "411790009f030230000", "2s631034000000d0"); // no exotics
-    cuts.AddCutCalo("0009b103", "411790009fb30230000", "2s631034000000d0"); // F+ < 0.95
+    cuts.AddCutCalo("000fb103", "411790009f030230000", "2s631034000000d0"); // no exotics
+    cuts.AddCutCalo("000fb103", "411790009fb30230000", "2s631034000000d0"); // F+ < 0.95
 
     //---------------------------------------
     // configs for eta meson pp 13 TeV
@@ -511,6 +512,7 @@ void AddTask_MesonJetCorr_Calo(
   }
 
   task->SetMesonKind(meson);
+  task->SetMesonZPt(runOnlyZPt);
   task->SetIsCalo(true);
   if(additionalTrainConfig.Contains("JET")){task->SetJetContainerAddName(nameJetFinder);}
   task->SetEventCutList(numberOfCuts, EventCutList);

--- a/PWGGA/GammaConv/macros/AddTask_MesonJetCorr_Conv.C
+++ b/PWGGA/GammaConv/macros/AddTask_MesonJetCorr_Conv.C
@@ -55,6 +55,7 @@ void AddTask_MesonJetCorr_Conv(
   bool setPi0Unstable = false,
   bool enableAddBackground = false,
   bool enableRadiusDep = false,
+  int runOnlyZPt = 0,           // if 0, bot pt and z histograms will be filled, if 1, pt histograms will be filled, if 2, only z histograms will be filled
   // subwagon config
   TString additionalTrainConfig = "0" // additional counter for trainconfig + special settings
 )
@@ -187,27 +188,27 @@ void AddTask_MesonJetCorr_Conv(
   } else if (trainConfig == 3) {
     cuts.AddCutPCM("00010103", "0dm00009f9730000dge0404000", "2152103500000000"); // in-Jet mass cut around pi0: 0.1-0.15, mixed jet back
   } else if (trainConfig == 6) {
-    cuts.AddCutPCM("0009c103", "0dm00009f9730000dge0404000", "2s52103500000000"); // Jet-low trigg in-Jet mass cut around pi0: 0.1-0.15, rotation back
+    cuts.AddCutPCM("000fc103", "0dm00009f9730000dge0404000", "2s52103500000000"); // Jet-low trigg in-Jet mass cut around pi0: 0.1-0.15, rotation back
   } else if (trainConfig == 7) {
-    cuts.AddCutPCM("0009b103", "0dm00009f9730000dge0404000", "2s52103500000000"); // Jet-high trigg in-Jet mass cut around pi0: 0.1-0.15, rotation back
+    cuts.AddCutPCM("000fb103", "0dm00009f9730000dge0404000", "2s52103500000000"); // Jet-high trigg in-Jet mass cut around pi0: 0.1-0.15, rotation back
   } else if (trainConfig == 16) { // same as 6 but with mixed jet back
-    cuts.AddCutPCM("0009c103", "0dm00009f9730000dge0404000", "2152103500000000"); // Jet-low trigg in-Jet mass cut around pi0: 0.1-0.15, mixed jet back
+    cuts.AddCutPCM("000fc103", "0dm00009f9730000dge0404000", "2152103500000000"); // Jet-low trigg in-Jet mass cut around pi0: 0.1-0.15, mixed jet back
   } else if (trainConfig == 17) { // same as 7 but with mixed jet back
-    cuts.AddCutPCM("0009b103", "0dm00009f9730000dge0404000", "2152103500000000"); // Jet-high trigg in-Jet mass cut around pi0: 0.1-0.15, mixed jet back
+    cuts.AddCutPCM("000fb103", "0dm00009f9730000dge0404000", "2152103500000000"); // Jet-high trigg in-Jet mass cut around pi0: 0.1-0.15, mixed jet back
   
   } else if (trainConfig == 20) {
     cuts.AddCutPCM("00010103", "0dm00009f9730000dge0404000", "es52103500000000"); // decay daughters inside jet
   } else if (trainConfig == 21) {
-    cuts.AddCutPCM("0009c103", "0dm00009f9730000dge0404000", "es52103500000000"); // decay daughters inside jet
-    cuts.AddCutPCM("0009b103", "0dm00009f9730000dge0404000", "es52103500000000"); // decay daughters inside jet
+    cuts.AddCutPCM("000fc103", "0dm00009f9730000dge0404000", "es52103500000000"); // decay daughters inside jet
+    cuts.AddCutPCM("000fb103", "0dm00009f9730000dge0404000", "es52103500000000"); // decay daughters inside jet
     
   // configs with TRD/ITS conversion requirement
   } else if (trainConfig == 22) {
     cuts.AddCutPCM("00010103", "0dm00009f9730000dge0474000", "2s52103500000000"); // in-Jet mass cut around pi0: 0.1-0.15, rotation back
   } else if (trainConfig == 23) {
-    cuts.AddCutPCM("0009c103", "0dm00009f9730000dge0474000", "2s52103500000000"); // in-Jet mass cut around pi0: 0.1-0.15, rotation back
+    cuts.AddCutPCM("000fc103", "0dm00009f9730000dge0474000", "2s52103500000000"); // in-Jet mass cut around pi0: 0.1-0.15, rotation back
   } else if (trainConfig == 24) {
-    cuts.AddCutPCM("0009b103", "0dm00009f9730000dge0474000", "2s52103500000000"); // in-Jet mass cut around pi0: 0.1-0.15, rotation back
+    cuts.AddCutPCM("000fb103", "0dm00009f9730000dge0474000", "2s52103500000000"); // in-Jet mass cut around pi0: 0.1-0.15, rotation back
   
   // qt cut variations
   } else if (trainConfig == 25) {
@@ -393,6 +394,7 @@ void AddTask_MesonJetCorr_Conv(
   }
 
   task->SetMesonKind(meson);
+  task->SetMesonZPt(runOnlyZPt);
   task->SetIsConv(true);
   task->SetJetContainerAddName(nameJetFinder);
   task->SetEventCutList(numberOfCuts, EventCutList);

--- a/PWGGA/GammaConv/macros/AddTask_MesonJetCorr_ConvCalo.C
+++ b/PWGGA/GammaConv/macros/AddTask_MesonJetCorr_ConvCalo.C
@@ -63,6 +63,7 @@ void AddTask_MesonJetCorr_ConvCalo(
   bool setPi0Unstable = false,
   bool enableAddBackground = false,
   bool enableRadiusDep = false,
+  int runOnlyZPt = 0,           // if 0, bot pt and z histograms will be filled, if 1, pt histograms will be filled, if 2, only z histograms will be filled
   // subwagon config
   TString additionalTrainConfig = "0" // additional counter for trainconfig
 )
@@ -205,39 +206,39 @@ void AddTask_MesonJetCorr_ConvCalo(
   } else if (trainConfig == 5) {
     cuts.AddCutPCMCalo("0008d103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2s63103400000010"); // EG1 in-Jet, mass cut pi0: 0.1-0.15, rotation back
   } else if (trainConfig == 6) {
-    cuts.AddCutPCMCalo("0009c103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2s63103400000010"); // Jet low trigg in-Jet, mass cut pi0: 0.1-0.15, rotation back
+    cuts.AddCutPCMCalo("000fc103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2s63103400000010"); // Jet low trigg in-Jet, mass cut pi0: 0.1-0.15, rotation back
   } else if (trainConfig == 7) {
-    cuts.AddCutPCMCalo("0009b103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2s63103400000010"); // Jet high trigg in-Jet, mass cut pi0: 0.1-0.15, rotation back
+    cuts.AddCutPCMCalo("000fb103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2s63103400000010"); // Jet high trigg in-Jet, mass cut pi0: 0.1-0.15, rotation back
 
   // EJ1 and EJ2 only EMCal triggers
   } else if (trainConfig == 8) {
-    cuts.AddCutPCMCalo("00095103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2s631034000000d0"); // Jet-low trigg in-jet, pi0 mass: 0.1-0.15, rotation back
+    cuts.AddCutPCMCalo("000f5103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2s631034000000d0"); // Jet-low trigg in-jet, pi0 mass: 0.1-0.15, rotation back
   } else if (trainConfig == 9) {
-    cuts.AddCutPCMCalo("00093103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2s631034000000d0"); // Jet-high trigg in-jet, pi0 mass: 0.1-0.15, rotation back
+    cuts.AddCutPCMCalo("000f3103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2s631034000000d0"); // Jet-high trigg in-jet, pi0 mass: 0.1-0.15, rotation back
 
   // configs with Mesons only in EMCal, EMCal triggers only
   } else if (trainConfig == 10) {
     cuts.AddCutPCMCalo("00010103", "0dm00009f9730000dge0404000", "111110009fe30230000", "2s631034000000d0"); // in-jet, pi0 mass: 0.1-0.15, rotation back
   } else if (trainConfig == 11) {
-    cuts.AddCutPCMCalo("00095103", "0dm00009f9730000dge0404000", "111110009fe30230000", "2s631034000000d0"); // Jet-low trigg in-jet, pi0 mass: 0.1-0.15, rotation back
+    cuts.AddCutPCMCalo("000f5103", "0dm00009f9730000dge0404000", "111110009fe30230000", "2s631034000000d0"); // Jet-low trigg in-jet, pi0 mass: 0.1-0.15, rotation back
   } else if (trainConfig == 12) {
-    cuts.AddCutPCMCalo("00093103", "0dm00009f9730000dge0404000", "111110009fe30230000", "2s631034000000d0"); // Jet-high trigg in-jet, pi0 mass: 0.1-0.15, rotation back
+    cuts.AddCutPCMCalo("000f3103", "0dm00009f9730000dge0404000", "111110009fe30230000", "2s631034000000d0"); // Jet-high trigg in-jet, pi0 mass: 0.1-0.15, rotation back
 
   } else if (trainConfig == 14) { // same as 4 but with jet mixing back
     cuts.AddCutPCMCalo("0008e103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2163103400000010"); // EG2 in-Jet, mass cut pi0: 0.1-0.15, mixed jet back
   } else if (trainConfig == 15) { // same as 5 but with jet mixing back
     cuts.AddCutPCMCalo("0008d103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2163103400000010"); // EG1 in-Jet, mass cut pi0: 0.1-0.15, mixed jet back
   } else if (trainConfig == 16) { // same as 6 but with jet mixing back
-    cuts.AddCutPCMCalo("0009c103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2163103400000010"); // Jet low trigg in-Jet, mass cut pi0: 0.1-0.15, mixed jet back
+    cuts.AddCutPCMCalo("000fc103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2163103400000010"); // Jet low trigg in-Jet, mass cut pi0: 0.1-0.15, mixed jet back
   } else if (trainConfig == 17) { // same as 7 but with jet mixing back
-    cuts.AddCutPCMCalo("0009b103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2163103400000010"); // Jet high trigg in-Jet, mass cut pi0: 0.1-0.15, mixed jet back
+    cuts.AddCutPCMCalo("000fb103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2163103400000010"); // Jet high trigg in-Jet, mass cut pi0: 0.1-0.15, mixed jet back
   
 
   } else if (trainConfig == 20) {
     cuts.AddCutPCMCalo("00010103", "0dm00009f9730000dge0404000", "411790009fe30230000", "es63103400000010"); // decay daughters also inside jet
   } else if (trainConfig == 21) {
-    cuts.AddCutPCMCalo("0009c103", "0dm00009f9730000dge0404000", "411790009fe30230000", "es63103400000010"); // decay daughters also inside jet
-    cuts.AddCutPCMCalo("0009b103", "0dm00009f9730000dge0404000", "411790009fe30230000", "es63103400000010"); // decay daughters also inside jet
+    cuts.AddCutPCMCalo("000fc103", "0dm00009f9730000dge0404000", "411790009fe30230000", "es63103400000010"); // decay daughters also inside jet
+    cuts.AddCutPCMCalo("000fb103", "0dm00009f9730000dge0404000", "411790009fe30230000", "es63103400000010"); // decay daughters also inside jet
 
 
   // configs with NonLinearity 
@@ -250,30 +251,30 @@ void AddTask_MesonJetCorr_ConvCalo(
   } else if (trainConfig == 25) {
     cuts.AddCutPCMCalo("0008d103", "0dm00009f9730000dge0404000", "411790109fe30230000", "2s63103400000010"); // EG1 in-Jet, mass cut pi0: 0.1-0.15, rotation back
   } else if (trainConfig == 26) {
-    cuts.AddCutPCMCalo("0009c103", "0dm00009f9730000dge0404000", "411790109fe30230000", "2s63103400000010"); // Jet low trigg in-Jet, mass cut pi0: 0.1-0.15, rotation back
+    cuts.AddCutPCMCalo("000fc103", "0dm00009f9730000dge0404000", "411790109fe30230000", "2s63103400000010"); // Jet low trigg in-Jet, mass cut pi0: 0.1-0.15, rotation back
   } else if (trainConfig == 27) {
-    cuts.AddCutPCMCalo("0009b103", "0dm00009f9730000dge0404000", "411790109fe30230000", "2s63103400000010"); // Jet high trigg in-Jet, mass cut pi0: 0.1-0.15, rotation back
+    cuts.AddCutPCMCalo("000fb103", "0dm00009f9730000dge0404000", "411790109fe30230000", "2s63103400000010"); // Jet high trigg in-Jet, mass cut pi0: 0.1-0.15, rotation back
 
 
    // configs with eta < 0.5
   } else if (trainConfig == 30) {
     cuts.AddCutPCMCalo("00010103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2s634034000000d0"); // in-jet, pi0 mass: 0.1-0.15, rotation back
   } else if (trainConfig == 31) {
-    cuts.AddCutPCMCalo("0009c103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2s634034000000d0"); // Jet-low trigg in-jet, pi0 mass: 0.1-0.15, rotation back
+    cuts.AddCutPCMCalo("000fc103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2s634034000000d0"); // Jet-low trigg in-jet, pi0 mass: 0.1-0.15, rotation back
   } else if (trainConfig == 32) {
-    cuts.AddCutPCMCalo("0009b103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2s634034000000d0"); // Jet-high trigg in-jet, pi0 mass: 0.1-0.15, rotation back
+    cuts.AddCutPCMCalo("000fb103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2s634034000000d0"); // Jet-high trigg in-jet, pi0 mass: 0.1-0.15, rotation back
 
   // configs with eta < 0.5, only EMCal triggers (not DCal)
   } else if (trainConfig == 33) {
-    cuts.AddCutPCMCalo("00095103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2s634034000000d0"); // Jet-low trigg in-jet, pi0 mass: 0.1-0.15, rotation back
+    cuts.AddCutPCMCalo("000f5103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2s634034000000d0"); // Jet-low trigg in-jet, pi0 mass: 0.1-0.15, rotation back
   } else if (trainConfig == 34) {
-    cuts.AddCutPCMCalo("00093103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2s634034000000d0"); // Jet-high trigg in-jet, pi0 mass: 0.1-0.15, rotation back
+    cuts.AddCutPCMCalo("000f3103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2s634034000000d0"); // Jet-high trigg in-jet, pi0 mass: 0.1-0.15, rotation back
 
   // configs with eta < 0.5, only EMCal triggers (not DCal), Mesons only with EMCal
   } else if (trainConfig == 35) {
-    cuts.AddCutPCMCalo("00095103", "0dm00009f9730000dge0404000", "111110009fe30230000", "2s634034000000d0"); // Jet-low trigg in-jet, pi0 mass: 0.1-0.15, rotation back
+    cuts.AddCutPCMCalo("000f5103", "0dm00009f9730000dge0404000", "111110009fe30230000", "2s634034000000d0"); // Jet-low trigg in-jet, pi0 mass: 0.1-0.15, rotation back
   } else if (trainConfig == 36) {
-    cuts.AddCutPCMCalo("00093103", "0dm00009f9730000dge0404000", "111110009fe30230000", "2s634034000000d0"); // Jet-high trigg in-jet, pi0 mass: 0.1-0.15, rotation back
+    cuts.AddCutPCMCalo("000f3103", "0dm00009f9730000dge0404000", "111110009fe30230000", "2s634034000000d0"); // Jet-high trigg in-jet, pi0 mass: 0.1-0.15, rotation back
 
 
 
@@ -359,164 +360,164 @@ void AddTask_MesonJetCorr_ConvCalo(
 
   // ------ EJ2 cut variations
   } else if (trainConfig == 130) { // 
-    cuts.AddCutPCMCalo("0009c103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2s63103400000010"); // NL var. etc which is handled in correction framework
+    cuts.AddCutPCMCalo("000fc103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2s63103400000010"); // NL var. etc which is handled in correction framework
   } else if (trainConfig == 131) { // background variation
-    cuts.AddCutPCMCalo("0009c103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2163103400000010"); // jet mixing back
+    cuts.AddCutPCMCalo("000fc103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2163103400000010"); // jet mixing back
   } else if (trainConfig == 132) { // alpha cut variation
-    cuts.AddCutPCMCalo("0009c103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2s63105400000010"); // alpha cut 0-0.75
-    cuts.AddCutPCMCalo("0009c103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2s63108400000010"); // alpha cut 0-0.65
+    cuts.AddCutPCMCalo("000fc103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2s63105400000010"); // alpha cut 0-0.75
+    cuts.AddCutPCMCalo("000fc103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2s63108400000010"); // alpha cut 0-0.65
   } else if (trainConfig == 133) { // opening angle var.
-    cuts.AddCutPCMCalo("0009c103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2s63103400000000"); // no opening angle cut
+    cuts.AddCutPCMCalo("000fc103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2s63103400000000"); // no opening angle cut
 
 
   } else if (trainConfig == 135) { // M02 variation (std M02 = 0.5)
-    cuts.AddCutPCMCalo("0009c103", "0dm00009f9730000dge0404000", "411790009fe30240000", "2s63103400000010"); // M02 = 0.4
-    cuts.AddCutPCMCalo("0009c103", "0dm00009f9730000dge0404000", "411790009fe30220000", "2s63103400000010"); // M02 = 0.7
-    cuts.AddCutPCMCalo("0009c103", "0dm00009f9730000dge0404000", "411790009fe30210000", "2s63103400000010"); // M02 = 1.0
-    cuts.AddCutPCMCalo("0009c103", "0dm00009f9730000dge0404000", "411790009fe302v0000", "2s63103400000010"); // 0.5 < M02 < 0.7
+    cuts.AddCutPCMCalo("000fc103", "0dm00009f9730000dge0404000", "411790009fe30240000", "2s63103400000010"); // M02 = 0.4
+    cuts.AddCutPCMCalo("000fc103", "0dm00009f9730000dge0404000", "411790009fe30220000", "2s63103400000010"); // M02 = 0.7
+    cuts.AddCutPCMCalo("000fc103", "0dm00009f9730000dge0404000", "411790009fe30210000", "2s63103400000010"); // M02 = 1.0
+    cuts.AddCutPCMCalo("000fc103", "0dm00009f9730000dge0404000", "411790009fe302v0000", "2s63103400000010"); // 0.5 < M02 < 0.7
   } else if (trainConfig == 136) { // TM variations for mesons
-    cuts.AddCutPCMCalo("0009c103", "0dm00009f9730000dge0404000", "4117900090e30230000", "2s63103400000010"); // no TM
-    cuts.AddCutPCMCalo("0009c103", "0dm00009f9730000dge0404000", "411790009ee30230000", "2s63103400000010"); // TM var EoverP 2.00
-    cuts.AddCutPCMCalo("0009c103", "0dm00009f9730000dge0404000", "411790009ge30230000", "2s63103400000010"); // TM var EoverP 1.5
-    cuts.AddCutPCMCalo("0009c103", "0dm00009f9730000dge0404000", "4117900097e30230000", "2s63103400000010"); // No E/p
-    cuts.AddCutPCMCalo("0009c103", "0dm00009f9730000dge0404000", "411790009le30230000", "2s63103400000010"); // std + sec TM
-    cuts.AddCutPCMCalo("0009c103", "0dm00009f9730000dge0404000", "411790009ne30230000", "2s63103400000010"); // TM var, Eta (0.035, 0.010, 2.5); Phi (0.085, 0.015, 2.)
+    cuts.AddCutPCMCalo("000fc103", "0dm00009f9730000dge0404000", "4117900090e30230000", "2s63103400000010"); // no TM
+    cuts.AddCutPCMCalo("000fc103", "0dm00009f9730000dge0404000", "411790009ee30230000", "2s63103400000010"); // TM var EoverP 2.00
+    cuts.AddCutPCMCalo("000fc103", "0dm00009f9730000dge0404000", "411790009ge30230000", "2s63103400000010"); // TM var EoverP 1.5
+    cuts.AddCutPCMCalo("000fc103", "0dm00009f9730000dge0404000", "4117900097e30230000", "2s63103400000010"); // No E/p
+    cuts.AddCutPCMCalo("000fc103", "0dm00009f9730000dge0404000", "411790009le30230000", "2s63103400000010"); // std + sec TM
+    cuts.AddCutPCMCalo("000fc103", "0dm00009f9730000dge0404000", "411790009ne30230000", "2s63103400000010"); // TM var, Eta (0.035, 0.010, 2.5); Phi (0.085, 0.015, 2.)
   } else if (trainConfig == 137) { // cluster time
-    cuts.AddCutPCMCalo("0009c103", "0dm00009f9730000dge0404000", "411790005fe30230000", "2s63103400000010"); // -50 - 50 ns
-    cuts.AddCutPCMCalo("0009c103", "0dm00009f9730000dge0404000", "411790006fe30230000", "2s63103400000010"); // -30 - 35 ns
-    cuts.AddCutPCMCalo("0009c103", "0dm00009f9730000dge0404000", "41179000afe30230000", "2s63103400000010"); // -12.5 - 13 ns
+    cuts.AddCutPCMCalo("000fc103", "0dm00009f9730000dge0404000", "411790005fe30230000", "2s63103400000010"); // -50 - 50 ns
+    cuts.AddCutPCMCalo("000fc103", "0dm00009f9730000dge0404000", "411790006fe30230000", "2s63103400000010"); // -30 - 35 ns
+    cuts.AddCutPCMCalo("000fc103", "0dm00009f9730000dge0404000", "41179000afe30230000", "2s63103400000010"); // -12.5 - 13 ns
   } else if (trainConfig == 138) { // NCell
-    cuts.AddCutPCMCalo("0009c103", "0dm00009f9730000dge0404000", "411790009fe3r230000", "2s63103400000010"); // EDC pi0 tagging for gamma clus, Gaussian Fit
-    cuts.AddCutPCMCalo("0009c103", "0dm00009f9730000dge0404000", "411790009fe3n230000", "2s63103400000010"); // PCMEDC pi0 tagging for gamma clus, Gaussian Fit
-    cuts.AddCutPCMCalo("0009c103", "0dm00009f9730000dge0404000", "411790009fe3m230000", "2s63103400000010"); // PCMEDC pi0 tagging for all clus, Gaussian Fit
-    cuts.AddCutPCMCalo("0009c103", "0dm00009f9730000dge0404000", "411790009fe3l230000", "2s63103400000010"); // PCMEDC pi0 tagging for gamma clus, pol2 fit
+    cuts.AddCutPCMCalo("000fc103", "0dm00009f9730000dge0404000", "411790009fe3r230000", "2s63103400000010"); // EDC pi0 tagging for gamma clus, Gaussian Fit
+    cuts.AddCutPCMCalo("000fc103", "0dm00009f9730000dge0404000", "411790009fe3n230000", "2s63103400000010"); // PCMEDC pi0 tagging for gamma clus, Gaussian Fit
+    cuts.AddCutPCMCalo("000fc103", "0dm00009f9730000dge0404000", "411790009fe3m230000", "2s63103400000010"); // PCMEDC pi0 tagging for all clus, Gaussian Fit
+    cuts.AddCutPCMCalo("000fc103", "0dm00009f9730000dge0404000", "411790009fe3l230000", "2s63103400000010"); // PCMEDC pi0 tagging for gamma clus, pol2 fit
   } else if (trainConfig == 139) { // min energy
-    cuts.AddCutPCMCalo("0009c103", "0dm00009f9730000dge0404000", "411790009fe10230000", "2s63103400000010"); // INT7, minE = 0.5
-    cuts.AddCutPCMCalo("0009c103", "0dm00009f9730000dge0404000", "411790009fe20230000", "2s63103400000010"); // INT7, minE = 0.6
-    cuts.AddCutPCMCalo("0009c103", "0dm00009f9730000dge0404000", "411790009fe40230000", "2s63103400000010"); // INT7, minE = 0.8
+    cuts.AddCutPCMCalo("000fc103", "0dm00009f9730000dge0404000", "411790009fe10230000", "2s63103400000010"); // INT7, minE = 0.5
+    cuts.AddCutPCMCalo("000fc103", "0dm00009f9730000dge0404000", "411790009fe20230000", "2s63103400000010"); // INT7, minE = 0.6
+    cuts.AddCutPCMCalo("000fc103", "0dm00009f9730000dge0404000", "411790009fe40230000", "2s63103400000010"); // INT7, minE = 0.8
   } else if (trainConfig == 140) { // Exotics
-    cuts.AddCutPCMCalo("0009c103", "0dm00009f9730000dge0404000", "411790009f030230000", "2s63103400000010"); // no exotics
-    cuts.AddCutPCMCalo("0009c103", "0dm00009f9730000dge0404000", "411790009fb30230000", "2s63103400000010"); // F+ < 0.95
+    cuts.AddCutPCMCalo("000fc103", "0dm00009f9730000dge0404000", "411790009f030230000", "2s63103400000010"); // no exotics
+    cuts.AddCutPCMCalo("000fc103", "0dm00009f9730000dge0404000", "411790009fb30230000", "2s63103400000010"); // F+ < 0.95
 
   } else if (trainConfig == 141) { // min pt electron variation
-    cuts.AddCutPCMCalo("0009c103", "0dm00069f9730000dge0404000", "411790009fe30230000", "2s63103400000010"); // min pT 40 MeV
-    cuts.AddCutPCMCalo("0009c103", "0dm00049f9730000dge0404000", "411790009fe30230000", "2s63103400000010"); // min pT 50 MeV
-    cuts.AddCutPCMCalo("0009c103", "0dm00019f9730000dge0404000", "411790009fe30230000", "2s63103400000010"); // min pT 100 MeV
+    cuts.AddCutPCMCalo("000fc103", "0dm00069f9730000dge0404000", "411790009fe30230000", "2s63103400000010"); // min pT 40 MeV
+    cuts.AddCutPCMCalo("000fc103", "0dm00049f9730000dge0404000", "411790009fe30230000", "2s63103400000010"); // min pT 50 MeV
+    cuts.AddCutPCMCalo("000fc103", "0dm00019f9730000dge0404000", "411790009fe30230000", "2s63103400000010"); // min pT 100 MeV
   } else if (trainConfig == 142) { // min pt electron variation
-    cuts.AddCutPCMCalo("0009c103", "0dm00008f9730000dge0404000", "411790009fe30230000", "2s63103400000010"); // TPC cluster 35%
-    cuts.AddCutPCMCalo("0009c103", "0dm00006f9730000dge0404000", "411790009fe30230000", "2s63103400000010"); // TPC cluster 70%
-    cuts.AddCutPCMCalo("0009c103", "0dm00009f9730000dge0604000", "411790009fe30230000", "2s63103400000010"); // cosPA 0.9
-    cuts.AddCutPCMCalo("0009c103", "0dm00009f9730000dge0304000", "411790009fe30230000", "2s63103400000010"); // cosPA 0.75
+    cuts.AddCutPCMCalo("000fc103", "0dm00008f9730000dge0404000", "411790009fe30230000", "2s63103400000010"); // TPC cluster 35%
+    cuts.AddCutPCMCalo("000fc103", "0dm00006f9730000dge0404000", "411790009fe30230000", "2s63103400000010"); // TPC cluster 70%
+    cuts.AddCutPCMCalo("000fc103", "0dm00009f9730000dge0604000", "411790009fe30230000", "2s63103400000010"); // cosPA 0.9
+    cuts.AddCutPCMCalo("000fc103", "0dm00009f9730000dge0304000", "411790009fe30230000", "2s63103400000010"); // cosPA 0.75
   } else if (trainConfig == 143) {
-    cuts.AddCutPCMCalo("0009c103", "0dm0000939730000dge0404000", "411790009fe30230000", "2s63103400000010"); // nsig electron   -4,5
-    cuts.AddCutPCMCalo("0009c103", "0dm0000969730000dge0404000", "411790009fe30230000", "2s63103400000010"); // nsig electron -2.5,4
-    cuts.AddCutPCMCalo("0009c103", "0dm00009f5730000dge0404000", "411790009fe30230000", "2s63103400000010"); // nsig pion 2,-10
-    cuts.AddCutPCMCalo("0009c103", "0dm00009f1730000dge0404000", "411790009fe30230000", "2s63103400000010"); // nsig pion 0,-10
+    cuts.AddCutPCMCalo("000fc103", "0dm0000939730000dge0404000", "411790009fe30230000", "2s63103400000010"); // nsig electron   -4,5
+    cuts.AddCutPCMCalo("000fc103", "0dm0000969730000dge0404000", "411790009fe30230000", "2s63103400000010"); // nsig electron -2.5,4
+    cuts.AddCutPCMCalo("000fc103", "0dm00009f5730000dge0404000", "411790009fe30230000", "2s63103400000010"); // nsig pion 2,-10
+    cuts.AddCutPCMCalo("000fc103", "0dm00009f1730000dge0404000", "411790009fe30230000", "2s63103400000010"); // nsig pion 0,-10
   } else if (trainConfig == 144) {
-    cuts.AddCutPCMCalo("0009c103", "0dm00009f9030000dge0404000", "411790009fe30230000", "2s63103400000010"); // pion nsig min mom 0.50 GeV/c
-    cuts.AddCutPCMCalo("0009c103", "0dm00009f9630000dge0404000", "411790009fe30230000", "2s63103400000010"); // pion nsig min mom 0.25 GeV/c
-    cuts.AddCutPCMCalo("0009c103", "0dm00009f9760000dge0404000", "411790009fe30230000", "2s63103400000010"); // pion nsig max mom 2.00 GeV/c
-    cuts.AddCutPCMCalo("0009c103", "0dm00009f9710000dge0404000", "411790009fe30230000", "2s63103400000010"); // pion nsig max mom 5.00 GeV/c
+    cuts.AddCutPCMCalo("000fc103", "0dm00009f9030000dge0404000", "411790009fe30230000", "2s63103400000010"); // pion nsig min mom 0.50 GeV/c
+    cuts.AddCutPCMCalo("000fc103", "0dm00009f9630000dge0404000", "411790009fe30230000", "2s63103400000010"); // pion nsig min mom 0.25 GeV/c
+    cuts.AddCutPCMCalo("000fc103", "0dm00009f9760000dge0404000", "411790009fe30230000", "2s63103400000010"); // pion nsig max mom 2.00 GeV/c
+    cuts.AddCutPCMCalo("000fc103", "0dm00009f9710000dge0404000", "411790009fe30230000", "2s63103400000010"); // pion nsig max mom 5.00 GeV/c
   } else if (trainConfig == 145) {
-    cuts.AddCutPCMCalo("0009c103", "0dm00009f97300008ge0404000", "411790009fe30230000", "2s63103400000010"); // qT max 0.05 1D
-    cuts.AddCutPCMCalo("0009c103", "0dm00009f97300003ge0404000", "411790009fe30230000", "2s63103400000010"); // qT max 0.05 1D
-    cuts.AddCutPCMCalo("0009c103", "0dm00009f97300002ge0404000", "411790009fe30230000", "2s63103400000010"); // qT max 0.06 1D
-    cuts.AddCutPCMCalo("0009c103", "0dm00009f97300009ge0404000", "411790009fe30230000", "2s63103400000010"); // qT max 0.03 1D
+    cuts.AddCutPCMCalo("000fc103", "0dm00009f97300008ge0404000", "411790009fe30230000", "2s63103400000010"); // qT max 0.05 1D
+    cuts.AddCutPCMCalo("000fc103", "0dm00009f97300003ge0404000", "411790009fe30230000", "2s63103400000010"); // qT max 0.05 1D
+    cuts.AddCutPCMCalo("000fc103", "0dm00009f97300002ge0404000", "411790009fe30230000", "2s63103400000010"); // qT max 0.06 1D
+    cuts.AddCutPCMCalo("000fc103", "0dm00009f97300009ge0404000", "411790009fe30230000", "2s63103400000010"); // qT max 0.03 1D
   } else if (trainConfig == 146) {
-    cuts.AddCutPCMCalo("0009c103", "0dm00009f9730000dg50404000", "411790009fe30230000", "2s63103400000010"); // Psi pair 0.1  1D
-    cuts.AddCutPCMCalo("0009c103", "0dm00009f9730000dg10404000", "411790009fe30230000", "2s63103400000010"); // Psi pair 0.1  1D
-    cuts.AddCutPCMCalo("0009c103", "0dm00009f9730000dg60404000", "411790009fe30230000", "2s63103400000010"); // Psi pair 0.05  1D
-    cuts.AddCutPCMCalo("0009c103", "0dm00009f9730000dg80404000", "411790009fe30230000", "2s63103400000010"); // Psi pair 0.2  1D
+    cuts.AddCutPCMCalo("000fc103", "0dm00009f9730000dg50404000", "411790009fe30230000", "2s63103400000010"); // Psi pair 0.1  1D
+    cuts.AddCutPCMCalo("000fc103", "0dm00009f9730000dg10404000", "411790009fe30230000", "2s63103400000010"); // Psi pair 0.1  1D
+    cuts.AddCutPCMCalo("000fc103", "0dm00009f9730000dg60404000", "411790009fe30230000", "2s63103400000010"); // Psi pair 0.05  1D
+    cuts.AddCutPCMCalo("000fc103", "0dm00009f9730000dg80404000", "411790009fe30230000", "2s63103400000010"); // Psi pair 0.2  1D
   } else if (trainConfig == 147) {
-    cuts.AddCutPCMCalo("0009c103", "0dm00009f9730000c259404000", "411790009fe30230000", "2s63103400000010"); // qT<0.110pT (2D) alpha<0.99
-    cuts.AddCutPCMCalo("0009c103", "0dm00009f9730000a259404000", "411790009fe30230000", "2s63103400000010"); // qT<0.125pT (2D) alpha<0.99
-    cuts.AddCutPCMCalo("0009c103", "0dm00009f9730000e259404000", "411790009fe30230000", "2s63103400000010"); // qT<0.130pT (2D) alpha<0.99
+    cuts.AddCutPCMCalo("000fc103", "0dm00009f9730000c259404000", "411790009fe30230000", "2s63103400000010"); // qT<0.110pT (2D) alpha<0.99
+    cuts.AddCutPCMCalo("000fc103", "0dm00009f9730000a259404000", "411790009fe30230000", "2s63103400000010"); // qT<0.125pT (2D) alpha<0.99
+    cuts.AddCutPCMCalo("000fc103", "0dm00009f9730000e259404000", "411790009fe30230000", "2s63103400000010"); // qT<0.130pT (2D) alpha<0.99
   } else if (trainConfig == 148) {
-    cuts.AddCutPCMCalo("0009c103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2s63103400000010"); // PsiPair<0.15exp(-0.065chi2)
-    cuts.AddCutPCMCalo("0009c103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2s63103400000010"); // PsiPair<0.18exp(-0.055chi2)
-    cuts.AddCutPCMCalo("0009c103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2s63103400000010"); // PsiPair<0.20exp(-0.050chi2)
+    cuts.AddCutPCMCalo("000fc103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2s63103400000010"); // PsiPair<0.15exp(-0.065chi2)
+    cuts.AddCutPCMCalo("000fc103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2s63103400000010"); // PsiPair<0.18exp(-0.055chi2)
+    cuts.AddCutPCMCalo("000fc103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2s63103400000010"); // PsiPair<0.20exp(-0.050chi2)
 
 
 
 
   // ------ EJ1 cut variations
   } else if (trainConfig == 160) { // 
-    cuts.AddCutPCMCalo("0009b103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2s63103400000010"); // NL var. etc which is handled in correction framework
+    cuts.AddCutPCMCalo("000fb103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2s63103400000010"); // NL var. etc which is handled in correction framework
   } else if (trainConfig == 161) { // background variation
-    cuts.AddCutPCMCalo("0009b103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2163103400000010"); // jet mixing back
+    cuts.AddCutPCMCalo("000fb103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2163103400000010"); // jet mixing back
   } else if (trainConfig == 162) { // alpha cut variation
-    cuts.AddCutPCMCalo("0009b103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2s63105400000010"); // alpha cut 0-0.75
-    cuts.AddCutPCMCalo("0009b103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2s63108400000010"); // alpha cut 0-0.65
+    cuts.AddCutPCMCalo("000fb103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2s63105400000010"); // alpha cut 0-0.75
+    cuts.AddCutPCMCalo("000fb103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2s63108400000010"); // alpha cut 0-0.65
   } else if (trainConfig == 163) { // opening angle var.
-    cuts.AddCutPCMCalo("0009b103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2s63103400000000"); // no opening angle cut
+    cuts.AddCutPCMCalo("000fb103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2s63103400000000"); // no opening angle cut
 
 
   } else if (trainConfig == 165) { // M02 variation (std M02 = 0.5)
-    cuts.AddCutPCMCalo("0009b103", "0dm00009f9730000dge0404000", "411790009fe30240000", "2s63103400000010"); // M02 = 0.4
-    cuts.AddCutPCMCalo("0009b103", "0dm00009f9730000dge0404000", "411790009fe30220000", "2s63103400000010"); // M02 = 0.7
-    cuts.AddCutPCMCalo("0009b103", "0dm00009f9730000dge0404000", "411790009fe30210000", "2s63103400000010"); // M02 = 1.0
-    cuts.AddCutPCMCalo("0009b103", "0dm00009f9730000dge0404000", "411790009fe302v0000", "2s63103400000010"); // 0.5 < M02 < 0.7
+    cuts.AddCutPCMCalo("000fb103", "0dm00009f9730000dge0404000", "411790009fe30240000", "2s63103400000010"); // M02 = 0.4
+    cuts.AddCutPCMCalo("000fb103", "0dm00009f9730000dge0404000", "411790009fe30220000", "2s63103400000010"); // M02 = 0.7
+    cuts.AddCutPCMCalo("000fb103", "0dm00009f9730000dge0404000", "411790009fe30210000", "2s63103400000010"); // M02 = 1.0
+    cuts.AddCutPCMCalo("000fb103", "0dm00009f9730000dge0404000", "411790009fe302v0000", "2s63103400000010"); // 0.5 < M02 < 0.7
   } else if (trainConfig == 166) { // TM variations for mesons
-    cuts.AddCutPCMCalo("0009b103", "0dm00009f9730000dge0404000", "4117900090e30230000", "2s63103400000010"); // no TM
-    cuts.AddCutPCMCalo("0009b103", "0dm00009f9730000dge0404000", "411790009ee30230000", "2s63103400000010"); // TM var EoverP 2.00
-    cuts.AddCutPCMCalo("0009b103", "0dm00009f9730000dge0404000", "411790009ge30230000", "2s63103400000010"); // TM var EoverP 1.5
-    cuts.AddCutPCMCalo("0009b103", "0dm00009f9730000dge0404000", "4117900097e30230000", "2s63103400000010"); // No E/p
-    cuts.AddCutPCMCalo("0009b103", "0dm00009f9730000dge0404000", "411790009le30230000", "2s63103400000010"); // std + sec TM
-    cuts.AddCutPCMCalo("0009b103", "0dm00009f9730000dge0404000", "411790009ne30230000", "2s63103400000010"); // TM var, Eta (0.035, 0.010, 2.5); Phi (0.085, 0.015, 2.)
+    cuts.AddCutPCMCalo("000fb103", "0dm00009f9730000dge0404000", "4117900090e30230000", "2s63103400000010"); // no TM
+    cuts.AddCutPCMCalo("000fb103", "0dm00009f9730000dge0404000", "411790009ee30230000", "2s63103400000010"); // TM var EoverP 2.00
+    cuts.AddCutPCMCalo("000fb103", "0dm00009f9730000dge0404000", "411790009ge30230000", "2s63103400000010"); // TM var EoverP 1.5
+    cuts.AddCutPCMCalo("000fb103", "0dm00009f9730000dge0404000", "4117900097e30230000", "2s63103400000010"); // No E/p
+    cuts.AddCutPCMCalo("000fb103", "0dm00009f9730000dge0404000", "411790009le30230000", "2s63103400000010"); // std + sec TM
+    cuts.AddCutPCMCalo("000fb103", "0dm00009f9730000dge0404000", "411790009ne30230000", "2s63103400000010"); // TM var, Eta (0.035, 0.010, 2.5); Phi (0.085, 0.015, 2.)
   } else if (trainConfig == 167) { // cluster time
-    cuts.AddCutPCMCalo("0009b103", "0dm00009f9730000dge0404000", "411790005fe30230000", "2s63103400000010"); // -50 - 50 ns
-    cuts.AddCutPCMCalo("0009b103", "0dm00009f9730000dge0404000", "411790006fe30230000", "2s63103400000010"); // -30 - 35 ns
-    cuts.AddCutPCMCalo("0009b103", "0dm00009f9730000dge0404000", "41179000afe30230000", "2s63103400000010"); // -12.5 - 13 ns
+    cuts.AddCutPCMCalo("000fb103", "0dm00009f9730000dge0404000", "411790005fe30230000", "2s63103400000010"); // -50 - 50 ns
+    cuts.AddCutPCMCalo("000fb103", "0dm00009f9730000dge0404000", "411790006fe30230000", "2s63103400000010"); // -30 - 35 ns
+    cuts.AddCutPCMCalo("000fb103", "0dm00009f9730000dge0404000", "41179000afe30230000", "2s63103400000010"); // -12.5 - 13 ns
   } else if (trainConfig == 168) { // NCell
-    cuts.AddCutPCMCalo("0009b103", "0dm00009f9730000dge0404000", "411790009fe3r230000", "2s63103400000010"); // EDC pi0 tagging for gamma clus, Gaussian Fit
-    cuts.AddCutPCMCalo("0009b103", "0dm00009f9730000dge0404000", "411790009fe3n230000", "2s63103400000010"); // PCMEDC pi0 tagging for gamma clus, Gaussian Fit
-    cuts.AddCutPCMCalo("0009b103", "0dm00009f9730000dge0404000", "411790009fe3m230000", "2s63103400000010"); // PCMEDC pi0 tagging for all clus, Gaussian Fit
-    cuts.AddCutPCMCalo("0009b103", "0dm00009f9730000dge0404000", "411790009fe3l230000", "2s63103400000010"); // PCMEDC pi0 tagging for gamma clus, pol2 fit
+    cuts.AddCutPCMCalo("000fb103", "0dm00009f9730000dge0404000", "411790009fe3r230000", "2s63103400000010"); // EDC pi0 tagging for gamma clus, Gaussian Fit
+    cuts.AddCutPCMCalo("000fb103", "0dm00009f9730000dge0404000", "411790009fe3n230000", "2s63103400000010"); // PCMEDC pi0 tagging for gamma clus, Gaussian Fit
+    cuts.AddCutPCMCalo("000fb103", "0dm00009f9730000dge0404000", "411790009fe3m230000", "2s63103400000010"); // PCMEDC pi0 tagging for all clus, Gaussian Fit
+    cuts.AddCutPCMCalo("000fb103", "0dm00009f9730000dge0404000", "411790009fe3l230000", "2s63103400000010"); // PCMEDC pi0 tagging for gamma clus, pol2 fit
   } else if (trainConfig == 169) { // min energy
-    cuts.AddCutPCMCalo("0009b103", "0dm00009f9730000dge0404000", "411790009fe10230000", "2s63103400000010"); // INT7, minE = 0.5
-    cuts.AddCutPCMCalo("0009b103", "0dm00009f9730000dge0404000", "411790009fe20230000", "2s63103400000010"); // INT7, minE = 0.6
-    cuts.AddCutPCMCalo("0009b103", "0dm00009f9730000dge0404000", "411790009fe40230000", "2s63103400000010"); // INT7, minE = 0.8
+    cuts.AddCutPCMCalo("000fb103", "0dm00009f9730000dge0404000", "411790009fe10230000", "2s63103400000010"); // INT7, minE = 0.5
+    cuts.AddCutPCMCalo("000fb103", "0dm00009f9730000dge0404000", "411790009fe20230000", "2s63103400000010"); // INT7, minE = 0.6
+    cuts.AddCutPCMCalo("000fb103", "0dm00009f9730000dge0404000", "411790009fe40230000", "2s63103400000010"); // INT7, minE = 0.8
   } else if (trainConfig == 170) { // Exotics
-    cuts.AddCutPCMCalo("0009b103", "0dm00009f9730000dge0404000", "411790009f030230000", "2s63103400000010"); // no exotics
-    cuts.AddCutPCMCalo("0009b103", "0dm00009f9730000dge0404000", "411790009fb30230000", "2s63103400000010"); // F+ < 0.95
+    cuts.AddCutPCMCalo("000fb103", "0dm00009f9730000dge0404000", "411790009f030230000", "2s63103400000010"); // no exotics
+    cuts.AddCutPCMCalo("000fb103", "0dm00009f9730000dge0404000", "411790009fb30230000", "2s63103400000010"); // F+ < 0.95
 
   } else if (trainConfig == 171) { // min pt electron variation
-    cuts.AddCutPCMCalo("0009b103", "0dm00069f9730000dge0404000", "411790009fe30230000", "2s63103400000010"); // min pT 40 MeV
-    cuts.AddCutPCMCalo("0009b103", "0dm00049f9730000dge0404000", "411790009fe30230000", "2s63103400000010"); // min pT 50 MeV
-    cuts.AddCutPCMCalo("0009b103", "0dm00019f9730000dge0404000", "411790009fe30230000", "2s63103400000010"); // min pT 100 MeV
+    cuts.AddCutPCMCalo("000fb103", "0dm00069f9730000dge0404000", "411790009fe30230000", "2s63103400000010"); // min pT 40 MeV
+    cuts.AddCutPCMCalo("000fb103", "0dm00049f9730000dge0404000", "411790009fe30230000", "2s63103400000010"); // min pT 50 MeV
+    cuts.AddCutPCMCalo("000fb103", "0dm00019f9730000dge0404000", "411790009fe30230000", "2s63103400000010"); // min pT 100 MeV
   } else if (trainConfig == 172) { // min pt electron variation
-    cuts.AddCutPCMCalo("0009b103", "0dm00008f9730000dge0404000", "411790009fe30230000", "2s63103400000010"); // TPC cluster 35%
-    cuts.AddCutPCMCalo("0009b103", "0dm00006f9730000dge0404000", "411790009fe30230000", "2s63103400000010"); // TPC cluster 70%
-    cuts.AddCutPCMCalo("0009b103", "0dm00009f9730000dge0604000", "411790009fe30230000", "2s63103400000010"); // cosPA 0.9
-    cuts.AddCutPCMCalo("0009b103", "0dm00009f9730000dge0304000", "411790009fe30230000", "2s63103400000010"); // cosPA 0.75
+    cuts.AddCutPCMCalo("000fb103", "0dm00008f9730000dge0404000", "411790009fe30230000", "2s63103400000010"); // TPC cluster 35%
+    cuts.AddCutPCMCalo("000fb103", "0dm00006f9730000dge0404000", "411790009fe30230000", "2s63103400000010"); // TPC cluster 70%
+    cuts.AddCutPCMCalo("000fb103", "0dm00009f9730000dge0604000", "411790009fe30230000", "2s63103400000010"); // cosPA 0.9
+    cuts.AddCutPCMCalo("000fb103", "0dm00009f9730000dge0304000", "411790009fe30230000", "2s63103400000010"); // cosPA 0.75
   } else if (trainConfig == 173) {
-    cuts.AddCutPCMCalo("0009b103", "0dm0000939730000dge0404000", "411790009fe30230000", "2s63103400000010"); // nsig electron   -4,5
-    cuts.AddCutPCMCalo("0009b103", "0dm0000969730000dge0404000", "411790009fe30230000", "2s63103400000010"); // nsig electron -2.5,4
-    cuts.AddCutPCMCalo("0009b103", "0dm00009f5730000dge0404000", "411790009fe30230000", "2s63103400000010"); // nsig pion 2,-10
-    cuts.AddCutPCMCalo("0009b103", "0dm00009f1730000dge0404000", "411790009fe30230000", "2s63103400000010"); // nsig pion 0,-10
+    cuts.AddCutPCMCalo("000fb103", "0dm0000939730000dge0404000", "411790009fe30230000", "2s63103400000010"); // nsig electron   -4,5
+    cuts.AddCutPCMCalo("000fb103", "0dm0000969730000dge0404000", "411790009fe30230000", "2s63103400000010"); // nsig electron -2.5,4
+    cuts.AddCutPCMCalo("000fb103", "0dm00009f5730000dge0404000", "411790009fe30230000", "2s63103400000010"); // nsig pion 2,-10
+    cuts.AddCutPCMCalo("000fb103", "0dm00009f1730000dge0404000", "411790009fe30230000", "2s63103400000010"); // nsig pion 0,-10
   } else if (trainConfig == 174) {
-    cuts.AddCutPCMCalo("0009b103", "0dm00009f9030000dge0404000", "411790009fe30230000", "2s63103400000010"); // pion nsig min mom 0.50 GeV/c
-    cuts.AddCutPCMCalo("0009b103", "0dm00009f9630000dge0404000", "411790009fe30230000", "2s63103400000010"); // pion nsig min mom 0.25 GeV/c
-    cuts.AddCutPCMCalo("0009b103", "0dm00009f9760000dge0404000", "411790009fe30230000", "2s63103400000010"); // pion nsig max mom 2.00 GeV/c
-    cuts.AddCutPCMCalo("0009b103", "0dm00009f9710000dge0404000", "411790009fe30230000", "2s63103400000010"); // pion nsig max mom 5.00 GeV/c
+    cuts.AddCutPCMCalo("000fb103", "0dm00009f9030000dge0404000", "411790009fe30230000", "2s63103400000010"); // pion nsig min mom 0.50 GeV/c
+    cuts.AddCutPCMCalo("000fb103", "0dm00009f9630000dge0404000", "411790009fe30230000", "2s63103400000010"); // pion nsig min mom 0.25 GeV/c
+    cuts.AddCutPCMCalo("000fb103", "0dm00009f9760000dge0404000", "411790009fe30230000", "2s63103400000010"); // pion nsig max mom 2.00 GeV/c
+    cuts.AddCutPCMCalo("000fb103", "0dm00009f9710000dge0404000", "411790009fe30230000", "2s63103400000010"); // pion nsig max mom 5.00 GeV/c
   } else if (trainConfig == 175) {
-    cuts.AddCutPCMCalo("0009b103", "0dm00009f97300008ge0404000", "411790009fe30230000", "2s63103400000010"); // qT max 0.05 1D
-    cuts.AddCutPCMCalo("0009b103", "0dm00009f97300003ge0404000", "411790009fe30230000", "2s63103400000010"); // qT max 0.05 1D
-    cuts.AddCutPCMCalo("0009b103", "0dm00009f97300002ge0404000", "411790009fe30230000", "2s63103400000010"); // qT max 0.06 1D
-    cuts.AddCutPCMCalo("0009b103", "0dm00009f97300009ge0404000", "411790009fe30230000", "2s63103400000010"); // qT max 0.03 1D
+    cuts.AddCutPCMCalo("000fb103", "0dm00009f97300008ge0404000", "411790009fe30230000", "2s63103400000010"); // qT max 0.05 1D
+    cuts.AddCutPCMCalo("000fb103", "0dm00009f97300003ge0404000", "411790009fe30230000", "2s63103400000010"); // qT max 0.05 1D
+    cuts.AddCutPCMCalo("000fb103", "0dm00009f97300002ge0404000", "411790009fe30230000", "2s63103400000010"); // qT max 0.06 1D
+    cuts.AddCutPCMCalo("000fb103", "0dm00009f97300009ge0404000", "411790009fe30230000", "2s63103400000010"); // qT max 0.03 1D
   } else if (trainConfig == 176) {
-    cuts.AddCutPCMCalo("0009b103", "0dm00009f9730000dg50404000", "411790009fe30230000", "2s63103400000010"); // Psi pair 0.1  1D
-    cuts.AddCutPCMCalo("0009b103", "0dm00009f9730000dg10404000", "411790009fe30230000", "2s63103400000010"); // Psi pair 0.1  1D
-    cuts.AddCutPCMCalo("0009b103", "0dm00009f9730000dg60404000", "411790009fe30230000", "2s63103400000010"); // Psi pair 0.05  1D
-    cuts.AddCutPCMCalo("0009b103", "0dm00009f9730000dg80404000", "411790009fe30230000", "2s63103400000010"); // Psi pair 0.2  1D
+    cuts.AddCutPCMCalo("000fb103", "0dm00009f9730000dg50404000", "411790009fe30230000", "2s63103400000010"); // Psi pair 0.1  1D
+    cuts.AddCutPCMCalo("000fb103", "0dm00009f9730000dg10404000", "411790009fe30230000", "2s63103400000010"); // Psi pair 0.1  1D
+    cuts.AddCutPCMCalo("000fb103", "0dm00009f9730000dg60404000", "411790009fe30230000", "2s63103400000010"); // Psi pair 0.05  1D
+    cuts.AddCutPCMCalo("000fb103", "0dm00009f9730000dg80404000", "411790009fe30230000", "2s63103400000010"); // Psi pair 0.2  1D
   } else if (trainConfig == 177) {
-    cuts.AddCutPCMCalo("0009b103", "0dm00009f9730000c259404000", "411790009fe30230000", "2s63103400000010"); // qT<0.110pT (2D) alpha<0.99
-    cuts.AddCutPCMCalo("0009b103", "0dm00009f9730000a259404000", "411790009fe30230000", "2s63103400000010"); // qT<0.125pT (2D) alpha<0.99
-    cuts.AddCutPCMCalo("0009b103", "0dm00009f9730000e259404000", "411790009fe30230000", "2s63103400000010"); // qT<0.130pT (2D) alpha<0.99
+    cuts.AddCutPCMCalo("000fb103", "0dm00009f9730000c259404000", "411790009fe30230000", "2s63103400000010"); // qT<0.110pT (2D) alpha<0.99
+    cuts.AddCutPCMCalo("000fb103", "0dm00009f9730000a259404000", "411790009fe30230000", "2s63103400000010"); // qT<0.125pT (2D) alpha<0.99
+    cuts.AddCutPCMCalo("000fb103", "0dm00009f9730000e259404000", "411790009fe30230000", "2s63103400000010"); // qT<0.130pT (2D) alpha<0.99
   } else if (trainConfig == 178) {
-    cuts.AddCutPCMCalo("0009b103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2s63103400000010"); // PsiPair<0.15exp(-0.065chi2)
-    cuts.AddCutPCMCalo("0009b103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2s63103400000010"); // PsiPair<0.18exp(-0.055chi2)
-    cuts.AddCutPCMCalo("0009b103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2s63103400000010"); // PsiPair<0.20exp(-0.050chi2)
+    cuts.AddCutPCMCalo("000fb103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2s63103400000010"); // PsiPair<0.15exp(-0.065chi2)
+    cuts.AddCutPCMCalo("000fb103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2s63103400000010"); // PsiPair<0.18exp(-0.055chi2)
+    cuts.AddCutPCMCalo("000fb103", "0dm00009f9730000dge0404000", "411790009fe30230000", "2s63103400000010"); // PsiPair<0.20exp(-0.050chi2)
 
 
     //---------------------------------------
@@ -675,6 +676,7 @@ void AddTask_MesonJetCorr_ConvCalo(
   }
 
   task->SetMesonKind(meson);
+  task->SetMesonZPt(runOnlyZPt);
   task->SetIsConvCalo(true);
   task->SetJetContainerAddName(nameJetFinder);
   task->SetEventCutList(numberOfCuts, EventCutList);

--- a/PWGGA/GammaConvBase/AliConvEventCuts.cxx
+++ b/PWGGA/GammaConvBase/AliConvEventCuts.cxx
@@ -639,7 +639,7 @@ void AliConvEventCuts::InitCutHistograms(TString name, Bool_t preCut){
     hTriggerClassSelected->GetXaxis()->SetBinLabel(36,"INEL>0");
     fHistograms->Add(hTriggerClassSelected);
 
-    if (fSpecialTrigger == 5 || fSpecialTrigger == 8 || fSpecialTrigger == 9 || fSpecialTrigger == 10){
+    if (fSpecialTrigger == 5 || fSpecialTrigger == 8 || fSpecialTrigger == 9 || fSpecialTrigger == 10 || fSpecialTrigger == 15){
       hTriggerClassesCorrelated= new TH1F(Form("TriggerCorrelations %s",GetCutNumber().Data()),"Triggers Correlated with EMCal triggers",21,-0.5,20.5);
       hTriggerClassesCorrelated->GetXaxis()->SetBinLabel( 1,"kMB");
       hTriggerClassesCorrelated->GetXaxis()->SetBinLabel( 2,"kINT7");
@@ -1602,6 +1602,14 @@ Bool_t AliConvEventCuts::SetSelectSpecialTrigger(Int_t selectSpecialTrigger)
     SETBIT(fTriggersEMCALSelected, kG2);
     fSpecialTriggerName="AliVEvent::kEMCEGA";
     break;
+  case 15: // f) basically the same as 9 but without overlap rejection for gamma triggers
+    fSpecialTrigger=15; // trigger alias kEMCEJE
+    fOfflineTriggerMask=AliVEvent::kEMCEJE;
+    fTriggerSelectedManually = kTRUE;
+    fTriggersEMCALSelected= 0;
+    SETBIT(fTriggersEMCALSelected, kJ2);
+    fSpecialTriggerName="AliVEvent::kEMCEJE";
+    break;
   default:
     AliError(Form("Warning: Special Trigger %d Not known",selectSpecialTrigger));
     return 0;
@@ -2556,6 +2564,103 @@ Bool_t AliConvEventCuts::SetSelectSubTriggerClass(Int_t selectSpecialSubTriggerC
     default:
       AliError(Form("Warning: Special Subtrigger Class %d Not known",selectSpecialSubTriggerClass));
       return 0;
+    }
+  } else if (fSpecialTrigger == 15){ // jet triggers without overlapp rejection for gamma triggers
+    switch(selectSpecialSubTriggerClass){
+      case 0: // all together
+        fSpecialSubTrigger=0;
+        fSpecialSubTriggerName="";
+        // AliInfo("Info: Nothing to be done");
+        break;
+      case 1: // 7EJE - CINT7 EJE
+        fSpecialSubTrigger=1;
+        fNSpecialSubTriggerOptions=1;
+        fSpecialSubTriggerName="7EJE";
+        fTriggersEMCALSelected= 0;
+        SETBIT(fTriggersEMCALSelected, kJ2);
+        break;
+      case 2: // 8EJE - CINT8 EJE
+        fSpecialSubTrigger=1;
+        fNSpecialSubTriggerOptions=1;
+        fSpecialSubTriggerName="8EJE";
+        fTriggersEMCALSelected= 0;
+        SETBIT(fTriggersEMCALSelected, kJ2);
+        break;
+      case 3: // 7EJ1 - CINT7 EJ1
+        fSpecialSubTrigger=1;
+        fNSpecialSubTriggerOptions=1;
+        fSpecialSubTriggerName="7EJ1";
+        fTriggersEMCALSelected= 0;
+        SETBIT(fTriggersEMCALSelected, kJ1);
+        break;
+      case 4: // 8EJ1 - CINT8 EJ1
+        fSpecialSubTrigger=1;
+        fNSpecialSubTriggerOptions=1;
+        fSpecialSubTriggerName="8EJ1";
+        fTriggersEMCALSelected= 0;
+        SETBIT(fTriggersEMCALSelected, kJ1);
+        break;
+      case 5: // 7EJ2 - CINT7 EJ2
+        fSpecialSubTrigger=1;
+        fNSpecialSubTriggerOptions=1;
+        fSpecialSubTriggerName="7EJ2";
+        fTriggersEMCALSelected= 0;
+        SETBIT(fTriggersEMCALSelected, kJ2);
+        break;
+      case 6: // 8EJ2 - CINT8 EJ2
+        fSpecialSubTrigger=1;
+        fNSpecialSubTriggerOptions=1;
+        fSpecialSubTriggerName="8EJ2";
+        fTriggersEMCALSelected= 0;
+        SETBIT(fTriggersEMCALSelected, kJ2);
+        break;
+      case 7: // 7DJ1 - CINT7 DJ1
+        fSpecialSubTrigger=1;
+        fNSpecialSubTriggerOptions=1;
+        fSpecialSubTriggerName="7DJ1";
+        fTriggersEMCALSelected= 0;
+        SETBIT(fTriggersEMCALSelected, kJ1);
+        break;
+      case 8: // 8DJ1 - CINT8 DJ1
+        fSpecialSubTrigger=1;
+        fNSpecialSubTriggerOptions=1;
+        fSpecialSubTriggerName="8DJ1";
+        fTriggersEMCALSelected= 0;
+        SETBIT(fTriggersEMCALSelected, kJ1);
+        break;
+      case 9: // 7DJ2 - CINT7 DJ2
+        fSpecialSubTrigger=1;
+        fNSpecialSubTriggerOptions=1;
+        fSpecialSubTriggerName="7DJ2";
+        fTriggersEMCALSelected= 0;
+        SETBIT(fTriggersEMCALSelected, kJ2);
+        break;
+      case 10: // 8DJ2 - CINT8 DJ2
+        fSpecialSubTrigger=1;
+        fNSpecialSubTriggerOptions=1;
+        fSpecialSubTriggerName="8DJ2";
+        fTriggersEMCALSelected= 0;
+        SETBIT(fTriggersEMCALSelected, kJ2);
+        break;
+      case 11: // high Jet trigger EMC+DMC
+        fSpecialSubTrigger=1;
+        fNSpecialSubTriggerOptions=2;
+        fSpecialSubTriggerName="7EJ1";
+        fSpecialSubTriggerNameAdditional="7DJ1";
+        fTriggersEMCALSelected= 0;
+        SETBIT(fTriggersEMCALSelected, kJ1);
+        break;
+      case 12: // low Jet trigger EMC+DMC
+        fSpecialSubTrigger=1;
+        fNSpecialSubTriggerOptions=2;
+        fSpecialSubTriggerName="7EJ2";
+        fSpecialSubTriggerNameAdditional="7DJ2";
+        fTriggersEMCALSelected= 0;
+        SETBIT(fTriggersEMCALSelected, kJ2);
+        break;
+      default:
+        AliError("Warning: Special Subtrigger Class Not known");
+        return 0;
     }
   }
   return 1;
@@ -5700,7 +5805,7 @@ Bool_t AliConvEventCuts::MimicTrigger(AliVEvent *event, Bool_t isMC ){
 
   // abort if mimicing not enabled
   if (!fMimicTrigger) return kTRUE;
-  if(!(fSpecialTrigger == 5 || fSpecialTrigger == 6 || fSpecialTrigger == 8 || fSpecialTrigger == 9 || fSpecialTrigger == 10 || fSpecialTrigger == 13  || fSpecialTrigger == 14 )) return kTRUE;   // not the correct trigger for mimcking
+  if(!(fSpecialTrigger == 5 || fSpecialTrigger == 6 || fSpecialTrigger == 8 || fSpecialTrigger == 9 || fSpecialTrigger == 10 || fSpecialTrigger == 13  || fSpecialTrigger == 14  || fSpecialTrigger == 15 )) return kTRUE;   // not the correct trigger for mimcking
 
   // Trigger mimicking based on decision by the AliAnalysisTaskEmcalTriggerSelection for L1 triggers
   // To get the correct values one has to select the correct dataset
@@ -5715,7 +5820,7 @@ Bool_t AliConvEventCuts::MimicTrigger(AliVEvent *event, Bool_t isMC ){
         if( (triggercont->IsEventSelected("EG1")) || (triggercont->IsEventSelected("DG1")) || (triggercont->IsEventSelected("EGA"))) return kTRUE;
       } else if( fSpecialTrigger == 5 || fSpecialTrigger == 10 ){
         if( triggercont->IsEventSelected("EMCL0") || triggercont->IsEventSelected("DMCL0") ) return kTRUE;
-      } else if( fSpecialTrigger == 9 ){
+      } else if( fSpecialTrigger == 9 || fSpecialTrigger == 15 ){
         if(fSpecialSubTriggerName.Contains("EJ2") || fSpecialSubTriggerName.Contains("DJ2") ){
           if( triggercont->IsEventSelected("EJ2") || triggercont->IsEventSelected("DJ2") ) return kTRUE;
         }
@@ -6434,9 +6539,97 @@ Bool_t AliConvEventCuts::IsTriggerSelected(AliVEvent *event, Bool_t isMC)
                 }
               }
             }
+            // jet triggers -> overlap with gamma triggers allowed for jet analyses only
+            if (fSpecialTrigger == 15){
+              if(fNSpecialSubTriggerOptions==2){
+                // trigger rejection for EMC and DMC triggers together
+                if (fSpecialSubTriggerName.CompareTo("7EJ1") == 0 && fSpecialSubTriggerNameAdditional.CompareTo("7DJ1") == 0){
+                  if (fInputHandler->IsEventSelected() & AliVEvent::kINT7) isSelected = 0;
+                  else if (firedTrigClass.Contains("7DJ2"))  isSelected = 0;
+                  else if (firedTrigClass.Contains("7EJ2"))  isSelected = 0;
+                  else if( fMimicTrigger == 2){
+                    auto triggercont = static_cast<PWG::EMCAL::AliEmcalTriggerDecisionContainer *>(event->FindListObject("EmcalTriggerDecision"));
+                    if(!(triggercont->IsEventSelected("DJ1") || triggercont->IsEventSelected("EJ1"))) isSelected = 0;
+                  }
+                } else if (fSpecialSubTriggerName.CompareTo("7EJ2") == 0 && fSpecialSubTriggerNameAdditional.CompareTo("7DJ2") == 0){
+                  if (fInputHandler->IsEventSelected() & AliVEvent::kINT7) isSelected = 0;
+                  else if( fMimicTrigger == 2){
+                    auto triggercont = static_cast<PWG::EMCAL::AliEmcalTriggerDecisionContainer *>(event->FindListObject("EmcalTriggerDecision"));
+                    if(!(triggercont->IsEventSelected("DJ2") || triggercont->IsEventSelected("EJ2"))) isSelected = 0;
+                  }
+                }
+              } else {
+                // separate rejection for EMC and DMC triggers
+                if( fSpecialSubTriggerName.CompareTo("7EJE") == 0){
+                  if (fInputHandler->IsEventSelected() & AliVEvent::kINT7) isSelected = 0;
+                  else if( fMimicTrigger == 2){
+                    auto triggercont = static_cast<PWG::EMCAL::AliEmcalTriggerDecisionContainer *>(event->FindListObject("EmcalTriggerDecision"));
+                    if(!triggercont->IsEventSelected("EJE")) isSelected = 0;
+                  }
+                } else if (fSpecialSubTriggerName.CompareTo("8EJE") == 0){
+                  if (fInputHandler->IsEventSelected() & AliVEvent::kINT8) isSelected = 0;
+                  else if( fMimicTrigger == 2){
+                    auto triggercont = static_cast<PWG::EMCAL::AliEmcalTriggerDecisionContainer *>(event->FindListObject("EmcalTriggerDecision"));
+                    if(!triggercont->IsEventSelected("EJE")) isSelected = 0;
+                  }
+                } else if (fSpecialSubTriggerName.CompareTo("7EJ1") == 0){
+                  if (fInputHandler->IsEventSelected() & AliVEvent::kINT7) isSelected = 0;
+                  else if (firedTrigClass.Contains("7EJ2"))  isSelected = 0;
+                  else if( fMimicTrigger == 2){
+                    auto triggercont = static_cast<PWG::EMCAL::AliEmcalTriggerDecisionContainer *>(event->FindListObject("EmcalTriggerDecision"));
+                    if(!triggercont->IsEventSelected("EJ1")) isSelected = 0;
+                  }
+                } else if (fSpecialSubTriggerName.CompareTo("8EJ1") == 0){
+                  if (fInputHandler->IsEventSelected() & AliVEvent::kINT8) isSelected = 0;
+                  else if (firedTrigClass.Contains("8EJ2"))  isSelected = 0;
+                  else if( fMimicTrigger == 2){
+                    auto triggercont = static_cast<PWG::EMCAL::AliEmcalTriggerDecisionContainer *>(event->FindListObject("EmcalTriggerDecision"));
+                    if(!triggercont->IsEventSelected("EJ2")) isSelected = 0;
+                  }
+                } else if (fSpecialSubTriggerName.CompareTo("7EJ2") == 0){
+                  if (fInputHandler->IsEventSelected() & AliVEvent::kINT7) isSelected = 0;
+                  else if( fMimicTrigger == 2){
+                    auto triggercont = static_cast<PWG::EMCAL::AliEmcalTriggerDecisionContainer *>(event->FindListObject("EmcalTriggerDecision"));
+                    if(!triggercont->IsEventSelected("EJ2")) isSelected = 0;
+                  }
+                } else if (fSpecialSubTriggerName.CompareTo("8EJ2") == 0){
+                  if (fInputHandler->IsEventSelected() & AliVEvent::kINT8) isSelected = 0;
+                  else if( fMimicTrigger == 2){
+                    auto triggercont = static_cast<PWG::EMCAL::AliEmcalTriggerDecisionContainer *>(event->FindListObject("EmcalTriggerDecision"));
+                    if(!triggercont->IsEventSelected("EJ2")) isSelected = 0;
+                  }
+                } else if (fSpecialSubTriggerName.CompareTo("7DJ1") == 0){
+                  if (fInputHandler->IsEventSelected() & AliVEvent::kINT7) isSelected = 0;
+                  else if (firedTrigClass.Contains("7DJ2"))  isSelected = 0;
+                  else if( fMimicTrigger == 2){
+                    auto triggercont = static_cast<PWG::EMCAL::AliEmcalTriggerDecisionContainer *>(event->FindListObject("EmcalTriggerDecision"));
+                    if(!triggercont->IsEventSelected("DJ1")) isSelected = 0;
+                  }
+                } else if (fSpecialSubTriggerName.CompareTo("8DJ1") == 0){
+                  if (fInputHandler->IsEventSelected() & AliVEvent::kINT8) isSelected = 0;
+                  else if (firedTrigClass.Contains("8DJ2"))  isSelected = 0;
+                  else if( fMimicTrigger == 2){
+                    auto triggercont = static_cast<PWG::EMCAL::AliEmcalTriggerDecisionContainer *>(event->FindListObject("EmcalTriggerDecision"));
+                    if(!triggercont->IsEventSelected("DJ1")) isSelected = 0;
+                  }
+                } else if (fSpecialSubTriggerName.CompareTo("7DJ2") == 0){
+                  if (fInputHandler->IsEventSelected() & AliVEvent::kINT7) isSelected = 0;
+                  else if( fMimicTrigger == 2){
+                    auto triggercont = static_cast<PWG::EMCAL::AliEmcalTriggerDecisionContainer *>(event->FindListObject("EmcalTriggerDecision"));
+                    if(!triggercont->IsEventSelected("DJ2")) isSelected = 0;
+                  }
+                } else if (fSpecialSubTriggerName.CompareTo("8DJ2") == 0){
+                  if (fInputHandler->IsEventSelected() & AliVEvent::kINT7) isSelected = 0;
+                  else if( fMimicTrigger == 2){
+                    auto triggercont = static_cast<PWG::EMCAL::AliEmcalTriggerDecisionContainer *>(event->FindListObject("EmcalTriggerDecision"));
+                    if(!triggercont->IsEventSelected("DJ2")) isSelected = 0;
+                  }
+                }
+              }
+            }
           }
           if (isSelected != 0 ){
-            if (fSpecialTrigger == 5 || fSpecialTrigger == 8 || fSpecialTrigger == 9 ){
+            if (fSpecialTrigger == 5 || fSpecialTrigger == 8 || fSpecialTrigger == 9  || fSpecialTrigger == 15 ){
               if (hTriggerClassesCorrelated){
                 if (fInputHandler->IsEventSelected() & AliVEvent::kMB)hTriggerClassesCorrelated->Fill(0);
                 if (fInputHandler->IsEventSelected() & AliVEvent::kINT7)hTriggerClassesCorrelated->Fill(1);
@@ -6504,7 +6697,7 @@ Bool_t AliConvEventCuts::IsTriggerSelected(AliVEvent *event, Bool_t isMC)
           }
 
         } else if (isMC){
-          if (fSpecialTrigger == 5 || fSpecialTrigger == 6 || fSpecialTrigger == 8 || fSpecialTrigger == 9){ // EMCAL triggers
+          if (fSpecialTrigger == 5 || fSpecialTrigger == 6 || fSpecialTrigger == 8 || fSpecialTrigger == 9 || fSpecialTrigger == 15 ){ // EMCAL triggers
             // isSelected = 0;
             // if (fTriggersEMCAL > 0)cout << "Special Trigger " << fSpecialTrigger << " triggers: " << fTriggersEMCAL << "    selected triggers: " << fTriggersEMCALSelected << " run number: " <<event->GetRunNumber()<<endl;
             // if (fTriggersEMCAL&fTriggersEMCALSelected){

--- a/PWGGA/GammaConvBase/AliResponseMatrixHelper.h
+++ b/PWGGA/GammaConvBase/AliResponseMatrixHelper.h
@@ -55,6 +55,12 @@ class MatrixHandler4D
   double getValueForBinIndexMesonY(const int index) const;
   double getValueForBinIndexJetY(const int index) const;
 
+
+  std::vector<double> getBinsMesonX() const { return vecBinsMesonX; }
+  std::vector<double> getBinsMesonY() const { return vecBinsMesonY; }
+  std::vector<double> getBinsJetX() const { return vecBinsJetX; }
+  std::vector<double> getBinsJetY() const { return vecBinsJetY; }
+
   void Fill(double valJetX, double valJetY, double valMesonX, double valMesonY, double val = 1);
 
   void AddBinContent(double valJetX, double valJetY, double valMesonX, double valMesonY, double val = 1, double err = 1);
@@ -68,6 +74,8 @@ class MatrixHandler4D
 
   void WeightResponseMatrix(TF1* funcMeson = nullptr, TF1* funcJet = nullptr);
   void WeightResponseMatrix(TF2* func);
+
+
 
  private:
   bool useTHNSparese = false;


### PR DESCRIPTION
- Enable the possibility to only run z or pt histograms inside jets. This is needed as the eta cut and jet finder can be different for these quantities.
-Can be steered via new AddTask Argument and if 0, both z and pt will be run (as previously)
- Switch trigger to allow for correct trigger overlap rejection: New SpecialTrigger is added which clones the previous case 9 but does not have an automatic overlapp rejection for the gamma triggers