### PR TITLE
[PWGEM-13] PWGGA/GammaConv - Add True hist minv E Clus NPrimMatched

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvCalo.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvCalo.h
@@ -60,11 +60,13 @@ class AliAnalysisTaskGammaConvCalo : public AliAnalysisTaskSE {
     void ProcessTrueMesonCandidates     ( AliAODConversionMother *Pi0Candidate,
                                           AliAODConversionPhoton *TrueGammaCandidate0,
                                           AliAODConversionPhoton *TrueGammaCandidate1,
-                                          Bool_t matched);
+                                          Bool_t matched,
+                                          int NPrimaryMatched = 0);
     void ProcessTrueMesonCandidatesAOD  ( AliAODConversionMother *Pi0Candidate,
                                           AliAODConversionPhoton *TrueGammaCandidate0,
                                           AliAODConversionPhoton *TrueGammaCandidate1,
-                                          Bool_t matched);
+                                          Bool_t matched,
+                                          int NPrimaryMatched = 0);
     void ProcessConversionPhotonsForMissingTags     ();
     void ProcessConversionPhotonsForMissingTagsAOD  ();
 
@@ -471,6 +473,7 @@ class AliAnalysisTaskGammaConvCalo : public AliAnalysisTaskSE {
     TH2F**                  fHistoTruePi0PureGammaInvMassECalib;                //! array of histogram with pure pi0 signal (only pure gammas) inv Mass, energy of cluster
     TH2F**                  fHistoTruePi0InvMassECalibPCM;                      //! array of histogram with pure pi0 signal inv Mass, energy of PCM
     TH3F**                  fHistoMotherInvMassECalibNMatchedPrim;              //! array of histogram with pi0 mass, calo photon energy and the number of matched primary tracks
+    TH3F**                  fHistoTruePi0InvMassECalibNMatchedPrim;             //! array of histogram with true pi0 mass, calo photon energy and the number of matched primary tracks
     // event histograms
     TH1F**                  fHistoNEvents;                                      //! array of histos with event information
     TH1F**                  fHistoNEventsWOWeight;                              //! array of histos with event information without event weights
@@ -539,7 +542,7 @@ class AliAnalysisTaskGammaConvCalo : public AliAnalysisTaskSE {
     AliAnalysisTaskGammaConvCalo(const AliAnalysisTaskGammaConvCalo&); // Prevent copy-construction
     AliAnalysisTaskGammaConvCalo &operator=(const AliAnalysisTaskGammaConvCalo&); // Prevent assignment
 
-    ClassDef(AliAnalysisTaskGammaConvCalo, 74);
+    ClassDef(AliAnalysisTaskGammaConvCalo, 75);
 };
 
 #endif

--- a/PWGGA/GammaConv/macros/AddTask_GammaCalo_PbPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaCalo_PbPb.C
@@ -31,12 +31,12 @@ void AddTask_GammaCalo_PbPb(
   // general setting for task
   Int_t     enableQAMesonTask             = 0,        // enable QA in AliAnalysisTaskGammaConvV1
   Int_t     enableQAClusterTask           = 0,        // enable additional QA task
-  Int_t     enableExtMatchAndQA           = 0,                            // disabled (0), extMatch (1), extQA_noCellQA (2), extMatch+extQA_noCellQA (3), extQA+cellQA (4), extMatch+extQA+cellQA (5)
+  Int_t     enableExtMatchAndQA           = 0,        // disabled (0), extMatch (1), extQA_noCellQA (2), extMatch+extQA_noCellQA (3), extQA+cellQA (4), extMatch+extQA+cellQA (5)
   Bool_t    enableLightOutput             = kFALSE,   // switch to run light output (only essential histograms for afterburner)
   Bool_t    enableTHnSparse               = kFALSE,   // switch on THNsparse
   Int_t     enableTriggerMimicking        = 0,        // enable trigger mimicking
-  Bool_t    enableHeaderOverlap           = kTRUE,   // enable trigger overlap rejection
-  TString   settingMaxFacPtHard           = "3.",       // maximum factor between hardest jet and ptHard generated
+  Bool_t    enableHeaderOverlap           = kTRUE,    // enable trigger overlap rejection
+  TString   settingMaxFacPtHard           = "3.",     // maximum factor between hardest jet and ptHard generated
   Int_t     debugLevel                    = 0,        // introducing debug levels for grid running
   // settings for weights
   // FPTW:fileNamePtWeights, FMUW:fileNameMultWeights, FCEF:fileNameCentFlattening, separate with ;


### PR DESCRIPTION
- Add a TH3D to monitor the invariant mass of true Pi0 as function of the cluster Energy and the number of matched primary tracks to this cluster. We saw in MC reco previously that there is basically no visible Pi0 peak when looking at more than 1 matched tracks indepented of centrality in PbPb 5TeV

- also aligend some comments in the AddTask_GammaCalo_PbPb.C