### PR TITLE
Kch and K0 resonance rejection

### DIFF
--- a/PWGCF/Correlations/KaonCorrelations/AliAnalysisTaskKaon2PC.h
+++ b/PWGCF/Correlations/KaonCorrelations/AliAnalysisTaskKaon2PC.h
@@ -82,7 +82,7 @@ class AliAnalysisTaskKaon2PC : public AliAnalysisTaskSE
         void                    SetPileUp(Bool_t pileupflag) {fRejectEventPileUp = pileupflag; }
         void                    SetRemoveResonance(Bool_t removePhiflag) {fRemoveResonance = removePhiflag; }
         void                    SetRemoveResonancek0s(Bool_t resonanceflag) {fRemoveResonancek0s = resonanceflag; }
-        void                    SetRemoveAnyResonance(Bool_t anyresonanceflag) {fRemoveAnyResonance = anyresonanceflag; }
+        void                    SetRemoveAnyResonance(Bool_t k0resonanceflag) {fRemoveK0Resonance = k0resonanceflag; }
         void                    SetRemoveKchResonance(Bool_t kchresonanceflag) {fRemoveKchResonance = kchresonanceflag; }  
         void                    SetRemovePhiResonance(Bool_t phiresonanceflag) {fRemovePhiResonance = phiresonanceflag; }
         void                    SetSkipMom(Bool_t skipmomflag) {skipmom = skipmomflag; }                   
@@ -163,6 +163,7 @@ class AliAnalysisTaskKaon2PC : public AliAnalysisTaskSE
        TH1F*                   fGetMom;         //! dummy histogram
        TH1F*                   fpdgCode;        //! dummy histogram
        TH1F*                   fpdgCodeaftercut; //! dummy histogram
+       TH1F*                   fpdgkch;         //! dummy histogram
 
        TH2F*                   fHistK0PhiEta;    //! dummy histogram
        TH2F*                   fHistPosPhiEta;   //! dummy histogram
@@ -231,7 +232,7 @@ class AliAnalysisTaskKaon2PC : public AliAnalysisTaskSE
        Bool_t                  fPidpTDependentMethod; // to enable pT dependent PID
        Bool_t                  fRemoveResonance; // flag to remove resonances in mc gen
        Bool_t                  fRemoveResonancek0s; // flag to remove resonances in mc gen k0 correlation
-       Bool_t                  fRemoveAnyResonance;
+       Bool_t                  fRemoveK0Resonance;
        Bool_t                  fRemoveKchResonance;
        Bool_t                  fRemovePhiResonance;
        Bool_t                  skipmom;


### PR DESCRIPTION
There was a small bug in the rejection procedure used in last commit. It is fixed here. Only primary tracks of neutral and charged kaons are used for correlation function measurement. 