### PR TITLE
PileUp OOB for PbPb analysis

### DIFF
--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoEventReaderAOD.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoEventReaderAOD.cxx
@@ -25,6 +25,7 @@
 
 #include "AliAODpidUtil.h"
 #include "AliAnalysisUtils.h"
+#include "AliEventCuts.h"
 #include "AliGenHijingEventHeader.h"
 
 #include "AliExternalTrackParam.h"
@@ -82,6 +83,7 @@ AliFemtoEventReaderAOD::AliFemtoEventReaderAOD():
   fCascadePileUpRemoval(kFALSE),
   fV0PileUpRemoval(kFALSE),
   fTrackPileUpRemoval(kFALSE),
+  fRejectTPCPileupWithITSTPCnCluCorr(kTRUE),
   fMVPlp(kFALSE),
   fOutOfBunchPlp(kFALSE),
   fMinVtxContr(0),
@@ -215,6 +217,7 @@ AliFemtoEventReaderAOD::AliFemtoEventReaderAOD(const AliFemtoEventReaderAOD &aRe
   fCascadePileUpRemoval(aReader.fCascadePileUpRemoval),
   fV0PileUpRemoval(aReader.fV0PileUpRemoval),
   fTrackPileUpRemoval(aReader.fTrackPileUpRemoval),
+  fRejectTPCPileupWithITSTPCnCluCorr(aReader.fRejectTPCPileupWithITSTPCnCluCorr),
   fMVPlp(aReader.fMVPlp),
   fOutOfBunchPlp(aReader.fOutOfBunchPlp),
   fMinVtxContr(aReader.fMinVtxContr),
@@ -337,6 +340,7 @@ AliFemtoEventReaderAOD &AliFemtoEventReaderAOD::operator=(const AliFemtoEventRea
   fCascadePileUpRemoval = aReader.fCascadePileUpRemoval;
   fV0PileUpRemoval = aReader.fV0PileUpRemoval;
   fTrackPileUpRemoval = aReader.fTrackPileUpRemoval;
+  fRejectTPCPileupWithITSTPCnCluCorr = aReader.fRejectTPCPileupWithITSTPCnCluCorr;
   fMVPlp = aReader.fMVPlp;
   fOutOfBunchPlp = aReader.fOutOfBunchPlp;
   fMinVtxContr = aReader.fMinVtxContr;
@@ -539,7 +543,21 @@ AliFemtoEvent *AliFemtoEventReaderAOD::CopyAODtoFemtoEvent()
 	}		
     }
   //**************************************
-  
+  //AliEventCuts
+    if (fRejectTPCPileupWithITSTPCnCluCorr){
+       fEventCuts = new AliEventCuts();
+       if(fRejectTPCPileupWithITSTPCnCluCorr) {
+         fEventCuts->SetRejectTPCPileupWithITSTPCnCluCorr(fRejectTPCPileupWithITSTPCnCluCorr);
+       }
+       
+       if (!fEventCuts->AcceptEvent(fEvent) == kFALSE){
+         delete fEventCuts;
+         return nullptr;
+       }
+    }
+       
+    
+    
   // AliAnalysisUtils
   if (fisPileUp || fpA2013) {
     fAnaUtils = new AliAnalysisUtils();
@@ -2678,6 +2696,11 @@ void AliFemtoEventReaderAOD::SetV0PileUpRemoval(Bool_t v0PileUpRemoval)
 void AliFemtoEventReaderAOD::SetTrackPileUpRemoval(Bool_t trackPileUpRemoval)
 {
   fTrackPileUpRemoval = trackPileUpRemoval;
+}
+
+void AliFemtoEventReaderAOD::SetRejectTPCPileupWithITSTPCnCluCorr(Bool_t RejectTPCPileupWithITSTPCnCluCorr)
+{
+  fRejectTPCPileupWithITSTPCnCluCorr = RejectTPCPileupWithITSTPCnCluCorr;
 }
 
 void AliFemtoEventReaderAOD::SetDCAglobalTrack(Int_t dcagt)

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoEventReaderAOD.h
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoEventReaderAOD.h
@@ -99,7 +99,9 @@ public:
   void SetCascadePileUpRemoval(Bool_t cascadePileUpRemoval);
   void SetV0PileUpRemoval(Bool_t v0PileUpRemoval);
   void SetTrackPileUpRemoval(Bool_t trackPileUpRemoval);
-
+  void SetRejectTPCPileupWithITSTPCnCluCorr(Bool_t RejectTPCPileupWithITSTPCnCluCorr);
+  
+  
   void SetMinVtxContr(Int_t contr = 1) {
     fMinVtxContr = contr;
   }
@@ -251,6 +253,7 @@ private:
   Bool_t fCascadePileUpRemoval;//pile-up removal for cascades (its+tof hits for pos, neg and bac tracks)
   Bool_t fV0PileUpRemoval;//pile-up removal for V0s
   Bool_t fTrackPileUpRemoval;//pile-up removal for tracks (its+tof hits of tracks)
+  Bool_t fRejectTPCPileupWithITSTPCnCluCorr;
   Bool_t fMVPlp;           ///< multi-vertex pileup rejection?
   Bool_t fOutOfBunchPlp;   ///out-of-bunch pileup rejection
   Int_t fMinVtxContr;      ///< no of contributors for pA 2013 data


### PR DESCRIPTION
The method SetRejectTPCPileupWithITSTPCnCluCorr(kTRUE) is included in the Reader class for the LHC18 period from PbPb collision