### PR TITLE
OOB pileup method for LHC18 PbPb

### DIFF
--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoEventReaderAOD.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoEventReaderAOD.cxx
@@ -549,15 +549,12 @@ AliFemtoEvent *AliFemtoEventReaderAOD::CopyAODtoFemtoEvent()
        if(fRejectTPCPileupWithITSTPCnCluCorr) {
          fEventCuts->SetRejectTPCPileupWithITSTPCnCluCorr(fRejectTPCPileupWithITSTPCnCluCorr);
        }
-       
-       if (!fEventCuts->AcceptEvent(fEvent) == kFALSE){
+       if (!fEventCuts->AcceptEvent(fEvent)){
          delete fEventCuts;
          return nullptr;
        }
     }
-       
-    
-    
+
   // AliAnalysisUtils
   if (fisPileUp || fpA2013) {
     fAnaUtils = new AliAnalysisUtils();


### PR DESCRIPTION
OOB pile-up method for the LHC18 dataset in the PbPb collision -> fixed