### PR TITLE
PWGGA/GammaConv: Add in-jet histograms to pure MC task

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskGammaPureMC.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaPureMC.h
@@ -4,6 +4,10 @@
 #include "AliAnalysisTaskSE.h"
 #include "AliAnalysisManager.h"
 
+#include <fastjet/PseudoJet.hh>
+#include <fastjet/ClusterSequenceArea.hh>
+
+
 class AliAnalysisTaskGammaPureMC : public AliAnalysisTaskSE {
   public:
     /**
@@ -66,6 +70,9 @@ class AliAnalysisTaskGammaPureMC : public AliAnalysisTaskSE {
     bool IsInEMCalAcceptance(AliVParticle* part) const;
     bool IsInV0Acceptance(AliVParticle* part) const;
     bool IsSecondary(AliVParticle* motherParticle) const;
+    void ProcessJets();
+    bool IsParticleInJet(const std::vector<fastjet::PseudoJet>& vecJet, double eta, double phi, int& index, double& R);
+    double GetFrag(const fastjet::PseudoJet& jet, const AliVParticle* part);
 
     // additional functions
     void SetLogBinningXTH1(TH1* histoRebin);
@@ -73,6 +80,8 @@ class AliAnalysisTaskGammaPureMC : public AliAnalysisTaskSE {
     void SetIsK0(Int_t isK0){fIsK0 = isK0;}
     void SetMaxPt(Double_t pTmax){fMaxpT = pTmax;}
     void SetDoMultStudies(Int_t tmp){fDoMultStudies = tmp;}
+    void SetDoJetStudies(int tmp) {fDoJetStudies = tmp;}
+    
 
   protected:
     TList*                fOutputContainer;           //! Output container
@@ -166,6 +175,17 @@ class AliAnalysisTaskGammaPureMC : public AliAnalysisTaskSE {
     TH2F*                 fHistPtV0MultEtaGG;                 //! histo for Eta pt vs V0 multiplicity
     TH2F*                 fHistPtV0MultEtaPrimeGG;            //! histo for EtaPrime pt vs V0 multiplicity
 
+    // jet studies
+    TH2F*                 fHistPi0PtJetPt;        //! histo for Pi0 pt vs jet Pt
+    TH2F*                 fHistEtaPtJetPt;        //! histo for Pi0 pt vs jet Pt
+
+    TH2F*                 fHistPi0ZJetPt;        //! histo for Pi0 pt vs jet Pt
+    TH2F*                 fHistEtaZJetPt;        //! histo for Pi0 pt vs jet Pt
+
+    TH2F*                 fHistJetPtY;  //! histo for jet pt
+    TH1D*                 fHistJetEta;  //! histo for jet eta
+    TH1D*                 fHistJetPhi;  //! histo for jet phi
+
 	  Int_t				          fIsK0;					  // k0 flag
     Int_t                 fIsMC;            // MC flag
     Double_t              fMaxpT;           // Max pT flag
@@ -173,11 +193,29 @@ class AliAnalysisTaskGammaPureMC : public AliAnalysisTaskSE {
     Int_t                 fNTracksInV0Acc;  // number of tracks in V0A+C acceptance for multiplicity studies
     Bool_t                fIsEvtINELgtZERO; // flag if event is INEL>0
 
+    // jet finding
+    int fDoJetStudies;                                      // 0 = off, 1 = standard, 2 = stable pi0 and eta for jet finder
+    double fJetRadius;                                      // jet radius parameter
+    double fJetMinE;                                        // minimum jet energy
+    double fJetAccEta;                                      // eta acceptance of jet
+    double fJetParticleAcc;                                 // acceptance of particles that contribute to jet for pt spectra
+    double fJetParticleAccFF;                               // acceptance of particles that contribute to jet for FF
+    fastjet::JetAlgorithm   	    fJetAlgorithm;            // jet algorithm
+    fastjet::Strategy 		        fJetStrategy;             // jet strategy parameter
+    fastjet::AreaType 		        fJetAreaType;             // jet rea type parameter
+    fastjet::RecombinationScheme  fJetRecombScheme;         // jet recomb. scheme parameter
+    double fJetGhostArea;                                   // jet ghost area
+    double fGhostEtaMax;                                    // maximum eta of ghost particles
+    int fActiveAreaRepeats;                                 // jet active area
+    fastjet::AreaType 		  fAreaType;                      // jet area type
+    std::vector<fastjet::PseudoJet> fVecJets;               //! vector containing all reconstructed jets
+     
+
   private:
     AliAnalysisTaskGammaPureMC(const AliAnalysisTaskGammaPureMC&); // Prevent copy-construction
     AliAnalysisTaskGammaPureMC &operator=(const AliAnalysisTaskGammaPureMC&); // Prevent assignment
 
-    ClassDef(AliAnalysisTaskGammaPureMC, 7);
+    ClassDef(AliAnalysisTaskGammaPureMC, 8);
 };
 
 #endif

--- a/PWGGA/GammaConv/CMakeLists.txt
+++ b/PWGGA/GammaConv/CMakeLists.txt
@@ -71,7 +71,6 @@ set(SRCS
     AliAnalysisTRDEfficiency.cxx
     AliAnalysisTaskElectronStudies.cxx
     # MC and cocktail tasks
-    AliAnalysisTaskGammaPureMC.cxx
     AliAnalysisTaskGammaCocktailMC.cxx
     AliAnalysisTaskHadronicCocktailMC.cxx
     AliAnalysisTaskOmegaMCStudies.cxx
@@ -109,13 +108,29 @@ set(SRCS
 #     AliAnalysisTaskdPhi.cxx
    )
 
+# MC task that needs fastjet
+if(FASTJET_FOUND)
+   set(SRCS ${SRCS}
+    AliAnalysisTaskGammaPureMC.cxx
+   )
+endif(FASTJET_FOUND)
+
 # Headers from sources
 string(REPLACE ".cxx" ".h" HDRS "${SRCS}")
 set(HDRS ${HDRS})
+
+# fastjet
+if(FASTJET_FOUND)
+    include_directories(${AliPhysics_SOURCE_DIR}/JETAN/JETAN)
+    include_directories(SYSTEM ${FASTJET_INCLUDE_DIR})
+    link_directories(${FASTJET_LIBS_DIR})
+    add_definitions(${FASTJET_DEFINITIONS})
+endif(FASTJET_FOUND)
+
 # Generate the dictionary
 # It will create G_ARG1.cxx and G_ARG1.h / ARG1 = function first argument
 get_directory_property(incdirs INCLUDE_DIRECTORIES)
-generate_dictionary("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
+generate_dictionary("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}" "${FASTJET_ROOTDICT_OPTS}")
 
 set(ROOT_DEPENDENCIES Core EG GenVector Geom Gpad Hist MathCore Matrix Net Physics RIO Tree TMVA)
 set(ALIROOT_DEPENDENCIES ANALYSIS ANALYSISalice AOD EMCALbase EMCALUtils ESD STEERBase PWGTRD PWGflowTasks Tender TenderSupplies PWGEMCALbase PWGEMCALtasks PWGEMCALtrigger PWGCaloTrackCorrBase PWGGAUtils PWGJETFW )
@@ -124,6 +139,11 @@ set(ALIPHYSICS_DEPENDENCIES PWGCocktail PWGGAGammaConvBase PWGEMCALtasks PWGEMCA
 # Generate the ROOT map
 # Dependecies
 set(LIBDEPS ${ALIROOT_DEPENDENCIES} ${ALIPHYSICS_DEPENDENCIES} ${ROOT_DEPENDENCIES})
+
+if(FASTJET_FOUND)
+    set(ALIROOT_DEPENDENCIES JETAN ${ALIROOT_DEPENDENCIES})
+endif(FASTJET_FOUND)
+
 generate_rootmap("${MODULE}" "${LIBDEPS}" "${CMAKE_CURRENT_SOURCE_DIR}/${MODULE}LinkDef.h")
 
 # Generate a PARfile target for this library
@@ -134,7 +154,7 @@ add_target_parfile(${MODULE} "${SRCS}" "${HDRS}" "${MODULE}LinkDef.h" "${LIBDEPS
 add_library(${MODULE}-object OBJECT ${SRCS} G__${MODULE}.cxx)
 # Add a library to the project using the object
 add_library_tested(${MODULE} SHARED $<TARGET_OBJECTS:${MODULE}-object>)
-target_link_libraries(${MODULE} ${ALIPHYSICS_DEPENDENCIES} ${ALIROOT_DEPENDENCIES} ${ROOT_DEPENDENCIES})
+target_link_libraries(${MODULE} ${ALIPHYSICS_DEPENDENCIES} ${ALIROOT_DEPENDENCIES} ${ROOT_DEPENDENCIES} ${FASTJET_LIBS})
 
 # Setting the correct headers for the object as gathered from the dependencies
 target_include_directories(${MODULE}-object PUBLIC $<TARGET_PROPERTY:${MODULE},INCLUDE_DIRECTORIES>)

--- a/PWGGA/GammaConv/PWGGAGammaConvLinkDef.h
+++ b/PWGGA/GammaConv/PWGGAGammaConvLinkDef.h
@@ -37,7 +37,9 @@
 #pragma link C++ class AliAnalysisTaskElectronStudies+;
 
 // MC and cocktail tasks
+#ifdef HAVE_FASTJET
 #pragma link C++ class AliAnalysisTaskGammaPureMC+;
+#endif
 #pragma link C++ class AliAnalysisTaskGammaCocktailMC+;
 #pragma link C++ class AliAnalysisTaskHadronicCocktailMC+;
 #pragma link C++ class AliAnalysisTaskOmegaMCStudies+;

--- a/PWGGA/GammaConv/macros/AddTask_GammaPureMC.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaPureMC.C
@@ -1,4 +1,4 @@
-void AddTask_GammaPureMC(Int_t isK0 = 0 , Double_t maxpT = 100 , Int_t doMultStudies = 0) {
+void AddTask_GammaPureMC(Int_t isK0 = 0 , Double_t maxpT = 100 , Int_t doMultStudies = 0, int doJetStudies = 0) {
 
   // ================== GetAnalysisManager ===============================
   AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
@@ -21,10 +21,18 @@ void AddTask_GammaPureMC(Int_t isK0 = 0 , Double_t maxpT = 100 , Int_t doMultStu
   task->SetIsK0(isK0);
   task->SetMaxPt(maxpT);
   task->SetDoMultStudies(doMultStudies);
+  task->SetDoJetStudies(doJetStudies);
 
+  TString AddString = "";
+  if(doMultStudies){
+    AddString+=Form("_Mult%i", doMultStudies);
+  }
+  if(doJetStudies){
+    AddString+=Form("_Jet%i", doJetStudies);
+  }
   //connect containers
   AliAnalysisDataContainer *coutput =
-    mgr->CreateContainer("GammaPureMC", TList::Class(), AliAnalysisManager::kOutputContainer, Form("%s:GammaPureMC",AliAnalysisManager::GetCommonFileName()));
+    mgr->CreateContainer(Form("GammaPureMC%s", AddString.Data()), TList::Class(), AliAnalysisManager::kOutputContainer, Form("%s:GammaPureMC%s",AliAnalysisManager::GetCommonFileName(), AddString.Data()));
 
   mgr->AddTask(task);
   mgr->ConnectInput(task,0,cinput);

--- a/PWGGA/Hyperon/CMakeLists.txt
+++ b/PWGGA/Hyperon/CMakeLists.txt
@@ -46,10 +46,18 @@ set(SRCS
 # Headers from sources
 string(REPLACE ".cxx" ".h" HDRS "${SRCS}")
 
+# fastjet
+if(FASTJET_FOUND)
+    include_directories(${AliPhysics_SOURCE_DIR}/JETAN/JETAN)
+    include_directories(SYSTEM ${FASTJET_INCLUDE_DIR})
+    link_directories(${FASTJET_LIBS_DIR})
+    add_definitions(${FASTJET_DEFINITIONS})
+endif(FASTJET_FOUND)
+
 # Generate the dictionary
 # It will create G_ARG1.cxx and G_ARG1.h / ARG1 = function first argument
 get_directory_property(incdirs INCLUDE_DIRECTORIES)
-generate_dictionary("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
+generate_dictionary("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}" "${FASTJET_ROOTDICT_OPTS}")
 
 set(ROOT_DEPENDENCIES Core EG GenVector Geom Gpad Hist MathCore Matrix Net Physics RIO Tree)
 set(ALIROOT_DEPENDENCIES ANALYSIS ANALYSISalice AOD EMCALbase EMCALUtils ESD STEERBase PWGTRD PWGEMCALbase PWGEMCALtrigger PWGflowTasks PWGGAGammaConvBase PWGGAGammaConv)
@@ -57,6 +65,11 @@ set(ALIROOT_DEPENDENCIES ANALYSIS ANALYSISalice AOD EMCALbase EMCALUtils ESD STE
 # Generate the ROOT map
 # Dependecies
 set(LIBDEPS ${ALIROOT_DEPENDENCIES} ${ROOT_DEPENDENCIES})
+
+if(FASTJET_FOUND)
+    set(ALIROOT_DEPENDENCIES JETAN ${ALIROOT_DEPENDENCIES})
+endif(FASTJET_FOUND)
+
 generate_rootmap("${MODULE}" "${LIBDEPS}" "${CMAKE_CURRENT_SOURCE_DIR}/${MODULE}LinkDef.h")
 
 # Generate a PARfile target for this library
@@ -67,7 +80,7 @@ add_target_parfile(${MODULE} "${SRCS}" "${HDRS}" "${MODULE}LinkDef.h" "${LIBDEPS
 add_library(${MODULE}-object OBJECT ${SRCS} G__${MODULE}.cxx)
 # Add a library to the project using the object
 add_library_tested(${MODULE} SHARED $<TARGET_OBJECTS:${MODULE}-object>)
-target_link_libraries(${MODULE} ${ALIROOT_DEPENDENCIES} ${ROOT_DEPENDENCIES})
+target_link_libraries(${MODULE} ${ALIROOT_DEPENDENCIES} ${ROOT_DEPENDENCIES} ${FASTJET_LIBS})
 
 # Setting the correct headers for the object as gathered from the dependencies
 target_include_directories(${MODULE}-object PUBLIC $<TARGET_PROPERTY:${MODULE},INCLUDE_DIRECTORIES>)


### PR DESCRIPTION
- In order to run MC predictions for the in-jet analysis, a jet finder and histograms for the pi0 and eta inside jets are implemented in the pure MC task
- Can be enabled via add task argument
- If add task argument set to 2, Pi0 and Eta are considered stable particles and are used in the jet finder instead of their decay products