### PR TITLE
[PWGEM013] PWGGA/GammaConv - Update neutral overlap cluster energy co…

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.cxx
@@ -3460,6 +3460,13 @@ void AliAnalysisTaskGammaCalo::ProcessClusters()
     nclus = arrClustersProcess->GetEntries();
   }
 
+  // energy correction for neutral overlap!
+  float cent = ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetCentrality(fInputEvent);
+  if(((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetDoEnergyCorrectionForOverlap() > 0){
+    ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->SetPoissonParamCentFunction(fIsMC);
+    ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->SetNMatchedTracksFunc(cent);
+  }
+
   vector<AliAODConversionPhoton*>         vectorCurrentClusters;
   vector<Int_t>                           vectorRejectCluster;
   vector<Double_t>                        vectorPhotonWeight;
@@ -3501,6 +3508,10 @@ void AliAnalysisTaskGammaCalo::ProcessClusters()
           clus = new AliAODCaloCluster(*(AliAODCaloCluster*)fInputEvent->GetCaloCluster(i));
       }
       if(!clus) continue;
+      // energy correction for neutral overlap!
+      if(((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetDoEnergyCorrectionForOverlap() > 0){
+        clus->SetE(clus->E() - ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->CorrectEnergyForOverlap(cent));
+      }
       totalClusterEnergy += clus->E();
       totalCellsinClusters += clus->GetNCells();
       delete clus;

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvCalo.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvCalo.cxx
@@ -3422,7 +3422,7 @@ void AliAnalysisTaskGammaConvCalo::ProcessClusters(){
     if (!clus) continue;
     // energy correction for neutral overlap!
     if(((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetDoEnergyCorrectionForOverlap() > 0){
-      clus->SetE(clus->E() - ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->CorrectEnergyForOverlap());
+      clus->SetE(clus->E() - ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->CorrectEnergyForOverlap(cent));
     }
     if(!((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->ClusterIsSelected(clus,fInputEvent,fMCEvent,fIsMC,fWeightJetJetMC,i)){
       if(fDoInvMassShowerShapeTree && ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->ClusterIsSelectedBeforeTrackMatch() ) tESDmapIsClusterAcceptedWithoutTrackMatch[i] = 1;

--- a/PWGGA/GammaConv/macros/AddTask_GammaCalo_PbPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaCalo_PbPb.C
@@ -1300,7 +1300,18 @@ void AddTask_GammaCalo_PbPb(
     cuts.AddCutCalo("11310e03","411790105fe30220000","01631031000000d0"); // 10-30%
     cuts.AddCutCalo("13530e03","411790105fe30220000","01631031000000d0"); // 30-50%
     cuts.AddCutCalo("15910e03","411790105fe30220000","01631031000000d0"); // 50-90%
-
+  // Mean neutral energy overlap correction!
+  } else if (trainConfig == 789){ // EMCAL+DCal clusters - 13 TeV emcal cuts with TM
+    cuts.AddCutCalo("10130e03","411790105te30220000","0s631031000000d0"); // 00-10%
+    cuts.AddCutCalo("11310e03","411790105te30220000","0s631031000000d0"); // 10-30%
+    cuts.AddCutCalo("13530e03","411790105te30220000","0s631031000000d0"); // 30-50%
+    cuts.AddCutCalo("15910e03","411790105te30220000","0s631031000000d0"); // 50-90%
+  // Random neutral energy overlap correction!
+  } else if (trainConfig == 790){ // EMCAL+DCal clusters - 13 TeV emcal cuts with TM
+    cuts.AddCutCalo("10130e03","411790105ue30220000","0s631031000000d0"); // 00-10%
+    cuts.AddCutCalo("11310e03","411790105ue30220000","0s631031000000d0"); // 10-30%
+    cuts.AddCutCalo("13530e03","411790105ue30220000","0s631031000000d0"); // 30-50%
+    cuts.AddCutCalo("15910e03","411790105ue30220000","0s631031000000d0"); // 50-90%
   // **********************************************************************************************************
   // ***************************** PHOS       QA configurations PbPb run 2 2018 *******************************
   // **********************************************************************************************************

--- a/PWGGA/GammaConvBase/AliCaloPhotonCuts.h
+++ b/PWGGA/GammaConvBase/AliCaloPhotonCuts.h
@@ -409,7 +409,7 @@ class AliCaloPhotonCuts : public AliAnalysisCuts {
 
     Bool_t      SetPoissonParamCentFunction(int isMC);
     Bool_t      SetNMatchedTracksFunc(float meanCent);
-    Double_t    CorrectEnergyForOverlap();
+    Double_t    CorrectEnergyForOverlap(float meanCent);
     Int_t       GetDoEnergyCorrectionForOverlap()               {return fDoEnergyCorrectionForOverlap;}
 
     // modify acceptance via histogram with cellID
@@ -603,7 +603,7 @@ class AliCaloPhotonCuts : public AliAnalysisCuts {
     Int_t     fDoEnergyCorrectionForOverlap;            // mask to switch on a special for PbPb developed cluster energy correction, 0 = off, 1 = on with mean, 2 = on with random values
     TF1*      fFuncPoissonParamCent;                    // TF1 to describe the poisson parameter that you get from fitting a poisson dsitribution to the number of matched tracks per cluster as function of centrality
     TF1*      fFuncNMatchedTracks;                      // TF1 poisson distribution to describe the number of matched tracks per cluster for a specific centrality
-    Double_t  fOverlapEnergy;                           // track matching cut value for the energy correction for neutral overlap. Current only standard value is 300 MeV based on the charged particle paper (CERN-EP-2022-266)
+    TF1*      fFuncMeanTrackPt;                         // TF1 distribution to describe the mean pT of tracks as function of centrality. Half of this value is used as neutral energy overlap correction.
 
     //vector
     std::vector<Int_t> fVectorMatchedClusterIDs;        // vector with cluster IDs that have been matched to tracks in merged cluster analysis
@@ -754,7 +754,7 @@ class AliCaloPhotonCuts : public AliAnalysisCuts {
 
   private:
 
-    ClassDef(AliCaloPhotonCuts,129)
+    ClassDef(AliCaloPhotonCuts,130)
 };
 
 #endif


### PR DESCRIPTION
…rrection

- In the CaloPhotonCut code, changed the energy value that was subtracted from the cluster energy from a static value (300 MeV) to a centrality dependent value. The value comes from mean pT charge particle distributions as functions of centrality that were fitted. A simple simulation for Pi0 decaying into two photons has shown that the mean energy of a decay photon from a Pi0 with a given pT X is X/2. So the energy that is subtracted from the cluster is now 0.5 of the charge particle mean pT at the given centrality. This is under the assumption, that the mean pT distribution of neutral pions follow the charge particle mean pT distribution, which seems resonable.
- Add two cut settings to use this correction for the calo only task, 789 for mean neutral energy and 790 for random energy correction. Mean and random refer to the assumend number of neutral particles per cluster that contribute to the total cluster energy.