### PR TITLE
passing non-const pointer

### DIFF
--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHdEdxCorrelations.cxx
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHdEdxCorrelations.cxx
@@ -630,7 +630,7 @@ namespace PWGJE
             // Get proper track properties
             track.Clear();
             track = trackIter->first;
-            AliVTrack *vTrack = dynamic_cast<AliVTrack *>(trackIter->second);
+            const AliVTrack *vTrack = dynamic_cast<AliVTrack *>(trackIter->second);
 
             // Artificial inefficiency
             // Note that we already randomly rejected tracks so that the same tracks will be rejected for the mixed events


### PR DESCRIPTION
For some reason passing a non-const vTrack to the AliPIDResponse::CheckPIDStatus method caused a segfault.