### PR TITLE
[PWGEM-13] PWGGA/GammaConvBase: AliCaloPhotonCuts - optimise neutral …

### DIFF
--- a/PWGGA/GammaConvBase/AliCaloPhotonCuts.h
+++ b/PWGGA/GammaConvBase/AliCaloPhotonCuts.h
@@ -25,7 +25,6 @@
 #include "AliPhotonIsolation.h"
 #include <vector>
 
-
 class AliESDEvent;
 class AliAODEvent;
 class AliConversionPhotonBase;
@@ -411,6 +410,7 @@ class AliCaloPhotonCuts : public AliAnalysisCuts {
     Bool_t      SetNMatchedTracksFunc(float meanCent);
     Double_t    CorrectEnergyForOverlap(float meanCent);
     Int_t       GetDoEnergyCorrectionForOverlap()               {return fDoEnergyCorrectionForOverlap;}
+    Double_t    GetMeanEForOverlap(Double_t cent, Double_t* par);
 
     // modify acceptance via histogram with cellID
     void        SetHistoToModifyAcceptance(TH1S* histAcc)       {fHistoModifyAcc  = histAcc; return;}
@@ -603,7 +603,8 @@ class AliCaloPhotonCuts : public AliAnalysisCuts {
     Int_t     fDoEnergyCorrectionForOverlap;            // mask to switch on a special for PbPb developed cluster energy correction, 0 = off, 1 = on with mean, 2 = on with random values
     TF1*      fFuncPoissonParamCent;                    // TF1 to describe the poisson parameter that you get from fitting a poisson dsitribution to the number of matched tracks per cluster as function of centrality
     TF1*      fFuncNMatchedTracks;                      // TF1 poisson distribution to describe the number of matched tracks per cluster for a specific centrality
-    TF1*      fFuncMeanTrackPt;                         // TF1 distribution to describe the mean pT of tracks as function of centrality. Half of this value is used as neutral energy overlap correction.
+    Double_t  fParamMeanTrackPt[3];                     // TF1 distribution to describe the mean pT of tracks as function of centrality. Half of this value is used as neutral energy overlap correction.
+    Float_t   fMeanNMatchedTracks;                      // Mean number of matched primary tracks, stored to reduce CPU time for neutral overlap correction
 
     //vector
     std::vector<Int_t> fVectorMatchedClusterIDs;        // vector with cluster IDs that have been matched to tracks in merged cluster analysis
@@ -754,7 +755,7 @@ class AliCaloPhotonCuts : public AliAnalysisCuts {
 
   private:
 
-    ClassDef(AliCaloPhotonCuts,130)
+    ClassDef(AliCaloPhotonCuts,131)
 };
 
 #endif


### PR DESCRIPTION
…overlap correction CPU time

- the mean value of the number of matched tracks per cluster is now calculated once per event and stored to recude CPU time
- the fnction to get the mean energy of the neutral overlap is changed from TF1 to a c function with a c-array as parameter to further reduce the CPU time
- fixed wrong factor in `CorrectEnergyForOverlap`, was 0.25 should be 0.5!