### PR TITLE
PWGGA/GammaConv: change track pt cut for isolation to 150MeV

### DIFF
--- a/PWGGA/GammaConv/macros/AddTask_GammaIsoTree.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaIsoTree.C
@@ -77,7 +77,7 @@ void AddTask_GammaIsoTree(
   Double_t                    fChi2PerClsTPC = 5;   
   Int_t                       fMinClsITS = 0;  
   Double_t                    fEtaCut = 0.9;  
-  Double_t                    fPtCut= 0.1;  
+  Double_t                    fPtCut= 0.15;  
   Double_t                    fYMCCut = 9999;  
 
   Double_t                    fAntiIsolation[2] = {5.,10};


### PR DESCRIPTION
due to an oversight three years ago the track pt cut was set to 100MeV instead of 150MeV