### PR TITLE
Checking for valid pointer to VTrack

### DIFF
--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHdEdxCorrelations.cxx
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHdEdxCorrelations.cxx
@@ -631,6 +631,11 @@ namespace PWGJE
             track.Clear();
             track = trackIter->first;
             const AliVTrack *vTrack = dynamic_cast<AliVTrack *>(trackIter->second);
+            if (!vTrack)
+            {
+              AliErrorStream() << "Could not retrieve associated track from trackIter, skipping track.\n";
+              continue;
+            }
 
             // Artificial inefficiency
             // Note that we already randomly rejected tracks so that the same tracks will be rejected for the mixed events


### PR DESCRIPTION
I think that somewhere a track does not have a valid second() (It's a bit unclear to me what this is, but it is the required input for the PID methods) In any case, I now check that my pointer to the output of this method is valid and skip it if it is not. Sorry for the lengthy debugging session.