### PR TITLE
[PWGEM-13] AddTask_GammaConv* - Fix single FEPC file option

### DIFF
--- a/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_PbPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_PbPb.C
@@ -1546,7 +1546,7 @@ void AddTask_GammaConvCalo_PbPb(
           return;
         }
         int lNFnames = lArrFnamesdEdxPostCalib->GetEntriesFast();
-        if (lNFnames && lNFnames != numberOfCuts){
+        if (!(lNFnames == 1) && !(lNFnames == numberOfCuts)){
           cout << "ERROR: FEPC either has to be one filename or several separated by a '+' where the number of filenames has to match the number of cuts in the trainconfig.\nOr no filename at all if the file from the OADB is to be taken\n";
           return;
         }

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_pPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_pPb.C
@@ -2009,7 +2009,7 @@ void AddTask_GammaConvCalo_pPb(
           return;
         }
         int lNFnames = lArrFnamesdEdxPostCalib->GetEntriesFast();
-        if (lNFnames && lNFnames != numberOfCuts){
+        if (!(lNFnames == 1) && !(lNFnames == numberOfCuts)){
           cout << "ERROR: FEPC either has to be one filename or several separated by a '+' where the number of filenames has to match the number of cuts in the trainconfig.\nOr no filename at all if the file from the OADB is to be taken\n";
           return;
         }

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_pp.C
@@ -4800,7 +4800,7 @@ void AddTask_GammaConvCalo_pp(
           return;
         }
         int lNFnames = lArrFnamesdEdxPostCalib->GetEntriesFast();
-        if (lNFnames && lNFnames != numberOfCuts){
+        if (!(lNFnames == 1) && !(lNFnames == numberOfCuts)){
           cout << "ERROR: FEPC either has to be one filename or several separated by a '+' where the number of filenames has to match the number of cuts in the trainconfig.\nOr no filename at all if the file from the OADB is to be taken\n";
           return;
         }

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvV1_PbPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvV1_PbPb.C
@@ -4109,7 +4109,7 @@ void AddTask_GammaConvV1_PbPb(
         return;
       }
       int lNFnames = lArrFnamesdEdxPostCalib->GetEntriesFast();
-      if (lNFnames && lNFnames != numberOfCuts){
+      if (!(lNFnames == 1) && !(lNFnames == numberOfCuts)){
         cout << "ERROR: FEPC either has to be one filename or several separated by a '+' where the number of filenames has to match the number of cuts in the trainconfig.\nOr no filename at all if the file from the OADB is to be taken\n";
         return;
       }


### PR DESCRIPTION
- Fixes an issue where giving a single FEPC file would result in an error message instead of just using that one file for all cuts.