### PR TITLE
[PWGEM] PWGGA: Fix neutral overlap correction:

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.cxx
@@ -3508,10 +3508,6 @@ void AliAnalysisTaskGammaCalo::ProcessClusters()
           clus = new AliAODCaloCluster(*(AliAODCaloCluster*)fInputEvent->GetCaloCluster(i));
       }
       if(!clus) continue;
-      // energy correction for neutral overlap!
-      if(((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetDoEnergyCorrectionForOverlap() > 0){
-        clus->SetE(clus->E() - ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->CorrectEnergyForOverlap(cent));
-      }
       totalClusterEnergy += clus->E();
       totalCellsinClusters += clus->GetNCells();
       delete clus;
@@ -3542,6 +3538,13 @@ void AliAnalysisTaskGammaCalo::ProcessClusters()
         clus = new AliAODCaloCluster(*(AliAODCaloCluster*)fInputEvent->GetCaloCluster(i));
     }
     if(!clus) continue;
+
+    // energy correction for neutral overlap!
+    if(!((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetDoFlatEnergySubtraction()){
+      if(((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetDoEnergyCorrectionForOverlap() > 0){
+        clus->SetE(clus->E() - ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->CorrectEnergyForOverlap(cent));
+      }
+    }
 
     if(((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetDoFlatEnergySubtraction()){
       if(totalUnclusteredE!=0 && totalActiveCells!=0 && totalCellsinClusters!=0){

--- a/PWGGA/GammaConvBase/AliCaloPhotonCuts.cxx
+++ b/PWGGA/GammaConvBase/AliCaloPhotonCuts.cxx
@@ -6042,7 +6042,7 @@ Bool_t AliCaloPhotonCuts::SetTrackMatchingCut(Int_t trackMatching)
       fFuncNMatchedTracks = new TF1("fFuncNMatchedTracks29", "TMath::Poisson(x,[0])", 0., 10.);
       fDoEnergyCorrectionForOverlap = 1;
       fEOverPMax = 1.75;
-      if(fIsMC > 1){
+      if(fIsMC >= 1){
         // values for HIJING 5.02 TeV Pb--Pb simulations
         fParamMeanTrackPt[0] = +6.20104e-01;
         fParamMeanTrackPt[1] = -2.62817e-04;
@@ -6066,7 +6066,7 @@ Bool_t AliCaloPhotonCuts::SetTrackMatchingCut(Int_t trackMatching)
       fFuncNMatchedTracks = new TF1("fFuncNMatchedTracks30", "TMath::Poisson(x,[0])", 0., 10.);
       fDoEnergyCorrectionForOverlap = 2;
       fEOverPMax = 1.75;
-      if(fIsMC > 1){
+      if(fIsMC >= 1){
         // values for HIJING 5.02 TeV Pb--Pb simulations
         fParamMeanTrackPt[0] = +6.20104e-01;
         fParamMeanTrackPt[1] = -2.62817e-04;


### PR DESCRIPTION
- Fix in GammaCalo task: Ppreviously the neutral overlap correction was not corretly applied, because it was only done when we would do the flat energy correction which should not be used together.
- Fix in CaloPhotonCuts: fParamMeanTrackPt values should be set for `fIsMC >= 1` with the MC values and not for `fIsMC > 1` which would only be for special MC like JJ MC. So before this fix normal MC used the same values as data, but we know that in MC the mean pT is lower than in data with HIJING.