### PR TITLE
[PWGEM-13] PWGGA/GammaConv: changed neutral overlap cut to not use TM

### DIFF
--- a/PWGGA/GammaConv/macros/AddTask_GammaCalo_PbPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaCalo_PbPb.C
@@ -1301,24 +1301,24 @@ void AddTask_GammaCalo_PbPb(
     cuts.AddCutCalo("13530e03","411790105fe30220000","01631031000000d0"); // 30-50%
     cuts.AddCutCalo("15910e03","411790105fe30220000","01631031000000d0"); // 50-90%
   // Mean neutral energy overlap correction!
-  } else if (trainConfig == 789){ // EMCAL+DCal clusters - 13 TeV emcal cuts with TM
+  } else if (trainConfig == 789){ // EMCAL+DCal clusters - 13 TeV emcal cuts w/o TM
     cuts.AddCutCalo("10130e03","411790105te30220000","0s631031000000d0"); // 00-10%
     cuts.AddCutCalo("11310e03","411790105te30220000","0s631031000000d0"); // 10-30%
     cuts.AddCutCalo("13530e03","411790105te30220000","0s631031000000d0"); // 30-50%
     cuts.AddCutCalo("15910e03","411790105te30220000","0s631031000000d0"); // 50-90%
   // Random neutral energy overlap correction!
-  } else if (trainConfig == 790){ // EMCAL+DCal clusters - 13 TeV emcal cuts with TM
+  } else if (trainConfig == 790){ // EMCAL+DCal clusters - 13 TeV emcal cuts w/o TM
     cuts.AddCutCalo("10130e03","411790105ue30220000","0s631031000000d0"); // 00-10%
     cuts.AddCutCalo("11310e03","411790105ue30220000","0s631031000000d0"); // 10-30%
     cuts.AddCutCalo("13530e03","411790105ue30220000","0s631031000000d0"); // 30-50%
     cuts.AddCutCalo("15910e03","411790105ue30220000","0s631031000000d0"); // 50-90%
-  } else if (trainConfig == 791){ // EMCAL+DCal clusters - 13 TeV emcal cuts with TM with Mean neutral energy overlap correction, cent and semi cent trigger with OOB pileup cut
+  } else if (trainConfig == 791){ // EMCAL+DCal clusters - 13 TeV emcal cuts w/o TM with Mean neutral energy overlap correction, cent and semi cent trigger with OOB pileup cut
     cuts.AddCutCalo("10130e13","411790105te30220000","0s631031000000d0"); // 00-10%
     cuts.AddCutCalo("11310e13","411790105te30220000","0s631031000000d0"); // 10-30%
     cuts.AddCutCalo("13530e13","411790105te30220000","0s631031000000d0"); // 30-50%
     cuts.AddCutCalo("15910e13","411790105te30220000","0s631031000000d0"); // 50-90%
   // Mean neutral energy overlap correction!
-  } else if (trainConfig == 792){ // EMCAL+DCal clusters - 13 TeV emcal cuts with TM with Mean neutral energy overlap correction, cent and semi cent trigger without OOB pileup cut
+  } else if (trainConfig == 792){ // EMCAL+DCal clusters - 13 TeV emcal cuts w/o TM with Mean neutral energy overlap correction, cent and semi cent trigger without OOB pileup cut
     cuts.AddCutCalo("10130013","411790105te30220000","0s631031000000d0"); // 00-10%
     cuts.AddCutCalo("11310013","411790105te30220000","0s631031000000d0"); // 10-30%
     cuts.AddCutCalo("13530013","411790105te30220000","0s631031000000d0"); // 30-50%

--- a/PWGGA/GammaConvBase/AliCaloPhotonCuts.cxx
+++ b/PWGGA/GammaConvBase/AliCaloPhotonCuts.cxx
@@ -6030,18 +6030,16 @@ Bool_t AliCaloPhotonCuts::SetTrackMatchingCut(Int_t trackMatching)
       fMinDistTrackToClusterPhi = -0.1;
       fMaxDistTrackToClusterPhi = 0.1;
       break;
-    case 29: // cut char 't' (like f so standard TM but with mean energy correction for overlap)
+    case 29: // cut char 't' (no TM but with mean energy correction for overlap), only use with cell tm!
       if (!fUseDistTrackToCluster) fUseDistTrackToCluster=kTRUE;
       if (!fUseEOverPVetoTM) fUseEOverPVetoTM=kTRUE;
-      fUsePtDepTrackToCluster = 1;
-      fFuncPtDepEta = new TF1("funcEta29", "[1] + 1 / pow(x + pow(1 / ([0] - [1]), 1 / [2]), [2])");
-      fFuncPtDepEta->SetParameters(0.04, 0.010, 2.5);
-      fFuncPtDepPhi = new TF1("funcPhi29", "[1] + 1 / pow(x + pow(1 / ([0] - [1]), 1 / [2]), [2])");
-      fFuncPtDepPhi->SetParameters(0.09, 0.015, 2.);
+      fUseDistTrackToCluster = kFALSE;
+      fMaxDistTrackToClusterEta = 0;
+      fMinDistTrackToClusterPhi = 0;
+      fMaxDistTrackToClusterPhi = 0;
       fFuncPoissonParamCent = new TF1("fFuncPoissonParamCent29", "[0] * TMath::Exp( (x + [1] ) / [2] )", 0., 90.);
       fFuncNMatchedTracks = new TF1("fFuncNMatchedTracks29", "TMath::Poisson(x,[0])", 0., 10.);
       fDoEnergyCorrectionForOverlap = 1;
-      fEOverPMax = 1.75;
       if(fIsMC >= 1){
         // values for HIJING 5.02 TeV Pb--Pb simulations
         fParamMeanTrackPt[0] = +6.20104e-01;
@@ -6054,18 +6052,16 @@ Bool_t AliCaloPhotonCuts::SetTrackMatchingCut(Int_t trackMatching)
         fParamMeanTrackPt[2] = -1.93788e-05;
       }
       break;
-    case 30: // cut char 'u' (like f so standard TM but with random energy correction for overlap)
+    case 30: // cut char 'u' (no TM but with random energy correction for overlap), only use with cell tm!
       if (!fUseDistTrackToCluster) fUseDistTrackToCluster=kTRUE;
       if (!fUseEOverPVetoTM) fUseEOverPVetoTM=kTRUE;
-      fUsePtDepTrackToCluster = 1;
-      fFuncPtDepEta = new TF1("funcEta30", "[1] + 1 / pow(x + pow(1 / ([0] - [1]), 1 / [2]), [2])");
-      fFuncPtDepEta->SetParameters(0.04, 0.010, 2.5);
-      fFuncPtDepPhi = new TF1("funcPhi30", "[1] + 1 / pow(x + pow(1 / ([0] - [1]), 1 / [2]), [2])");
-      fFuncPtDepPhi->SetParameters(0.09, 0.015, 2.);
+      fUseDistTrackToCluster = kFALSE;
+      fMaxDistTrackToClusterEta = 0;
+      fMinDistTrackToClusterPhi = 0;
+      fMaxDistTrackToClusterPhi = 0;
       fFuncPoissonParamCent = new TF1("fFuncPoissonParamCent30", "[0] * TMath::Exp( (x + [1] ) / [2] )", 0., 90.);
       fFuncNMatchedTracks = new TF1("fFuncNMatchedTracks30", "TMath::Poisson(x,[0])", 0., 10.);
       fDoEnergyCorrectionForOverlap = 2;
-      fEOverPMax = 1.75;
       if(fIsMC >= 1){
         // values for HIJING 5.02 TeV Pb--Pb simulations
         fParamMeanTrackPt[0] = +6.20104e-01;


### PR DESCRIPTION
- Neutral Overlap Correction should be run with cell track matching and hence should not be used with normal primary track matching, so the cut settings `t` and `u` where changed to only use the neutral overlap correction but no primary track matching