### PR TITLE
PWGGA/GammaConv: Add late conversion rejection cuts for Calorimeters

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.cxx
@@ -234,6 +234,16 @@ AliAnalysisTaskGammaCalo::AliAnalysisTaskGammaCalo(): AliAnalysisTaskSE(),
   fHistoTrueEtaPtAlpha(NULL),
   fHistoTruePi0PtOpenAngle(NULL),
   fHistoTrueEtaPtOpenAngle(NULL),
+  fHistoTruePi0GGClusterAngleVsPt(NULL),
+  fHistoTruePi0GCClusterAngleVsPt(NULL),
+  fHistoTruePi0CCClusterAngleVsPt(NULL),
+  fHistoTruePi0CCSameGammaClusterAngleVsPt(NULL),
+  fHistoTruePi0CCSameGammaClusterZDiffVsPt(NULL),
+  fHistoTruePi0GGClusterZDiffVsPt(NULL),
+  fHistoTruePi0GGClusterOAVsPt(NULL),
+  fHistoTruePi0GCClusterOAVsPt(NULL),
+  fHistoTruePi0CCClusterOAVsPt(NULL),
+  fHistoTruePi0CCSameGammaClusterOAVsPt(NULL),
   fHistoClusPhotonBGPt(NULL),
   fHistoClusPhotonPlusConvBGPt(NULL),
   fHistoClustPhotonElectronBGPtM02(NULL),
@@ -583,6 +593,16 @@ AliAnalysisTaskGammaCalo::AliAnalysisTaskGammaCalo(const char *name):
   fHistoTrueEtaPtAlpha(NULL),
   fHistoTruePi0PtOpenAngle(NULL),
   fHistoTrueEtaPtOpenAngle(NULL),
+  fHistoTruePi0GGClusterAngleVsPt(NULL),
+  fHistoTruePi0GCClusterAngleVsPt(NULL),
+  fHistoTruePi0CCClusterAngleVsPt(NULL),
+  fHistoTruePi0CCSameGammaClusterAngleVsPt(NULL),
+  fHistoTruePi0CCSameGammaClusterZDiffVsPt(NULL),
+  fHistoTruePi0GGClusterZDiffVsPt(NULL),
+  fHistoTruePi0GGClusterOAVsPt(NULL),
+  fHistoTruePi0GCClusterOAVsPt(NULL),
+  fHistoTruePi0CCClusterOAVsPt(NULL),
+  fHistoTruePi0CCSameGammaClusterOAVsPt(NULL),
   fHistoClusPhotonBGPt(NULL),
   fHistoClusPhotonPlusConvBGPt(NULL),
   fHistoClustPhotonElectronBGPtM02(NULL),
@@ -2105,6 +2125,18 @@ void AliAnalysisTaskGammaCalo::UserCreateOutputObjects(){
         fHistoTrueBckFullMesonContainedInOneClusterInvMassPt = new TH2F*[fnCuts];
         fHistoTrueBckAsymEClustersInvMassPt                  = new TH2F*[fnCuts];
         fHistoTrueBckContInvMassPt        = new TH2F*[fnCuts];
+
+        fHistoTruePi0GGClusterAngleVsPt           = new TH2F*[fnCuts];
+        fHistoTruePi0GCClusterAngleVsPt           = new TH2F*[fnCuts];
+        fHistoTruePi0CCClusterAngleVsPt           = new TH2F*[fnCuts];
+        fHistoTruePi0CCSameGammaClusterAngleVsPt  = new TH2F*[fnCuts];
+        fHistoTruePi0CCSameGammaClusterZDiffVsPt  = new TH2F*[fnCuts];
+        fHistoTruePi0GGClusterZDiffVsPt           = new TH2F*[fnCuts];
+        fHistoTruePi0GGClusterOAVsPt              = new TH2F*[fnCuts];
+        fHistoTruePi0GCClusterOAVsPt              = new TH2F*[fnCuts];
+        fHistoTruePi0CCClusterOAVsPt              = new TH2F*[fnCuts];
+        fHistoTruePi0CCSameGammaClusterOAVsPt     = new TH2F*[fnCuts];
+
         if( !fDoPi0Only ){
           fHistoTrueEtaPtOpenAngle          = new TH2F*[fnCuts];
           fHistoTrueEtaPtAlpha              = new TH2F*[fnCuts];
@@ -2914,6 +2946,60 @@ void AliAnalysisTaskGammaCalo::UserCreateOutputObjects(){
           fHistoTruePi0PtY[iCut]->SetXTitle("#it{p}_{T} (GeV/#it{c})");
           fHistoTruePi0PtY[iCut]->SetYTitle("y");
           fTrueList[iCut]->Add(fHistoTruePi0PtY[iCut]);
+
+          if(((AliCaloPhotonCuts*)fClusterCutArray->At(iCut))->GetIsConversionRecovery() == 2){
+            fHistoTruePi0GGClusterAngleVsPt[iCut] = new TH2F("ESD_True_Pi0_GG_AngleBetweenClusters_Pt", "ESD_True_Pi0_GG_AngleBetweenClusters_Pt", 160, 0, 1.6, nBinsPt, arrPtBinning);
+            fHistoTruePi0GGClusterAngleVsPt[iCut]->SetXTitle("tan^{-1}(#Delta #Theta / #Delta #phi)");
+            fHistoTruePi0GGClusterAngleVsPt[iCut]->SetYTitle("#it{p}_{T} (GeV/#it{c})");
+            fTrueList[iCut]->Add(fHistoTruePi0GGClusterAngleVsPt[iCut]);
+
+            fHistoTruePi0GCClusterAngleVsPt[iCut] = new TH2F("ESD_True_Pi0_GC_AngleBetweenClusters_Pt", "ESD_True_Pi0_GC_AngleBetweenClusters_Pt", 160, 0, 1.6, nBinsPt, arrPtBinning);
+            fHistoTruePi0GCClusterAngleVsPt[iCut]->SetXTitle("tan^{-1}(#Delta #Theta / #Delta #phi)");
+            fHistoTruePi0GCClusterAngleVsPt[iCut]->SetYTitle("#it{p}_{T} (GeV/#it{c})");
+            fTrueList[iCut]->Add(fHistoTruePi0GCClusterAngleVsPt[iCut]);
+
+            fHistoTruePi0CCClusterAngleVsPt[iCut] = new TH2F("ESD_True_Pi0_CC_AngleBetweenClusters_Pt", "ESD_True_Pi0_CC_AngleBetweenClusters_Pt", 160, 0, 1.6, nBinsPt, arrPtBinning);
+            fHistoTruePi0CCClusterAngleVsPt[iCut]->SetXTitle("tan^{-1}(#Delta #Theta / #Delta #phi)");
+            fHistoTruePi0CCClusterAngleVsPt[iCut]->SetYTitle("#it{p}_{T} (GeV/#it{c})");
+            fTrueList[iCut]->Add(fHistoTruePi0CCClusterAngleVsPt[iCut]);
+
+            fHistoTruePi0CCSameGammaClusterAngleVsPt[iCut] = new TH2F("ESD_True_Pi0_CC_SameGamma_AngleBetweenClusters_Pt", "ESD_True_Pi0_CC_SameGamma_AngleBetweenClusters_Pt", 160, 0, 1.6, nBinsPt, arrPtBinning);
+            fHistoTruePi0CCSameGammaClusterAngleVsPt[iCut]->SetXTitle("tan^{-1}(#Delta #Theta / #Delta #phi)");
+            fHistoTruePi0CCSameGammaClusterAngleVsPt[iCut]->SetYTitle("#it{p}_{T} (GeV/#it{c})");
+            fTrueList[iCut]->Add(fHistoTruePi0CCSameGammaClusterAngleVsPt[iCut]);
+
+            fHistoTruePi0GGClusterZDiffVsPt[iCut] = new TH2F("ESD_True_Pi0_GG_DeltaEtaBetweenClusters_Pt", "ESD_True_Pi0_GG_DeltaEtaBetweenClusters_Pt", 50, 0, 0.5, nBinsPt, arrPtBinning);
+            fHistoTruePi0GGClusterZDiffVsPt[iCut]->SetXTitle("#Delta #eta");
+            fHistoTruePi0GGClusterZDiffVsPt[iCut]->SetYTitle("#it{p}_{T} (GeV/#it{c})");
+            fTrueList[iCut]->Add(fHistoTruePi0GGClusterZDiffVsPt[iCut]);
+
+            fHistoTruePi0CCSameGammaClusterZDiffVsPt[iCut] = new TH2F("ESD_True_Pi0_CC_SameGamma_DeltaEtaBetweenClusters_Pt", "ESD_True_Pi0_CC_SameGamma_DeltaEtaBetweenClusters_Pt", 50, 0, 0.5, nBinsPt, arrPtBinning);
+            fHistoTruePi0CCSameGammaClusterZDiffVsPt[iCut]->SetXTitle("#Delta #eta");
+            fHistoTruePi0CCSameGammaClusterZDiffVsPt[iCut]->SetYTitle("#it{p}_{T} (GeV/#it{c})");
+            fTrueList[iCut]->Add(fHistoTruePi0CCSameGammaClusterZDiffVsPt[iCut]);
+
+            fHistoTruePi0GGClusterOAVsPt[iCut] = new TH2F("ESD_True_Pi0_GG_OABetweenClusters_Pt", "ESD_True_Pi0_GG_OABetweenClusters_Pt", 160, 0, 1.6, 20, 0, 0.4);
+            fHistoTruePi0GGClusterOAVsPt[iCut]->SetXTitle("tan^{-1}(#Delta #Theta / #Delta #phi)");
+            fHistoTruePi0GGClusterOAVsPt[iCut]->SetYTitle("opening angle");
+            fTrueList[iCut]->Add(fHistoTruePi0GGClusterOAVsPt[iCut]);
+
+            fHistoTruePi0GCClusterOAVsPt[iCut] = new TH2F("ESD_True_Pi0_GC_OABetweenClusters_Pt", "ESD_True_Pi0_GC_OABetweenClusters_Pt", 160, 0, 1.6, 20, 0, 0.4);
+            fHistoTruePi0GCClusterOAVsPt[iCut]->SetXTitle("tan^{-1}(#Delta #Theta / #Delta #phi)");
+            fHistoTruePi0GCClusterOAVsPt[iCut]->SetYTitle("opening angle");
+            fTrueList[iCut]->Add(fHistoTruePi0GCClusterOAVsPt[iCut]);
+
+            fHistoTruePi0CCClusterOAVsPt[iCut] = new TH2F("ESD_True_Pi0_CC_OABetweenClusters_Pt", "ESD_True_Pi0_CC_OABetweenClusters_Pt", 160, 0, 1.6, 20, 0, 0.4);
+            fHistoTruePi0CCClusterOAVsPt[iCut]->SetXTitle("tan^{-1}(#Delta #Theta / #Delta #phi)");
+            fHistoTruePi0CCClusterOAVsPt[iCut]->SetYTitle("opening angle");
+            fTrueList[iCut]->Add(fHistoTruePi0CCClusterOAVsPt[iCut]);
+
+            fHistoTruePi0CCSameGammaClusterOAVsPt[iCut] = new TH2F("ESD_True_Pi0_CC_SameGamma_OABetweenClusters_Pt", "ESD_True_Pi0_CC_SameGamma_OABetweenClusters_Pt", 160, 0, 1.6, 20, 0, 0.4);
+            fHistoTruePi0CCSameGammaClusterOAVsPt[iCut]->SetXTitle("tan^{-1}(#Delta #Theta / #Delta #phi)");
+            fHistoTruePi0CCSameGammaClusterOAVsPt[iCut]->SetYTitle("opening angle");
+            fTrueList[iCut]->Add(fHistoTruePi0CCSameGammaClusterOAVsPt[iCut]);
+          }
+          
+
           if( !fDoPi0Only ){
             fHistoTrueEtaPtY[iCut]          = new TH2F("ESD_TrueEta_Pt_Y", "ESD_TrueEta_Pt_Y", nBinsQAPt, arrQAPtBinning, 150, -1.5, 1.5);
             fHistoTrueEtaPtY[iCut]->SetXTitle("#it{p}_{T} (GeV/#it{c})");
@@ -2995,6 +3081,19 @@ void AliAnalysisTaskGammaCalo::UserCreateOutputObjects(){
             fHistoTrueBckAsymEClustersInvMassPt[iCut]->Sumw2();
             fHistoTrueBckContInvMassPt[iCut]->Sumw2();
 
+            if(((AliCaloPhotonCuts*)fClusterCutArray->At(iCut))->GetIsConversionRecovery() == 2){
+              fHistoTruePi0GGClusterAngleVsPt[iCut]->Sumw2();
+              fHistoTruePi0GCClusterAngleVsPt[iCut]->Sumw2();
+              fHistoTruePi0CCClusterAngleVsPt[iCut]->Sumw2();
+              fHistoTruePi0CCSameGammaClusterAngleVsPt[iCut]->Sumw2();
+              fHistoTruePi0GGClusterZDiffVsPt[iCut]->Sumw2();
+              fHistoTruePi0CCSameGammaClusterZDiffVsPt[iCut]->Sumw2();
+              fHistoTruePi0GGClusterOAVsPt[iCut]->Sumw2();
+              fHistoTruePi0GCClusterOAVsPt[iCut]->Sumw2();
+              fHistoTruePi0CCClusterOAVsPt[iCut]->Sumw2();
+              fHistoTruePi0CCSameGammaClusterOAVsPt[iCut]->Sumw2();
+            }
+            
             fHistoTruePi0CaloPhotonInvMassPt[iCut]->Sumw2();
             fHistoTruePi0CaloMixedPhotonConvPhotonInvMassPt[iCut]->Sumw2();
             fHistoTruePi0CaloConvertedPhotonInvMassPt[iCut]->Sumw2();
@@ -5905,9 +6004,17 @@ void AliAnalysisTaskGammaCalo::ProcessTrueMesonCandidatesAOD(AliAODConversionMot
       if(previouslyNotFoundTrueMesons && !fDoLightOutput && fHistoTrueEtaInvMassPtAdditional[fiCut]) fHistoTrueEtaInvMassPtAdditional[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(),tempTruePi0CandWeight);
     }
     if (fDoMesonQA > 0 && fDoMesonQA < 3){
+      auto arrConvRej = ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetAngleForConvReject(TrueGammaCandidate0, TrueGammaCandidate1); // get information about angular position of two clusters
       // both gammas are real gammas
       if (TrueGammaCandidate0->IsLargestComponentPhoton() && TrueGammaCandidate1->IsLargestComponentPhoton()) {
-        if (isTruePi0)fHistoTruePi0CaloPhotonInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(), tempTruePi0CandWeight);
+        if (isTruePi0){
+          fHistoTruePi0CaloPhotonInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(), tempTruePi0CandWeight);
+          if(((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetIsConversionRecovery() == 2){
+            fHistoTruePi0GGClusterAngleVsPt[fiCut]->Fill( arrConvRej.first, Pi0Candidate->Pt(), tempTruePi0CandWeight);
+            fHistoTruePi0GGClusterZDiffVsPt[fiCut]->Fill( std::abs(TrueGammaCandidate0->Eta() - TrueGammaCandidate1->Eta()), Pi0Candidate->Pt(), tempTruePi0CandWeight);
+            fHistoTruePi0GGClusterOAVsPt[fiCut]->Fill( arrConvRej.first, arrConvRej.second, tempTruePi0CandWeight);
+          }
+        }
         if (isTrueEta && !fDoPi0Only)fHistoTrueEtaCaloPhotonInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(), tempTruePi0CandWeight);
       }
       // both particles are electrons
@@ -5917,14 +6024,33 @@ void AliAnalysisTaskGammaCalo::ProcessTrueMesonCandidatesAOD(AliAODConversionMot
       }
       // both particles are converted electrons
       if ((TrueGammaCandidate0->IsLargestComponentElectron() && TrueGammaCandidate0->IsConversion()) && (TrueGammaCandidate1->IsLargestComponentElectron() && TrueGammaCandidate1->IsConversion()) ){
-        if (isTruePi0 )fHistoTruePi0CaloConvertedPhotonInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(), tempTruePi0CandWeight);
+        if (isTruePi0 ){
+          fHistoTruePi0CaloConvertedPhotonInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(), tempTruePi0CandWeight);
+          if(((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetIsConversionRecovery() == 2){
+            fHistoTruePi0CCClusterAngleVsPt[fiCut]->Fill( arrConvRej.first, Pi0Candidate->Pt(), tempTruePi0CandWeight);
+            fHistoTruePi0CCClusterOAVsPt[fiCut]->Fill( arrConvRej.first, arrConvRej.second, tempTruePi0CandWeight);
+          }
+        }
         if (isTrueEta && !fDoPi0Only)fHistoTrueEtaCaloConvertedPhotonInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(), tempTruePi0CandWeight);
+        if(isSameConvertedGamma){
+          if(((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetIsConversionRecovery() == 2){
+            fHistoTruePi0CCSameGammaClusterAngleVsPt[fiCut]->Fill( arrConvRej.first, Pi0Candidate->Pt(), tempTruePi0CandWeight);
+            fHistoTruePi0CCSameGammaClusterZDiffVsPt[fiCut]->Fill( std::abs(TrueGammaCandidate0->Eta() - TrueGammaCandidate1->Eta()), Pi0Candidate->Pt(), tempTruePi0CandWeight);
+            fHistoTruePi0CCSameGammaClusterOAVsPt[fiCut]->Fill( arrConvRej.first, arrConvRej.second, tempTruePi0CandWeight);
+          }
+        }
       }
       // 1 gamma is converted the other one is normals
       if ( (TrueGammaCandidate0->IsLargestComponentPhoton() && TrueGammaCandidate1->IsLargestComponentElectron() && TrueGammaCandidate1->IsConversion()) ||
         (TrueGammaCandidate1->IsLargestComponentPhoton() && TrueGammaCandidate0->IsLargestComponentElectron() && TrueGammaCandidate0->IsConversion())
       ) {
-        if (isTruePi0) fHistoTruePi0CaloMixedPhotonConvPhotonInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(), tempTruePi0CandWeight);
+        if (isTruePi0){
+          if(((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetIsConversionRecovery() == 2){
+            fHistoTruePi0GCClusterAngleVsPt[fiCut]->Fill( arrConvRej.first, Pi0Candidate->Pt(), tempTruePi0CandWeight);
+            fHistoTruePi0GCClusterOAVsPt[fiCut]->Fill( arrConvRej.first, arrConvRej.second, tempTruePi0CandWeight);
+          }
+          fHistoTruePi0CaloMixedPhotonConvPhotonInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(), tempTruePi0CandWeight);
+        }
         if (isTrueEta && !fDoPi0Only) fHistoTrueEtaCaloMixedPhotonConvPhotonInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(), tempTruePi0CandWeight);
       }
 

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.h
@@ -324,6 +324,16 @@ class AliAnalysisTaskGammaCalo : public AliAnalysisTaskSE {
     TH2F**                fHistoTrueEtaPtAlpha;                                 //! array of histos with validated eta, pt, alpha
     TH2F**                fHistoTruePi0PtOpenAngle;                             //! array of histos with validated pi0, pt, openAngle
     TH2F**                fHistoTrueEtaPtOpenAngle;                             //! array of histos with validated eta, pt, openAngle
+    TH2F**                fHistoTruePi0GGClusterAngleVsPt;                      //! array of histos with validated pi0 vs angle between clusters with respect to z-direction for true GG pairs
+    TH2F**                fHistoTruePi0GCClusterAngleVsPt;                      //! array of histos with validated pi0 vs angle between clusters with respect to z-direction for true GC pairs
+    TH2F**                fHistoTruePi0CCClusterAngleVsPt;                      //! array of histos with validated pi0 vs angle between clusters with respect to z-direction for true CC pairs
+    TH2F**                fHistoTruePi0CCSameGammaClusterAngleVsPt;             //! array of histos with validated pi0 vs angle between clusters with respect to z-direction for true CC pairs coming from the same photon
+    TH2F**                fHistoTruePi0GGClusterZDiffVsPt;                      //! array of histos with validated pi0 vs angle between clusters with respect to z-direction for true GG pairs
+    TH2F**                fHistoTruePi0CCSameGammaClusterZDiffVsPt;             //! array of histos with validated pi0 vs delta eta clusters for true CC pairs coming from the same photon
+    TH2F**                fHistoTruePi0GGClusterOAVsPt;                         //! array of histos with validated pi0 vs angle between clusters for true GG pairs
+    TH2F**                fHistoTruePi0GCClusterOAVsPt;                         //! array of histos with validated pi0 vs angle between clusters for true GC pairs
+    TH2F**                fHistoTruePi0CCClusterOAVsPt;                         //! array of histos with validated pi0 vs angle between clusters for true CC pairs
+    TH2F**                fHistoTruePi0CCSameGammaClusterOAVsPt;                //! array of histos with validated pi0 vs angle between clusters for true CC pairs coming from the same photon
     // MC validated reconstructed quantities photons
     TH2F**                fHistoClusPhotonBGPt;                                 //! array of histos with cluster photon BG, pt, source
     TH2F**                fHistoClusPhotonPlusConvBGPt;                         //! array of histos with cluster photon plus conv BG, pt, source
@@ -521,7 +531,7 @@ class AliAnalysisTaskGammaCalo : public AliAnalysisTaskSE {
     AliAnalysisTaskGammaCalo(const AliAnalysisTaskGammaCalo&);                  // Prevent copy-construction
     AliAnalysisTaskGammaCalo &operator=(const AliAnalysisTaskGammaCalo&);       // Prevent assignment
 
-    ClassDef(AliAnalysisTaskGammaCalo, 94);
+    ClassDef(AliAnalysisTaskGammaCalo, 95);
 };
 
 #endif

--- a/PWGGA/GammaConv/macros/AddTask_GammaCalo_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaCalo_pp.C
@@ -2401,6 +2401,12 @@ void AddTask_GammaCalo_pp(
     cuts.AddCutCalo("00010113","411790109fei02v0000","0s631031000000d0"); // INT7 energy 0.2 GeV
     cuts.AddCutCalo("00010113","411790109feg02v0000","0s631031000000d0"); // INT7 energy 0.3 GeV
     cuts.AddCutCalo("00010113","411790109feh02v0000","0s631031000000d0"); // INT7 energy 0.4 GeV
+  } else if (trainConfig == 1926){  // pp 13 TeV variations: conversion rejection
+    cuts.AddCutCalo("00010113","411790109fe302v0a00","0s631031000000d0"); // INT7 with conversion rejection
+  } else if (trainConfig == 1927){  // pp 13 TeV variations: conversion rejection
+    cuts.AddCutCalo("00010113","411790109fe302v0b00","0s631031000000d0"); // INT7 with conversion rejection, min angle 0.02
+    cuts.AddCutCalo("00010113","411790109fe302v0c00","0s631031000000d0"); // INT7 with conversion rejection, min angle 0.05
+    cuts.AddCutCalo("00010113","411790109fe302v0d00","0s631031000000d0"); // INT7 with conversion rejection, min angle 0.1
 
 
   //-----------  EG2 std cut
@@ -2469,6 +2475,8 @@ void AddTask_GammaCalo_pp(
     cuts.AddCutCalo("0008e113","411790109fe3l2v0000","0s631031000000d0"); // EG2 PCMEDC pi0 tagging for gamma clus, pol2 fit
   } else if (trainConfig == 1954){  // pp 13 TeV variations: cell track matching
     cuts.AddCutCalo("0008e113","4117901090e302v0000","0s631031000000d0"); // EG2 no TM
+  } else if (trainConfig == 1956){  // pp 13 TeV variations: conversion rejection
+    cuts.AddCutCalo("0008e113","411790109fe302v0a00","0s631031000000d0"); // EG2 with conversion rejection
 
 
   //-----------  EG1 std cut
@@ -2537,6 +2545,8 @@ void AddTask_GammaCalo_pp(
     cuts.AddCutCalo("0008d113","411790109fe3l2v0000","0s631031000000d0"); // EG1 PCMEDC pi0 tagging for gamma clus, pol2 fit
   } else if (trainConfig == 1984){  // pp 13 TeV variations: cell track matching
     cuts.AddCutCalo("0008d113","4117901090e302v0000","0s631031000000d0"); // EG1 no TM
+  } else if (trainConfig == 1986){  // pp 13 TeV variations: conversion rejection
+    cuts.AddCutCalo("0008d113","411790109fe302v0a00","0s631031000000d0"); // EG1 with conversion rejection
 
   } else if (trainConfig == 1990){ // only track matched clusters
     cuts.AddCutCalo("00010113","411790109qe3n2v0000","0s631031000000d0"); // with NCell effi

--- a/PWGGA/GammaConvBase/AliCaloPhotonCuts.h
+++ b/PWGGA/GammaConvBase/AliCaloPhotonCuts.h
@@ -395,6 +395,8 @@ class AliCaloPhotonCuts : public AliAnalysisCuts {
     Bool_t      GetHighestPtMatchedTrackToCluster(AliVEvent* event, AliVCluster* cluster, Int_t &trackLabel);
     Bool_t      IsClusterPi0(AliVEvent *event, AliMCEvent *mcEvent, AliVCluster *cluster);
     Bool_t      CheckForReconstructedConversionPairs(vector<AliAODConversionPhoton*> &vecPhotons, vector<Int_t> &vecReject);
+    std::pair<double, double>    GetAngleForConvReject(const TLorentzVector &photon1, const TLorentzVector &photon2);
+    std::pair<double, double>    GetAngleForConvReject(const AliAODConversionPhoton *photon1, const AliAODConversionPhoton *photon2);
     Bool_t      CheckVectorForIndexAndAdd(vector<Int_t> &vec, Int_t tobechecked, Bool_t addIndex );
     void        CleanClusterLabels(AliVCluster* clus,AliMCEvent *mcEvent);
     void        CleanClusterLabels(AliVCluster* clus,TClonesArray *aodTrackArray);
@@ -587,6 +589,8 @@ class AliCaloPhotonCuts : public AliAnalysisCuts {
     Double_t  fMinM20;                                  // minimum M20
     Bool_t    fUseM20;                                  // flag for switching on M20 cut
     Float_t   fMaxMGGRecConv;                           // maximum invariant mass below which the 2 clusters are gonna be combined assuming they are from a photon
+    Float_t   fConvRejMinAngle;                         // minimum angle with respect to z that two clusters need in order to not be rejected as conversions (conversion should only be bend by magnetic field and therefore their position in z should be the same)
+    Float_t   fConvRejMaxOpenAngle;                     // maximum opening angle of a cluster pair to be considerd to be a conversion from the same photon
     Int_t     fUseRecConv;                              // flag to switch on conversion recovery
     Double_t  fMaxDispersion;                           // maximum dispersion
     Bool_t    fUseDispersion;                           // flag for switching on dispersion cut
@@ -749,13 +753,14 @@ class AliCaloPhotonCuts : public AliAnalysisCuts {
     // histogram for conv candidate rejection
     TH2F*     fHistInvMassDiCluster;                    // histogram for monitoring di-cluster mass
     TH2F*     fHistInvMassConvFlagging;                 // histogram for monitoring rejected di-cluster mass
+    TH1F*     fHistDiClusterAngle;                      // histogram for monitoring di-cluster angle with respect to z
     Int_t     fNMaxDCalModules;                         // max number of DCal Modules
     Int_t     fgkDCALCols;                              // Number of columns in DCal
     Bool_t    fIsAcceptedForBasic;                      // basic counting
 
   private:
 
-    ClassDef(AliCaloPhotonCuts,131)
+    ClassDef(AliCaloPhotonCuts,132)
 };
 
 #endif


### PR DESCRIPTION
- Cut similar to PsiPair cut for PCM
- Calculate Angle with respect to z-direction
- For late conversion pairs angle should be 0. This is then used as a criterium to reject those clusters