### PR TITLE
Handling weird efficiencies

### DIFF
--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHdEdxCorrelations.cxx
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHdEdxCorrelations.cxx
@@ -691,6 +691,11 @@ namespace PWGJE
 
                 // Calculate single particle tracking efficiency of mixed events for correlations
                 efficiency = EffCorrection(bgTrackVec.Eta(), bgTrackVec.Pt());
+                if(efficiency==0){
+                  cout<<efficiency<<" <- Efficiency for eta="<<bgTrackVec.Eta()<<" and pt="<<bgTrackVec.Pt()<<" Skipping"<<endl;
+                  continue;
+                }
+
 
                 // Phi is [-0.5*TMath::Pi(), 3*TMath::Pi()/2.]
                 GetDeltaEtaDeltaPhiDeltaR(bgTrackVec, jet, deltaEta, deltaPhi, deltaR);


### PR DESCRIPTION
It seems like occasionally my efficiencies are 0 in my mixed events causing the sparse to be unusable. This check and skips those cases. I don't think it will happen often(can't reproduce locally without hardcoding efficiency to 0) so the cout is probably ok even though it is bad code. 