### PR TITLE
[PWGEM-13] PWGGA/GammaConv: Add EMCal neutral overlap correction base…

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.cxx
@@ -3580,7 +3580,7 @@ void AliAnalysisTaskGammaCalo::ProcessClusters()
 
   // energy correction for neutral overlap!
   float cent = ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetCentrality(fInputEvent);
-  if(((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetDoEnergyCorrectionForOverlap() > 0){
+  if(((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetDoEnergyCorrectionForOverlap() > 0 && ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetDoEnergyCorrectionForOverlap() <= 2){
     ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->SetPoissonParamCentFunction(fIsMC);
     ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->SetNMatchedTracksFunc(cent);
   }
@@ -3660,7 +3660,12 @@ void AliAnalysisTaskGammaCalo::ProcessClusters()
     // energy correction for neutral overlap!
     if(!((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetDoFlatEnergySubtraction()){
       if(((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetDoEnergyCorrectionForOverlap() > 0){
-        clus->SetE(clus->E() - ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->CorrectEnergyForOverlap(cent));
+        if(((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetDoEnergyCorrectionForOverlap() <= 2){
+          clus->SetE(clus->E() - ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->CorrectEnergyForOverlap(cent));
+        }
+        else if(((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetDoEnergyCorrectionForOverlap() == 3){
+          clus->SetE(clus->E() - (float) clus->GetNCells() * ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->CorrectEnergyForOverlap(cent));
+        }
       }
     }
 

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvCalo.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvCalo.cxx
@@ -3381,7 +3381,7 @@ void AliAnalysisTaskGammaConvCalo::ProcessClusters(){
 
   // energy correction for neutral overlap!
   float cent = ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetCentrality(fInputEvent);
-  if(((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetDoEnergyCorrectionForOverlap() > 0){
+  if(((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetDoEnergyCorrectionForOverlap() > 0 && ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetDoEnergyCorrectionForOverlap() <= 2) {
     ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->SetPoissonParamCentFunction(fIsMC);
     ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->SetNMatchedTracksFunc(cent);
   }
@@ -3422,7 +3422,11 @@ void AliAnalysisTaskGammaConvCalo::ProcessClusters(){
     if (!clus) continue;
     // energy correction for neutral overlap!
     if(((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetDoEnergyCorrectionForOverlap() > 0){
-      clus->SetE(clus->E() - ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->CorrectEnergyForOverlap(cent));
+      if(((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetDoEnergyCorrectionForOverlap() <= 2){
+        clus->SetE(clus->E() - ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->CorrectEnergyForOverlap(cent));
+      } else if(((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetDoEnergyCorrectionForOverlap() == 3){
+        clus->SetE(clus->E() - (float) clus->GetNCells() * ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->CorrectEnergyForOverlap(cent));
+      }
     }
     if(!((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->ClusterIsSelected(clus,fInputEvent,fMCEvent,fIsMC,fWeightJetJetMC,i)){
       if(fDoInvMassShowerShapeTree && ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->ClusterIsSelectedBeforeTrackMatch() ) tESDmapIsClusterAcceptedWithoutTrackMatch[i] = 1;

--- a/PWGGA/GammaConv/macros/AddTask_GammaCalo_PbPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaCalo_PbPb.C
@@ -1323,6 +1323,11 @@ void AddTask_GammaCalo_PbPb(
     cuts.AddCutCalo("11310013","411790105te30220000","0s631031000000d0"); // 10-30%
     cuts.AddCutCalo("13530013","411790105te30220000","0s631031000000d0"); // 30-50%
     cuts.AddCutCalo("15910013","411790105te30220000","0s631031000000d0"); // 50-90%
+  } else if (trainConfig == 793){ // EMCAL+DCal clusters - 13 TeV emcal cuts w/o TM with Mean neutral energy overlap correction using Ncharge per cell, cent and semi cent trigger with OOB pileup cut
+    cuts.AddCutCalo("10130e13","411790105ve30220000","0s631031000000d0"); // 00-10%
+    cuts.AddCutCalo("11310e13","411790105ve30220000","0s631031000000d0"); // 10-30%
+    cuts.AddCutCalo("13530e13","411790105ve30220000","0s631031000000d0"); // 30-50%
+    cuts.AddCutCalo("15910e13","411790105ve30220000","0s631031000000d0"); // 50-90%
   // **********************************************************************************************************
   // ***************************** PHOS       QA configurations PbPb run 2 2018 *******************************
   // **********************************************************************************************************


### PR DESCRIPTION
…d on mean Nch/cell

- Add new option for neutral overlap correction which is based on the mean number of charged particles per cell instead of mean matched tracks per cluster as before. This new option is track matching option 'v'