### PR TITLE
[PWGEM-13] PWGGA/GammaConv: Addition of NonLin like Neutral Overlap C…

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.cxx
@@ -3660,11 +3660,15 @@ void AliAnalysisTaskGammaCalo::ProcessClusters()
     // energy correction for neutral overlap!
     if(!((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetDoFlatEnergySubtraction()){
       if(((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetDoEnergyCorrectionForOverlap() > 0){
+        // Neutral Overlap correction via mean number of matched primary tracks per cluster
         if(((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetDoEnergyCorrectionForOverlap() <= 2){
           clus->SetE(clus->E() - ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->CorrectEnergyForOverlap(cent));
-        }
-        else if(((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetDoEnergyCorrectionForOverlap() == 3){
+        } else if(((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetDoEnergyCorrectionForOverlap() == 3){
+          // Neutral Overlap correction via mean number of charged particles per cell
           clus->SetE(clus->E() - (float) clus->GetNCells() * ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->CorrectEnergyForOverlap(cent));
+        } else if(((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetDoEnergyCorrectionForOverlap() == 4){
+          // Neutral Overlap correction via NonLin like correction
+          clus->SetE(clus->E() * ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->CorrectEnergyForOverlap(cent, clus->E()));
         }
       }
     }

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvCalo.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvCalo.cxx
@@ -3422,10 +3422,15 @@ void AliAnalysisTaskGammaConvCalo::ProcessClusters(){
     if (!clus) continue;
     // energy correction for neutral overlap!
     if(((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetDoEnergyCorrectionForOverlap() > 0){
+      // Neutral Overlap correction via mean number of matched primary tracks per cluster
       if(((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetDoEnergyCorrectionForOverlap() <= 2){
         clus->SetE(clus->E() - ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->CorrectEnergyForOverlap(cent));
       } else if(((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetDoEnergyCorrectionForOverlap() == 3){
+        // Neutral Overlap correction via mean number of charged particles per cell
         clus->SetE(clus->E() - (float) clus->GetNCells() * ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->CorrectEnergyForOverlap(cent));
+      } else if(((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetDoEnergyCorrectionForOverlap() == 4){
+        // Neutral Overlap correction via NonLin like correction
+        clus->SetE(clus->E() * ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->CorrectEnergyForOverlap(cent, clus->E()));
       }
     }
     if(!((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->ClusterIsSelected(clus,fInputEvent,fMCEvent,fIsMC,fWeightJetJetMC,i)){

--- a/PWGGA/GammaConv/macros/AddTask_GammaCalo_PbPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaCalo_PbPb.C
@@ -1255,57 +1255,56 @@ void AddTask_GammaCalo_PbPb(
   } else if (trainConfig == 770){ // EMCAL+DCal clusters - QA
     cuts.AddCutCalo("10930013","4117900000032220000","01331031000000d0"); //  0-90% QA (open timing)
 
-  } else if (trainConfig == 780){ // EMCAL+DCal clusters - no TM - no Ncell - no raised thresholds
-    cuts.AddCutCalo("10130e03","4117901050e30220000","01331061000000d0"); //
-    cuts.AddCutCalo("11310e03","4117901050e30220000","01331061000000d0"); //
-    cuts.AddCutCalo("13530e03","4117901050e30220000","01331031000000d0"); //
-    cuts.AddCutCalo("15910e03","4117901050e30220000","01331031000000d0"); //
-  } else if (trainConfig == 781){ // EMCAL+DCal clusters - no TM - new PbPb pileup cut
-    cuts.AddCutCalo("10130e03","41179010500a2220000","01331061000000d0"); //
-    cuts.AddCutCalo("11310e03","41179010500b2220000","01331061000000d0"); //
-    cuts.AddCutCalo("13530e03","4117901050032220000","01331031000000d0"); //
-    cuts.AddCutCalo("15910e03","4117901050032220000","01331031000000d0"); //
-  } else if (trainConfig == 782){ // EMCAL+DCal clusters - no TM - no Ncell - no raised thresholds, strict timing
-    cuts.AddCutCalo("10130e03","41179010a0e30220000","01331061000000d0"); //
-    cuts.AddCutCalo("11310e03","41179010a0e30220000","01331061000000d0"); //
-    cuts.AddCutCalo("13530e03","41179010a0e30220000","01331031000000d0"); //
-    cuts.AddCutCalo("15910e03","41179010a0e30220000","01331031000000d0"); //
-  } else if (trainConfig == 783){ // EMCAL+DCal clusters - no TM - no Ncell - no raised thresholds
-    cuts.AddCutCalo("1018da13","4117901050e30220000","01331061000000d0"); //
-    cuts.AddCutCalo("1138da13","4117901050e30220000","01331061000000d0"); //
-    cuts.AddCutCalo("1358da13","4117901050e30220000","01331031000000d0"); //
-    cuts.AddCutCalo("1598da13","4117901050e30220000","01331031000000d0"); //
-  } else if (trainConfig == 784){ // EMCAL+DCal clusters - no TM - no Ncell - no raised thresholds
-    cuts.AddCutCalo("1018ea13","4117901050e30220000","01331061000000d0"); //
-    cuts.AddCutCalo("1138ea13","4117901050e30220000","01331061000000d0"); //
-    cuts.AddCutCalo("1358ea13","4117901050e30220000","01331031000000d0"); //
-    cuts.AddCutCalo("1598ea13","4117901050e30220000","01331031000000d0"); //
-  } else if (trainConfig == 785){ // EMCAL+DCal clusters - 13 TeV emcal cuts wo TM
-    cuts.AddCutCalo("10130e03","4117901050e30220000","0s631031000000d0"); // 00-10%
-    cuts.AddCutCalo("11310e03","4117901050e30220000","0s631031000000d0"); // 10-30%
-    cuts.AddCutCalo("13530e03","4117901050e30220000","0s631031000000d0"); // 30-50%
-    cuts.AddCutCalo("15910e03","4117901050e30220000","0s631031000000d0"); // 50-90%
-  } else if (trainConfig == 786){ // EMCAL+DCal clusters - 13 TeV emcal cuts with TM
-    cuts.AddCutCalo("10130e03","411790105fe30220000","0s631031000000d0"); // 00-10%
-    cuts.AddCutCalo("11310e03","411790105fe30220000","0s631031000000d0"); // 10-30%
-    cuts.AddCutCalo("13530e03","411790105fe30220000","0s631031000000d0"); // 30-50%
-    cuts.AddCutCalo("15910e03","411790105fe30220000","0s631031000000d0"); // 50-90%
-  } else if (trainConfig == 787){ // EMCAL+DCal clusters - 13 TeV emcal mixed event wo TM
-    cuts.AddCutCalo("10130e03","4117901050e30220000","01631031000000d0"); // 00-10%
-    cuts.AddCutCalo("11310e03","4117901050e30220000","01631031000000d0"); // 10-30%
-    cuts.AddCutCalo("13530e03","4117901050e30220000","01631031000000d0"); // 30-50%
-    cuts.AddCutCalo("15910e03","4117901050e30220000","01631031000000d0"); // 50-90%
-  } else if (trainConfig == 788){ // EMCAL+DCal clusters - 13 TeV emcal mixed event cuts with TM
-    cuts.AddCutCalo("10130e03","411790105fe30220000","01631031000000d0"); // 00-10%
-    cuts.AddCutCalo("11310e03","411790105fe30220000","01631031000000d0"); // 10-30%
-    cuts.AddCutCalo("13530e03","411790105fe30220000","01631031000000d0"); // 30-50%
-    cuts.AddCutCalo("15910e03","411790105fe30220000","01631031000000d0"); // 50-90%
-  // Mean neutral energy overlap correction!
-  } else if (trainConfig == 789){ // EMCAL+DCal clusters - 13 TeV emcal cuts w/o TM
-    cuts.AddCutCalo("10130e03","411790105te30220000","0s631031000000d0"); // 00-10%
-    cuts.AddCutCalo("11310e03","411790105te30220000","0s631031000000d0"); // 10-30%
-    cuts.AddCutCalo("13530e03","411790105te30220000","0s631031000000d0"); // 30-50%
-    cuts.AddCutCalo("15910e03","411790105te30220000","0s631031000000d0"); // 50-90%
+  } else if (trainConfig == 780){ // EMCAL+DCal standard with 4 cents
+    cuts.AddCutCalo("10130e13","4117901050e30220000","01631031000000d0"); // 00-10%
+    cuts.AddCutCalo("11310e13","4117901050e30220000","01631031000000d0"); // 10-30%
+    cuts.AddCutCalo("13530e13","4117901050e30220000","01631031000000d0"); // 30-50%
+    cuts.AddCutCalo("15910e13","4117901050e30220000","01631031000000d0"); // 50-90%
+  } else if (trainConfig == 781){ // EMCAL+DCal standard with rotation method
+    cuts.AddCutCalo("10130e13","4117901050e30220000","0s631031000000d0"); // 00-10%
+    cuts.AddCutCalo("11310e13","4117901050e30220000","0s631031000000d0"); // 10-30%
+    cuts.AddCutCalo("13530e13","4117901050e30220000","0s631031000000d0"); // 30-50%
+    cuts.AddCutCalo("15910e13","4117901050e30220000","0s631031000000d0"); // 50-90%
+  } else if (trainConfig == 782){ // EMCAL+DCal standard with 4 cents without OOB Pileup correction
+    cuts.AddCutCalo("10130013","4117901050e30220000","01631031000000d0"); // 00-10%
+    cuts.AddCutCalo("11310013","4117901050e30220000","01631031000000d0"); // 10-30%
+    cuts.AddCutCalo("13530013","4117901050e30220000","01631031000000d0"); // 30-50%
+    cuts.AddCutCalo("15910013","4117901050e30220000","01631031000000d0"); // 50-90%
+  } else if (trainConfig == 783){ // EMCAL+DCal standard with rotation method without OOB Pileup correction
+    cuts.AddCutCalo("10130013","4117901050e30220000","0s631031000000d0"); // 00-10%
+    cuts.AddCutCalo("11310013","4117901050e30220000","0s631031000000d0"); // 10-30%
+    cuts.AddCutCalo("13530013","4117901050e30220000","0s631031000000d0"); // 30-50%
+    cuts.AddCutCalo("15910013","4117901050e30220000","0s631031000000d0"); // 50-90%
+  } else if (trainConfig == 784){ // EMCAL+DCal clusters - Neutral Overlap with mean N matched tracks per cluster
+    cuts.AddCutCalo("10130e13","411790105te30220000","01631031000000d0"); // 00-10%
+    cuts.AddCutCalo("11310e13","411790105te30220000","01631031000000d0"); // 10-30%
+    cuts.AddCutCalo("13530e13","411790105te30220000","01631031000000d0"); // 30-50%
+    cuts.AddCutCalo("15910e13","411790105te30220000","01631031000000d0"); // 50-90%
+  } else if (trainConfig == 785){ // EMCAL+DCal clusters - Neutral Overlap with mean N matched tracks per cluster without OOB Pileup correction
+    cuts.AddCutCalo("10130013","411790105te30220000","01631031000000d0"); // 00-10%
+    cuts.AddCutCalo("11310013","411790105te30220000","01631031000000d0"); // 10-30%
+    cuts.AddCutCalo("13530013","411790105te30220000","01631031000000d0"); // 30-50%
+    cuts.AddCutCalo("15910013","411790105te30220000","01631031000000d0"); // 50-90%
+  } else if (trainConfig == 786){ // EMCAL+DCal clusters - Neutral Overlap NonLin like
+    cuts.AddCutCalo("10130e13","411790105we30220000","01631031000000d0"); // 00-10%
+    cuts.AddCutCalo("11310e13","411790105we30220000","01631031000000d0"); // 10-30%
+    cuts.AddCutCalo("13530e13","411790105we30220000","01631031000000d0"); // 30-50%
+    cuts.AddCutCalo("15910e13","411790105we30220000","01631031000000d0"); // 50-90%
+  } else if (trainConfig == 787){ // EMCAL+DCal clusters -  Neutral Overlap NonLin like without OOB Pileup correction
+    cuts.AddCutCalo("10130013","411790105we30220000","01631031000000d0"); // 00-10%
+    cuts.AddCutCalo("11310013","411790105we30220000","01631031000000d0"); // 10-30%
+    cuts.AddCutCalo("13530013","411790105we30220000","01631031000000d0"); // 30-50%
+    cuts.AddCutCalo("15910013","411790105we30220000","01631031000000d0"); // 50-90%
+  } else if (trainConfig == 788){ // EMCAL+DCal clusters - Neutral Overlap with mean charged tracks per cell
+    cuts.AddCutCalo("10130e13","411790105ve30220000","01631031000000d0"); // 00-10%
+    cuts.AddCutCalo("11310e13","411790105ve30220000","01631031000000d0"); // 10-30%
+    cuts.AddCutCalo("13530e13","411790105ve30220000","01631031000000d0"); // 30-50%
+    cuts.AddCutCalo("15910e13","411790105ve30220000","01631031000000d0"); // 50-90%
+  } else if (trainConfig == 789){ // EMCAL+DCal clusters -  Neutral Overlap with mean charged tracks per cell without OOB Pileup correction
+    cuts.AddCutCalo("10130013","411790105ve30220000","01631031000000d0"); // 00-10%
+    cuts.AddCutCalo("11310013","411790105ve30220000","01631031000000d0"); // 10-30%
+    cuts.AddCutCalo("13530013","411790105ve30220000","01631031000000d0"); // 30-50%
+    cuts.AddCutCalo("15910013","411790105ve30220000","01631031000000d0"); // 50-90%
   // Random neutral energy overlap correction!
   } else if (trainConfig == 790){ // EMCAL+DCal clusters - 13 TeV emcal cuts w/o TM
     cuts.AddCutCalo("10130e03","411790105ue30220000","0s631031000000d0"); // 00-10%

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_PbPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_PbPb.C
@@ -1033,43 +1033,52 @@ void AddTask_GammaConvCalo_PbPb(
   // ***************************** PCM-EMC configurations PbPb run 2 2018 *************************************
   // **********************************************************************************************************
   } else if (trainConfig == 750){ // EMCAL clusters - 0-100%
-    cuts.AddCutPCMCalo("10930013","0dm00009ab770c00amd0404000","411790105te30220000","0r63103100000010"); //  0-100%
-  } else if (trainConfig == 751){ // EMCAL clusters - 4 cent classes with 0-10 and 30-50 triggered
-    cuts.AddCutPCMCalo("10130e03","0dm00009ab770c00amd0404000","411790105te30220000","0r63103100000010"); //  0-10%
-    cuts.AddCutPCMCalo("11310e03","0dm00009ab770c00amd0404000","411790105te30220000","0r63103100000010"); // 10-30%
-    cuts.AddCutPCMCalo("13530e03","0dm00009ab770c00amd0404000","411790105te30220000","0r63103100000010"); // 30-50%
-    cuts.AddCutPCMCalo("15910e03","0dm00009ab770c00amd0404000","411790105te30220000","0r63103100000010"); // 50-90%
+    cuts.AddCutPCMCalo("10930013","0dm00009ab770c00amd0404000","411790105te30220000","0163103100000010"); //  0-100%
+  } else if (trainConfig == 751){ // EMCAL clusters - 4 cent classes with 0-10 and 30-50 triggered with neutral overlap correction via N matched tracks per cluster
+    cuts.AddCutPCMCalo("10130e03","0dm00009ab770c00amd0404000","411790105te30220000","0163103100000010"); //  0-10%
+    cuts.AddCutPCMCalo("11310e03","0dm00009ab770c00amd0404000","411790105te30220000","0163103100000010"); // 10-30%
+    cuts.AddCutPCMCalo("13530e03","0dm00009ab770c00amd0404000","411790105te30220000","0163103100000010"); // 30-50%
+    cuts.AddCutPCMCalo("15910e03","0dm00009ab770c00amd0404000","411790105te30220000","0163103100000010"); // 50-90%
   } else if (trainConfig == 752){ // EMCAL clusters - 4 cent classes with 0-10 and 30-50 triggered - w/o track matching
-    cuts.AddCutPCMCalo("10130e03","0dm00009ab770c00amd0404000","4117901050e30220000","0r63103100000010"); //  0-10%
-    cuts.AddCutPCMCalo("11310e03","0dm00009ab770c00amd0404000","4117901050e30220000","0r63103100000010"); // 10-30%
-    cuts.AddCutPCMCalo("13530e03","0dm00009ab770c00amd0404000","4117901050e30220000","0r63103100000010"); // 30-50%
-    cuts.AddCutPCMCalo("15910e03","0dm00009ab770c00amd0404000","4117901050e30220000","0r63103100000010"); // 50-90%
-  } else if (trainConfig == 753){ // EMCAL clusters - cen4 cent classes with 0-10 and 30-50 triggered without OOB pile up correction for MC
-    cuts.AddCutPCMCalo("10130053","0dm00009ab770c00amd0404000","411790105te30220000","0r63103100000010"); //  0-10%
-    cuts.AddCutPCMCalo("11310053","0dm00009ab770c00amd0404000","411790105te30220000","0r63103100000010"); // 10-30%
-    cuts.AddCutPCMCalo("13530053","0dm00009ab770c00amd0404000","411790105te30220000","0r63103100000010"); // 30-50%
-    cuts.AddCutPCMCalo("15910053","0dm00009ab770c00amd0404000","411790105te30220000","0r63103100000010"); // 50-90%
+    cuts.AddCutPCMCalo("10130e03","0dm00009ab770c00amd0404000","4117901050e30220000","0163103100000010"); //  0-10%
+    cuts.AddCutPCMCalo("11310e03","0dm00009ab770c00amd0404000","4117901050e30220000","0163103100000010"); // 10-30%
+    cuts.AddCutPCMCalo("13530e03","0dm00009ab770c00amd0404000","4117901050e30220000","0163103100000010"); // 30-50%
+    cuts.AddCutPCMCalo("15910e03","0dm00009ab770c00amd0404000","4117901050e30220000","0163103100000010"); // 50-90%
+  } else if (trainConfig == 753){ // EMCAL clusters - cen4 cent classes with 0-10 and 30-50 triggered without OOB pile up correction for MC with neutral overlap correction via N matched tracks per cluster
+    cuts.AddCutPCMCalo("10130053","0dm00009ab770c00amd0404000","411790105te30220000","0163103100000010"); //  0-10%
+    cuts.AddCutPCMCalo("11310053","0dm00009ab770c00amd0404000","411790105te30220000","0163103100000010"); // 10-30%
+    cuts.AddCutPCMCalo("13530053","0dm00009ab770c00amd0404000","411790105te30220000","0163103100000010"); // 30-50%
+    cuts.AddCutPCMCalo("15910053","0dm00009ab770c00amd0404000","411790105te30220000","0163103100000010"); // 50-90%
   } else if (trainConfig == 754){ // EMCAL clusters - cen4 cent classes with 0-10 and 30-50 triggered without OOB pile up correction for MC - w/o track matching
-    cuts.AddCutPCMCalo("10130053","0dm00009ab770c00amd0404000","4117901050e30220000","0r63103100000010"); //  0-10%
-    cuts.AddCutPCMCalo("11310053","0dm00009ab770c00amd0404000","4117901050e30220000","0r63103100000010"); // 10-30%
-    cuts.AddCutPCMCalo("13530053","0dm00009ab770c00amd0404000","4117901050e30220000","0r63103100000010"); // 30-50%
-    cuts.AddCutPCMCalo("15910053","0dm00009ab770c00amd0404000","4117901050e30220000","0r63103100000010"); // 50-90%
-  } else if (trainConfig == 755){ // EMCAL clusters - cen4 cent classes with 0-10 and 30-50 triggered without OOB pile up correction for MC with added Signal!
-    cuts.AddCutPCMCalo("10130023","0dm00009ab770c00amd0404000","411790105te30220000","0r63103100000010"); //  0-10%
-    cuts.AddCutPCMCalo("11310023","0dm00009ab770c00amd0404000","411790105te30220000","0r63103100000010"); // 10-30%
-    cuts.AddCutPCMCalo("13530023","0dm00009ab770c00amd0404000","411790105te30220000","0r63103100000010"); // 30-50%
-    cuts.AddCutPCMCalo("15910023","0dm00009ab770c00amd0404000","411790105te30220000","0r63103100000010"); // 50-90%
+    cuts.AddCutPCMCalo("10130053","0dm00009ab770c00amd0404000","4117901050e30220000","0163103100000010"); //  0-10%
+    cuts.AddCutPCMCalo("11310053","0dm00009ab770c00amd0404000","4117901050e30220000","0163103100000010"); // 10-30%
+    cuts.AddCutPCMCalo("13530053","0dm00009ab770c00amd0404000","4117901050e30220000","0163103100000010"); // 30-50%
+    cuts.AddCutPCMCalo("15910053","0dm00009ab770c00amd0404000","4117901050e30220000","0163103100000010"); // 50-90%
+  } else if (trainConfig == 755){ // EMCAL clusters - cen4 cent classes with 0-10 and 30-50 triggered without OOB pile up correction for MC with added Signal! with neutral overlap correction via N matched tracks per cluster
+    cuts.AddCutPCMCalo("10130023","0dm00009ab770c00amd0404000","411790105te30220000","0163103100000010"); //  0-10%
+    cuts.AddCutPCMCalo("11310023","0dm00009ab770c00amd0404000","411790105te30220000","0163103100000010"); // 10-30%
+    cuts.AddCutPCMCalo("13530023","0dm00009ab770c00amd0404000","411790105te30220000","0163103100000010"); // 30-50%
+    cuts.AddCutPCMCalo("15910023","0dm00009ab770c00amd0404000","411790105te30220000","0163103100000010"); // 50-90%
   } else if (trainConfig == 756){ // EMCAL clusters - cen4 cent classes with 0-10 and 30-50 triggered without OOB pile up correction for MC with added Signal! - w/o track matching
-    cuts.AddCutPCMCalo("10130023","0dm00009ab770c00amd0404000","4117901050e30220000","0r63103100000010"); //  0-10%
-    cuts.AddCutPCMCalo("11310023","0dm00009ab770c00amd0404000","4117901050e30220000","0r63103100000010"); // 10-30%
-    cuts.AddCutPCMCalo("13530023","0dm00009ab770c00amd0404000","4117901050e30220000","0r63103100000010"); // 30-50%
-    cuts.AddCutPCMCalo("15910023","0dm00009ab770c00amd0404000","4117901050e30220000","0r63103100000010"); // 50-90%
-  } else if (trainConfig == 757){ // EMCAL clusters - 0-10 triggered without OOB pile up correction for MC
-    cuts.AddCutPCMCalo("10130053","0dm00009ab770c00amd0404000","411790105te30220000","0r63103100000010"); //  0-10%
-  } else if (trainConfig == 758){ // EMCAL clusters - 30-50 triggered without OOB pile up correction for MC
-    cuts.AddCutPCMCalo("13530053","0dm00009ab770c00amd0404000","411790105te30220000","0r63103100000010"); // 30-50%
-  } else if (trainConfig == 759){ // EMCAL clusters - 0-10 triggered without OOB pile up correction for MC - w/o track matching
-    cuts.AddCutPCMCalo("10130053","0dm00009ab770c00amd0404000","4117901050e30220000","0r63103100000010"); //  0-10%
+    cuts.AddCutPCMCalo("10130023","0dm00009ab770c00amd0404000","4117901050e30220000","0163103100000010"); //  0-10%
+    cuts.AddCutPCMCalo("11310023","0dm00009ab770c00amd0404000","4117901050e30220000","0163103100000010"); // 10-30%
+    cuts.AddCutPCMCalo("13530023","0dm00009ab770c00amd0404000","4117901050e30220000","0163103100000010"); // 30-50%
+    cuts.AddCutPCMCalo("15910023","0dm00009ab770c00amd0404000","4117901050e30220000","0163103100000010"); // 50-90%
+  } else if (trainConfig == 757){ // EMCAL clusters - cen4 cent classes with 0-10 and 30-50 triggered with neutral overlap correction NonLin like
+    cuts.AddCutPCMCalo("10130e03","0dm00009ab770c00amd0404000","4117901050e30220000","0163103100000010"); //  0-10%
+    cuts.AddCutPCMCalo("11310e03","0dm00009ab770c00amd0404000","4117901050e30220000","0163103100000010"); // 10-30%
+    cuts.AddCutPCMCalo("13530e03","0dm00009ab770c00amd0404000","4117901050e30220000","0163103100000010"); // 30-50%
+    cuts.AddCutPCMCalo("15910e03","0dm00009ab770c00amd0404000","4117901050e30220000","0163103100000010"); // 50-90%
+  } else if (trainConfig == 758){ // EMCAL clusters - cen4 cent classes with 0-10 and 30-50 triggered without OOB pile up correction for MC with added Signal! with neutral overlap correction NonLin like
+    cuts.AddCutPCMCalo("10130023","0dm00009ab770c00amd0404000","411790105te30220000","0163103100000010"); //  0-10%
+    cuts.AddCutPCMCalo("11310023","0dm00009ab770c00amd0404000","411790105te30220000","0163103100000010"); // 10-30%
+    cuts.AddCutPCMCalo("13530023","0dm00009ab770c00amd0404000","411790105te30220000","0163103100000010"); // 30-50%
+    cuts.AddCutPCMCalo("15910023","0dm00009ab770c00amd0404000","411790105te30220000","0163103100000010"); // 50-90%
+  } else if (trainConfig == 759){ // EMCAL clusters - cen4 cent classes with 0-10 and 30-50 triggered without OOB pile up correction for MC - with neutral overlap correction NonLin like
+    cuts.AddCutPCMCalo("10130053","0dm00009ab770c00amd0404000","4117901050e30220000","0163103100000010"); //  0-10%
+    cuts.AddCutPCMCalo("11310053","0dm00009ab770c00amd0404000","4117901050e30220000","0163103100000010"); // 10-30%
+    cuts.AddCutPCMCalo("13530053","0dm00009ab770c00amd0404000","4117901050e30220000","0163103100000010"); // 30-50%
+    cuts.AddCutPCMCalo("15910053","0dm00009ab770c00amd0404000","4117901050e30220000","0163103100000010"); // 50-90%
   } else if (trainConfig == 760){ // EMCAL clusters - 30-50 triggered without OOB pile up correction for MC - w/o track matching
     cuts.AddCutPCMCalo("13530053","0dm00009ab770c00amd0404000","4117901050e30220000","0r63103100000010"); // 30-50%
   } else if (trainConfig == 764){ // EMCAL+DCal clusters - 13 TeV PCM-EMC cuts

--- a/PWGGA/GammaConvBase/AliCaloPhotonCuts.cxx
+++ b/PWGGA/GammaConvBase/AliCaloPhotonCuts.cxx
@@ -6063,6 +6063,7 @@ Bool_t AliCaloPhotonCuts::SetTrackMatchingCut(Int_t trackMatching)
         fParamMeanTrackPt[2] = -1.93788e-05;
       }
       break;
+
     case 30: // cut char 'u' (no TM but with random energy correction for overlap), only use with cell tm!
       if (!fUseDistTrackToCluster) fUseDistTrackToCluster=kTRUE;
       if (!fUseEOverPVetoTM) fUseEOverPVetoTM=kTRUE;
@@ -6085,6 +6086,7 @@ Bool_t AliCaloPhotonCuts::SetTrackMatchingCut(Int_t trackMatching)
         fParamMeanTrackPt[2] = -1.93788e-05;
       }
       break;
+
     case 31: // cut char 'v' (no TM but with mean energy correction for overlap using mean charge particle per cell), only use with cell tm!
       if (!fUseDistTrackToCluster) fUseDistTrackToCluster=kTRUE;
       if (!fUseEOverPVetoTM) fUseEOverPVetoTM=kTRUE;
@@ -6106,6 +6108,16 @@ Bool_t AliCaloPhotonCuts::SetTrackMatchingCut(Int_t trackMatching)
         fParamMeanTrackPt[1] = +2.33711e-04;
         fParamMeanTrackPt[2] = -1.93788e-05;
       }
+      break;
+    
+    case 32: // cut char 'w' NonLin like fitted to pp 13 TeV
+      if (!fUseDistTrackToCluster) fUseDistTrackToCluster=kTRUE;
+      if (!fUseEOverPVetoTM) fUseEOverPVetoTM=kTRUE;
+      fUseDistTrackToCluster = kFALSE;
+      fMaxDistTrackToClusterEta = 0;
+      fMinDistTrackToClusterPhi = 0;
+      fMaxDistTrackToClusterPhi = 0;
+      fDoEnergyCorrectionForOverlap = 4;
       break;
 
     default:
@@ -10757,7 +10769,7 @@ Bool_t AliCaloPhotonCuts::SetNMatchedTracksFunc(float meanCent){
 
 // Function to get the energy value to subtract from a cluster to account for
 // neutral overlap in PbPb 5 TeV
-Double_t AliCaloPhotonCuts::CorrectEnergyForOverlap(float meanCent){
+Double_t AliCaloPhotonCuts::CorrectEnergyForOverlap(float meanCent, float E){
   switch (fDoEnergyCorrectionForOverlap){
     case 0:
       return 0.;
@@ -10767,6 +10779,20 @@ Double_t AliCaloPhotonCuts::CorrectEnergyForOverlap(float meanCent){
       return 0.5 * fFuncNMatchedTracks->GetRandom(0.0, 8.0) * GetMeanEForOverlap(meanCent, fParamMeanTrackPt);
     case 3:
       return 0.5 * fFuncNMatchedTracks->Eval(meanCent) * GetMeanEForOverlap(meanCent, fParamMeanTrackPt);
+    case 4:
+      if(meanCent < 10){
+        if(E > 3.5) E = 3.5;
+        return 1.09645e+00 - 3.49489e-01 * E + 1.56646e-01 * E * E - 2.03620e-02 * E * E * E;
+      } else if (meanCent < 30){
+        if(E > 3.8) E = 3.8;
+        return 1.03972e+00 - 1.79650e-01 * E + 8.41570e-02 * E * E - 1.13454e-02 * E * E * E;
+      } else if (meanCent < 50){
+        if(E > 3.3) E = 3.3;
+        return 1.00734e+00 - 6.42114e-02 * E + 3.03931e-02 * E * E - 4.16131e-03 * E * E * E;
+      } else {
+        if(E > 3.5) E = 3.5;
+        return 9.95241e-01 - 1.49339e-02 * E + 8.08355e-03 * E * E - 1.33936e-03 * E * E * E;
+      }
     default:
       return 0;
   }

--- a/PWGGA/GammaConvBase/AliCaloPhotonCuts.h
+++ b/PWGGA/GammaConvBase/AliCaloPhotonCuts.h
@@ -410,7 +410,7 @@ class AliCaloPhotonCuts : public AliAnalysisCuts {
 
     Bool_t      SetPoissonParamCentFunction(int isMC);
     Bool_t      SetNMatchedTracksFunc(float meanCent);
-    Double_t    CorrectEnergyForOverlap(float meanCent);
+    Double_t    CorrectEnergyForOverlap(float meanCent, float E = 0);
     Int_t       GetDoEnergyCorrectionForOverlap()               {return fDoEnergyCorrectionForOverlap;}
     Double_t    GetMeanEForOverlap(Double_t cent, Double_t* par);
 


### PR DESCRIPTION
…orrection

- Add case `w` for TrackMatching as implementation of first iteration of NonLin like neutral overlap correction
- Add specific cases for this to the GammaConvCalo and GammaCalo Analysis tasks
- Add and updated GCoCa and GCa trainconfigs (most notably added GCa version without OOB pileup correction for MC!)