### PR TITLE
Modifying electron rejection cut

### DIFF
--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoMJTrackCut.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoMJTrackCut.cxx
@@ -120,6 +120,7 @@ ClassImp(AliFemtoMJTrackCut)
     fMaxPforTPCpid(10000.0),
     fMinPforITSpid(0.0),
    fMaxPforITSpid(10000.0),
+   fMaxNsigmaERejection(0.0),
    fElectronRejection(0)
 {
   // Default constructor
@@ -1375,6 +1376,11 @@ void AliFemtoMJTrackCut::SetNsigmaRejection(Double_t nsigma)
   fNsigmaRejection = nsigma;
 }
 
+void AliFemtoMJTrackCut::SetMaxNsigmaERejection(Double_t nsigma)
+{
+  fMaxNsigmaERejection = nsigma;
+}
+
 void AliFemtoMJTrackCut::SetNsigmaAccept(Double_t nsigma)
 {
   fNsigmaAccept = nsigma;
@@ -1406,7 +1412,7 @@ Bool_t AliFemtoMJTrackCut::CheckITSClusterRequirement(AliESDtrackCuts::ITSCluste
 
 bool AliFemtoMJTrackCut::IsElectron(float nsigmaTPCE, float nsigmaTPCPi,float nsigmaTPCK, float nsigmaTPCP)
 {
-  if(TMath::Abs(nsigmaTPCE)<3 && TMath::Abs(nsigmaTPCPi)>3 && TMath::Abs(nsigmaTPCK)>3 && TMath::Abs(nsigmaTPCP)>3)
+  if(TMath::Abs(nsigmaTPCE)< fMaxNsigmaERejection)
       return false;
    else
      return true;

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoMJTrackCut.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoMJTrackCut.h
@@ -68,6 +68,7 @@ class AliFemtoMJTrackCut : public AliFemtoTrackCut
   void SetNsigma(Double_t);
   void SetNsigma2(Double_t);
   void SetNsigmaRejection(Double_t);
+  void SetMaxNsigmaERejection(Double_t);
   void SetNsigmaAccept(Double_t);
   void SetClusterRequirementITS(AliESDtrackCuts::Detector det, AliESDtrackCuts::ITSClusterRequirement req = AliESDtrackCuts::kOff);
 
@@ -98,6 +99,7 @@ class AliFemtoMJTrackCut : public AliFemtoTrackCut
   Double_t          fNsigma2;             // number of sigmas - 3 by default
   Double_t          fNsigmaRejection;     // number of sigmas for rejection - 3 by default
   Double_t          fNsigmaAccept;        // number of sigmas for rejection - 3 by default
+  Double_t          fMaxNsigmaERejection; // number of sigmas for electron rejection - 1 by default
 
   short             fminTPCclsF;         // min number of findable clusters in the TPC
   short             fminTPCncls;         // min number of clusters in the TPC


### PR DESCRIPTION
Modified the electron rejection cut to make it stricter. The default value is set to zero which rejects no electrons. Higher values of this parameter `fMaxNsigmaERejection` would reject more electrons.