### PR TITLE
PWGGA/GammaConv: AliCaloPhotonCuts - Increment ClassDef

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskConvCaloCalibration.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskConvCaloCalibration.cxx
@@ -1330,11 +1330,13 @@ void AliAnalysisTaskConvCaloCalibration::ProcessClusters(){
         }
         if(!fGeomEMCAL)fGeomEMCAL = AliEMCALGeometry::GetInstance();
         Int_t SupMod = fGeomEMCAL->GetSuperModuleNumber(clus->GetCellAbsId(0));
-        fHistoClusTrackdEtaSM[fiCut][SupMod]->Fill(dEta, fWeightJetJetMC);
-        fHistoClusTrackdPhiSM[fiCut][SupMod]->Fill(dPhi, fWeightJetJetMC);
-        if(inTrack->Pt()>5){
-          fHistoClusHighPtTrackdEtaSM[fiCut][SupMod]->Fill(dEta, fWeightJetJetMC);
-          fHistoClusHighPtTrackdPhiSM[fiCut][SupMod]->Fill(dPhi, fWeightJetJetMC);
+        if(fDoMesonQA > 0){
+          fHistoClusTrackdEtaSM[fiCut][SupMod]->Fill(dEta, fWeightJetJetMC);
+          fHistoClusTrackdPhiSM[fiCut][SupMod]->Fill(dPhi, fWeightJetJetMC);
+          if(inTrack->Pt()>5){
+            fHistoClusHighPtTrackdEtaSM[fiCut][SupMod]->Fill(dEta, fWeightJetJetMC);
+            fHistoClusHighPtTrackdPhiSM[fiCut][SupMod]->Fill(dPhi, fWeightJetJetMC);
+          }
         }
       } // end loop over tracks
     }

--- a/PWGGA/GammaConv/AliAnalysisTaskConvCaloCalibration.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskConvCaloCalibration.h
@@ -229,16 +229,16 @@ protected:
   TH1F**                  fHistoJetJetNTrials;                                //! array of histos with ntrials for jetjet
 
   // additional variables
-  Double_t*               fUnsmearedPx;                                       //[fNGammaCandidates]
-  Double_t*               fUnsmearedPy;                                       //[fNGammaCandidates]
-  Double_t*               fUnsmearedPz;                                       //[fNGammaCandidates]
-  Double_t*               fUnsmearedE;                                        //[fNGammaCandidates]
+  Double_t*               fUnsmearedPx;                                       // [fNGammaCandidates]
+  Double_t*               fUnsmearedPy;                                       // [fNGammaCandidates]
+  Double_t*               fUnsmearedPz;                                       // [fNGammaCandidates]
+  Double_t*               fUnsmearedE;                                        // [fNGammaCandidates]
   Double_t*               fMesonInvMassWindow;                                // minimum inv mass for histos
 
-  Int_t*                  fMCEventPos;                                        //[fNGammaCandidates]
-  Int_t*                  fMCEventNeg;                                        //[fNGammaCandidates]
-  Int_t*                  fESDArrayPos;                                       //[fNGammaCandidates]
-  Int_t*                  fESDArrayNeg;                                       //[fNGammaCandidates]
+  Int_t*                  fMCEventPos;                                        // [fNGammaCandidates]
+  Int_t*                  fMCEventNeg;                                        // [fNGammaCandidates]
+  Int_t*                  fESDArrayPos;                                       // [fNGammaCandidates]
+  Int_t*                  fESDArrayNeg;                                       // [fNGammaCandidates]
 
   Double_t                fEventPlaneAngle;                                   // EventPlaneAngle
   Double_t                fMesonInvMassMin;                                   // minimum inv mass for histos

--- a/PWGGA/GammaConvBase/AliCaloPhotonCuts.cxx
+++ b/PWGGA/GammaConvBase/AliCaloPhotonCuts.cxx
@@ -2051,6 +2051,7 @@ void AliCaloPhotonCuts::InitCutHistograms(TString name){
       fHistElectronPositronClusterMatch->Sumw2();
       fHistElectronPositronClusterMatchSub->Sumw2();
       fHistElectronPositronClusterMatchEoverP->Sumw2();
+      fHistElectronPositronClusterMatchEoverPVsE->Sumw2();
       fHistTrueElectronPositronClusterMatch->Sumw2();
       fHistTrueNoElectronPositronClusterMatch->Sumw2();
       fHistElectronClusterMatchTruePID->Sumw2();

--- a/PWGGA/GammaConvBase/AliCaloPhotonCuts.h
+++ b/PWGGA/GammaConvBase/AliCaloPhotonCuts.h
@@ -762,7 +762,7 @@ class AliCaloPhotonCuts : public AliAnalysisCuts {
 
   private:
 
-    ClassDef(AliCaloPhotonCuts,132)
+    ClassDef(AliCaloPhotonCuts,133)
 };
 
 #endif


### PR DESCRIPTION
- Previous commit did not increment ClassDef, thus should fix it
- Also added spaces to some comments for AliAnalysisTaskConvCaloCalibration memebers which produced warnings before

PWGGA/GammaConv/AliAnalysisTaskConvCaloCalibration.cxx fix QAMesonFlag

- Fix a bug with the QAMesonFlag where a histogram is only initilized if its set, but was always accessed later.