### PR TITLE
PWG/EMCAL: Add option for cell energy calibration per column

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.cxx
@@ -168,7 +168,7 @@ AliEMCALRecoUtils::AliEMCALRecoUtils(const AliEMCALRecoUtils & reco)
   for (Int_t i = 0; i < 10 ; i++) { fNCellEfficiencyParams[i] = reco.fNCellEfficiencyParams[i] ; }
   for (Int_t j = 0; j < 5  ; j++) { fMCGenerToAccept[j]       = reco.fMCGenerToAccept[j]       ; }
   for (Int_t j = 0; j < 4  ; j++) { fBadStatusSelection[j]    = reco.fBadStatusSelection[j]    ; }
-  for (Int_t j = 0; j < 4  ; j++) { fAdditionalScaleSM[j]     = reco.fAdditionalScaleSM[j]     ; }
+  for (Int_t j = 0; j < 96 ; j++) { fAdditionalScaleSM[j]     = reco.fAdditionalScaleSM[j]     ; }
 
   if(reco.fEMCALBadChannelMap) {
     // Copy constructor - not taking ownership over calibration histograms
@@ -226,8 +226,9 @@ AliEMCALRecoUtils & AliEMCALRecoUtils::operator = (const AliEMCALRecoUtils & rec
   fUseDetermineLowGain       = reco.fUseDetermineLowGain;
   fCalibData                 = reco.fCalibData;
   fUseAdditionalScale        = reco.fUseAdditionalScale;
-  for (Int_t j = 0; j < 4; j++)
+  for (Int_t j = 0; j < 96; j++){
     fAdditionalScaleSM[j]         = reco.fAdditionalScaleSM[j];
+  }
   fSmearClusterEnergy        = reco.fSmearClusterEnergy;
   fNCellEfficiencyFunction   = reco.fNCellEfficiencyFunction;
 
@@ -506,6 +507,17 @@ Bool_t AliEMCALRecoUtils::AcceptCalibrateCell(Int_t absID, Int_t bc,
         } else { // no TRD modules in front
           amp *= fAdditionalScaleSM[3];
         }
+      }
+    //____________________________________
+    } else if (fUseAdditionalScale == 5) { // Experimental values for column by column cell energy absolute calibration
+      // calculate absolute column from relative column (ieta is per SM)
+      int iCol = ieta;
+      if(imod%2){
+        if( imod > 11 && imod < 18) iCol+=64;
+        else iCol+=48;
+      }
+      if(iCol < 96){
+        amp *= fAdditionalScaleSM[iCol];
       }
     }
 
@@ -2411,7 +2423,7 @@ void AliEMCALRecoUtils::InitParameters()
   for (Int_t i = 0; i < 10  ; i++) fNCellEfficiencyParams[i] = 0.;
 
   // additional scale for different SM types (default value is 1)
-  for (Int_t i = 0; i < 3; i++) fAdditionalScaleSM[i] = 1.;
+  for (Int_t i = 0; i < 96; i++) fAdditionalScaleSM[i] = 1.;
 }
 
 ///

--- a/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.h
+++ b/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.h
@@ -175,8 +175,8 @@ public:
   void     SetUseTowerShaperNonlinarityCorrection(Bool_t doCorr)     { fUseShaperNonlin = doCorr ; }
   void     SetUseDetermineLowGain(Bool_t doCorr)                     { fUseDetermineLowGain = doCorr ; }
   void     SetUseTowerAdditionalScaleCorrection(Int_t doCorr)        { fUseAdditionalScale = doCorr;}
-  void     SetTowerAdditionalScaleCorrection(Int_t i, Float_t val)   { if(i < 4 && i >= 0) fAdditionalScaleSM[i] = val;
-                                                                       else AliInfo(Form("fAdditionalScaleSM index %d larger than 4 or negative, do nothing\n",i));}
+  void     SetTowerAdditionalScaleCorrection(Int_t i, Float_t val)   { if(i < 96 && i >= 0) fAdditionalScaleSM[i] = val;
+                                                                       else AliInfo(Form("fAdditionalScaleSM index %d larger than 96 or negative, do nothing\n",i));}
 
   //-----------------------------------------------------
   // MC clusters energy smearing
@@ -637,8 +637,8 @@ private:
   Bool_t     fUseShaperNonlin;           ///< Shaper non linearity correction for towers
   Bool_t     fUseDetermineLowGain;       ///< If set on true, wether a cell is low gain or high gain is not taken from cell info but calculated directly from cell ADC value
   AliEMCALCalibData* fCalibData;         ///< EMCAL calib data
-  Int_t     fUseAdditionalScale;         ///< Switch for additional scale on cell level: 1 = default (Scales for Full, 2/3 and 1/3 SM), 2 = diff. scales for regions behind TRD support, 3 = Run1 scales behind SM with TRD in front and without, 4 = Same as 3 but additionally values for with and without TRD support structures
-  Float_t    fAdditionalScaleSM[4];      ///< Value for additional scale on cell level. 
+  Int_t      fUseAdditionalScale;        ///< Switch for additional scale on cell level: 1 = default (Scales for Full, 2/3 and 1/3 SM), 2 = diff. scales for regions behind TRD support, 3 = Run1 scales behind SM with TRD in front and without, 4 = Same as 3 but additionally values for with and without TRD support structures, 5 = calibration factors applied column by column (96 in total)
+  Float_t    fAdditionalScaleSM[96];     ///< Value for additional scale on cell level. 
 
   // Energy smearing for MC
   Bool_t     fSmearClusterEnergy;        ///< Smear cluster energy, to be done only for simulated data to match real data

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEnergy.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEnergy.cxx
@@ -37,7 +37,7 @@ AliEmcalCorrectionCellEnergy::AliEmcalCorrectionCellEnergy() :
   ,fCustomRecalibFilePath("")
   ,fLoad1DRecalibFactors(0)
 {
-  for(unsigned int i = 0; i < 4; ++i){
+  for(unsigned int i = 0; i < 96; ++i){
     fAdditionalScaleSM.push_back(1); // set default values to 1
   }
 
@@ -544,7 +544,7 @@ Bool_t AliEmcalCorrectionCellEnergy::CheckIfRunChanged()
   if(fUseAdditionalScale)
   {
     fRecoUtils->SetUseTowerAdditionalScaleCorrection(fAdditionalScaleMode);
-    for(int i = 0; i < 4; ++i){
+    for(int i = 0; i < 96; ++i){
       fRecoUtils->SetTowerAdditionalScaleCorrection(i, fAdditionalScaleSM[i]);
     }
   }


### PR DESCRIPTION
- The absolute cell energy calibration is done in order to account for material in front of the detector, and hence not all cells should be calibrated to the nominal Pi0 mass. Effects due to the material are taken from MC simulations
- Previously, the Full, 2/3 and 1/3 SM types were calibrated seperatly, or the part where TRD support structures are visible had a different absolute calibration than the rest of the detector
- This new commit enables a column by column calibration, to refine the idea o calibrating the TRD support regions differntly
- This is only an esperimental setting! And is used to test calibration improvments for Run3