### PR TITLE
PWGGA/GammaConv: - Changed CutSetting from no TM to standard PbPb TM

### DIFF
--- a/PWGGA/GammaConv/macros/AddTask_GammaCalo_PbPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaCalo_PbPb.C
@@ -1258,25 +1258,25 @@ void AddTask_GammaCalo_PbPb(
     cuts.AddCutCalo("10930013","4117900000032220000","01331031000000d0"); //  0-90% QA (open timing)
 
   } else if (trainConfig == 780){ // EMCAL+DCal standard with 4 cents
-    cuts.AddCutCalo("10130e03","4117901050e30220000","01331031000000d0"); // 00-10%
-    cuts.AddCutCalo("11310e03","4117901050e30220000","01331031000000d0"); // 10-30%
-    cuts.AddCutCalo("13530e03","4117901050e30220000","01331031000000d0"); // 30-50%
-    cuts.AddCutCalo("15910e03","4117901050e30220000","01331031000000d0"); // 50-90%
+    cuts.AddCutCalo("10130e03","411790105ke30220000","01331031000000d0"); // 00-10%
+    cuts.AddCutCalo("11310e03","411790105ke30220000","01331031000000d0"); // 10-30%
+    cuts.AddCutCalo("13530e03","411790105ke30220000","01331031000000d0"); // 30-50%
+    cuts.AddCutCalo("15910e03","411790105ke30220000","01331031000000d0"); // 50-90%
   } else if (trainConfig == 781){ // EMCAL+DCal standard with rotation method
-    cuts.AddCutCalo("10130e03","4117901050e30220000","0s631031000000d0"); // 00-10%
-    cuts.AddCutCalo("11310e03","4117901050e30220000","0s631031000000d0"); // 10-30%
-    cuts.AddCutCalo("13530e03","4117901050e30220000","0s631031000000d0"); // 30-50%
-    cuts.AddCutCalo("15910e03","4117901050e30220000","0s631031000000d0"); // 50-90%
+    cuts.AddCutCalo("10130e03","411790105ke30220000","0s631031000000d0"); // 00-10%
+    cuts.AddCutCalo("11310e03","411790105ke30220000","0s631031000000d0"); // 10-30%
+    cuts.AddCutCalo("13530e03","411790105ke30220000","0s631031000000d0"); // 30-50%
+    cuts.AddCutCalo("15910e03","411790105ke30220000","0s631031000000d0"); // 50-90%
   } else if (trainConfig == 782){ // EMCAL+DCal standard with 4 cents without OOB Pileup correction
-    cuts.AddCutCalo("10130053","4117901050e30220000","01331031000000d0"); // 00-10%
-    cuts.AddCutCalo("11310053","4117901050e30220000","01331031000000d0"); // 10-30%
-    cuts.AddCutCalo("13530053","4117901050e30220000","01331031000000d0"); // 30-50%
-    cuts.AddCutCalo("15910053","4117901050e30220000","01331031000000d0"); // 50-90%
+    cuts.AddCutCalo("10130053","411790105ke30220000","01331031000000d0"); // 00-10%
+    cuts.AddCutCalo("11310053","411790105ke30220000","01331031000000d0"); // 10-30%
+    cuts.AddCutCalo("13530053","411790105ke30220000","01331031000000d0"); // 30-50%
+    cuts.AddCutCalo("15910053","411790105ke30220000","01331031000000d0"); // 50-90%
   } else if (trainConfig == 783){ // EMCAL+DCal standard with rotation method without OOB Pileup correction
-    cuts.AddCutCalo("10130053","4117901050e30220000","0s631031000000d0"); // 00-10%
-    cuts.AddCutCalo("11310053","4117901050e30220000","0s631031000000d0"); // 10-30%
-    cuts.AddCutCalo("13530053","4117901050e30220000","0s631031000000d0"); // 30-50%
-    cuts.AddCutCalo("15910053","4117901050e30220000","0s631031000000d0"); // 50-90%
+    cuts.AddCutCalo("10130053","411790105ke30220000","0s631031000000d0"); // 00-10%
+    cuts.AddCutCalo("11310053","411790105ke30220000","0s631031000000d0"); // 10-30%
+    cuts.AddCutCalo("13530053","411790105ke30220000","0s631031000000d0"); // 30-50%
+    cuts.AddCutCalo("15910053","411790105ke30220000","0s631031000000d0"); // 50-90%
   } else if (trainConfig == 784){ // EMCAL+DCal clusters - Neutral Overlap with mean N matched tracks per cluster
     cuts.AddCutCalo("10130e03","411790105te30220000","01331031000000d0"); // 00-10%
     cuts.AddCutCalo("11310e03","411790105te30220000","01331031000000d0"); // 10-30%
@@ -1330,10 +1330,10 @@ void AddTask_GammaCalo_PbPb(
     cuts.AddCutCalo("13530e13","411790105ve30220000","0s631031000000d0"); // 30-50%
     cuts.AddCutCalo("15910e13","411790105ve30220000","0s631031000000d0"); // 50-90%
   } else if (trainConfig == 794){ // EMCAL+DCal standard with 4 cents without OOB Pileup correction, Added Signal
-    cuts.AddCutCalo("10130023","4117901050e30220000","01331031000000d0"); // 00-10%
-    cuts.AddCutCalo("11310023","4117901050e30220000","01331031000000d0"); // 10-30%
-    cuts.AddCutCalo("13530023","4117901050e30220000","01331031000000d0"); // 30-50%
-    cuts.AddCutCalo("15910023","4117901050e30220000","01331031000000d0"); // 50-90%
+    cuts.AddCutCalo("10130023","411790105ke30220000","01331031000000d0"); // 00-10%
+    cuts.AddCutCalo("11310023","411790105ke30220000","01331031000000d0"); // 10-30%
+    cuts.AddCutCalo("13530023","411790105ke30220000","01331031000000d0"); // 30-50%
+    cuts.AddCutCalo("15910023","411790105ke30220000","01331031000000d0"); // 50-90%
   } else if (trainConfig == 795){ // EMCAL+DCal clusters -  Neutral Overlap NonLin like without OOB Pileup correction, Added Signal
     cuts.AddCutCalo("10130023","411790105we30220000","01331031000000d0"); // 00-10%
     cuts.AddCutCalo("11310023","411790105we30220000","01331031000000d0"); // 10-30%
@@ -1488,13 +1488,13 @@ void AddTask_GammaCalo_PbPb(
   } else if (trainConfig == 1009){ // EMCAL+DCal clusters -  Neutral Overlap NonLin like without OOB Pileup correction, Added Signal - rotation background method
     cuts.AddCutCalo("10130023","411790105we30220000","0s331031000000d0"); // 00-10%
   } else if (trainConfig == 1080){ // EMCAL+DCal standard
-    cuts.AddCutCalo("10130e03","4117901050e30220000","01331031000000d0"); // 00-10%
+    cuts.AddCutCalo("10130e03","411790105ke30220000","01331031000000d0"); // 00-10%
   } else if (trainConfig == 1081){ // EMCAL+DCal standard with rotation method
-    cuts.AddCutCalo("10130e03","4117901050e30220000","0s631031000000d0"); // 00-10%
+    cuts.AddCutCalo("10130e03","411790105ke30220000","0s631031000000d0"); // 00-10%
   } else if (trainConfig == 1082){ // EMCAL+DCal standard without OOB Pileup correction
-    cuts.AddCutCalo("10130053","4117901050e30220000","01331031000000d0"); // 00-10%
+    cuts.AddCutCalo("10130053","411790105ke30220000","01331031000000d0"); // 00-10%
   } else if (trainConfig == 1083){ // EMCAL+DCal standard with rotation method without OOB Pileup correction
-    cuts.AddCutCalo("10130053","4117901050e30220000","0s631031000000d0"); // 00-10%
+    cuts.AddCutCalo("10130053","411790105ke30220000","0s631031000000d0"); // 00-10%
   } else if (trainConfig == 1084){ // EMCAL+DCal clusters - Neutral Overlap with mean N matched tracks per cluster
     cuts.AddCutCalo("10130e03","411790105te30220000","01331031000000d0"); // 00-10%
   } else if (trainConfig == 1085){ // EMCAL+DCal clusters - Neutral Overlap with mean N matched tracks per cluster without OOB Pileup correction
@@ -1519,7 +1519,7 @@ void AddTask_GammaCalo_PbPb(
     cuts.AddCutCalo("10130e13","411790105ve30220000","0s631031000000d0"); // 00-10%
   // Added Signal
   } else if (trainConfig == 1094){ // EMCAL+DCal standard with 4 cents without OOB Pileup correction, Added Signal
-    cuts.AddCutCalo("10130023","4117901050e30220000","01331031000000d0"); // 00-10%
+    cuts.AddCutCalo("10130023","411790105ke30220000","01331031000000d0"); // 00-10%
   } else if (trainConfig == 1095){ // EMCAL+DCal clusters -  Neutral Overlap NonLin like without OOB Pileup correction, Added Signal
     cuts.AddCutCalo("10130023","411790105we30220000","01331031000000d0"); // 00-10%
   } else if (trainConfig == 1096){ // EMCAL+DCal clusters -  Neutral Overlap with mean charged tracks per cell without OOB Pileup correction, Added Signal
@@ -1545,13 +1545,13 @@ void AddTask_GammaCalo_PbPb(
   } else if (trainConfig == 3009){ // EMCAL+DCal clusters -  Neutral Overlap NonLin like without OOB Pileup correction, Added Signal - rotation background method
     cuts.AddCutCalo("11310023","411790105we30220000","0s331031000000d0"); // 10-30%
   } else if (trainConfig == 3080){ // EMCAL+DCal standard
-    cuts.AddCutCalo("11310e03","4117901050e30220000","01331031000000d0"); // 10-30%
+    cuts.AddCutCalo("11310e03","411790105ke30220000","01331031000000d0"); // 10-30%
   } else if (trainConfig == 3081){ // EMCAL+DCal standard with rotation method
-    cuts.AddCutCalo("11310e03","4117901050e30220000","0s631031000000d0"); // 10-30%
+    cuts.AddCutCalo("11310e03","411790105ke30220000","0s631031000000d0"); // 10-30%
   } else if (trainConfig == 3082){ // EMCAL+DCal standard without OOB Pileup correction
-    cuts.AddCutCalo("11310053","4117901050e30220000","01331031000000d0"); // 10-30%
+    cuts.AddCutCalo("11310053","411790105ke30220000","01331031000000d0"); // 10-30%
   } else if (trainConfig == 3083){ // EMCAL+DCal standard with rotation method without OOB Pileup correction
-    cuts.AddCutCalo("11310053","4117901050e30220000","0s631031000000d0"); // 10-30%
+    cuts.AddCutCalo("11310053","411790105ke30220000","0s631031000000d0"); // 10-30%
   } else if (trainConfig == 3084){ // EMCAL+DCal clusters - Neutral Overlap with mean N matched tracks per cluster
     cuts.AddCutCalo("11310e03","411790105te30220000","01331031000000d0"); // 10-30%
   } else if (trainConfig == 3085){ // EMCAL+DCal clusters - Neutral Overlap with mean N matched tracks per cluster without OOB Pileup correction
@@ -1576,7 +1576,7 @@ void AddTask_GammaCalo_PbPb(
     cuts.AddCutCalo("11310e13","411790105ve30220000","0s631031000000d0"); // 10-30%
   // Added Signal
   } else if (trainConfig == 3094){ // EMCAL+DCal standard with 4 cents without OOB Pileup correction, Added Signal
-    cuts.AddCutCalo("11310023","4117901050e30220000","01331031000000d0"); // 10-30%
+    cuts.AddCutCalo("11310023","411790105ke30220000","01331031000000d0"); // 10-30%
   } else if (trainConfig == 3095){ // EMCAL+DCal clusters -  Neutral Overlap NonLin like without OOB Pileup correction, Added Signal
     cuts.AddCutCalo("11310023","411790105we30220000","01331031000000d0"); // 10-30%
   } else if (trainConfig == 3096){ // EMCAL+DCal clusters -  Neutral Overlap with mean charged tracks per cell without OOB Pileup correction, Added Signal
@@ -1602,13 +1602,13 @@ void AddTask_GammaCalo_PbPb(
   } else if (trainConfig == 5009){ // EMCAL+DCal clusters -  Neutral Overlap NonLin like without OOB Pileup correction, Added Signal - rotation background method
     cuts.AddCutCalo("13530023","411790105we30220000","0s331031000000d0"); // 30-50%
   } else if (trainConfig == 5080){ // EMCAL+DCal standard
-    cuts.AddCutCalo("13530e03","4117901050e30220000","01331031000000d0"); // 30-50%
+    cuts.AddCutCalo("13530e03","411790105ke30220000","01331031000000d0"); // 30-50%
   } else if (trainConfig == 5081){ // EMCAL+DCal standard with rotation method
-    cuts.AddCutCalo("13530e03","4117901050e30220000","0s631031000000d0"); // 30-50%
+    cuts.AddCutCalo("13530e03","411790105ke30220000","0s631031000000d0"); // 30-50%
   } else if (trainConfig == 5082){ // EMCAL+DCal standard without OOB Pileup correction
-    cuts.AddCutCalo("13530053","4117901050e30220000","01331031000000d0"); // 30-50%
+    cuts.AddCutCalo("13530053","411790105ke30220000","01331031000000d0"); // 30-50%
   } else if (trainConfig == 5083){ // EMCAL+DCal standard with rotation method without OOB Pileup correction
-    cuts.AddCutCalo("13530053","4117901050e30220000","0s631031000000d0"); // 30-50%
+    cuts.AddCutCalo("13530053","411790105ke30220000","0s631031000000d0"); // 30-50%
   } else if (trainConfig == 5084){ // EMCAL+DCal clusters - Neutral Overlap with mean N matched tracks per cluster
     cuts.AddCutCalo("13530e03","411790105te30220000","01331031000000d0"); // 30-50%
   } else if (trainConfig == 5085){ // EMCAL+DCal clusters - Neutral Overlap with mean N matched tracks per cluster without OOB Pileup correction
@@ -1633,7 +1633,7 @@ void AddTask_GammaCalo_PbPb(
     cuts.AddCutCalo("13530e13","411790105ve30220000","0s631031000000d0"); // 30-50%
   // Added Signal
   } else if (trainConfig == 5094){ // EMCAL+DCal standard with 4 cents without OOB Pileup correction, Added Signal
-    cuts.AddCutCalo("13530023","4117901050e30220000","01331031000000d0"); // 30-50%
+    cuts.AddCutCalo("13530023","411790105ke30220000","01331031000000d0"); // 30-50%
   } else if (trainConfig == 5095){ // EMCAL+DCal clusters -  Neutral Overlap NonLin like without OOB Pileup correction, Added Signal
     cuts.AddCutCalo("13530023","411790105we30220000","01331031000000d0"); // 30-50%
   } else if (trainConfig == 5096){ // EMCAL+DCal clusters -  Neutral Overlap with mean charged tracks per cell without OOB Pileup correction, Added Signal
@@ -1659,13 +1659,13 @@ void AddTask_GammaCalo_PbPb(
   } else if (trainConfig == 9009){ // EMCAL+DCal clusters -  Neutral Overlap NonLin like without OOB Pileup correction, Added Signal - rotation background method
     cuts.AddCutCalo("15910023","411790105we30220000","0s331031000000d0"); // 50-90%
   } else if (trainConfig == 9080){ // EMCAL+DCal standard
-    cuts.AddCutCalo("15910e03","4117901050e30220000","01331031000000d0"); // 50-90%
+    cuts.AddCutCalo("15910e03","411790105ke30220000","01331031000000d0"); // 50-90%
   } else if (trainConfig == 9081){ // EMCAL+DCal standard with rotation method
-    cuts.AddCutCalo("15910e03","4117901050e30220000","0s631031000000d0"); // 50-90%
+    cuts.AddCutCalo("15910e03","411790105ke30220000","0s631031000000d0"); // 50-90%
   } else if (trainConfig == 9082){ // EMCAL+DCal standard without OOB Pileup correction
-    cuts.AddCutCalo("15910053","4117901050e30220000","01331031000000d0"); // 50-90%
+    cuts.AddCutCalo("15910053","411790105ke30220000","01331031000000d0"); // 50-90%
   } else if (trainConfig == 9083){ // EMCAL+DCal standard with rotation method without OOB Pileup correction
-    cuts.AddCutCalo("15910053","4117901050e30220000","0s631031000000d0"); // 50-90%
+    cuts.AddCutCalo("15910053","411790105ke30220000","0s631031000000d0"); // 50-90%
   } else if (trainConfig == 9084){ // EMCAL+DCal clusters - Neutral Overlap with mean N matched tracks per cluster
     cuts.AddCutCalo("15910e03","411790105te30220000","01331031000000d0"); // 50-90%
   } else if (trainConfig == 9085){ // EMCAL+DCal clusters - Neutral Overlap with mean N matched tracks per cluster without OOB Pileup correction
@@ -1690,7 +1690,7 @@ void AddTask_GammaCalo_PbPb(
     cuts.AddCutCalo("15910e13","411790105ve30220000","0s631031000000d0"); // 50-90%
   // Added Signal
   } else if (trainConfig == 9094){ // EMCAL+DCal standard with 4 cents without OOB Pileup correction, Added Signal
-    cuts.AddCutCalo("15910023","4117901050e30220000","01331031000000d0"); // 50-90%
+    cuts.AddCutCalo("15910023","411790105ke30220000","01331031000000d0"); // 50-90%
   } else if (trainConfig == 9095){ // EMCAL+DCal clusters -  Neutral Overlap NonLin like without OOB Pileup correction, Added Signal
     cuts.AddCutCalo("15910023","411790105we30220000","01331031000000d0"); // 50-90%
   } else if (trainConfig == 9096){ // EMCAL+DCal clusters -  Neutral Overlap with mean charged tracks per cell without OOB Pileup correction, Added Signal

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_PbPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_PbPb.C
@@ -1039,31 +1039,31 @@ void AddTask_GammaConvCalo_PbPb(
     cuts.AddCutPCMCalo("11310e03","0dm00009ab770c00amd0404000","411790105te30220000","0133103100000010"); // 10-30%
     cuts.AddCutPCMCalo("13530e03","0dm00009ab770c00amd0404000","411790105te30220000","0133103100000010"); // 30-50%
     cuts.AddCutPCMCalo("15910e03","0dm00009ab770c00amd0404000","411790105te30220000","0133103100000010"); // 50-90%
-  } else if (trainConfig == 752){ // EMCAL clusters - 4 cent classes with 0-10 and 30-50 triggered - w/o track matching
-    cuts.AddCutPCMCalo("10130e03","0dm00009ab770c00amd0404000","4117901050e30220000","0133103100000010"); //  0-10%
-    cuts.AddCutPCMCalo("11310e03","0dm00009ab770c00amd0404000","4117901050e30220000","0133103100000010"); // 10-30%
-    cuts.AddCutPCMCalo("13530e03","0dm00009ab770c00amd0404000","4117901050e30220000","0133103100000010"); // 30-50%
-    cuts.AddCutPCMCalo("15910e03","0dm00009ab770c00amd0404000","4117901050e30220000","0133103100000010"); // 50-90%
+  } else if (trainConfig == 752){ // EMCAL clusters - 4 cent classes with 0-10 and 30-50 triggered -standard PbPb TM for secondaries
+    cuts.AddCutPCMCalo("10130e03","0dm00009ab770c00amd0404000","411790105ke30220000","0133103100000010"); //  0-10%
+    cuts.AddCutPCMCalo("11310e03","0dm00009ab770c00amd0404000","411790105ke30220000","0133103100000010"); // 10-30%
+    cuts.AddCutPCMCalo("13530e03","0dm00009ab770c00amd0404000","411790105ke30220000","0133103100000010"); // 30-50%
+    cuts.AddCutPCMCalo("15910e03","0dm00009ab770c00amd0404000","411790105ke30220000","0133103100000010"); // 50-90%
   } else if (trainConfig == 753){ // EMCAL clusters - cen4 cent classes with 0-10 and 30-50 triggered without OOB pile up correction for MC with neutral overlap correction via N matched tracks per cluster
     cuts.AddCutPCMCalo("10130053","0dm00009ab770c00amd0404000","411790105te30220000","0133103100000010"); //  0-10%
     cuts.AddCutPCMCalo("11310053","0dm00009ab770c00amd0404000","411790105te30220000","0133103100000010"); // 10-30%
     cuts.AddCutPCMCalo("13530053","0dm00009ab770c00amd0404000","411790105te30220000","0133103100000010"); // 30-50%
     cuts.AddCutPCMCalo("15910053","0dm00009ab770c00amd0404000","411790105te30220000","0133103100000010"); // 50-90%
-  } else if (trainConfig == 754){ // EMCAL clusters - cen4 cent classes with 0-10 and 30-50 triggered without OOB pile up correction for MC - w/o track matching
-    cuts.AddCutPCMCalo("10130053","0dm00009ab770c00amd0404000","4117901050e30220000","0133103100000010"); //  0-10%
-    cuts.AddCutPCMCalo("11310053","0dm00009ab770c00amd0404000","4117901050e30220000","0133103100000010"); // 10-30%
-    cuts.AddCutPCMCalo("13530053","0dm00009ab770c00amd0404000","4117901050e30220000","0133103100000010"); // 30-50%
-    cuts.AddCutPCMCalo("15910053","0dm00009ab770c00amd0404000","4117901050e30220000","0133103100000010"); // 50-90%
+  } else if (trainConfig == 754){ // EMCAL clusters - cen4 cent classes with 0-10 and 30-50 triggered without OOB pile up correction for MC -standard PbPb TM for secondaries
+    cuts.AddCutPCMCalo("10130053","0dm00009ab770c00amd0404000","411790105ke30220000","0133103100000010"); //  0-10%
+    cuts.AddCutPCMCalo("11310053","0dm00009ab770c00amd0404000","411790105ke30220000","0133103100000010"); // 10-30%
+    cuts.AddCutPCMCalo("13530053","0dm00009ab770c00amd0404000","411790105ke30220000","0133103100000010"); // 30-50%
+    cuts.AddCutPCMCalo("15910053","0dm00009ab770c00amd0404000","411790105ke30220000","0133103100000010"); // 50-90%
   } else if (trainConfig == 755){ // EMCAL clusters - cen4 cent classes with 0-10 and 30-50 triggered without OOB pile up correction for MC with added Signal! with neutral overlap correction via N matched tracks per cluster
     cuts.AddCutPCMCalo("10130023","0dm00009ab770c00amd0404000","411790105te30220000","0133103100000010"); //  0-10%
     cuts.AddCutPCMCalo("11310023","0dm00009ab770c00amd0404000","411790105te30220000","0133103100000010"); // 10-30%
     cuts.AddCutPCMCalo("13530023","0dm00009ab770c00amd0404000","411790105te30220000","0133103100000010"); // 30-50%
     cuts.AddCutPCMCalo("15910023","0dm00009ab770c00amd0404000","411790105te30220000","0133103100000010"); // 50-90%
-  } else if (trainConfig == 756){ // EMCAL clusters - cen4 cent classes with 0-10 and 30-50 triggered without OOB pile up correction for MC with added Signal! - w/o track matching
-    cuts.AddCutPCMCalo("10130023","0dm00009ab770c00amd0404000","4117901050e30220000","0133103100000010"); //  0-10%
-    cuts.AddCutPCMCalo("11310023","0dm00009ab770c00amd0404000","4117901050e30220000","0133103100000010"); // 10-30%
-    cuts.AddCutPCMCalo("13530023","0dm00009ab770c00amd0404000","4117901050e30220000","0133103100000010"); // 30-50%
-    cuts.AddCutPCMCalo("15910023","0dm00009ab770c00amd0404000","4117901050e30220000","0133103100000010"); // 50-90%
+  } else if (trainConfig == 756){ // EMCAL clusters - cen4 cent classes with 0-10 and 30-50 triggered without OOB pile up correction for MC with added Signal! -standard PbPb TM for secondaries
+    cuts.AddCutPCMCalo("10130023","0dm00009ab770c00amd0404000","411790105ke30220000","0133103100000010"); //  0-10%
+    cuts.AddCutPCMCalo("11310023","0dm00009ab770c00amd0404000","411790105ke30220000","0133103100000010"); // 10-30%
+    cuts.AddCutPCMCalo("13530023","0dm00009ab770c00amd0404000","411790105ke30220000","0133103100000010"); // 30-50%
+    cuts.AddCutPCMCalo("15910023","0dm00009ab770c00amd0404000","411790105ke30220000","0133103100000010"); // 50-90%
   } else if (trainConfig == 757){ // EMCAL clusters - cen4 cent classes with 0-10 and 30-50 triggered with neutral overlap correction NonLin like
     cuts.AddCutPCMCalo("10130e03","0dm00009ab770c00amd0404000","411790105we30220000","0133103100000010"); //  0-10%
     cuts.AddCutPCMCalo("11310e03","0dm00009ab770c00amd0404000","411790105we30220000","0133103100000010"); // 10-30%
@@ -1147,29 +1147,29 @@ void AddTask_GammaConvCalo_PbPb(
     cuts.AddCutPCMCalo("13530013","0dm00009ab770c00amd0404000","411790105te30220000","0r63103100000010"); // 30-50%
     cuts.AddCutPCMCalo("15910013","0dm00009ab770c00amd0404000","411790105te30220000","0r63103100000010"); // 50-90%
   } else if (trainConfig == 781){ // EMCAL+DCal clusters - with cent and semi cent trigger with OOB pileup cut w/o TM
-    cuts.AddCutPCMCalo("10130e13","0dm00009ab770c00amd0404000","4117901050e30220000","0r63103100000010"); // 00-10%
-    cuts.AddCutPCMCalo("11310e13","0dm00009ab770c00amd0404000","4117901050e30220000","0r63103100000010"); // 10-30%
-    cuts.AddCutPCMCalo("13530e13","0dm00009ab770c00amd0404000","4117901050e30220000","0r63103100000010"); // 30-50%
-    cuts.AddCutPCMCalo("15910e13","0dm00009ab770c00amd0404000","4117901050e30220000","0r63103100000010"); // 50-90%
+    cuts.AddCutPCMCalo("10130e13","0dm00009ab770c00amd0404000","411790105ke30220000","0r63103100000010"); // 00-10%
+    cuts.AddCutPCMCalo("11310e13","0dm00009ab770c00amd0404000","411790105ke30220000","0r63103100000010"); // 10-30%
+    cuts.AddCutPCMCalo("13530e13","0dm00009ab770c00amd0404000","411790105ke30220000","0r63103100000010"); // 30-50%
+    cuts.AddCutPCMCalo("15910e13","0dm00009ab770c00amd0404000","411790105ke30220000","0r63103100000010"); // 50-90%
   } else if (trainConfig == 782){ // EMCAL+DCal clusters - with cent and semi cent trigger without OOB pileup cut w/o TM
-    cuts.AddCutPCMCalo("10130013","0dm00009ab770c00amd0404000","4117901050e30220000","0r63103100000010"); // 00-10%
-    cuts.AddCutPCMCalo("11310013","0dm00009ab770c00amd0404000","4117901050e30220000","0r63103100000010"); // 10-30%
-    cuts.AddCutPCMCalo("13530013","0dm00009ab770c00amd0404000","4117901050e30220000","0r63103100000010"); // 30-50%
-    cuts.AddCutPCMCalo("15910013","0dm00009ab770c00amd0404000","4117901050e30220000","0r63103100000010"); // 50-90%
+    cuts.AddCutPCMCalo("10130013","0dm00009ab770c00amd0404000","411790105ke30220000","0r63103100000010"); // 00-10%
+    cuts.AddCutPCMCalo("11310013","0dm00009ab770c00amd0404000","411790105ke30220000","0r63103100000010"); // 10-30%
+    cuts.AddCutPCMCalo("13530013","0dm00009ab770c00amd0404000","411790105ke30220000","0r63103100000010"); // 30-50%
+    cuts.AddCutPCMCalo("15910013","0dm00009ab770c00amd0404000","411790105ke30220000","0r63103100000010"); // 50-90%
   } else if (trainConfig == 783){ // EMCAL+DCal clusters - cent without TM
-    cuts.AddCutPCMCalo("30110013","0dm00009ab770c00amd0404000","4117901050e30220000","0r63103100000010"); // 00-05%
-    cuts.AddCutPCMCalo("31210013","0dm00009ab770c00amd0404000","4117901050e30220000","0r63103100000010"); // 05-10%
+    cuts.AddCutPCMCalo("30110013","0dm00009ab770c00amd0404000","411790105ke30220000","0r63103100000010"); // 00-05%
+    cuts.AddCutPCMCalo("31210013","0dm00009ab770c00amd0404000","411790105ke30220000","0r63103100000010"); // 05-10%
   } else if (trainConfig == 784){ // EMCAL+DCal clusters - semi-central without TM
-    cuts.AddCutPCMCalo("11210013","0dm00009ab770c00amd0404000","4117901050e30220000","0r63103100000010"); // 10-20%
-    cuts.AddCutPCMCalo("12310013","0dm00009ab770c00amd0404000","4117901050e30220000","0r63103100000010"); // 20-30%
-    cuts.AddCutPCMCalo("13410013","0dm00009ab770c00amd0404000","4117901050e30220000","0r63103100000010"); // 30-40%
+    cuts.AddCutPCMCalo("11210013","0dm00009ab770c00amd0404000","411790105ke30220000","0r63103100000010"); // 10-20%
+    cuts.AddCutPCMCalo("12310013","0dm00009ab770c00amd0404000","411790105ke30220000","0r63103100000010"); // 20-30%
+    cuts.AddCutPCMCalo("13410013","0dm00009ab770c00amd0404000","411790105ke30220000","0r63103100000010"); // 30-40%
   } else if (trainConfig == 785){ // EMCAL+DCal clusters - semi peripheral without TM
-    cuts.AddCutPCMCalo("14510013","0dm00009ab770c00amd0404000","4117901050e30220000","0r63103100000010"); // 40-50%
-    cuts.AddCutPCMCalo("15610013","0dm00009ab770c00amd0404000","4117901050e30220000","0r63103100000010"); // 50-60%
+    cuts.AddCutPCMCalo("14510013","0dm00009ab770c00amd0404000","411790105ke30220000","0r63103100000010"); // 40-50%
+    cuts.AddCutPCMCalo("15610013","0dm00009ab770c00amd0404000","411790105ke30220000","0r63103100000010"); // 50-60%
   } else if (trainConfig == 786){ // EMCAL+DCal clusters - peripheral without TM
-    cuts.AddCutPCMCalo("16710013","0dm00009ab770c00amd0404000","4117901050e30220000","0r63103100000010"); // 60-70%
-    cuts.AddCutPCMCalo("17810013","0dm00009ab770c00amd0404000","4117901050e30220000","0r63103100000010"); // 70-80%
-    cuts.AddCutPCMCalo("18910013","0dm00009ab770c00amd0404000","4117901050e30220000","0r63103100000010"); // 80-90%
+    cuts.AddCutPCMCalo("16710013","0dm00009ab770c00amd0404000","411790105ke30220000","0r63103100000010"); // 60-70%
+    cuts.AddCutPCMCalo("17810013","0dm00009ab770c00amd0404000","411790105ke30220000","0r63103100000010"); // 70-80%
+    cuts.AddCutPCMCalo("18910013","0dm00009ab770c00amd0404000","411790105ke30220000","0r63103100000010"); // 80-90%
 
   // **********************************************************************************************************
   // ***************************** PCM-PHOS       QA configurations PbPb run 2 2018 ***************************
@@ -1322,16 +1322,16 @@ void AddTask_GammaConvCalo_PbPb(
   // 0 - 10 %
   } else if (trainConfig == 1051){ // EMCAL clusters - 00-10 triggered with neutral overlap correction via N matched tracks per cluster
     cuts.AddCutPCMCalo("10130e03","0dm00009ab770c00amd0404000","411790105te30220000","0133103100000010"); //  0-10%
-  } else if (trainConfig == 1052){ // EMCAL clusters - 00-10 triggered - w/o track matching
-    cuts.AddCutPCMCalo("10130e03","0dm00009ab770c00amd0404000","4117901050e30220000","0133103100000010"); //  0-10%
+  } else if (trainConfig == 1052){ // EMCAL clusters - 00-10 triggered -standard PbPb TM for secondaries
+    cuts.AddCutPCMCalo("10130e03","0dm00009ab770c00amd0404000","411790105ke30220000","0133103100000010"); //  0-10%
   } else if (trainConfig == 1053){ // EMCAL clusters - 00-10 triggered without OOB pile up correction for MC with neutral overlap correction via N matched tracks per cluster
     cuts.AddCutPCMCalo("10130053","0dm00009ab770c00amd0404000","411790105te30220000","0133103100000010"); //  0-10%
-  } else if (trainConfig == 1054){ // EMCAL clusters - 00-10 triggered without OOB pile up correction for MC - w/o track matching
-    cuts.AddCutPCMCalo("10130053","0dm00009ab770c00amd0404000","4117901050e30220000","0133103100000010"); //  0-10%
+  } else if (trainConfig == 1054){ // EMCAL clusters - 00-10 triggered without OOB pile up correction for MC -standard PbPb TM for secondaries
+    cuts.AddCutPCMCalo("10130053","0dm00009ab770c00amd0404000","411790105ke30220000","0133103100000010"); //  0-10%
   } else if (trainConfig == 1055){ // EMCAL clusters - 00-10 triggered without OOB pile up correction for MC with added Signal! with neutral overlap correction via N matched tracks per cluster
     cuts.AddCutPCMCalo("10130023","0dm00009ab770c00amd0404000","411790105te30220000","0133103100000010"); //  0-10%
-  } else if (trainConfig == 1056){ // EMCAL clusters - 00-10 triggered without OOB pile up correction for MC with added Signal! - w/o track matching
-    cuts.AddCutPCMCalo("10130023","0dm00009ab770c00amd0404000","4117901050e30220000","0133103100000010"); //  0-10%
+  } else if (trainConfig == 1056){ // EMCAL clusters - 00-10 triggered without OOB pile up correction for MC with added Signal! -standard PbPb TM for secondaries
+    cuts.AddCutPCMCalo("10130023","0dm00009ab770c00amd0404000","411790105ke30220000","0133103100000010"); //  0-10%
   } else if (trainConfig == 1057){ // EMCAL clusters - 00-10 triggered with neutral overlap correction NonLin like
     cuts.AddCutPCMCalo("10130e03","0dm00009ab770c00amd0404000","411790105we30220000","0133103100000010"); //  0-10%
   } else if (trainConfig == 1058){ // EMCAL clusters - 00-10 triggered without OOB pile up correction for MC with added Signal! with neutral overlap correction NonLin like
@@ -1348,16 +1348,16 @@ void AddTask_GammaConvCalo_PbPb(
   // 10 - 30 %
   } else if (trainConfig == 3051){ // EMCAL clusters - 10-30 with neutral overlap correction via N matched tracks per cluster
     cuts.AddCutPCMCalo("11310e03","0dm00009ab770c00amd0404000","411790105te30220000","0133103100000010"); // 10-30%
-  } else if (trainConfig == 3052){ // EMCAL clusters - 10-30 - w/o track matching
-    cuts.AddCutPCMCalo("11310e03","0dm00009ab770c00amd0404000","4117901050e30220000","0133103100000010"); // 10-30%
+  } else if (trainConfig == 3052){ // EMCAL clusters - 10-30 -standard PbPb TM for secondaries
+    cuts.AddCutPCMCalo("11310e03","0dm00009ab770c00amd0404000","411790105ke30220000","0133103100000010"); // 10-30%
   } else if (trainConfig == 3053){ // EMCAL clusters - 10-30 without OOB pile up correction for MC with neutral overlap correction via N matched tracks per cluster
     cuts.AddCutPCMCalo("11310053","0dm00009ab770c00amd0404000","411790105te30220000","0133103100000010"); // 10-30%
-  } else if (trainConfig == 3054){ // EMCAL clusters - 10-30 without OOB pile up correction for MC - w/o track matching
-    cuts.AddCutPCMCalo("11310053","0dm00009ab770c00amd0404000","4117901050e30220000","0133103100000010"); // 10-30%
+  } else if (trainConfig == 3054){ // EMCAL clusters - 10-30 without OOB pile up correction for MC -standard PbPb TM for secondaries
+    cuts.AddCutPCMCalo("11310053","0dm00009ab770c00amd0404000","411790105ke30220000","0133103100000010"); // 10-30%
   } else if (trainConfig == 3055){ // EMCAL clusters - 10-30 without OOB pile up correction for MC with added Signal! with neutral overlap correction via N matched tracks per cluster
     cuts.AddCutPCMCalo("11310023","0dm00009ab770c00amd0404000","411790105te30220000","0133103100000010"); // 10-30%
-  } else if (trainConfig == 3056){ // EMCAL clusters - 10-30 without OOB pile up correction for MC with added Signal! - w/o track matching
-    cuts.AddCutPCMCalo("11310023","0dm00009ab770c00amd0404000","4117901050e30220000","0133103100000010"); // 10-30%
+  } else if (trainConfig == 3056){ // EMCAL clusters - 10-30 without OOB pile up correction for MC with added Signal! -standard PbPb TM for secondaries
+    cuts.AddCutPCMCalo("11310023","0dm00009ab770c00amd0404000","411790105ke30220000","0133103100000010"); // 10-30%
   } else if (trainConfig == 3057){ // EMCAL clusters - 10-30 with neutral overlap correction NonLin like
     cuts.AddCutPCMCalo("11310e03","0dm00009ab770c00amd0404000","411790105we30220000","0133103100000010"); // 10-30%
   } else if (trainConfig == 3058){ // EMCAL clusters - 10-30 without OOB pile up correction for MC with added Signal! with neutral overlap correction NonLin like
@@ -1374,16 +1374,16 @@ void AddTask_GammaConvCalo_PbPb(
   // 30 - 50%
   } else if (trainConfig == 5051){ // EMCAL clusters - 30-50 triggered with neutral overlap correction via N matched tracks per cluster
     cuts.AddCutPCMCalo("13530e03","0dm00009ab770c00amd0404000","411790105te30220000","0133103100000010"); // 30-50%
-  } else if (trainConfig == 5052){ // EMCAL clusters - 30-50 triggered - w/o track matching
-    cuts.AddCutPCMCalo("13530e03","0dm00009ab770c00amd0404000","4117901050e30220000","0133103100000010"); // 30-50%
+  } else if (trainConfig == 5052){ // EMCAL clusters - 30-50 triggered -standard PbPb TM for secondaries
+    cuts.AddCutPCMCalo("13530e03","0dm00009ab770c00amd0404000","411790105ke30220000","0133103100000010"); // 30-50%
   } else if (trainConfig == 5053){ // EMCAL clusters - 30-50 triggered without OOB pile up correction for MC with neutral overlap correction via N matched tracks per cluster
     cuts.AddCutPCMCalo("13530053","0dm00009ab770c00amd0404000","411790105te30220000","0133103100000010"); // 30-50%
-  } else if (trainConfig == 5054){ // EMCAL clusters - 30-50 triggered without OOB pile up correction for MC - w/o track matching
-    cuts.AddCutPCMCalo("13530053","0dm00009ab770c00amd0404000","4117901050e30220000","0133103100000010"); // 30-50%
+  } else if (trainConfig == 5054){ // EMCAL clusters - 30-50 triggered without OOB pile up correction for MC -standard PbPb TM for secondaries
+    cuts.AddCutPCMCalo("13530053","0dm00009ab770c00amd0404000","411790105ke30220000","0133103100000010"); // 30-50%
   } else if (trainConfig == 5055){ // EMCAL clusters - 30-50 triggered without OOB pile up correction for MC with added Signal! with neutral overlap correction via N matched tracks per cluster
     cuts.AddCutPCMCalo("13530023","0dm00009ab770c00amd0404000","411790105te30220000","0133103100000010"); // 30-50%
-  } else if (trainConfig == 5056){ // EMCAL clusters - 30-50 triggered without OOB pile up correction for MC with added Signal! - w/o track matching
-    cuts.AddCutPCMCalo("13530023","0dm00009ab770c00amd0404000","4117901050e30220000","0133103100000010"); // 30-50%
+  } else if (trainConfig == 5056){ // EMCAL clusters - 30-50 triggered without OOB pile up correction for MC with added Signal! -standard PbPb TM for secondaries
+    cuts.AddCutPCMCalo("13530023","0dm00009ab770c00amd0404000","411790105ke30220000","0133103100000010"); // 30-50%
   } else if (trainConfig == 5057){ // EMCAL clusters - 30-50 triggered with neutral overlap correction NonLin like
     cuts.AddCutPCMCalo("13530e03","0dm00009ab770c00amd0404000","411790105we30220000","0133103100000010"); // 30-50%
   } else if (trainConfig == 5058){ // EMCAL clusters - 30-50 triggered without OOB pile up correction for MC with added Signal! with neutral overlap correction NonLin like
@@ -1400,16 +1400,16 @@ void AddTask_GammaConvCalo_PbPb(
   // 50-90%
   } else if (trainConfig == 9051){ // EMCAL clusters - 50-90 with neutral overlap correction via N matched tracks per cluster
     cuts.AddCutPCMCalo("15910e03","0dm00009ab770c00amd0404000","411790105te30220000","0133103100000010"); // 50-90%
-  } else if (trainConfig == 9052){ // EMCAL clusters - 50-90 - w/o track matching
-    cuts.AddCutPCMCalo("15910e03","0dm00009ab770c00amd0404000","4117901050e30220000","0133103100000010"); // 50-90%
+  } else if (trainConfig == 9052){ // EMCAL clusters - 50-90 -standard PbPb TM for secondaries
+    cuts.AddCutPCMCalo("15910e03","0dm00009ab770c00amd0404000","411790105ke30220000","0133103100000010"); // 50-90%
   } else if (trainConfig == 9053){ // EMCAL clusters - 50-90 without OOB pile up correction for MC with neutral overlap correction via N matched tracks per cluster
     cuts.AddCutPCMCalo("15910053","0dm00009ab770c00amd0404000","411790105te30220000","0133103100000010"); // 50-90%
-  } else if (trainConfig == 9054){ // EMCAL clusters - 50-90 without OOB pile up correction for MC - w/o track matching
-    cuts.AddCutPCMCalo("15910053","0dm00009ab770c00amd0404000","4117901050e30220000","0133103100000010"); // 50-90%
+  } else if (trainConfig == 9054){ // EMCAL clusters - 50-90 without OOB pile up correction for MC -standard PbPb TM for secondaries
+    cuts.AddCutPCMCalo("15910053","0dm00009ab770c00amd0404000","411790105ke30220000","0133103100000010"); // 50-90%
   } else if (trainConfig == 9055){ // EMCAL clusters - 50-90 without OOB pile up correction for MC with added Signal! with neutral overlap correction via N matched tracks per cluster
     cuts.AddCutPCMCalo("15910023","0dm00009ab770c00amd0404000","411790105te30220000","0133103100000010"); // 50-90%
-  } else if (trainConfig == 9056){ // EMCAL clusters - 50-90 without OOB pile up correction for MC with added Signal! - w/o track matching
-    cuts.AddCutPCMCalo("15910023","0dm00009ab770c00amd0404000","4117901050e30220000","0133103100000010"); // 50-90%
+  } else if (trainConfig == 9056){ // EMCAL clusters - 50-90 without OOB pile up correction for MC with added Signal! -standard PbPb TM for secondaries
+    cuts.AddCutPCMCalo("15910023","0dm00009ab770c00amd0404000","411790105ke30220000","0133103100000010"); // 50-90%
   } else if (trainConfig == 9057){ // EMCAL clusters - 50-90 with neutral overlap correction NonLin like
     cuts.AddCutPCMCalo("15910e03","0dm00009ab770c00amd0404000","411790105we30220000","0133103100000010"); // 50-90%
   } else if (trainConfig == 9058){ // EMCAL clusters - 50-90 without OOB pile up correction for MC with added Signal! with neutral overlap correction NonLin like

--- a/PWGGA/GammaConvBase/AliCaloPhotonCuts.cxx
+++ b/PWGGA/GammaConvBase/AliCaloPhotonCuts.cxx
@@ -5964,21 +5964,18 @@ Bool_t AliCaloPhotonCuts::SetTrackMatchingCut(Int_t trackMatching)
       break;
     case 18: //i TM cut for PbPb EMC clusters - tight
       if (!fUseDistTrackToCluster) fUseDistTrackToCluster=kTRUE;
-      if (!fUseTMMIPsubtraction) fUseTMMIPsubtraction=kTRUE;
       fMaxDistTrackToClusterEta = 0.010;
       fMinDistTrackToClusterPhi = -0.011;
       fMaxDistTrackToClusterPhi = 0.011;
       break;
     case 19: //j TM cut for PbPb EMC clusters - loose
       if (!fUseDistTrackToCluster) fUseDistTrackToCluster=kTRUE;
-      if (!fUseTMMIPsubtraction) fUseTMMIPsubtraction=kTRUE;
       fMaxDistTrackToClusterEta = 0.015;
       fMinDistTrackToClusterPhi = -0.02;
       fMaxDistTrackToClusterPhi = 0.02;
       break;
     case 20: //k TM cut for PbPb EMC clusters
       if (!fUseDistTrackToCluster) fUseDistTrackToCluster=kTRUE;
-      if (!fUseTMMIPsubtraction) fUseTMMIPsubtraction=kTRUE;
       fUsePtDepTrackToCluster = 1;
       fFuncPtDepEta = new TF1("funcEta20", "[1] + 1 / pow(x + pow(1 / ([0] - [1]), 1 / [2]), [2])");
       fFuncPtDepEta->SetParameters(0.04, 0.010, 2.5);


### PR DESCRIPTION
- we need this change since we use the TM Cut also for secondaries

IMPORTANT: This will remove MIPSubtraction from the CaloPhotonCuts where it should not be used from anymore. MIPSubtraction should be used via the yaml config file for the EMCal Correction task.