### PR TITLE
Changing inheritance of AliFemtoPairCutMInv class

### DIFF
--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoPairCutMInv.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoPairCutMInv.cxx
@@ -19,7 +19,7 @@ ClassImp(AliFemtoPairCutMInv)
 
 //__________________
 AliFemtoPairCutMInv::AliFemtoPairCutMInv():
-  AliFemtoPairCut(),
+  AliFemtoPairCutRadialDistance(),
   fNPairsFailed(0),
   fNPairsPassed(0),
   fMInvMin(0),
@@ -31,7 +31,7 @@ AliFemtoPairCutMInv::AliFemtoPairCutMInv():
 }
 //__________________
 AliFemtoPairCutMInv::AliFemtoPairCutMInv(double m1, double m2, double minvmin, double minvmax):
-  AliFemtoPairCut(),
+  AliFemtoPairCutRadialDistance(),
   fNPairsFailed(0),
   fNPairsPassed(0),
   fMInvMin(minvmin),
@@ -42,7 +42,7 @@ AliFemtoPairCutMInv::AliFemtoPairCutMInv(double m1, double m2, double minvmin, d
 }
 //__________________
 AliFemtoPairCutMInv::AliFemtoPairCutMInv(const AliFemtoPairCutMInv& c) : 
-  AliFemtoPairCut(c),
+  AliFemtoPairCutRadialDistance(c),
   fNPairsFailed(0),
   fNPairsPassed(0),
   fMInvMin(0),

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoPairCutMInv.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoPairCutMInv.h
@@ -12,9 +12,9 @@
 #ifndef ALIFEMTOPAIRCUTMINV_H
 #define ALIFEMTOPAIRCUTMINV_H
 
-#include "AliFemtoPairCut.h"
+#include "AliFemtoPairCutRadialDistance.h"
 
-class AliFemtoPairCutMInv : public AliFemtoPairCut{
+class AliFemtoPairCutMInv : public AliFemtoPairCutRadialDistance{
 public:
   AliFemtoPairCutMInv();
   AliFemtoPairCutMInv(double m1, double m2, double minvmin, double minvmax);
@@ -25,7 +25,7 @@ public:
   virtual bool Pass(const AliFemtoPair* pair);
   virtual AliFemtoString Report();
   virtual TList *ListSettings();
-  AliFemtoPairCut* Clone() const;
+  AliFemtoPairCutMInv* Clone() const;
 
  protected:
   Double_t fNPairsFailed;
@@ -40,7 +40,7 @@ public:
 #endif
 };
 
-inline AliFemtoPairCut* AliFemtoPairCutMInv::Clone() const
+inline AliFemtoPairCutMInv* AliFemtoPairCutMInv::Clone() const
   { AliFemtoPairCutMInv* c = new AliFemtoPairCutMInv(*this); return c;}
 
 #endif


### PR DESCRIPTION
The inheritance of AliFemtoPairCutMInv class is changed inorder to perform the rejection of phi meson resonance candidates using invariance mass cut.