### PR TITLE
PWGGA/GammaConv: EMC MC timing cut + new NOC

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.h
@@ -214,6 +214,7 @@ class AliAnalysisTaskGammaCalo : public AliAnalysisTaskSE {
     TH1F***               fHistoClusGammaE_DDL_woL0_TrigEv_TrBM;                //! array of histos with cluster, E, only clusters on Triggered Bad map
     TH1I**                fHistoGoodMesonClusters;                              //! Histograms which stores if Pi0 Clusters Trigger
     TH1F**                fHistoClusOverlapHeadersGammaPt;                      //! array of histos with cluster, pt overlapping with other headers
+    TH1F**                fHistoClusOverlapMBHeaderGammaPt;                     //! array of histos with cluster, pt overlapping with MB header
     TH1F**                fHistoClusAllHeadersGammaPt;                          //! array of histos with cluster, pt all headers
     TH1F**                fHistoClusRejectedHeadersGammaPt;                     //! array of histos with cluster, pt rejected with other headers
     TH2F**                fHistoClusGammaPtM02;                                 //! array of histos with cluster M02 vs. pt
@@ -498,6 +499,7 @@ class AliAnalysisTaskGammaCalo : public AliAnalysisTaskSE {
     Int_t                 fDoClusterQA;                                         // flag for cluster QA
     Bool_t                fIsFromDesiredHeader;                                 // flag for MC headers
     Bool_t                fIsOverlappingWithOtherHeader;                        // flag for particles in MC overlapping between headers
+    Bool_t                fIsOverlapWithMBHeader;                               // flag for particles overlapping with MB header when MB header is one of the selected headers
     Int_t                 fIsMC;                                                // flag for MC information
     Bool_t                fDoTHnSparse;                                         // flag for using THnSparses for background estimation
     Bool_t                fSetPlotHistsExtQA;                                   // flag for extended QA hists
@@ -529,7 +531,7 @@ class AliAnalysisTaskGammaCalo : public AliAnalysisTaskSE {
     AliAnalysisTaskGammaCalo(const AliAnalysisTaskGammaCalo&);                  // Prevent copy-construction
     AliAnalysisTaskGammaCalo &operator=(const AliAnalysisTaskGammaCalo&);       // Prevent assignment
 
-    ClassDef(AliAnalysisTaskGammaCalo, 96);
+    ClassDef(AliAnalysisTaskGammaCalo, 97);
 };
 
 #endif

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvCalo.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvCalo.h
@@ -261,8 +261,9 @@ class AliAnalysisTaskGammaConvCalo : public AliAnalysisTaskSE {
     TH1F**                  fHistoClusGammaE_BothBM_highestE;   //! array of histos with cluster, E; Only highest cluster in event, which is good on triggered bad map and analysis bad map;  MB and tigger but use only triggered clusters for trigger
     TH1F**                  fHistoClusGammaE_AnaBM_highestE;    //! array of histos with cluster, E; Only highest cluster in event, which is good on analysis bad map; Only MB
     TH1F**                  fHistoClusGammaE_onlyTriggered;     //! array of histos with cluster, E
-    TH1I**                  fHistoGoodMesonClusters;              //! Histograms which stores if Pi0 Clusters Trigger
+    TH1I**                  fHistoGoodMesonClusters;            //! Histograms which stores if Pi0 Clusters Trigger
     TH1F**                  fHistoClusOverlapHeadersGammaPt;    //! array of histos with cluster, pt overlapping with other headers
+    TH1F**                  fHistoClusOverlapMBHeaderGammaPt;   //! array of histos with cluster, pt overlapping with MB header
     TH1F**                  fHistoClusAllHeadersGammaPt;        //! array of histos with cluster, pt all headers
     TH1F**                  fHistoClusRejectedHeadersGammaPt;   //! array of histos with cluster, pt rejected headers
 
@@ -523,6 +524,7 @@ class AliAnalysisTaskGammaConvCalo : public AliAnalysisTaskSE {
     Int_t                   fDoClusterQA;                                       // flag for cluster QA
     Bool_t                  fIsFromDesiredHeader;                               //! flag for MC headers
     Bool_t                  fIsOverlappingWithOtherHeader;                      //! flag for particles in MC overlapping between headers
+    Bool_t                  fIsOverlapWithMBHeader;                             //! flag for particles overlapping with MB header when MB header is one of the selected headers
     Int_t                   fIsMC;                                              // flag for MC information
     Bool_t                  fDoTHnSparse;                                       // flag for using THnSparses for background estimation
     Bool_t                  fSetPlotHistsExtQA;                                 // flag for extended QA hists
@@ -542,7 +544,7 @@ class AliAnalysisTaskGammaConvCalo : public AliAnalysisTaskSE {
     AliAnalysisTaskGammaConvCalo(const AliAnalysisTaskGammaConvCalo&); // Prevent copy-construction
     AliAnalysisTaskGammaConvCalo &operator=(const AliAnalysisTaskGammaConvCalo&); // Prevent assignment
 
-    ClassDef(AliAnalysisTaskGammaConvCalo, 75);
+    ClassDef(AliAnalysisTaskGammaConvCalo, 76);
 };
 
 #endif

--- a/PWGGA/GammaConv/macros/AddTask_GammaCalo_PbPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaCalo_PbPb.C
@@ -1871,38 +1871,85 @@ void AddTask_GammaCalo_PbPb(
       fillSingle(8);
       fillFromTo(10, 19);
     }
-    else if (headerSelectionInt == 28) {                                  // PCM + all EMCal + HIJING + PileUp Pi0 + Eta
+    else if (headerSelectionInt == 28) {                                  // PCM + PileUp Pi0 + Eta
+      fillSingle(1);
+      fillSingle(6);
+      fillSingle(8);
+      fillSingle(9);
+    }
+    else if (headerSelectionInt == 29) {                                  // PCM + all EMCal + HIJING + PileUp Pi0 + Eta
       fillSingle(1);
       fillSingle(6);
       fillFromTo(8, 19);
     }
-    else if (headerSelectionInt == 29) {                                  // PCM + all EMCal Pi0
+    else if (headerSelectionInt == 30) {                                  // all EMCal Pi0
+      fillFromTo(10, 14);
+    }
+    else if (headerSelectionInt == 31) {                                  // all EMCal + HIJING Pi0
+      fillSingle(8);
+      fillFromTo(10, 14);
+    }
+    else if (headerSelectionInt == 32) {                                  // all EMCal + HIJING + PileUp Pi0
+      fillFromTo(8, 14);
+    }
+    else if (headerSelectionInt == 33) {                                  // PCM + all EMCal Pi0
       fillSingle(1);
       fillFromTo(10, 14);
     }
-    else if (headerSelectionInt == 30) {                                  // PCM + all EMCal + HIJING Pi0
+    else if (headerSelectionInt == 34) {                                  // PCM + all EMCal + HIJING Pi0
       fillSingle(1);
       fillSingle(8);
       fillFromTo(10, 14);
     }
-    else if (headerSelectionInt == 31) {                                  // PCM + all EMCal + HIJING + PileUp Pi0
+    else if (headerSelectionInt == 35) {                                  // PCM + all EMCal + HIJING + PileUp Pi0
       fillSingle(1);
       fillFromTo(8, 14);
     }
-    else if (headerSelectionInt == 32) {                                  // PCM + all EMCal Eta
+    else if (headerSelectionInt == 36) {                                  // PCM + HIJING + PileUp Pi0
+      fillSingle(1);
+      fillSingle(8);
+      fillSingle(9);
+    }
+    else if (headerSelectionInt == 37) {                                  // PCM + HIJING Pi0
+      fillSingle(1);
+      fillSingle(8);
+      fillSingle(9);
+    }
+    else if (headerSelectionInt == 38) {                                  // all EMCal Eta
+      fillFromTo(15, 19);
+    }
+    else if (headerSelectionInt == 39) {                                  // all EMCal + HIJING Eta
+      fillSingle(8);
+      fillFromTo(15, 19);
+    }
+    else if (headerSelectionInt == 40) {                                  // all EMCal + HIJING + PileUp Eta
+      fillSingle(8);
+      fillSingle(9);
+      fillFromTo(15, 14);
+    }
+    else if (headerSelectionInt == 41) {                                  // PCM + all EMCal Eta
       fillSingle(6);
       fillFromTo(15, 19);
     }
-    else if (headerSelectionInt == 33) {                                  // PCM + all EMCal + HIJING Eta
+    else if (headerSelectionInt == 42) {                                  // PCM + all EMCal + HIJING Eta
       fillSingle(6);
       fillSingle(8);
       fillFromTo(15, 19);
     }
-    else if (headerSelectionInt == 34) {                                  // PCM + all EMCal + HIJING + PileUp Eta
+    else if (headerSelectionInt == 43) {                                  // PCM + all EMCal + HIJING + PileUp Eta
       fillSingle(6);
       fillSingle(8);
       fillSingle(9);
       fillFromTo(15, 19);
+    }
+    else if (headerSelectionInt == 44) {                                  // PCM + HIJING + PileUp Eta
+      fillSingle(6);
+      fillSingle(8);
+      fillSingle(9);
+    }
+    else if (headerSelectionInt == 45) {                                  // PCM + HIJING Eta
+      fillSingle(6);
+      fillSingle(8);
     }
     else {
       Error(Form("%s_%i", addTaskName.Data(),  trainConfig), "No valid header selection");

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_PbPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_PbPb.C
@@ -1586,7 +1586,6 @@ void AddTask_GammaConvCalo_PbPb(
     } 
     else if (headerSelectionInt == 24) { fillFromTo(10, 19); }            // all EMCal
     else if (headerSelectionInt == 25) { fillFromTo(1, 19); }             // all
-    else if (headerSelectionInt == 25) { fillFromTo(1, 19); }             // all
     else if (headerSelectionInt == 26) {                                  // PCM + all EMCal Pi0 + Eta
       fillSingle(1);
       fillSingle(6);
@@ -1598,38 +1597,85 @@ void AddTask_GammaConvCalo_PbPb(
       fillSingle(8);
       fillFromTo(10, 19);
     }
-    else if (headerSelectionInt == 28) {                                  // PCM + all EMCal + HIJING + PileUp Pi0 + Eta
+    else if (headerSelectionInt == 28) {                                  // PCM + PileUp Pi0 + Eta
+      fillSingle(1);
+      fillSingle(6);
+      fillSingle(8);
+      fillSingle(9);
+    }
+    else if (headerSelectionInt == 29) {                                  // PCM + all EMCal + HIJING + PileUp Pi0 + Eta
       fillSingle(1);
       fillSingle(6);
       fillFromTo(8, 19);
     }
-    else if (headerSelectionInt == 29) {                                  // PCM + all EMCal Pi0
+    else if (headerSelectionInt == 30) {                                  // all EMCal Pi0
+      fillFromTo(10, 14);
+    }
+    else if (headerSelectionInt == 31) {                                  // all EMCal + HIJING Pi0
+      fillSingle(8);
+      fillFromTo(10, 14);
+    }
+    else if (headerSelectionInt == 32) {                                  // all EMCal + HIJING + PileUp Pi0
+      fillFromTo(8, 14);
+    }
+    else if (headerSelectionInt == 33) {                                  // PCM + all EMCal Pi0
       fillSingle(1);
       fillFromTo(10, 14);
     }
-    else if (headerSelectionInt == 30) {                                  // PCM + all EMCal + HIJING Pi0
+    else if (headerSelectionInt == 34) {                                  // PCM + all EMCal + HIJING Pi0
       fillSingle(1);
       fillSingle(8);
       fillFromTo(10, 14);
     }
-    else if (headerSelectionInt == 31) {                                  // PCM + all EMCal + HIJING + PileUp Pi0
+    else if (headerSelectionInt == 35) {                                  // PCM + all EMCal + HIJING + PileUp Pi0
       fillSingle(1);
       fillFromTo(8, 14);
     }
-    else if (headerSelectionInt == 32) {                                  // PCM + all EMCal Eta
+    else if (headerSelectionInt == 36) {                                  // PCM + HIJING + PileUp Pi0
+      fillSingle(1);
+      fillSingle(8);
+      fillSingle(9);
+    }
+    else if (headerSelectionInt == 37) {                                  // PCM + HIJING Pi0
+      fillSingle(1);
+      fillSingle(8);
+      fillSingle(9);
+    }
+    else if (headerSelectionInt == 38) {                                  // all EMCal Eta
+      fillFromTo(15, 19);
+    }
+    else if (headerSelectionInt == 39) {                                  // all EMCal + HIJING Eta
+      fillSingle(8);
+      fillFromTo(15, 19);
+    }
+    else if (headerSelectionInt == 40) {                                  // all EMCal + HIJING + PileUp Eta
+      fillSingle(8);
+      fillSingle(9);
+      fillFromTo(15, 14);
+    }
+    else if (headerSelectionInt == 41) {                                  // PCM + all EMCal Eta
       fillSingle(6);
       fillFromTo(15, 19);
     }
-    else if (headerSelectionInt == 33) {                                  // PCM + all EMCal + HIJING Eta
+    else if (headerSelectionInt == 42) {                                  // PCM + all EMCal + HIJING Eta
       fillSingle(6);
       fillSingle(8);
       fillFromTo(15, 19);
     }
-    else if (headerSelectionInt == 34) {                                  // PCM + all EMCal + HIJING + PileUp Eta
+    else if (headerSelectionInt == 43) {                                  // PCM + all EMCal + HIJING + PileUp Eta
       fillSingle(6);
       fillSingle(8);
       fillSingle(9);
       fillFromTo(15, 19);
+    }
+    else if (headerSelectionInt == 44) {                                  // PCM + HIJING + PileUp Eta
+      fillSingle(6);
+      fillSingle(8);
+      fillSingle(9);
+    }
+    else if (headerSelectionInt == 45) {                                  // PCM + HIJING Eta
+      fillSingle(6);
+      fillSingle(8);
     }
     else {
       Error(Form("%s_%i", addTaskName.Data(),  trainConfig), "No valid header selection");

--- a/PWGGA/GammaConvBase/AliCaloPhotonCuts.cxx
+++ b/PWGGA/GammaConvBase/AliCaloPhotonCuts.cxx
@@ -146,7 +146,9 @@ AliCaloPhotonCuts::AliCaloPhotonCuts(Int_t isMC, const char *name,const char *ti
   fMinTimeDiff(-10e10),
   fMaxTimeDiffHighPt(10e10),
   fMinTimeDiffHighPt(-10e10),
+  fOffsetTimeMC(0),
   fUseTimeDiff(0),
+  fUseTimeDiffMC(0),
   fMaxDistTrackToClusterEta(0),
   fMinDistTrackToClusterPhi(0),
   fMaxDistTrackToClusterPhi(0),
@@ -401,7 +403,9 @@ AliCaloPhotonCuts::AliCaloPhotonCuts(const AliCaloPhotonCuts &ref) :
   fMinTimeDiff(ref.fMinTimeDiff),
   fMaxTimeDiffHighPt(ref.fMaxTimeDiffHighPt),
   fMinTimeDiffHighPt(ref.fMinTimeDiffHighPt),
+  fOffsetTimeMC(ref.fOffsetTimeMC),
   fUseTimeDiff(ref.fUseTimeDiff),
+  fUseTimeDiffMC(ref.fUseTimeDiffMC),
   fMaxDistTrackToClusterEta(ref.fMaxDistTrackToClusterEta),
   fMinDistTrackToClusterPhi(ref.fMinDistTrackToClusterPhi),
   fMaxDistTrackToClusterPhi(ref.fMaxDistTrackToClusterPhi),
@@ -2509,6 +2513,12 @@ Bool_t AliCaloPhotonCuts::ClusterQualityCuts(AliVCluster* cluster, AliVEvent *ev
         if(fHistClusterIdentificationCuts)fHistClusterIdentificationCuts->Fill(cutIndex, cluster->E(), weight);//1
         return kFALSE;
       }
+    }
+  }
+  if(fUseTimeDiffMC){
+    if( ( (cluster->GetTOF() - fOffsetTimeMC) < fMinTimeDiff || (cluster->GetTOF() - fOffsetTimeMC) > fMaxTimeDiff) && (isMC>0)){
+      if(fHistClusterIdentificationCuts) fHistClusterIdentificationCuts->Fill(cutIndex, cluster->E(), weight);//1
+      return kFALSE;
     }
   }
   cutIndex++;//2, next cut
@@ -5480,6 +5490,22 @@ Bool_t AliCaloPhotonCuts::SetDistanceToBadChannelCut(Int_t distanceToBadChannel)
 //___________________________________________________________________
 Bool_t AliCaloPhotonCuts::SetTimingCut(Int_t timing)
 {
+  // special case for LHC18qr HIJING MC where we need correction as well:
+  if(fCurrentMC==kNoMC){
+    AliV0ReaderV1* V0Reader = (AliV0ReaderV1*) AliAnalysisManager::GetAnalysisManager()->GetTask(fV0ReaderName.Data());
+    if( V0Reader == NULL ){
+      AliFatal(Form("No V0Reader called '%s' could be found within AliCaloPhotonCuts::ApplyNonLinearity",fV0ReaderName.Data()));
+      return kFALSE;
+    }
+    fPeriodName = V0Reader->GetPeriodName();
+    fCurrentMC = FindEnumForMCSet(fPeriodName);
+
+    printf("AliCaloPhotonCuts:Period name has been set to %s, period-enum: %o\n",fPeriodName.Data(),fCurrentMC ) ;
+  }
+  if(fCurrentMC == kPbPb5T18HIJING){
+    fOffsetTimeMC = 61.6e-8;
+    if (!fUseTimeDiffMC) fUseTimeDiffMC=1;
+  }
   switch(timing){
   case 0:
     fUseTimeDiff=0;
@@ -10816,6 +10842,38 @@ Bool_t AliCaloPhotonCuts::SetNMatchedTracksFunc(float meanCent){
   return true;
 }
 
+// Sigmoid function to smooth out two different epxonential functions for the neutral overlap correction
+Double_t AliCaloPhotonCuts::Sigmoid(Double_t x, Double_t a, Double_t b, Double_t c) {
+    // Sigmoid function: a + b / (1 + exp(-c * x))
+    return a + b / (1 + TMath::Exp(-c * x));
+}
+
+// Function to describe the neutral overlap correction factor which is build of two exponential decays which transit around a minium by a sigmoid function
+Double_t AliCaloPhotonCuts::NOCFunction(Double_t x, Double_t start_y, Double_t a_drop, Double_t b_drop, Double_t c_drop, Double_t c_rise, Double_t transition_width) {
+    // Parameters:
+    // start_y = starting y value
+    // a_drop = amplitude of the drop
+    // b_drop = x value where the drop occurs
+    // c_drop = decay constant for the drop
+    // c_rise = decay constant for the rise
+    // transition_width = transition width
+
+    // Calculate the transition point
+    Double_t transition_point = b_drop;
+
+    // Calculate the drop and rise components
+    Double_t drop = start_y - a_drop * TMath::Exp(-c_drop * (x - b_drop));
+    Double_t rise = (start_y - drop) * TMath::Exp(-c_rise * (x - transition_point)) + drop;
+
+    // Calculate the sigmoid blending factor
+    Double_t sigmoid_factor = AliCaloPhotonCuts::Sigmoid(x - transition_point, 0.5, 0.5, 1.0 / transition_width);
+
+    // Blend between drop and rise using the sigmoid function
+    Double_t result = drop + sigmoid_factor * (rise - drop);
+
+    return result;
+}
+
 // Function to get the energy value to subtract from a cluster to account for
 // neutral overlap in PbPb 5 TeV
 Double_t AliCaloPhotonCuts::CorrectEnergyForOverlap(float meanCent, float E){
@@ -10829,6 +10887,44 @@ Double_t AliCaloPhotonCuts::CorrectEnergyForOverlap(float meanCent, float E){
     case 3:
       return 0.5 * fFuncNMatchedTracks->Eval(meanCent) * GetMeanEForOverlap(meanCent, fParamMeanTrackPt);
     case 4:
+      {
+        double val = 0;
+        if(meanCent < 10){
+          if(!fIsMC){
+            val = AliCaloPhotonCuts::NOCFunction(E, 9.17025e-01, 1.76666e-01, 2.77792e+00, 1.05948e+00, 3.12356e-01, 1.);
+            return (val > 1.) ? 1. : val;
+          }
+          else{
+            return 1; // MC not yet evaluated
+          }
+        } else if (meanCent < 30){
+          if(!fIsMC){
+            val = AliCaloPhotonCuts::NOCFunction(E, 9.60674e-01, 1.51515e-01, 2.67887e+00, 8.74107e-01, 3.12633e-01, 1.);
+            return (val > 1.) ? 1. : val;
+          }
+          else{
+            return 1; // MC not yet evaluated
+          }
+        } else if (meanCent < 50){
+          if(!fIsMC){
+            val = AliCaloPhotonCuts::NOCFunction(E, 9.82136e-01, 8.30071e-02, 2.25544e+00, 7.94315e-01, 3.58387e-01, 1.);
+            return (val > 1.) ? 1. : val;
+          }
+          else{
+            return 1; // MC not yet evaluated
+          }
+        } else {
+          if(!fIsMC){
+            val = AliCaloPhotonCuts::NOCFunction(E, 9.98134e-01, 5.38729e-02, 2.00466e+00, 6.65691e-01, 3.49447e-01, 1.);
+            return (val > 1.) ? 1. : val;
+          }
+          else{
+            return 1; // MC not yet evaluated
+          }
+        }
+        return 1.;
+      }
+    case 5: // old NonLin like approach
       {
         double temp = 0.0;
         double tempE = 0.0;

--- a/PWGGA/GammaConvBase/AliCaloPhotonCuts.h
+++ b/PWGGA/GammaConvBase/AliCaloPhotonCuts.h
@@ -410,6 +410,8 @@ class AliCaloPhotonCuts : public AliAnalysisCuts {
 
     Bool_t      SetPoissonParamCentFunction(int isMC);
     Bool_t      SetNMatchedTracksFunc(float meanCent);
+    Double_t    Sigmoid(Double_t x, Double_t a, Double_t b, Double_t c);
+    Double_t    NOCFunction(Double_t x, Double_t start_y, Double_t a_drop, Double_t b_drop, Double_t c_drop, Double_t c_rise, Double_t transition_width);        // Function which describes the Neutral Overlap Correction factor
     Double_t    CorrectEnergyForOverlap(float meanCent, float E = 0);
     Int_t       GetDoEnergyCorrectionForOverlap()               {return fDoEnergyCorrectionForOverlap;}
     Double_t    GetMeanEForOverlap(Double_t cent, Double_t* par);
@@ -543,7 +545,9 @@ class AliCaloPhotonCuts : public AliAnalysisCuts {
     Double_t  fMinTimeDiff;                             // minimum time difference to triggered collision
     Double_t  fMaxTimeDiffHighPt;                       // maximum time difference to triggered collision at high Pt
     Double_t  fMinTimeDiffHighPt;                       // minimum time difference to triggered collision at high Pt
+    Double_t  fOffsetTimeMC;                            // time offset difference to triggered collision in MC, seen in PbPb 5.02 TeV production
     Bool_t    fUseTimeDiff;                             // flag for switching on time difference cut
+    Bool_t    fUseTimeDiffMC;                           // flag for switching on time difference cut for MC, needed in PbPb 5.02 TeV production
     Double_t  fMaxDistTrackToClusterEta;                // minimum distance between track and cluster in eta
     Double_t  fMinDistTrackToClusterPhi;                // minimum distance between track and cluster in phi
     Double_t  fMaxDistTrackToClusterPhi;                // maximum distance between track and cluster in phi
@@ -762,7 +766,7 @@ class AliCaloPhotonCuts : public AliAnalysisCuts {
 
   private:
 
-    ClassDef(AliCaloPhotonCuts,133)
+    ClassDef(AliCaloPhotonCuts,134)
 };
 
 #endif

--- a/PWGGA/GammaConvBase/AliConvEventCuts.h
+++ b/PWGGA/GammaConvBase/AliConvEventCuts.h
@@ -3,6 +3,7 @@
 
 // Class handling all kinds of selection cuts for Gamma Conversion analysis
 // Authors: Friederike Bock, Daniel Muehlheim
+#include <map>
 #include <TObjString.h>
 #include "AliAODTrack.h"
 #include "AliESDtrack.h"
@@ -397,6 +398,32 @@ class AliConvEventCuts : public AliAnalysisCuts {
 
       enum phosTriggerType{kPHOSAny,kPHOSL0,kPHOSL1low,kPHOSL1med,kPHOSL1high} ;
 
+      /**
+       * @enum mcHeader
+       * @brief Possible Headers for Injected MC
+       */
+      enum MCHeaders {
+        kMinBias  = 0,    //!< MB header
+        kPileUp   = 1,    //!< PileUp header
+        kPi0PCM   = 2,    //!< Injected Pi0 in PCM acceptance
+        kPi0PHOSa = 3,    //!< Injected Pi0 in PHOS acceptance
+        kPi0PHOSb = 4,    //!< Injected Pi0 in PHOS acceptance
+        kPi0PHOSc = 5,    //!< Injected Pi0 in PHOS acceptance
+        kPi0PHOSd = 6,    //!< Injected Pi0 in PHOS acceptance
+        kEtaPCM   = 7,    //!< Injected Eta in PCM acceptance
+        kEtaPHOSa = 8,    //!< Injected Eta in PHOS acceptance
+        kPi0EMCe  = 9,    //!< Injected Pi0 in EMC acceptance
+        kPi0EMCf  = 10,   //!< Injected Pi0 in EMC acceptance
+        kPi0EMCg  = 11,   //!< Injected Pi0 in DCal acceptance
+        kPi0EMCh  = 12,   //!< Injected Pi0 in DCal acceptance
+        kPi0EMCi  = 13,   //!< Injected Pi0 in EMC acceptance
+        kEtaEMCb  = 9,    //!< Injected Eta in EMC acceptance
+        kEtaEMCc  = 10,   //!< Injected Eta in EMC acceptance
+        kEtaEMCd  = 11,   //!< Injected Eta in EMC acceptance
+        kEtaEMCe  = 12,   //!< Injected Eta in DCal acceptance
+        kEtaEMCf  = 13    //!< Injected Eta in DCal acceptance
+      };
+
 
       AliConvEventCuts(const char *name="EventCuts", const char * title="Event Cuts");
       AliConvEventCuts(const AliConvEventCuts&);
@@ -579,6 +606,7 @@ class AliConvEventCuts : public AliAnalysisCuts {
       Bool_t    GetUseINELgtZERO()                                                  { return fINELgtZEROTrigger                                 ; }
       void      GetCorrectEtaShiftFromPeriod();
       void      GetNotRejectedParticles(Int_t rejection, TList *HeaderList, AliVEvent *event);
+      void      FillHeaderMap(TList *HeaderList, AliVEvent *event);
       Double_t  GetV0Multiplicity(AliVEvent *event) const;
       Int_t     GetNumberOfTPCClusters(AliVEvent *event) const;
       TClonesArray*     GetArrayFromEvent(AliVEvent* event, const char *name, const char *clname=0);
@@ -732,6 +760,7 @@ class AliConvEventCuts : public AliAnalysisCuts {
       std::vector<int>            fNotRejectedStart;                      //[fnHeaders]
       std::vector<int>            fNotRejectedEnd;                        //[fnHeaders]
       std::vector<TString>        fGeneratorNames;                        //[fnHeaders]
+      std::map<int, MCHeaders>    fHeaderMap;                             //!< Map from header index to header enum
       PeriodVar                   fPeriodEnum;                            ///< period selector
       EnergyVar                   fEnergyEnum;                            ///< energy selector
       AliTimeRangeCut             fTimeRangeCut;                          //!
@@ -835,7 +864,7 @@ class AliConvEventCuts : public AliAnalysisCuts {
   private:
 
       /// \cond CLASSIMP
-      ClassDef(AliConvEventCuts,92)
+      ClassDef(AliConvEventCuts,93)
       /// \endcond
 };
 


### PR DESCRIPTION
- Add more options for injection header selection to `AddTask_GammaCalo_PbPb.C` and `AddTask_GammaConvCalo_PbPb.C`
- Add cluster timing cut for all MCs that are `kPbPb5T18HIJING`. This timing cut uses the width as in data, but also uses an offset, since we have seen an offset of 61.6 ns in all MCs anchored to LHC18qr
- Add a new NOC (neutral overlap correction) which was determined by fitting the mass^2 ratio of Pi0s in pp 13 TeV and PbPb 5.02 TeV with PCM-EMC as function of the cluster energy. The old NonLin like correction was fitted to EMC only data where the energy range was much smaller and the uncertainties made the fit very unstable. This should be a much better correction now.

- Add histogram `fHistoClusOverlapMBHeaderGammaPt` to AliAnalysisTaskGammaCalo, to track if cluster has overlap with MB header if MB header is not selected