### PR TITLE
PWGGA/GammaConvV1: Add mc pt histo

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvV1.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvV1.cxx
@@ -4677,22 +4677,33 @@ void AliAnalysisTaskGammaConvV1::ProcessTrueMesonCandidatesAOD(AliAODConversionM
       } else { // Only primary pi0 for efficiency calculation
         Float_t weighted= 1;
         iMesonMCInfo = 6;
-        if (static_cast<AliAODMCParticle*>(fAODMCTrackArray->At(gamma1MotherLabel))->Pt()>0.005){
+        Double_t lMotherMCPt = static_cast<AliAODMCParticle*>(fAODMCTrackArray->At(gamma1MotherLabel))->Pt();
+        if (lMotherMCPt>0.005){
           weighted= fiEventCut->GetWeightForMeson(gamma1MotherLabel, 0x0, fInputEvent);
         }
-        fHistoTruePrimaryMotherInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(),weighted*fWeightJetJetMC*weightMatBudget);
-        fHistoTruePrimaryMotherW0WeightingInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(),fWeightJetJetMC);
-        pESDTruePrimaryMotherWeightsInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(),weighted*weightMatBudget*fWeightJetJetMC);
+        fHistoTruePrimaryMotherInvMassPt[fiCut]->Fill(Pi0Candidate->M(),
+                                                      Pi0Candidate->Pt(),
+                                                      weighted*fWeightJetJetMC*weightMatBudget);
+        
+        fHistoTruePrimaryMotherW0WeightingInvMassPt[fiCut]->Fill(Pi0Candidate->M(),
+                                                                 Pi0Candidate->Pt(),
+                                                                 fWeightJetJetMC);
+        
+        pESDTruePrimaryMotherWeightsInvMassPt[fiCut]->Fill(Pi0Candidate->M(),
+                                                           Pi0Candidate->Pt(),
+                                                           weighted*weightMatBudget*fWeightJetJetMC);
 
         if (fDoMesonQA > 0 && fIsMC < 2){
           if(isTruePi0){ // Only primary pi0 for resolution
-            fHistoTruePrimaryPi0MCPtResolPt[fiCut]->Fill(static_cast<AliAODMCParticle*>(fAODMCTrackArray->At(gamma1MotherLabel))->Pt(),
-                                (Pi0Candidate->Pt()-static_cast<AliAODMCParticle*>(fAODMCTrackArray->At(gamma1MotherLabel))->Pt())/static_cast<AliAODMCParticle*>(fAODMCTrackArray->At(gamma1MotherLabel))->Pt(),weighted*weightMatBudget);
+            fHistoTruePrimaryPi0MCPtResolPt[fiCut]->Fill(lMotherMCPt,
+                                                         (Pi0Candidate->Pt()-lMotherMCPt)/lMotherMCPt,
+                                                         weighted*weightMatBudget);
 
           }
           if (isTrueEta){ // Only primary eta for resolution
-            fHistoTruePrimaryEtaMCPtResolPt[fiCut]->Fill(static_cast<AliAODMCParticle*>(fAODMCTrackArray->At(gamma1MotherLabel))->Pt(),
-                                (Pi0Candidate->Pt()-static_cast<AliAODMCParticle*>(fAODMCTrackArray->At(gamma1MotherLabel))->Pt())/static_cast<AliAODMCParticle*>(fAODMCTrackArray->At(gamma1MotherLabel))->Pt(),weighted*weightMatBudget);
+            fHistoTruePrimaryEtaMCPtResolPt[fiCut]->Fill(lMotherMCPt,
+                                                         (Pi0Candidate->Pt()-lMotherMCPt)/lMotherMCPt,
+                                                         weighted*weightMatBudget);
           }
         }
       }

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvV1.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvV1.cxx
@@ -178,6 +178,8 @@ AliAnalysisTaskGammaConvV1::AliAnalysisTaskGammaConvV1(): AliAnalysisTaskSE(),
   fHistoTrueMotherInvMassPt(NULL),
   fHistoTruePrimaryMotherInvMassPt(NULL),
   fHistoTruePrimaryMotherW0WeightingInvMassPt(NULL),
+  fHistoTruePrimaryMotherInvMassMCPt(NULL),
+  fHistoTruePrimaryMotherW0WeightingInvMassMCPt(NULL),
   pESDTruePrimaryMotherWeightsInvMassPt(NULL),
   fHistoTruePrimaryPi0MCPtResolPt(NULL),
   fHistoTruePrimaryEtaMCPtResolPt(NULL),
@@ -533,6 +535,8 @@ AliAnalysisTaskGammaConvV1::AliAnalysisTaskGammaConvV1(const char *name):
   fHistoTrueMotherInvMassPt(NULL),
   fHistoTruePrimaryMotherInvMassPt(NULL),
   fHistoTruePrimaryMotherW0WeightingInvMassPt(NULL),
+  fHistoTruePrimaryMotherInvMassMCPt(NULL),
+  fHistoTruePrimaryMotherW0WeightingInvMassMCPt(NULL),
   pESDTruePrimaryMotherWeightsInvMassPt(NULL),
   fHistoTruePrimaryPi0MCPtResolPt(NULL),
   fHistoTruePrimaryEtaMCPtResolPt(NULL),
@@ -1829,6 +1833,8 @@ void AliAnalysisTaskGammaConvV1::UserCreateOutputObjects(){
       fHistoMultipleCountTrueEta                     = new TH1F*[fnCuts];
       fHistoTruePrimaryMotherInvMassPt               = new TH2F*[fnCuts];
       fHistoTruePrimaryMotherW0WeightingInvMassPt    = new TH2F*[fnCuts];
+      fHistoTruePrimaryMotherInvMassMCPt             = new TH2F*[fnCuts];
+      fHistoTruePrimaryMotherW0WeightingInvMassMCPt  = new TH2F*[fnCuts];
       pESDTruePrimaryMotherWeightsInvMassPt          = new TProfile2D*[fnCuts];
       fHistoTrueSecondaryMotherInvMassPt             = new TH2F*[fnCuts];
       fHistoTrueSecondaryMotherFromK0sInvMassPt      = new TH2F*[fnCuts];
@@ -2307,7 +2313,14 @@ void AliAnalysisTaskGammaConvV1::UserCreateOutputObjects(){
             fHistoTrueEtaPtOpenAngle[iCut]    = new TH2F("ESD_TrueEta_Pt_OpenAngle", "ESD_TrueEta_Pt_OpenAngle", nBinsQAPt, arrQAPtBinning, 200, 0, 2*TMath::Pi());
             fTrueList[iCut]->Add(fHistoTrueEtaPtOpenAngle[iCut]);
           }
-
+          
+          fHistoTruePrimaryMotherInvMassMCPt[iCut]  = new TH2F("ESD_TruePrimaryMother_InvMass_MCPt", "ESD_TruePrimaryMother_InvMass_MCPt", 800, 0, 0.8, nBinsPt, arrPtBinning);
+          fHistoTruePrimaryMotherInvMassMCPt[iCut]->Sumw2();
+          fTrueList[iCut]->Add(fHistoTruePrimaryMotherInvMassMCPt[iCut]);
+          fHistoTruePrimaryMotherW0WeightingInvMassMCPt[iCut]   = new TH2F("ESD_TruePrimaryMotherW0Weights_InvMass_MCPt", "ESD_TruePrimaryMotherW0Weights_InvMass_MCPt", 800, 0, 0.8, nBinsPt, arrPtBinning);
+          fHistoTruePrimaryMotherW0WeightingInvMassMCPt[iCut]->Sumw2();
+          fTrueList[iCut]->Add(fHistoTruePrimaryMotherW0WeightingInvMassMCPt[iCut]);
+        
           fHistoTruePi0PtAlpha[iCut]          = new TH2F("ESD_TruePi0_Pt_Alpha", "ESD_TruePi0_Pt_Alpha", nBinsQAPt, arrQAPtBinning, 100, 0, 1);
           fTrueList[iCut]->Add(fHistoTruePi0PtAlpha[iCut]);
           fHistoTrueEtaPtAlpha[iCut]          = new TH2F("ESD_TrueEta_Pt_Alpha", "ESD_TrueEta_Pt_Alpha", nBinsQAPt, arrQAPtBinning, 100, 0, 1);
@@ -4694,6 +4707,13 @@ void AliAnalysisTaskGammaConvV1::ProcessTrueMesonCandidatesAOD(AliAODConversionM
                                                            weighted*weightMatBudget*fWeightJetJetMC);
 
         if (fDoMesonQA > 0 && fIsMC < 2){
+          fHistoTruePrimaryMotherInvMassMCPt[fiCut]->Fill(Pi0Candidate->M(),
+                                                          lMotherMCPt,
+                                                          weighted*fWeightJetJetMC*weightMatBudget);
+        
+          fHistoTruePrimaryMotherW0WeightingInvMassMCPt[fiCut]->Fill(Pi0Candidate->M(),
+                                                                     lMotherMCPt,
+                                                                     fWeightJetJetMC);
           if(isTruePi0){ // Only primary pi0 for resolution
             fHistoTruePrimaryPi0MCPtResolPt[fiCut]->Fill(lMotherMCPt,
                                                          (Pi0Candidate->Pt()-lMotherMCPt)/lMotherMCPt,

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvV1.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvV1.h
@@ -233,6 +233,8 @@ class AliAnalysisTaskGammaConvV1 : public AliAnalysisTaskSE {
     TH2F**                            fHistoTrueMotherInvMassPt;                    //!
     TH2F**                            fHistoTruePrimaryMotherInvMassPt;             //!
     TH2F**                            fHistoTruePrimaryMotherW0WeightingInvMassPt;  //!
+    TH2F**                            fHistoTruePrimaryMotherInvMassMCPt;           //!
+    TH2F**                            fHistoTruePrimaryMotherW0WeightingInvMassMCPt;//!
     TProfile2D**                      pESDTruePrimaryMotherWeightsInvMassPt;        //!
     TH2F**                            fHistoTruePrimaryPi0MCPtResolPt;              //!
     TH2F**                            fHistoTruePrimaryEtaMCPtResolPt;              //!
@@ -503,7 +505,7 @@ class AliAnalysisTaskGammaConvV1 : public AliAnalysisTaskSE {
 
     AliAnalysisTaskGammaConvV1(const AliAnalysisTaskGammaConvV1&); // Prevent copy-construction
     AliAnalysisTaskGammaConvV1 &operator=(const AliAnalysisTaskGammaConvV1&); // Prevent assignment
-    ClassDef(AliAnalysisTaskGammaConvV1, 61);
+    ClassDef(AliAnalysisTaskGammaConvV1, 62);
 };
 
 #endif


### PR DESCRIPTION
add two histos that allow for better comparison of meson true efficiencies between MC productions with differing pt shapes of generated particles