### PR TITLE
PWGGA/GammaConv: Add shifted NonLin without cell scale

### DIFF
--- a/PWGGA/GammaConv/macros/AddTask_GammaCalo_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaCalo_pp.C
@@ -4245,6 +4245,9 @@ void AddTask_GammaCalo_pp(
 
   } else if (trainConfig == 2568) { // Non-Lin with only MC based TB correction
     cuts.AddCutCalo("00010113","411799909fe302v0000","0s631031000000d0"); // INT7 PCM-EMC FT, additional 0.5% shift
+  
+  } else if (trainConfig == 2569) { // Non-Lin without cell scale but shited to match the cell scale absolute position
+    cuts.AddCutCalo("00010113","411797609fe302v0000","0s631031000000d0"); // INT7 PCM-EMC FT, additional 2.5% shift
 
   } else if (trainConfig == 2570) { // NonLin applied in CF, min energy = 700MeV
     cuts.AddCutCalo("00052113","411790009fe32230000","0s631031000000d0"); // EMC7

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_pp.C
@@ -2819,13 +2819,17 @@ void AddTask_GammaConvCalo_pp(
 
 
   } else if (trainConfig == 2185){ // old way of doing the NonLin
-    cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411791109f030200000","0r63103100000010"); // INT7, no NCell cut
-    cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411791109f03h200000","0r63103100000010"); // INT7, only 1 cell clusters
-    cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411791109f032200000","0r63103100000010"); // INT7, with NCell >= 2 cut
+    cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411791109fe30220000","0r63103100000010"); // INT7, no NCell cut
+    cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411791109f03h000000","0r63103100000010"); // INT7, only 1 cell clusters
+    cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411791109fe32220000","0r63103100000010"); // INT7, with NCell >= 2 cut
   } else if (trainConfig == 2186){ // old way of doing the NonLin
-    cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411791209f030200000","0r63103100000010"); // INT7, no NCell cut
-    cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411791209f03h200000","0r63103100000010"); // INT7, only 1 cell clusters
-    cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411791209f032200000","0r63103100000010"); // INT7, with NCell >= 2 cut
+    cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411791209fe30220000","0r63103100000010"); // INT7, no NCell cut
+    cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411791209f03h000000","0r63103100000010"); // INT7, only 1 cell clusters
+    cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411791209fe32220000","0r63103100000010"); // INT7, with NCell >= 2 cut
+  } else if (trainConfig == 2187){ // old way of doing the NonLin with additional 2.5% shift
+    cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411797609fe30220000","0r63103100000010"); // INT7, no NCell cut
+    cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411797609f03h000000","0r63103100000010"); // INT7, only 1 cell clusters
+    cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411797609fe32220000","0r63103100000010"); // INT7, with NCell >= 2 cut
 
 
   } else if (trainConfig == 2190){ // low Bfield

--- a/PWGGA/GammaConvBase/AliCaloPhotonCuts.cxx
+++ b/PWGGA/GammaConvBase/AliCaloPhotonCuts.cxx
@@ -8903,6 +8903,21 @@ void AliCaloPhotonCuts::ApplyNonLinearity(AliVCluster* cluster, Int_t isMC, AliV
         energy /= FunctionNL_DExp(energy, 1.0163161769, 1.0745426880, -2.6533554672, 1.0253717488, 0.8132587660, -2.5997134051);
       }
       break;
+    
+    case 76: // same as 11 but shifted by 2.5% upwards to match the scale of the case 01
+      if(isMC > 0){ // MC
+        energy /= FunctionNL_OfficialTB_100MeV_MC_V2(energy);
+        // fine tuning based on gaussian fits on PCMEMC in pPb5TeV
+        energy /= FunctionNL_kSDM(energy, 0.987912, -2.94105, -0.273207) ;
+        energy *= 1.015; // 1% additional correction + 2.5% shift
+        if(cluster->GetNCells() == 1){ // different fine tuning for 1 cell clusters
+          energy /= 0.99;
+        }
+      } else { // data
+        energy /= FunctionNL_OfficialTB_100MeV_Data_V2(energy);
+        energy *= 1.025;
+      }
+      break;
 
     // *************** 80 + x **** modified tender Settings 1 - PbPb
 


### PR DESCRIPTION
- For NonLin studies, add NonLin without cell sclae, but shift data and MC to the same mass position as if one would apply the cell scale