### PR TITLE
PWGGA/GammaConv: Add new NOC with Maxwell Boltzmann Fits

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.cxx
@@ -3762,17 +3762,22 @@ void AliAnalysisTaskGammaCalo::ProcessClusters()
     fIsFromDesiredHeader          = kTRUE;
     fIsOverlappingWithOtherHeader = kFALSE;
     fIsOverlapWithMBHeader        = kFALSE;
+    int particleFromBGEvent = 0;
+    int labelFromBGEvent = 0;
     // test whether largest contribution to cluster orginates in added signals
     if (fIsMC>0 && ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetSignalRejection() > 0){
       // Set the jetjet weight to 1 in case the photon candidate orignated from the minimum bias header
-      if ( ((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsParticleFromBGEvent(PhotonCandidate->GetCaloPhotonMCLabel(0), fMCEvent, fInputEvent) == 2 && ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetSignalRejection() == 4) tempPhotonWeight = 1;
-      if ( ((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsParticleFromBGEvent(PhotonCandidate->GetCaloPhotonMCLabel(0), fMCEvent, fInputEvent) == 0) fIsFromDesiredHeader = kFALSE;
-      if ( ((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsParticleFromBGEvent(PhotonCandidate->GetCaloPhotonMCLabel(0), fMCEvent, fInputEvent) == 2) fIsOverlapWithMBHeader = kTRUE;
+      particleFromBGEvent = ((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsParticleFromBGEvent(PhotonCandidate->GetCaloPhotonMCLabel(0), fMCEvent, fInputEvent);
+      if ( particleFromBGEvent == 2 && ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetSignalRejection() == 4) tempPhotonWeight = 1;
+      if ( particleFromBGEvent == 0) fIsFromDesiredHeader = kFALSE;
+      if ( particleFromBGEvent == 2) fIsFromDesiredHeader = kFALSE;
       if (clus->GetNLabels()>1){
         Int_t* mclabelsCluster = clus->GetLabels();
         if (fLocalDebugFlag > 1)   cout << "testing if other labels in cluster belong to different header, need to test " << (Int_t)clus->GetNLabels()-1 << " additional labels" << endl;
         for (Int_t l = 1; l < (Int_t)clus->GetNLabels(); l++ ){
-          if (((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsParticleFromBGEvent(mclabelsCluster[l], fMCEvent, fInputEvent, fLocalDebugFlag) == 0) fIsOverlappingWithOtherHeader = kTRUE;
+          labelFromBGEvent = ((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsParticleFromBGEvent(mclabelsCluster[l], fMCEvent, fInputEvent, fLocalDebugFlag);
+          if (labelFromBGEvent == 0) fIsOverlappingWithOtherHeader = kTRUE;
+          if (labelFromBGEvent == 2) fIsOverlapWithMBHeader = kTRUE;
         }
         if (fLocalDebugFlag > 1 && fIsOverlappingWithOtherHeader) cout << "found overlapping header: " << endl;
       }

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvCalo.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvCalo.cxx
@@ -3483,20 +3483,23 @@ void AliAnalysisTaskGammaConvCalo::ProcessClusters(){
     fIsFromDesiredHeader            = kTRUE;
     fIsOverlappingWithOtherHeader   = kFALSE;
     fIsOverlapWithMBHeader          = kFALSE;
+    int particleFromBGEvent = 0;
+    int labelFromBGEvent = 0;
     //TString periodName         = fV0Reader->GetPeriodName();
     // test whether largest contribution to cluster orginates in added signals
     if (fIsMC>0 && ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetSignalRejection() > 0){
-      if (((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsParticleFromBGEvent(PhotonCandidate->GetCaloPhotonMCLabel(0), fMCEvent, fInputEvent) == 0){
+      particleFromBGEvent = ((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsParticleFromBGEvent(PhotonCandidate->GetCaloPhotonMCLabel(0), fMCEvent, fInputEvent);
+      if ( particleFromBGEvent == 0 || particleFromBGEvent == 2){
         fIsFromDesiredHeader = kFALSE;
-      }
-      if ( ((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsParticleFromBGEvent(PhotonCandidate->GetCaloPhotonMCLabel(0), fMCEvent, fInputEvent) == 2){
-        fIsOverlapWithMBHeader = kTRUE;
       }
       if (clus->GetNLabels()>1){
         Int_t* mclabelsCluster = clus->GetLabels();
         for (Int_t l = 1; l < (Int_t)clus->GetNLabels(); l++ ){
-          if (((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsParticleFromBGEvent(mclabelsCluster[l], fMCEvent, fInputEvent) == 0){
+          labelFromBGEvent = ((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsParticleFromBGEvent(mclabelsCluster[l], fMCEvent, fInputEvent);
+          if (labelFromBGEvent == 0){
             fIsOverlappingWithOtherHeader = kTRUE;
+          } else if (labelFromBGEvent == 2){
+            fIsOverlapWithMBHeader = kTRUE;
           }
         }
       }

--- a/PWGGA/GammaConv/macros/AddTask_GammaCalo_PbPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaCalo_PbPb.C
@@ -1389,6 +1389,21 @@ void AddTask_GammaCalo_PbPb(
     cuts.AddCutCalo("11310023","411790105we30220000","0s331031000000d0"); // 10-30%
     cuts.AddCutCalo("13530023","411790105we30220000","0s331031000000d0"); // 30-50%
     cuts.AddCutCalo("15910023","411790105we30220000","0s331031000000d0"); // 50-90%
+  } else if (trainConfig == 806){ // EMCAL+DCal clusters - Neutral Overlap Correction maxwell boltzmann
+    cuts.AddCutCalo("10130e03","411790105xe30220000","01331031000000d0"); // 00-10%
+    cuts.AddCutCalo("11310e03","411790105xe30220000","01331031000000d0"); // 10-30%
+    cuts.AddCutCalo("13530e03","411790105xe30220000","01331031000000d0"); // 30-50%
+    cuts.AddCutCalo("15910e03","411790105xe30220000","01331031000000d0"); // 50-90%
+  } else if (trainConfig == 807){ // EMCAL+DCal clusters -  Neutral Overlap Correction maxwell boltzmann without OOB Pileup correction
+    cuts.AddCutCalo("10130053","411790105xe30220000","01331031000000d0"); // 00-10%
+    cuts.AddCutCalo("11310053","411790105xe30220000","01331031000000d0"); // 10-30%
+    cuts.AddCutCalo("13530053","411790105xe30220000","01331031000000d0"); // 30-50%
+    cuts.AddCutCalo("15910053","411790105xe30220000","01331031000000d0"); // 50-90%
+  } else if (trainConfig == 808){ // EMCAL+DCal clusters -  Neutral Overlap Correction maxwell boltzmann without OOB Pileup correction, Added Signal
+    cuts.AddCutCalo("10130023","411790105xe30220000","01331031000000d0"); // 00-10%
+    cuts.AddCutCalo("11310023","411790105xe30220000","01331031000000d0"); // 10-30%
+    cuts.AddCutCalo("13530023","411790105xe30220000","01331031000000d0"); // 30-50%
+    cuts.AddCutCalo("15910023","411790105xe30220000","01331031000000d0"); // 50-90%
   // **********************************************************************************************************
   // ***************************** PHOS       QA configurations PbPb run 2 2018 *******************************
   // **********************************************************************************************************
@@ -1487,6 +1502,13 @@ void AddTask_GammaCalo_PbPb(
     cuts.AddCutCalo("10130053","411790105we30220000","0s331031000000d0"); // 00-10%
   } else if (trainConfig == 1009){ // EMCAL+DCal clusters -  Neutral Overlap NonLin like without OOB Pileup correction, Added Signal - rotation background method
     cuts.AddCutCalo("10130023","411790105we30220000","0s331031000000d0"); // 00-10%
+  } else if (trainConfig == 1010){ // EMCAL+DCal clusters - Neutral Overlap Correction maxwell boltzmann
+    cuts.AddCutCalo("10130e03","411790105xe30220000","01331031000000d0"); // 00-10%
+  } else if (trainConfig == 1011){ // EMCAL+DCal clusters -  Neutral Overlap Correction maxwell boltzmann without OOB Pileup correction
+    cuts.AddCutCalo("10130053","411790105xe30220000","01331031000000d0"); // 00-10%
+  } else if (trainConfig == 1012){ // EMCAL+DCal clusters -  Neutral Overlap Correction maxwell boltzmann without OOB Pileup correction, Added Signal
+    cuts.AddCutCalo("10130023","411790105xe30220000","01331031000000d0"); // 00-10%
+  //***********************************************************************************************************
   } else if (trainConfig == 1080){ // EMCAL+DCal standard
     cuts.AddCutCalo("10130e03","411790105ke30220000","01331031000000d0"); // 00-10%
   } else if (trainConfig == 1081){ // EMCAL+DCal standard with rotation method
@@ -1544,6 +1566,13 @@ void AddTask_GammaCalo_PbPb(
     cuts.AddCutCalo("11310053","411790105we30220000","0s331031000000d0"); // 10-30%
   } else if (trainConfig == 3009){ // EMCAL+DCal clusters -  Neutral Overlap NonLin like without OOB Pileup correction, Added Signal - rotation background method
     cuts.AddCutCalo("11310023","411790105we30220000","0s331031000000d0"); // 10-30%
+  } else if (trainConfig == 3010){ // EMCAL+DCal clusters - Neutral Overlap Correction maxwell boltzmann
+    cuts.AddCutCalo("11310e03","411790105xe30220000","01331031000000d0"); // 10-30%
+  } else if (trainConfig == 3011){ // EMCAL+DCal clusters -  Neutral Overlap Correction maxwell boltzmann without OOB Pileup correction
+    cuts.AddCutCalo("11310053","411790105xe30220000","01331031000000d0"); // 10-30%
+  } else if (trainConfig == 3012){ // EMCAL+DCal clusters -  Neutral Overlap Correction maxwell boltzmann without OOB Pileup correction, Added Signal
+    cuts.AddCutCalo("11310023","411790105xe30220000","01331031000000d0"); // 10-30%
+  //***********************************************************************************************************
   } else if (trainConfig == 3080){ // EMCAL+DCal standard
     cuts.AddCutCalo("11310e03","411790105ke30220000","01331031000000d0"); // 10-30%
   } else if (trainConfig == 3081){ // EMCAL+DCal standard with rotation method
@@ -1601,6 +1630,13 @@ void AddTask_GammaCalo_PbPb(
     cuts.AddCutCalo("13530053","411790105we30220000","0s331031000000d0"); // 30-50%
   } else if (trainConfig == 5009){ // EMCAL+DCal clusters -  Neutral Overlap NonLin like without OOB Pileup correction, Added Signal - rotation background method
     cuts.AddCutCalo("13530023","411790105we30220000","0s331031000000d0"); // 30-50%
+  } else if (trainConfig == 5010){ // EMCAL+DCal clusters - Neutral Overlap Correction maxwell boltzmann
+    cuts.AddCutCalo("13530e03","411790105xe30220000","01331031000000d0"); // 30-50%
+  } else if (trainConfig == 5011){ // EMCAL+DCal clusters -  Neutral Overlap Correction maxwell boltzmann without OOB Pileup correction
+    cuts.AddCutCalo("13530053","411790105xe30220000","01331031000000d0"); // 30-50%
+  } else if (trainConfig == 5012){ // EMCAL+DCal clusters -  Neutral Overlap Correction maxwell boltzmann without OOB Pileup correction, Added Signal
+    cuts.AddCutCalo("13530023","411790105xe30220000","01331031000000d0"); // 30-50%
+  //***********************************************************************************************************
   } else if (trainConfig == 5080){ // EMCAL+DCal standard
     cuts.AddCutCalo("13530e03","411790105ke30220000","01331031000000d0"); // 30-50%
   } else if (trainConfig == 5081){ // EMCAL+DCal standard with rotation method
@@ -1658,6 +1694,13 @@ void AddTask_GammaCalo_PbPb(
     cuts.AddCutCalo("15910053","411790105we30220000","0s331031000000d0"); // 50-90%
   } else if (trainConfig == 9009){ // EMCAL+DCal clusters -  Neutral Overlap NonLin like without OOB Pileup correction, Added Signal - rotation background method
     cuts.AddCutCalo("15910023","411790105we30220000","0s331031000000d0"); // 50-90%
+  } else if (trainConfig == 9010){ // EMCAL+DCal clusters - Neutral Overlap Correction maxwell boltzmann
+    cuts.AddCutCalo("15910e03","411790105xe30220000","01331031000000d0"); // 50-90%
+  } else if (trainConfig == 9011){ // EMCAL+DCal clusters -  Neutral Overlap Correction maxwell boltzmann without OOB Pileup correction
+    cuts.AddCutCalo("15910053","411790105xe30220000","01331031000000d0"); // 50-90%
+  } else if (trainConfig == 9012){ // EMCAL+DCal clusters -  Neutral Overlap Correction maxwell boltzmann without OOB Pileup correction, Added Signal
+    cuts.AddCutCalo("15910023","411790105xe30220000","01331031000000d0"); // 50-90%
+  //***********************************************************************************************************
   } else if (trainConfig == 9080){ // EMCAL+DCal standard
     cuts.AddCutCalo("15910e03","411790105ke30220000","01331031000000d0"); // 50-90%
   } else if (trainConfig == 9081){ // EMCAL+DCal standard with rotation method

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_PbPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_PbPb.C
@@ -1170,6 +1170,21 @@ void AddTask_GammaConvCalo_PbPb(
     cuts.AddCutPCMCalo("16710013","0dm00009ab770c00amd0404000","411790105ke30220000","0r63103100000010"); // 60-70%
     cuts.AddCutPCMCalo("17810013","0dm00009ab770c00amd0404000","411790105ke30220000","0r63103100000010"); // 70-80%
     cuts.AddCutPCMCalo("18910013","0dm00009ab770c00amd0404000","411790105ke30220000","0r63103100000010"); // 80-90%
+  } else if (trainConfig == 787){ // EMCAL clusters - cen4 cent classes with 0-10 and 30-50 triggered with neutral overlap correction maxwell boltzmann
+    cuts.AddCutPCMCalo("10130e03","0dm00009ab770c00amd0404000","411790105xe30220000","0133103100000010"); //  0-10%
+    cuts.AddCutPCMCalo("11310e03","0dm00009ab770c00amd0404000","411790105xe30220000","0133103100000010"); // 10-30%
+    cuts.AddCutPCMCalo("13530e03","0dm00009ab770c00amd0404000","411790105xe30220000","0133103100000010"); // 30-50%
+    cuts.AddCutPCMCalo("15910e03","0dm00009ab770c00amd0404000","411790105xe30220000","0133103100000010"); // 50-90%
+  } else if (trainConfig == 788){ // EMCAL clusters - cen4 cent classes with 0-10 and 30-50 triggered without OOB pile up correction for MC with added Signal! with neutral overlap correction maxwell boltzmann
+    cuts.AddCutPCMCalo("10130023","0dm00009ab770c00amd0404000","411790105xe30220000","0133103100000010"); //  0-10%
+    cuts.AddCutPCMCalo("11310023","0dm00009ab770c00amd0404000","411790105xe30220000","0133103100000010"); // 10-30%
+    cuts.AddCutPCMCalo("13530023","0dm00009ab770c00amd0404000","411790105xe30220000","0133103100000010"); // 30-50%
+    cuts.AddCutPCMCalo("15910023","0dm00009ab770c00amd0404000","411790105xe30220000","0133103100000010"); // 50-90%
+  } else if (trainConfig == 789){ // EMCAL clusters - cen4 cent classes with 0-10 and 30-50 triggered without OOB pile up correction for MC - with neutral overlap correction maxwell boltzmann
+    cuts.AddCutPCMCalo("10130053","0dm00009ab770c00amd0404000","411790105xe30220000","0133103100000010"); //  0-10%
+    cuts.AddCutPCMCalo("11310053","0dm00009ab770c00amd0404000","411790105xe30220000","0133103100000010"); // 10-30%
+    cuts.AddCutPCMCalo("13530053","0dm00009ab770c00amd0404000","411790105xe30220000","0133103100000010"); // 30-50%
+    cuts.AddCutPCMCalo("15910053","0dm00009ab770c00amd0404000","411790105xe30220000","0133103100000010"); // 50-90%
 
   // **********************************************************************************************************
   // ***************************** PCM-PHOS       QA configurations PbPb run 2 2018 ***************************
@@ -1344,6 +1359,12 @@ void AddTask_GammaConvCalo_PbPb(
     cuts.AddCutPCMCalo("10130023","0dm00009ab770c00amd0404000","411790105ve30220000","0133103100000010"); //  0-10%
   } else if (trainConfig == 1062){ // EMCAL clusters - 00-10 triggered without OOB pile up correction for MC - with neutral overlap correction charged particle density
     cuts.AddCutPCMCalo("10130053","0dm00009ab770c00amd0404000","411790105ve30220000","0133103100000010"); //  0-10%
+  } else if (trainConfig == 1063){ // EMCAL clusters - cen4 cent classes with 0-10 and 30-50 triggered with neutral overlap correction maxwell boltzmann
+    cuts.AddCutPCMCalo("10130e03","0dm00009ab770c00amd0404000","411790105xe30220000","0133103100000010"); //  0-10%
+  } else if (trainConfig == 1064){ // EMCAL clusters - cen4 cent classes with 0-10 and 30-50 triggered without OOB pile up correction for MC with added Signal! with neutral overlap correction maxwell boltzmann
+    cuts.AddCutPCMCalo("10130023","0dm00009ab770c00amd0404000","411790105xe30220000","0133103100000010"); //  0-10%
+  } else if (trainConfig == 1065){ // EMCAL clusters - cen4 cent classes with 0-10 and 30-50 triggered without OOB pile up correction for MC - with neutral overlap correction maxwell boltzmann
+    cuts.AddCutPCMCalo("10130053","0dm00009ab770c00amd0404000","411790105xe30220000","0133103100000010"); //  0-10%
 
   // 10 - 30 %
   } else if (trainConfig == 3051){ // EMCAL clusters - 10-30 with neutral overlap correction via N matched tracks per cluster
@@ -1370,6 +1391,12 @@ void AddTask_GammaConvCalo_PbPb(
     cuts.AddCutPCMCalo("11310023","0dm00009ab770c00amd0404000","411790105ve30220000","0133103100000010"); // 10-30%
   } else if (trainConfig == 3062){ // EMCAL clusters - 10-30 without OOB pile up correction for MC - with neutral overlap correction charged particle density
     cuts.AddCutPCMCalo("11310053","0dm00009ab770c00amd0404000","411790105ve30220000","0133103100000010"); // 10-30%
+  } else if (trainConfig == 3063){ // EMCAL clusters - cen4 cent classes with 0-10 and 30-50 triggered with neutral overlap correction maxwell boltzmann
+    cuts.AddCutPCMCalo("11310e03","0dm00009ab770c00amd0404000","411790105xe30220000","0133103100000010"); // 10-30%
+  } else if (trainConfig == 3064){ // EMCAL clusters - cen4 cent classes with 0-10 and 30-50 triggered without OOB pile up correction for MC with added Signal! with neutral overlap correction maxwell boltzmann
+    cuts.AddCutPCMCalo("11310023","0dm00009ab770c00amd0404000","411790105xe30220000","0133103100000010"); // 10-30%
+  } else if (trainConfig == 3065){ // EMCAL clusters - cen4 cent classes with 0-10 and 30-50 triggered without OOB pile up correction for MC - with neutral overlap correction maxwell boltzmann
+    cuts.AddCutPCMCalo("11310053","0dm00009ab770c00amd0404000","411790105xe30220000","0133103100000010"); // 10-30%
 
   // 30 - 50%
   } else if (trainConfig == 5051){ // EMCAL clusters - 30-50 triggered with neutral overlap correction via N matched tracks per cluster
@@ -1396,6 +1423,12 @@ void AddTask_GammaConvCalo_PbPb(
     cuts.AddCutPCMCalo("13530023","0dm00009ab770c00amd0404000","411790105ve30220000","0133103100000010"); // 30-50%
   } else if (trainConfig == 5062){ // EMCAL clusters - 30-50 triggered without OOB pile up correction for MC - with neutral overlap correction charged particle density
     cuts.AddCutPCMCalo("13530053","0dm00009ab770c00amd0404000","411790105ve30220000","0133103100000010"); // 30-50%
+  } else if (trainConfig == 5063){ // EMCAL clusters - cen4 cent classes with 0-10 and 30-50 triggered with neutral overlap correction maxwell boltzmann
+    cuts.AddCutPCMCalo("13530e03","0dm00009ab770c00amd0404000","411790105xe30220000","0133103100000010"); // 30-50%
+  } else if (trainConfig == 5064){ // EMCAL clusters - cen4 cent classes with 0-10 and 30-50 triggered without OOB pile up correction for MC with added Signal! with neutral overlap correction maxwell boltzmann
+    cuts.AddCutPCMCalo("13530023","0dm00009ab770c00amd0404000","411790105xe30220000","0133103100000010"); // 30-50%
+  } else if (trainConfig == 5065){ // EMCAL clusters - cen4 cent classes with 0-10 and 30-50 triggered without OOB pile up correction for MC - with neutral overlap correction maxwell boltzmann
+    cuts.AddCutPCMCalo("13530053","0dm00009ab770c00amd0404000","411790105xe30220000","0133103100000010"); // 30-50%
   
   // 50-90%
   } else if (trainConfig == 9051){ // EMCAL clusters - 50-90 with neutral overlap correction via N matched tracks per cluster
@@ -1422,6 +1455,12 @@ void AddTask_GammaConvCalo_PbPb(
     cuts.AddCutPCMCalo("15910023","0dm00009ab770c00amd0404000","411790105ve30220000","0133103100000010"); // 50-90%
   } else if (trainConfig == 9062){ // EMCAL clusters - 50-90 without OOB pile up correction for MC - with neutral overlap correction charged particle density
     cuts.AddCutPCMCalo("15910053","0dm00009ab770c00amd0404000","411790105ve30220000","0133103100000010"); // 50-90%
+  } else if (trainConfig == 9063){ // EMCAL clusters - cen4 cent classes with 0-10 and 30-50 triggered with neutral overlap correction maxwell boltzmann
+    cuts.AddCutPCMCalo("15910e03","0dm00009ab770c00amd0404000","411790105xe30220000","0133103100000010"); // 50-90%
+  } else if (trainConfig == 9064){ // EMCAL clusters - cen4 cent classes with 0-10 and 30-50 triggered without OOB pile up correction for MC with added Signal! with neutral overlap correction maxwell boltzmann
+    cuts.AddCutPCMCalo("15910023","0dm00009ab770c00amd0404000","411790105xe30220000","0133103100000010"); // 50-90%
+  } else if (trainConfig == 9065){ // EMCAL clusters - cen4 cent classes with 0-10 and 30-50 triggered without OOB pile up correction for MC - with neutral overlap correction maxwell boltzmann
+    cuts.AddCutPCMCalo("15910053","0dm00009ab770c00amd0404000","411790105xe30220000","0133103100000010"); // 50-90%
   } else {
     Error(Form("GammaConvCalo_%i",trainConfig), "wrong trainConfig variable no cuts have been specified for the configuration");
     return;

--- a/PWGGA/GammaConvBase/AliCaloPhotonCuts.h
+++ b/PWGGA/GammaConvBase/AliCaloPhotonCuts.h
@@ -613,6 +613,7 @@ class AliCaloPhotonCuts : public AliAnalysisCuts {
     TF1*      fFuncNMatchedTracks;                      // TF1 poisson distribution to describe the number of matched tracks per cluster for a specific centrality
     Double_t  fParamMeanTrackPt[3];                     // TF1 distribution to describe the mean pT of tracks as function of centrality. Half of this value is used as neutral energy overlap correction.
     Float_t   fMeanNMatchedTracks;                      // Mean number of matched primary tracks, stored to reduce CPU time for neutral overlap correction
+    TF1*      fFuncNOCMaxBoltz;                         // TF1 Maxwell Boltzmann to describe the neutral overlap correction for a specific centrality
 
     //vector
     std::vector<Int_t> fVectorMatchedClusterIDs;        // vector with cluster IDs that have been matched to tracks in merged cluster analysis
@@ -767,7 +768,7 @@ class AliCaloPhotonCuts : public AliAnalysisCuts {
 
   private:
 
-    ClassDef(AliCaloPhotonCuts,134)
+    ClassDef(AliCaloPhotonCuts,135)
 };
 
 #endif


### PR DESCRIPTION
- Add new NOC (Neutral Overlap Correction) trackmatching cut `x`
- Fix cluster headeroverlap histograms with MB header and reduce number of function calls of `IsParticleFromBGEvent` for GammaCalo and GammaConvCalo
- Add new train configs with new NOC to GammaCalo and GammaConvCalo