### PR TITLE
PWGGA/GammaConv: MesonJetCorr: Add Jet acceptance restriction

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskConvJet.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskConvJet.h
@@ -36,7 +36,9 @@ class AliAnalysisTaskConvJet : public AliAnalysisTaskEmcalJet
     const char* ntracks = "usedefault",
     const char* nclusters = "usedefault",
     const char* ncells = "usedefault",
-    const char* suffix = "");
+    const char* suffix = "",
+    double distToEMCBorder = 0.
+    );
 
   Double_t GetNJets() { return fNJets; }
   std::vector<Double_t> GetVectorJetPt() { return fVectorJetPt; }
@@ -82,6 +84,9 @@ class AliAnalysisTaskConvJet : public AliAnalysisTaskEmcalJet
 
   void FindPartonsJet(TClonesArray* arrMCPart);
 
+  void SetDistToEMCBorder(const double tmp) {fDistToEMCBorder = tmp;}
+  double GetDistToEMCBorder() {return fDistToEMCBorder;}
+
  protected:
   void ExecOnce();
   Bool_t FillHistograms();
@@ -119,13 +124,16 @@ class AliAnalysisTaskConvJet : public AliAnalysisTaskEmcalJet
 
   UInt_t fAccType;
   UInt_t fAccTypeMC;
+  
+  double fDistToEMCBorder;      // distance cut to the border of the EMCal, (if set to 0.4, jet with R=0.4 is fully on the EMCal)
 
  private:
+  bool IsJetAccepted(const AliEmcalJet *jet);
   AliAnalysisTaskConvJet(const AliAnalysisTaskConvJet&);
   AliAnalysisTaskConvJet& operator=(const AliAnalysisTaskConvJet&);
 
   /// \cond CLASSIMP
-  ClassDef(AliAnalysisTaskConvJet, 16);
+  ClassDef(AliAnalysisTaskConvJet, 17);
   /// \endcond
 };
 #endif

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvJet.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvJet.C
@@ -2,11 +2,13 @@ AliAnalysisTaskConvJet* AddTask_GammaConvJet(
   const char *ntracks            = "usedefault",
   const char *nclusters          = "usedefault",
   const char* ncells             = "usedefault",
-  const char *suffix             = ""
+  const char *suffix             = "",
+  double distToEMCBorder         = 0.
 )
 {
   return AliAnalysisTaskConvJet::AddTask_GammaConvJet(ntracks,
       nclusters,
       ncells,
-      suffix);
+      suffix,
+      distToEMCBorder);
 }


### PR DESCRIPTION
- Cut out jets that are a certain distance to the border of the EMCal
- This is on order to study the effect if the jet is not fully on the EMCal (one of the leading uncertainties in the preliminary results)
- Cut can be set as an argument to the AddTask
- Cut is both eta and phi: If a cut of 0.4 is chosen, a jet with R=0.4 is guaranteed to be full on the EMCal (=fiducial acceptance).