### PR TITLE
PWGGA/GammaConv: Reduce Memory for PbPb

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.cxx
@@ -387,7 +387,7 @@ AliAnalysisTaskGammaCalo::AliAnalysisTaskGammaCalo(): AliAnalysisTaskSE(),
   fnCuts(0),
   fiCut(0),
   fIsHeavyIon(0),
-  fDoLightOutput(kFALSE),
+  fDoLightOutput(0),
   fDoECalibOutput(kFALSE),
   fDoMesonAnalysis(kTRUE),
   fDoMesonQA(0),
@@ -750,7 +750,7 @@ AliAnalysisTaskGammaCalo::AliAnalysisTaskGammaCalo(const char *name):
   fnCuts(0),
   fiCut(0),
   fIsHeavyIon(0),
-  fDoLightOutput(kFALSE),
+  fDoLightOutput(0),
   fDoECalibOutput(kFALSE),
   fDoMesonAnalysis(kTRUE),
   fDoMesonQA(0),
@@ -1081,14 +1081,15 @@ void AliAnalysisTaskGammaCalo::UserCreateOutputObjects(){
       else arrClusPtBinning[i]                = maxClusterPt;
     }
   } else if (((AliConvEventCuts*)fV0Reader->GetEventCuts())->GetEnergyEnum() == AliConvEventCuts::kPbPb5TeV  ){
-    nBinsPt                   = 108;
+    nBinsMinv                 = 400;
+    nBinsPt                   = 49;
     minPt                     = 0;
     maxPt                     = 40;
     for(Int_t i=0; i<nBinsPt+1;i++){
-      if (i < 1) arrPtBinning[i]              = 0.5*i;
-      else if(i<56) arrPtBinning[i]           = 0.5+0.1*(i-1);
-      else if(i<80) arrPtBinning[i]           = 6.+0.25*(i-56);
-      else if(i<108) arrPtBinning[i]          = 12.+1.0*(i-80);
+      if(i<=20)           arrPtBinning[i]  = 0.0   + 0.2*i;             // 0.2 GeV bin width until 4 GeV
+      else if(i<=30)      arrPtBinning[i]  = 4.0   + 0.5*(i-20);        // 0.5 GeV                 9 GeV
+      else if(i<=41)      arrPtBinning[i]  = 9.0   + 1.0*(i-30);        // 1.0 GeV                 15 GeV
+      else if(i<=49) arrPtBinning[i]       = 20.   + 2.5*(i-41);        // 2.5 GeV                 40 GeV
       else arrPtBinning[i]                    = maxPt;
     }
     nBinsQAPt                 = 92;

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.h
@@ -66,7 +66,7 @@ class AliAnalysisTaskGammaCalo : public AliAnalysisTaskSE {
     void ProcessAODSphericityParticles();
 
     // switches for additional analysis streams or outputs
-    void SetLightOutput(Bool_t flag){fDoLightOutput = flag;}
+    void SetLightOutput(Int_t flag){fDoLightOutput = flag;}
     void SetECalibOutput( Bool_t flag ){fDoECalibOutput = flag;}
     void SetDoMesonAnalysis(Bool_t flag){fDoMesonAnalysis = flag;}
     void SetDoMesonQA(Int_t flag){fDoMesonQA = flag;}
@@ -493,7 +493,7 @@ class AliAnalysisTaskGammaCalo : public AliAnalysisTaskSE {
     Int_t                 fnCuts;                                               // number of cuts to be analysed in parallel
     Int_t                 fiCut;                                                // current cut
     Int_t                 fIsHeavyIon;                                          // switch for pp = 0, PbPb = 1, pPb = 2
-    Bool_t                fDoLightOutput;                                       // switch for running light output, kFALSE -> normal mode, kTRUE -> light mode
+    Int_t                 fDoLightOutput;                                       // switch for running light output, 0 -> normal mode, 1 -> light mode, 2 -> minimum
     Bool_t                fDoECalibOutput;                                      // switch for running with E-Calib Histograms in Light Output, kFALSE -> no E-Calib Histograms, kTRUE -> with E-Calib Histograms
     Bool_t                fDoMesonAnalysis;                                     // flag for meson analysis
     Int_t                 fDoMesonQA;                                           // flag for meson QA

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvCalo.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvCalo.cxx
@@ -1253,14 +1253,15 @@ void AliAnalysisTaskGammaConvCalo::UserCreateOutputObjects(){
       else arrClusPtBinning[i]                = maxClusterPt;
     }
   } else if (((AliConvEventCuts*)fV0Reader->GetEventCuts())->GetEnergyEnum() == AliConvEventCuts::kPbPb5TeV  ){
-    nBinsPt                   = 110;
+    nBinsMinv                 = 400;
+    nBinsPt                   = 49;
     minPt                     = 0;
     maxPt                     = 40;
     for(Int_t i=0; i<nBinsPt+1;i++){
-      if (i < 1) arrPtBinning[i]              = 0.3*i;
-      else if(i<58) arrPtBinning[i]           = 0.3+0.1*(i-1);
-      else if(i<82) arrPtBinning[i]           = 6.+0.25*(i-58);
-      else if(i<110) arrPtBinning[i]          = 12.+1.0*(i-82);
+      if(i<=20)           arrPtBinning[i]  = 0.0   + 0.2*i;             // 0.2 GeV bin width until 4 GeV
+      else if(i<=30)      arrPtBinning[i]  = 4.0   + 0.5*(i-20);        // 0.5 GeV                 9 GeV
+      else if(i<=41)      arrPtBinning[i]  = 9.0   + 1.0*(i-30);        // 1.0 GeV                 15 GeV
+      else if(i<=49) arrPtBinning[i]       = 20.   + 2.5*(i-41);        // 2.5 GeV                 40 GeV
       else arrPtBinning[i]                    = maxPt;
     }
     nBinsQAPt                 = 92;
@@ -1615,8 +1616,6 @@ void AliAnalysisTaskGammaConvCalo::UserCreateOutputObjects(){
             ( ((AliConvEventCuts*)fV0Reader->GetEventCuts())->GetEnergyEnum() == AliConvEventCuts::k13TeV ||
                     ((AliConvEventCuts*)fV0Reader->GetEventCuts())->GetEnergyEnum() == AliConvEventCuts::k13TeVLowB )){
             nBinsPt                   = 310;
-        } else {
-            nBinsPt                   = 238;
         }
         if(fPi0EtaSwitch == 1){ // pi0 only
             nBinsMinv=200*0.3/0.8;

--- a/PWGGA/GammaConv/macros/AddTask_GammaCalo_PbPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaCalo_PbPb.C
@@ -32,7 +32,7 @@ void AddTask_GammaCalo_PbPb(
   Int_t     enableQAMesonTask             = 0,        // enable QA in AliAnalysisTaskGammaConvV1
   Int_t     enableQAClusterTask           = 0,        // enable additional QA task
   Int_t     enableExtMatchAndQA           = 0,        // disabled (0), extMatch (1), extQA_noCellQA (2), extMatch+extQA_noCellQA (3), extQA+cellQA (4), extMatch+extQA+cellQA (5)
-  Bool_t    enableLightOutput             = kFALSE,   // switch to run light output (only essential histograms for afterburner)
+  Int_t     enableLightOutput             = 0,        // switch to run light output (only essential histograms for afterburner)
   Bool_t    enableTHnSparse               = kFALSE,   // switch on THNsparse
   Int_t     enableTriggerMimicking        = 0,        // enable trigger mimicking
   Bool_t    enableHeaderOverlap           = kTRUE,    // enable trigger overlap rejection
@@ -191,6 +191,7 @@ void AddTask_GammaCalo_PbPb(
   task->SetIsHeavyIon(isHeavyIon);
   task->SetIsMC(isMC);
   task->SetV0ReaderName(V0ReaderName);
+  if (enableLightOutput >= 4) task->SetECalibOutput(kTRUE);
   task->SetCorrectionTaskSetting(corrTaskSetting);
   task->SetLightOutput(enableLightOutput);
   task->SetDoPrimaryTrackMatching(doPrimaryTrackMatching);
@@ -2182,6 +2183,7 @@ void AddTask_GammaCalo_PbPb(
       AliCaloTrackMatcher* fTrackMatcher = new AliCaloTrackMatcher(TrackMatcherName.Data(),caloCutPos.Atoi(),trackMatcherRunningMode);
       fTrackMatcher->SetV0ReaderName(V0ReaderName);
       fTrackMatcher->SetCorrectionTaskSetting(corrTaskSetting);
+      if (enableLightOutput == 4) fTrackMatcher->SetLightOutput(kTRUE);
       mgr->AddTask(fTrackMatcher);
       mgr->ConnectInput(fTrackMatcher,0,cinput);
     }
@@ -2266,7 +2268,7 @@ void AddTask_GammaCalo_PbPb(
     }
 
     analysisEventCuts[i]->SetDebugLevel(0);
-    analysisEventCuts[i]->SetLightOutput(enableLightOutput);
+    if (enableLightOutput > 0) analysisEventCuts[i]->SetLightOutput(1);
     if(fMinPtHardSet)
       analysisEventCuts[i]->SetMinFacPtHard(minFacPtHard);
     if(fMaxPtHardSet)
@@ -2287,19 +2289,23 @@ void AddTask_GammaCalo_PbPb(
       if (headerSelectionInt == 1 || headerSelectionInt == 4 || headerSelectionInt == 12 ) analysisEventCuts[i]->SetAddedSignalPDGCode(111);
       if (headerSelectionInt == 2 || headerSelectionInt == 5 || headerSelectionInt == 13 ) analysisEventCuts[i]->SetAddedSignalPDGCode(221);
     }
+    if (enableLightOutput == 1 || enableLightOutput == 2 ) analysisEventCuts[i]->SetLightOutput(1);
+    if (enableLightOutput == 4) analysisEventCuts[i]->SetLightOutput(2);
 
     analysisClusterCuts[i]  = new AliCaloPhotonCuts(isMC);
     analysisClusterCuts[i]->SetHistoToModifyAcceptance(histoAcc);
     analysisClusterCuts[i]->SetV0ReaderName(V0ReaderName);
     analysisClusterCuts[i]->SetCorrectionTaskSetting(corrTaskSetting);
     analysisClusterCuts[i]->SetCaloTrackMatcherName(TrackMatcherName);
-    analysisClusterCuts[i]->SetLightOutput(enableLightOutput);
+    if (enableLightOutput == 1 || enableLightOutput == 2 || enableLightOutput ==5 ) analysisClusterCuts[i]->SetLightOutput(1);
+    if (enableLightOutput == 4) analysisClusterCuts[i]->SetLightOutput(2);
     analysisClusterCuts[i]->InitializeCutsFromCutString((cuts.GetClusterCut(i)).Data());
     ClusterCutList->Add(analysisClusterCuts[i]);
     analysisClusterCuts[i]->SetExtendedMatchAndQA(enableExtMatchAndQA);
 
     analysisMesonCuts[i]    = new AliConversionMesonCuts();
-    analysisMesonCuts[i]->SetLightOutput(enableLightOutput);
+    if (enableLightOutput > 0 && enableLightOutput != 4) analysisMesonCuts[i]->SetLightOutput(1);
+    if (enableLightOutput == 4) analysisMesonCuts[i]->SetLightOutput(2);
     analysisMesonCuts[i]->InitializeCutsFromCutString((cuts.GetMesonCut(i)).Data());
     analysisMesonCuts[i]->SetIsMergedClusterCut(2);
     analysisMesonCuts[i]->SetCaloMesonCutsObject(analysisClusterCuts[i]);

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_PbPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_PbPb.C
@@ -218,7 +218,7 @@ void AddTask_GammaConvCalo_PbPb(
   }
   if (enableLightOutput >= 1 && enableLightOutput != 4) task->SetLightOutput(1);
   else if (enableLightOutput == 4) task->SetLightOutput(2);
-  if (enableLightOutput == 5) task->SetECalibOutput(1);
+  if (enableLightOutput == 4 || enableLightOutput == 5) task->SetECalibOutput(1);
   if (enableLightOutput == 6) task->SetECalibOutput(2);
   task->SetDoPrimaryTrackMatching(doPrimaryTrackMatching);
   task->SetTrackMatcherRunningMode(trackMatcherRunningMode);
@@ -2032,6 +2032,7 @@ void AddTask_GammaConvCalo_PbPb(
       AliCaloTrackMatcher* fTrackMatcher = new AliCaloTrackMatcher(TrackMatcherName.Data(),caloCutPos.Atoi(),trackMatcherRunningMode);
       fTrackMatcher->SetV0ReaderName(V0ReaderName);
       fTrackMatcher->SetCorrectionTaskSetting(corrTaskSetting);
+      if (enableLightOutput == 4) fTrackMatcher->SetLightOutput(kTRUE);
       mgr->AddTask(fTrackMatcher);
       mgr->ConnectInput(fTrackMatcher,0,cinput);
     }
@@ -2129,7 +2130,8 @@ void AddTask_GammaConvCalo_PbPb(
       }
     }
 
-    if (enableLightOutput > 0) analysisEventCuts[i]->SetLightOutput(1);
+    if (enableLightOutput == 1 || enableLightOutput == 2 ) analysisEventCuts[i]->SetLightOutput(1);
+    if (enableLightOutput == 4) analysisEventCuts[i]->SetLightOutput(2);
     analysisEventCuts[i]->InitializeCutsFromCutString((cuts.GetEventCut(i)).Data());
     if (generatorName.CompareTo("LHC14a1b") ==0 || generatorName.CompareTo("LHC14a1c") ==0 ){
       if (headerSelectionInt == 1 || headerSelectionInt == 4 || headerSelectionInt == 12 ) analysisEventCuts[i]->SetAddedSignalPDGCode(111);
@@ -2215,7 +2217,9 @@ void AddTask_GammaConvCalo_PbPb(
       analysisCuts[i]->SetDoElecDeDxPostCalibration(kTRUE);
       cout << "Enabled TPC dEdx recalibration." << endl;
     }
-    if (enableLightOutput > 0) analysisCuts[i]->SetLightOutput(1);
+    if (enableLightOutput == 1 || enableLightOutput == 2 || enableLightOutput == 5 ) analysisCuts[i]->SetLightOutput(1);
+    if (enableLightOutput == 4) analysisCuts[i]->SetLightOutput(2);
+    if (enableLightOutput == 0) analysisCuts[i]->SetPlotTrackPID(kTRUE);
     analysisCuts[i]->InitializeCutsFromCutString((cuts.GetPhotonCut(i)).Data());
     ConvCutList->Add(analysisCuts[i]);
     analysisCuts[i]->SetFillCutHistograms("",kFALSE);
@@ -2225,13 +2229,15 @@ void AddTask_GammaConvCalo_PbPb(
     analysisClusterCuts[i]->SetV0ReaderName(V0ReaderName);
     analysisClusterCuts[i]->SetCorrectionTaskSetting(corrTaskSetting);
     analysisClusterCuts[i]->SetCaloTrackMatcherName(TrackMatcherName);
-    if (enableLightOutput > 0) analysisClusterCuts[i]->SetLightOutput(1);
+    if (enableLightOutput == 1 || enableLightOutput == 2 || enableLightOutput == 5 ) analysisClusterCuts[i]->SetLightOutput(1);
+    if (enableLightOutput == 4) analysisClusterCuts[i]->SetLightOutput(2);
     analysisClusterCuts[i]->InitializeCutsFromCutString((cuts.GetClusterCut(i)).Data());
     ClusterCutList->Add(analysisClusterCuts[i]);
     analysisClusterCuts[i]->SetExtendedMatchAndQA(enableExtMatchAndQA);
 
     analysisMesonCuts[i] = new AliConversionMesonCuts();
-    if (enableLightOutput > 0) analysisMesonCuts[i]->SetLightOutput(1);
+    if (enableLightOutput > 0 && enableLightOutput != 4) analysisMesonCuts[i]->SetLightOutput(1);
+    if (enableLightOutput == 4) analysisMesonCuts[i]->SetLightOutput(2);
     analysisMesonCuts[i]->SetRunningMode(2);
     analysisMesonCuts[i]->InitializeCutsFromCutString((cuts.GetMesonCut(i)).Data());
     MesonCutList->Add(analysisMesonCuts[i]);
@@ -2253,7 +2259,7 @@ void AddTask_GammaConvCalo_PbPb(
   task->SetDoMesonAnalysis(kTRUE);
   task->SetDoMesonQA(enableQAMesonTask); //Attention new switch for Pi0 QA
   task->SetDoPhotonQA(enableQAPhotonTask);  //Attention new switch small for Photon QA
-  task->SetDoClusterQA(1);  //Attention new switch small for Cluster QA
+  if (enableLightOutput != 4) task->SetDoClusterQA(1);  //Attention new switch small for Cluster QA
   task->SetEnableSortingOfMCClusLabels(enableSortingMCLabels);
   task->SetDoTreeInvMassShowerShape(doTreeClusterShowerShape);
   task->SetUseTHnSparse(enableTHnSparse);


### PR DESCRIPTION
- changed minv and pT binning for PbPb 5.02 TeV for GCoCa and GCa
- excluded EventCutList, ClusterCutList and MesonCutList from Output if enableLightOutput > 1