### PR TITLE
PWGGA/GammaConv: ADd new NOC obtained from <E_clus-E_y>/E_y

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.cxx
@@ -278,8 +278,8 @@ AliAnalysisTaskGammaCalo::AliAnalysisTaskGammaCalo(): AliAnalysisTaskSE(),
   fHistoTrueClusSubLeadingPt(NULL),
   fHistoTrueClusNParticles(NULL),
   fHistoTrueClusEMNonLeadingPt(NULL),
-  fHistoTrueClusGammaEResNTrackPt(NULL),
-  fHistoTrueClusPhotonGammaEResNPrimTrackPt(NULL),
+  fHistoTrueClusGammaEResE(NULL),
+  fHistoTrueClusPhotonGammaEResE(NULL),
   fHistoTrueNLabelsInClus(NULL),
   fHistoTruePrimaryClusGammaPt(NULL),
   fHistoTruePrimaryClusGammaESDPtMCPt(NULL),
@@ -641,8 +641,8 @@ AliAnalysisTaskGammaCalo::AliAnalysisTaskGammaCalo(const char *name):
   fHistoTrueClusSubLeadingPt(NULL),
   fHistoTrueClusNParticles(NULL),
   fHistoTrueClusEMNonLeadingPt(NULL),
-  fHistoTrueClusGammaEResNTrackPt(NULL),
-  fHistoTrueClusPhotonGammaEResNPrimTrackPt(NULL),
+  fHistoTrueClusGammaEResE(NULL),
+  fHistoTrueClusPhotonGammaEResE(NULL),
   fHistoTrueNLabelsInClus(NULL),
   fHistoTruePrimaryClusGammaPt(NULL),
   fHistoTruePrimaryClusGammaESDPtMCPt(NULL),
@@ -936,7 +936,6 @@ void AliAnalysisTaskGammaCalo::UserCreateOutputObjects(){
   Double_t *arrQAPtBinning    = new Double_t[1200];
   Double_t *arrClusPtBinning  = new Double_t[1200];
   std::vector<double> arrResBinning;
-  std::vector<double> arrNMatchedTracks;
   if( fDoPi0Only ){
     nBinsMinv                 = 150;
     maxMinv                  = 0.3;
@@ -1138,9 +1137,6 @@ void AliAnalysisTaskGammaCalo::UserCreateOutputObjects(){
         valRes += 0.05;
       else
         break;
-    }
-    for (int i = 0; i < 10; ++i) {
-      arrNMatchedTracks.push_back(i-0.5);
     }
   }
 
@@ -2030,9 +2026,8 @@ void AliAnalysisTaskGammaCalo::UserCreateOutputObjects(){
       fHistoTrueClusSubLeadingPt                = new TH1F*[fnCuts];
       fHistoTrueClusNParticles                  = new TH1F*[fnCuts];
       fHistoTrueClusEMNonLeadingPt              = new TH1F*[fnCuts];
-      fHistoTrueClusGammaEResNTrackPt                 = new TH3F*[fnCuts];
-      fHistoTrueClusPhotonGammaEResNPrimTrackPt = new TH3F*[fnCuts];
-      fHistoTrueClusPhotonGammaEResNTrackPt     = new TH3F*[fnCuts];
+      fHistoTrueClusGammaEResE                  = new TH2F*[fnCuts];
+      fHistoTrueClusPhotonGammaEResE            = new TH2F*[fnCuts];
     }
 
     if(fDoMesonAnalysis){
@@ -2712,44 +2707,37 @@ void AliAnalysisTaskGammaCalo::UserCreateOutputObjects(){
         fHistoTrueClusEMNonLeadingPt[iCut]          = new TH1F("TrueClusEMNonLeading_Pt", "TrueClusEMNonLeading_Pt", nBinsClusterPt, arrClusPtBinning);
         fHistoTrueClusEMNonLeadingPt[iCut]->SetXTitle("#it{p}_{T} (GeV/#it{c})");
         fTrueList[iCut]->Add(fHistoTrueClusEMNonLeadingPt[iCut]);
-        fHistoTrueClusGammaEResNTrackPt[iCut]          = new TH3F("TrueClusGammaERes_Pt", "TrueClusGammaERes_Pt", nBinsClusterPt, arrClusPtBinning, arrNMatchedTracks.size()-1, arrNMatchedTracks.data(),  arrResBinning.size()-1, arrResBinning.data());
-        fHistoTrueClusGammaEResNTrackPt[iCut]->SetXTitle("#it{p}_{T} (GeV/#it{c})");
-        fHistoTrueClusGammaEResNTrackPt[iCut]->SetYTitle("#it{N}_{matched track}");
-        fHistoTrueClusGammaEResNTrackPt[iCut]->SetZTitle("(#it{E}_{rec}-#it{E}_{true})/#it{E}_{true}");
-        fTrueList[iCut]->Add(fHistoTrueClusGammaEResNTrackPt[iCut]);
-        fHistoTrueClusPhotonGammaEResNPrimTrackPt[iCut]          = new TH3F("TrueClusPhotonGammaERes_NPrimTrack_Pt", "TrueClusPhotonGammaERes_NPrimTrack_Pt", nBinsClusterPt, arrClusPtBinning, arrNMatchedTracks.size()-1, arrNMatchedTracks.data(), arrResBinning.size()-1, arrResBinning.data());
-        fHistoTrueClusPhotonGammaEResNPrimTrackPt[iCut]->SetXTitle("#it{p}_{T} (GeV/#it{c})");
-        fHistoTrueClusPhotonGammaEResNPrimTrackPt[iCut]->SetYTitle("#it{N}_{matched primary track}");
-        fHistoTrueClusPhotonGammaEResNPrimTrackPt[iCut]->SetZTitle("(#it{E}_{rec}-#it{E}_{true})/#it{E}_{true}");
-        fTrueList[iCut]->Add(fHistoTrueClusPhotonGammaEResNPrimTrackPt[iCut]);
-        fHistoTrueClusPhotonGammaEResNTrackPt[iCut]          = new TH3F("TrueClusPhotonGammaERes_NTrack_Pt", "TrueClusPhotonGammaERes_NPrimTrack_Pt", nBinsClusterPt, arrClusPtBinning, arrNMatchedTracks.size()-1, arrNMatchedTracks.data(), arrResBinning.size()-1, arrResBinning.data());
-        fHistoTrueClusPhotonGammaEResNTrackPt[iCut]->SetXTitle("#it{p}_{T} (GeV/#it{c})");
-        fHistoTrueClusPhotonGammaEResNTrackPt[iCut]->SetYTitle("#it{N}_{matched track}");
-        fHistoTrueClusPhotonGammaEResNTrackPt[iCut]->SetZTitle("(#it{E}_{rec}-#it{E}_{true})/#it{E}_{true}");
-        fTrueList[iCut]->Add(fHistoTrueClusPhotonGammaEResNTrackPt[iCut]);
+        fHistoTrueClusGammaEResE[iCut]          = new TH2F("TrueClusGammaERes_E", "TrueClusGammaERes_E", nBinsClusterPt, arrClusPtBinning,  arrResBinning.size()-1, arrResBinning.data());
+        fHistoTrueClusGammaEResE[iCut]->SetXTitle("#it{E}_{rec} (GeV)");
+        fHistoTrueClusGammaEResE[iCut]->SetYTitle("(#it{E}_{rec}-#it{E}_{true})/#it{E}_{true}");
+        fTrueList[iCut]->Add(fHistoTrueClusGammaEResE[iCut]);
+        fHistoTrueClusPhotonGammaEResE[iCut]          = new TH2F("TrueClusPhotonGammaERes_E", "TrueClusPhotonGammaERes_E", nBinsClusterPt, arrClusPtBinning, arrResBinning.size()-1, arrResBinning.data());
+        fHistoTrueClusPhotonGammaEResE[iCut]->SetXTitle("#it{E}_{rec} (GeV)");
+        fHistoTrueClusPhotonGammaEResE[iCut]->SetYTitle("(#it{E}_{rec}-#it{E}_{true})/#it{E}_{true}");
+        fTrueList[iCut]->Add(fHistoTrueClusPhotonGammaEResE[iCut]);
         
 
         if (fIsMC > 1){
-            fHistoTrueClusUnConvGammaPt[iCut]->Sumw2();
-            fHistoTrueClusUnConvGammaMCPt[iCut]->Sumw2();
-            if (!fDoLightOutput)
-              fHistoTrueClusUnConvGammaPtM02[iCut]->Sumw2();
-            fHistoTrueClusElectronPt[iCut]->Sumw2();
-            fHistoTrueClusConvGammaPt[iCut]->Sumw2();
-            fHistoTrueClusConvGammaMCPt[iCut]->Sumw2();
-            fHistoTrueClusConvGammaFullyPt[iCut]->Sumw2();
-            fHistoTrueClusMergedGammaPt[iCut]->Sumw2();
-            fHistoTrueClusMergedPartConvGammaPt[iCut]->Sumw2();
-            fHistoTrueClusDalitzPt[iCut]->Sumw2();
-            fHistoTrueClusDalitzMergedPt[iCut]->Sumw2();
-            fHistoTrueClusPhotonFromElecMotherPt[iCut]->Sumw2();
-            fHistoTrueClusShowerPt[iCut]->Sumw2();
-            fHistoTrueClusSubLeadingPt[iCut]->Sumw2();
-            fHistoTrueClusNParticles[iCut]->Sumw2();
-            fHistoTrueClusEMNonLeadingPt[iCut]->Sumw2();
-            fHistoTrueClusGammaEResNTrackPt[iCut]->Sumw2();
-            fHistoTrueClusPhotonGammaEResNPrimTrackPt[iCut]->Sumw2();
-            fHistoTrueClusPhotonGammaEResNTrackPt[iCut]->Sumw2();
+          fHistoTrueClusUnConvGammaPt[iCut]->Sumw2();
+          fHistoTrueClusUnConvGammaMCPt[iCut]->Sumw2();
+          if (!fDoLightOutput) fHistoTrueClusUnConvGammaPtM02[iCut]->Sumw2();
+          fHistoTrueClusElectronPt[iCut]->Sumw2();
+          fHistoTrueClusConvGammaPt[iCut]->Sumw2();
+          fHistoTrueClusConvGammaMCPt[iCut]->Sumw2();
+          fHistoTrueClusConvGammaFullyPt[iCut]->Sumw2();
+          fHistoTrueClusMergedGammaPt[iCut]->Sumw2();
+          fHistoTrueClusMergedPartConvGammaPt[iCut]->Sumw2();
+          fHistoTrueClusDalitzPt[iCut]->Sumw2();
+          fHistoTrueClusDalitzMergedPt[iCut]->Sumw2();
+          fHistoTrueClusPhotonFromElecMotherPt[iCut]->Sumw2();
+          fHistoTrueClusShowerPt[iCut]->Sumw2();
+          fHistoTrueClusSubLeadingPt[iCut]->Sumw2();
+          fHistoTrueClusNParticles[iCut]->Sumw2();
+          fHistoTrueClusEMNonLeadingPt[iCut]->Sumw2();
+          if(fDoClusterQA > 0 ){
+            fHistoTrueClusGammaEResE[iCut]->Sumw2();
+            fHistoTrueClusPhotonGammaEResE[iCut]->Sumw2();
+          }
         }
       }
       if(fDoMesonAnalysis){
@@ -3687,7 +3675,7 @@ void AliAnalysisTaskGammaCalo::ProcessClusters()
         } else if(((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetDoEnergyCorrectionForOverlap() == 3){
           // Neutral Overlap correction via mean number of charged particles per cell
           clus->SetE(clus->E() - 12.f * ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->CorrectEnergyForOverlap(cent));
-        } else if(((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetDoEnergyCorrectionForOverlap() == 4){
+        } else if(((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetDoEnergyCorrectionForOverlap() >= 4){
           // Neutral Overlap correction via NonLin like correction
           clus->SetE(clus->E() * ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->CorrectEnergyForOverlap(cent, clus->E()));
         }
@@ -4285,7 +4273,7 @@ void AliAnalysisTaskGammaCalo::ProcessTrueClusterCandidates(AliAODConversionPhot
     fHistoTrueClusGammaPt[fiCut]->Fill(TruePhotonCandidate->Pt(), tempPhotonWeight);
     if (!fDoLightOutput && fDoClusterQA > 0){
       fHistoTrueClusGammaPtM02[fiCut]->Fill(TruePhotonCandidate->Pt(), clusterM02, tempPhotonWeight);
-      fHistoTrueClusGammaEResNTrackPt[fiCut]->Fill(TruePhotonCandidate->Pt(), NMatchedTracks, (TruePhotonCandidate->E()-Photon->E())/Photon->E(), tempPhotonWeight);
+      fHistoTrueClusGammaEResE[fiCut]->Fill(TruePhotonCandidate->E(), (TruePhotonCandidate->E()-Photon->E())/Photon->E(), tempPhotonWeight);
     }
   } else if (fDoClusterQA > 0) fHistoTrueClusEMNonLeadingPt[fiCut]->Fill(TruePhotonCandidate->Pt());
   if (fDoClusterQA > 0){
@@ -4294,8 +4282,7 @@ void AliAnalysisTaskGammaCalo::ProcessTrueClusterCandidates(AliAODConversionPhot
       fHistoTrueClusUnConvGammaMCPt[fiCut]->Fill(Photon->Pt(), tempPhotonWeight);
       if (!fDoLightOutput) {
         fHistoTrueClusUnConvGammaPtM02[fiCut]->Fill(TruePhotonCandidate->Pt(), clusterM02, tempPhotonWeight);
-        fHistoTrueClusPhotonGammaEResNPrimTrackPt[fiCut]->Fill(TruePhotonCandidate->Pt(), NMatchedPrimTracks, (TruePhotonCandidate->E()-Photon->E())/Photon->E(), tempPhotonWeight);
-        fHistoTrueClusPhotonGammaEResNTrackPt[fiCut]->Fill(TruePhotonCandidate->Pt(), NMatchedTracks, (TruePhotonCandidate->E()-Photon->E())/Photon->E(), tempPhotonWeight);
+        fHistoTrueClusPhotonGammaEResE[fiCut]->Fill(TruePhotonCandidate->E(), (TruePhotonCandidate->E()-Photon->E())/Photon->E(), tempPhotonWeight);
       }
     }
     if (TruePhotonCandidate->IsLargestComponentElectron())
@@ -4465,7 +4452,7 @@ void AliAnalysisTaskGammaCalo::ProcessTrueClusterCandidatesAOD(AliAODConversionP
     fHistoTrueClusGammaPt[fiCut]->Fill(TruePhotonCandidate->Pt(), tempPhotonWeight);
     if (!fDoLightOutput && fDoClusterQA > 0) {
       fHistoTrueClusGammaPtM02[fiCut]->Fill(TruePhotonCandidate->Pt(), clusterM02, tempPhotonWeight);
-      fHistoTrueClusGammaEResNTrackPt[fiCut]->Fill(TruePhotonCandidate->Pt(), NMatchedTracks, (TruePhotonCandidate->E()-Photon->E())/Photon->E(), tempPhotonWeight);
+      fHistoTrueClusGammaEResE[fiCut]->Fill(TruePhotonCandidate->E(), (TruePhotonCandidate->E()-Photon->E())/Photon->E(), tempPhotonWeight);
     }
   } else if (fDoClusterQA > 0) fHistoTrueClusEMNonLeadingPt[fiCut]->Fill(TruePhotonCandidate->Pt());
   if (fDoClusterQA > 0){
@@ -4474,8 +4461,7 @@ void AliAnalysisTaskGammaCalo::ProcessTrueClusterCandidatesAOD(AliAODConversionP
       fHistoTrueClusUnConvGammaMCPt[fiCut]->Fill(Photon->Pt(), tempPhotonWeight);
       if (!fDoLightOutput) {
         fHistoTrueClusUnConvGammaPtM02[fiCut]->Fill(TruePhotonCandidate->Pt(), clusterM02, tempPhotonWeight);
-        fHistoTrueClusPhotonGammaEResNPrimTrackPt[fiCut]->Fill(TruePhotonCandidate->Pt(), NMatchedPrimTracks, (TruePhotonCandidate->E()-Photon->E())/Photon->E(), tempPhotonWeight);
-        fHistoTrueClusPhotonGammaEResNTrackPt[fiCut]->Fill(TruePhotonCandidate->Pt(), NMatchedTracks, (TruePhotonCandidate->E()-Photon->E())/Photon->E(), tempPhotonWeight);
+        fHistoTrueClusPhotonGammaEResE[fiCut]->Fill(TruePhotonCandidate->E(), (TruePhotonCandidate->E()-Photon->E())/Photon->E(), tempPhotonWeight);
       }
     }
     if (TruePhotonCandidate->IsLargestComponentElectron())

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.h
@@ -370,9 +370,8 @@ class AliAnalysisTaskGammaCalo : public AliAnalysisTaskSE {
     TH1F**                fHistoTrueClusSubLeadingPt;                               //! array of histos with pi0/eta/eta_prime in subleading contribution
     TH1F**                fHistoTrueClusNParticles;                                 //! array of histos with number of different particles (pi0/eta/eta_prime) contributing to cluster
     TH1F**                fHistoTrueClusEMNonLeadingPt;                             //! array of histos with cluster with largest energy by hadron
-    TH3F**                fHistoTrueClusGammaEResNTrackPt;                          //! array of histos with photon (validated and conversions) energy resolution ((E_rec-E_true)/E_true) as function of N matched tracks and pT_rec
-    TH3F**                fHistoTrueClusPhotonGammaEResNPrimTrackPt;                //! array of histos with validated photon energy resolution ((E_rec-E_true)/E_true) as function of N matched primary tracks and pT_rec 
-    TH3F**                fHistoTrueClusPhotonGammaEResNTrackPt;                    //! array of histos with validated photon energy resolution ((E_rec-E_true)/E_true) as function of N matched tracks and pT_rec
+    TH2F**                fHistoTrueClusGammaEResE;                                 //! array of histos with photon (validated and conversions) energy resolution ((E_rec-E_true)/E_true) as function of E_rec
+    TH2F**                fHistoTrueClusPhotonGammaEResE;                           //! array of histos with validated photon energy resolution ((E_rec-E_true)/E_true) as function of E_rec 
     TH1F**                fHistoTrueNLabelsInClus;                                  //! array of histos with number of labels in cluster
     TH1F**                fHistoTruePrimaryClusGammaPt;                             //! array of histos with validated primary photon cluster, pt
     TH2F**                fHistoTruePrimaryClusGammaESDPtMCPt;                      //! array of histos with validated primary photon cluster, rec Pt, MC pt

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvCalo.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvCalo.h
@@ -407,6 +407,8 @@ class AliAnalysisTaskGammaConvCalo : public AliAnalysisTaskSE {
     TH1F**                  fHistoTrueClusSubLeadingPt;                         //! array of histos with pi0/eta/eta_prime in subleading contribution
     TH1F**                  fHistoTrueClusNMothers;                             //! array of histos with number of different particles (pi0/eta/eta_prime) contributing to cluster
     TH1F**                  fHistoTrueClusEMNonLeadingPt;                       //! array of histos with cluster with largest energy by hadron
+    TH2F**                  fHistoTrueClusGammaEResE;                           //! array of histos with photon (validated and conversions) energy resolution ((E_rec-E_true)/E_true) as function of E_rec
+    TH2F**                  fHistoTrueClusPhotonGammaEResE;                     //! array of histos with validated photon energy resolution ((E_rec-E_true)/E_true) as function of E_rec 
     TH2F**                  fHistoTrueNLabelsInClusPt;                          //! array of histos with number of labels in cluster
     TH1F**                  fHistoTruePrimaryClusGammaPt;                       //! array of histos with validated primary cluster, photons, pt
     TH2F**                  fHistoTruePrimaryClusGammaESDPtMCPt;                //! array of histos with validated primary cluster, photons, rec Pt, MC pt

--- a/PWGGA/GammaConv/macros/AddTask_GammaCalo_PbPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaCalo_PbPb.C
@@ -1559,6 +1559,16 @@ void AddTask_GammaCalo_PbPb(
     cuts.AddCutCalo("11310023","411790105te30220000","01331031000000d0"); // 10-30%
     cuts.AddCutCalo("13530023","411790105te30220000","01331031000000d0"); // 30-50%
     cuts.AddCutCalo("15910023","411790105te30220000","01331031000000d0"); // 50-90%
+  } else if (trainConfig == 1015){ // 4 cents with mean N matched tracks per cluster data
+    cuts.AddCutCalo("10130e03","411790105ye30220000","01331031000000d0"); // 00-10%
+    cuts.AddCutCalo("11310e03","411790105ye30220000","01331031000000d0"); // 10-30%
+    cuts.AddCutCalo("13530e03","411790105ye30220000","01331031000000d0"); // 30-50%
+    cuts.AddCutCalo("15910e03","411790105ye30220000","01331031000000d0"); // 50-90%
+  } else if (trainConfig == 1016){ // 4 cents, with mean N matched tracks per cluster MC no OOB Pileup correction for MC
+    cuts.AddCutCalo("10130053","411790105ye30220000","01331031000000d0"); // 00-10%
+    cuts.AddCutCalo("11310053","411790105ye30220000","01331031000000d0"); // 10-30%
+    cuts.AddCutCalo("13530053","411790105ye30220000","01331031000000d0"); // 30-50%
+    cuts.AddCutCalo("15910053","411790105ye30220000","01331031000000d0"); // 50-90%
   // with rotation background
   } else if (trainConfig == 1050){ // 4 cents
     cuts.AddCutCalo("10130e03","411790105ke30220000","0s331031000000d0"); // 00-10%
@@ -1635,6 +1645,16 @@ void AddTask_GammaCalo_PbPb(
     cuts.AddCutCalo("11310023","411790105te30220000","0s331031000000d0"); // 10-30%
     cuts.AddCutCalo("13530023","411790105te30220000","0s331031000000d0"); // 30-50%
     cuts.AddCutCalo("15910023","411790105te30220000","0s331031000000d0"); // 50-90%
+  } else if (trainConfig == 1065){ // 4 cents with mean N matched tracks per cluster data
+    cuts.AddCutCalo("10130e03","411790105ye30220000","0s331031000000d0"); // 00-10%
+    cuts.AddCutCalo("11310e03","411790105ye30220000","0s331031000000d0"); // 10-30%
+    cuts.AddCutCalo("13530e03","411790105ye30220000","0s331031000000d0"); // 30-50%
+    cuts.AddCutCalo("15910e03","411790105ye30220000","0s331031000000d0"); // 50-90%
+  } else if (trainConfig == 1066){ // 4 cents, with mean N matched tracks per cluster MC no OOB Pileup correction for MC
+    cuts.AddCutCalo("10130053","411790105ye30220000","0s331031000000d0"); // 00-10%
+    cuts.AddCutCalo("11310053","411790105ye30220000","0s331031000000d0"); // 10-30%
+    cuts.AddCutCalo("13530053","411790105ye30220000","0s331031000000d0"); // 30-50%
+    cuts.AddCutCalo("15910053","411790105ye30220000","0s331031000000d0"); // 50-90%
   // **********************************************************************************************************
   // **************************** EMC configurations PbPb run 2 2018 pass 3 cent ******************************
   // **********************************************************************************************************
@@ -1669,6 +1689,10 @@ void AddTask_GammaCalo_PbPb(
     cuts.AddCutCalo("10130023","411790105te30220000","01331031000000d0"); // 00-10%
   } else if (trainConfig == 1114){ // central, with mean N matched tracks per cluster MC no OOB Pileup correction for MC with added signal (copy for pi0 + eta)
     cuts.AddCutCalo("10130023","411790105te30220000","01331031000000d0"); // 00-10%
+  } else if (trainConfig == 1115){ // central with mean N matched tracks per cluster data
+    cuts.AddCutCalo("10130e03","411790105ye30220000","01331031000000d0"); // 00-10%
+  } else if (trainConfig == 1116){ // central, with mean N matched tracks per cluster MC no OOB Pileup correction for MC
+    cuts.AddCutCalo("10130053","411790105ye30220000","01331031000000d0"); // 00-10%
   // with rotation background
   } else if (trainConfig == 1150){ // central
     cuts.AddCutCalo("10130e03","411790105ke30220000","0s331031000000d0"); // 00-10%
@@ -1700,6 +1724,10 @@ void AddTask_GammaCalo_PbPb(
     cuts.AddCutCalo("10130023","411790105te30220000","0s331031000000d0"); // 00-10%
   } else if (trainConfig == 1164){ // central, with mean N matched tracks per cluster MC no OOB Pileup correction for MC with added signal (copy for pi0 + eta)
     cuts.AddCutCalo("10130023","411790105te30220000","0s331031000000d0"); // 00-10%
+  } else if (trainConfig == 1165){ // central with mean N matched tracks per cluster data
+    cuts.AddCutCalo("10130e03","411790105ye30220000","0s331031000000d0"); // 00-10%
+  } else if (trainConfig == 1166){ // central, with mean N matched tracks per cluster MC no OOB Pileup correction for MC
+    cuts.AddCutCalo("10130053","411790105ye30220000","0s331031000000d0"); // 00-10%
   // **********************************************************************************************************
   // ************************** EMC configurations PbPb run 2 2018 pass 3 semicent ****************************
   // **********************************************************************************************************
@@ -1734,6 +1762,10 @@ void AddTask_GammaCalo_PbPb(
     cuts.AddCutCalo("11310023","411790105te30220000","01331031000000d0"); // 10-30%
   } else if (trainConfig == 1314){ // semicent, with mean N matched tracks per cluster MC no OOB Pileup correction for MC with added signal (copy for pi0 + eta)
     cuts.AddCutCalo("11310023","411790105te30220000","01331031000000d0"); // 10-30%
+  } else if (trainConfig == 1315){ // semicent with mean N matched tracks per cluster data
+    cuts.AddCutCalo("11310e03","411790105ye30220000","01331031000000d0"); // 10-30%
+  } else if (trainConfig == 1316){ // semicent, with mean N matched tracks per cluster MC no OOB Pileup correction for MC
+    cuts.AddCutCalo("11310053","411790105ye30220000","01331031000000d0"); // 10-30%
   // with rotation background
   } else if (trainConfig == 1350){ // semicent
     cuts.AddCutCalo("11310e03","411790105ke30220000","0s331031000000d0"); // 10-30%
@@ -1765,6 +1797,10 @@ void AddTask_GammaCalo_PbPb(
     cuts.AddCutCalo("11310023","411790105te30220000","0s331031000000d0"); // 10-30%
   } else if (trainConfig == 1364){ // semicent, with mean N matched tracks per cluster MC no OOB Pileup correction for MC with added signal (copy for pi0 + eta)
     cuts.AddCutCalo("11310023","411790105te30220000","0s331031000000d0"); // 10-30%
+  } else if (trainConfig == 1365){ // semicent with mean N matched tracks per cluster data
+    cuts.AddCutCalo("11310e03","411790105ye30220000","0s331031000000d0"); // 10-30%
+  } else if (trainConfig == 1366){ // semicent, with mean N matched tracks per cluster MC no OOB Pileup correction for MC
+    cuts.AddCutCalo("11310053","411790105ye30220000","0s331031000000d0"); // 10-30%
   // **********************************************************************************************************
   // *********************** EMC configurations PbPb run 2 2018 pass 3 semiperipheral *************************
   // **********************************************************************************************************
@@ -1799,6 +1835,10 @@ void AddTask_GammaCalo_PbPb(
     cuts.AddCutCalo("13530023","411790105te30220000","01331031000000d0"); // 30-50%
   } else if (trainConfig == 1514){ // semiperipheral, with mean N matched tracks per cluster MC no OOB Pileup correction for MC with added signal (copy for pi0 + eta)
     cuts.AddCutCalo("13530023","411790105te30220000","01331031000000d0"); // 30-50%
+  } else if (trainConfig == 1515){ // semiperipheral with mean N matched tracks per cluster data
+    cuts.AddCutCalo("13530e03","411790105ye30220000","01331031000000d0"); // 30-50%
+  } else if (trainConfig == 1516){ // semiperipheral, with mean N matched tracks per cluster MC no OOB Pileup correction for MC
+    cuts.AddCutCalo("13530053","411790105ye30220000","01331031000000d0"); // 30-50%
   // with rotation background
   } else if (trainConfig == 1550){ // semiperipheral
     cuts.AddCutCalo("13530e03","411790105ke30220000","0s331031000000d0"); // 30-50%
@@ -1830,6 +1870,10 @@ void AddTask_GammaCalo_PbPb(
     cuts.AddCutCalo("13530023","411790105te30220000","0s331031000000d0"); // 30-50%
   } else if (trainConfig == 1564){ // semiperipheral, with mean N matched tracks per cluster MC no OOB Pileup correction for MC with added signal (copy for pi0 + eta)
     cuts.AddCutCalo("13530023","411790105te30220000","0s331031000000d0"); // 30-50%
+  } else if (trainConfig == 1565){ // semiperipheral with mean N matched tracks per cluster data
+    cuts.AddCutCalo("13530e03","411790105ye30220000","0s331031000000d0"); // 30-50%
+  } else if (trainConfig == 1566){ // semiperipheral, with mean N matched tracks per cluster MC no OOB Pileup correction for MC
+    cuts.AddCutCalo("13530053","411790105ye30220000","0s331031000000d0"); // 30-50%
   // **********************************************************************************************************
   // ************************* EMC configurations PbPb run 2 2018 pass 3 peripheral ***************************
   // **********************************************************************************************************
@@ -1864,6 +1908,10 @@ void AddTask_GammaCalo_PbPb(
     cuts.AddCutCalo("15910023","411790105te30220000","01331031000000d0"); // 50-90%
   } else if (trainConfig == 1914){ // peripheral, with mean N matched tracks per cluster MC no OOB Pileup correction for MC with added signal (copy for pi0 + eta)
     cuts.AddCutCalo("15910023","411790105te30220000","01331031000000d0"); // 50-90%
+  } else if (trainConfig == 1915){ // peripheral with mean N matched tracks per cluster data
+    cuts.AddCutCalo("15910e03","411790105ye30220000","01331031000000d0"); // 50-90%
+  } else if (trainConfig == 1916){ // peripheral, with mean N matched tracks per cluster MC no OOB Pileup correction for MC
+    cuts.AddCutCalo("15910053","411790105ye30220000","01331031000000d0"); // 50-90%
   // with rotation background
   } else if (trainConfig == 1950){ // peripheral
     cuts.AddCutCalo("15910e03","411790105ke30220000","0s331031000000d0"); // 50-90%
@@ -1895,6 +1943,10 @@ void AddTask_GammaCalo_PbPb(
     cuts.AddCutCalo("15910023","411790105te30220000","0s331031000000d0"); // 50-90%
   } else if (trainConfig == 1964){ // peripheral, with mean N matched tracks per cluster MC no OOB Pileup correction for MC with added signal (copy for pi0 + eta)
     cuts.AddCutCalo("15910023","411790105te30220000","0s331031000000d0"); // 50-90%
+  } else if (trainConfig == 1965){ // peripheral with mean N matched tracks per cluster data
+    cuts.AddCutCalo("15910e03","411790105ye30220000","0s331031000000d0"); // 50-90%
+  } else if (trainConfig == 1966){ // peripheral, with mean N matched tracks per cluster MC no OOB Pileup correction for MC
+    cuts.AddCutCalo("15910053","411790105ye30220000","0s331031000000d0"); // 50-90%
     // **********************************************************************************************************
   // ***************************** EMC configurations PbPb run 2 2015 pass 3 *******************************
   // **********************************************************************************************************
@@ -1974,6 +2026,16 @@ void AddTask_GammaCalo_PbPb(
     cuts.AddCutCalo("11310023","411790105te30220000","01331031000000d0"); // 10-30%
     cuts.AddCutCalo("13510023","411790105te30220000","01331031000000d0"); // 30-50%
     cuts.AddCutCalo("15910023","411790105te30220000","01331031000000d0"); // 50-90%
+  } else if (trainConfig == 2015){ // 4 cents with NOC via <E_clus-E>/E
+    cuts.AddCutCalo("10110e03","411790105ye30220000","01331031000000d0"); // 00-10%
+    cuts.AddCutCalo("11310e03","411790105ye30220000","01331031000000d0"); // 10-30%
+    cuts.AddCutCalo("13510e03","411790105ye30220000","01331031000000d0"); // 30-50%
+    cuts.AddCutCalo("15910e03","411790105ye30220000","01331031000000d0"); // 50-90%
+  } else if (trainConfig == 2016){ // 4 cents, with NOC via <E_clus-E>/E no OOB Pileup correction for MC
+    cuts.AddCutCalo("10110053","411790105ye30220000","01331031000000d0"); // 00-10%
+    cuts.AddCutCalo("11310053","411790105ye30220000","01331031000000d0"); // 10-30%
+    cuts.AddCutCalo("13510053","411790105ye30220000","01331031000000d0"); // 30-50%
+    cuts.AddCutCalo("15910053","411790105ye30220000","01331031000000d0"); // 50-90%
   // with rotation background
   } else if (trainConfig == 2050){ // 4 cents
     cuts.AddCutCalo("10110e03","411790105ke30220000","0s331031000000d0"); // 00-10%
@@ -2050,6 +2112,16 @@ void AddTask_GammaCalo_PbPb(
     cuts.AddCutCalo("11310023","411790105te30220000","0s331031000000d0"); // 10-30%
     cuts.AddCutCalo("13510023","411790105te30220000","0s331031000000d0"); // 30-50%
     cuts.AddCutCalo("15910023","411790105te30220000","0s331031000000d0"); // 50-90%
+  } else if (trainConfig == 2065){ // 4 cents with NOC via <E_clus-E>/E
+    cuts.AddCutCalo("10110e03","411790105ye30220000","0s331031000000d0"); // 00-10%
+    cuts.AddCutCalo("11310e03","411790105ye30220000","0s331031000000d0"); // 10-30%
+    cuts.AddCutCalo("13510e03","411790105ye30220000","0s331031000000d0"); // 30-50%
+    cuts.AddCutCalo("15910e03","411790105ye30220000","0s331031000000d0"); // 50-90%
+  } else if (trainConfig == 2066){ // 4 cents, with NOC via <E_clus-E>/E no OOB Pileup correction for MC
+    cuts.AddCutCalo("10110053","411790105ye30220000","0s331031000000d0"); // 00-10%
+    cuts.AddCutCalo("11310053","411790105ye30220000","0s331031000000d0"); // 10-30%
+    cuts.AddCutCalo("13510053","411790105ye30220000","0s331031000000d0"); // 30-50%
+    cuts.AddCutCalo("15910053","411790105ye30220000","0s331031000000d0"); // 50-90%
   // **********************************************************************************************************
   // **************************** EMC configurations PbPb run 2 2015 pass 3 cent ******************************
   // **********************************************************************************************************
@@ -2084,6 +2156,10 @@ void AddTask_GammaCalo_PbPb(
     cuts.AddCutCalo("10110023","411790105te30220000","01331031000000d0"); // 00-10%
   } else if (trainConfig == 2114){ // central, with mean N matched tracks per cluster MC no OOB Pileup correction for MC with added signal (copy for pi0 + eta)
     cuts.AddCutCalo("10110023","411790105te30220000","01331031000000d0"); // 00-10%
+  } else if (trainConfig == 2115){ // central NOC via <E_clus-E>/E data
+    cuts.AddCutCalo("10110e03","411790105ye30220000","01331031000000d0"); // 00-10%
+  } else if (trainConfig == 2116){ // central, NOC via <E_clus-E>/E MC no OOB Pileup correction for MC
+    cuts.AddCutCalo("10110053","411790105ye30220000","01331031000000d0"); // 00-10%
   // with rotation background
   } else if (trainConfig == 2150){ // central
     cuts.AddCutCalo("10110e03","411790105ke30220000","0s331031000000d0"); // 00-10%
@@ -2115,6 +2191,10 @@ void AddTask_GammaCalo_PbPb(
     cuts.AddCutCalo("10110023","411790105te30220000","0s331031000000d0"); // 00-10%
   } else if (trainConfig == 2164){ // central, with mean N matched tracks per cluster MC no OOB Pileup correction for MC with added signal (copy for pi0 + eta)
     cuts.AddCutCalo("10110023","411790105te30220000","0s331031000000d0"); // 00-10%
+  } else if (trainConfig == 2165){ // central NOC via <E_clus-E>/E data
+    cuts.AddCutCalo("10110e03","411790105ye30220000","0s331031000000d0"); // 00-10%
+  } else if (trainConfig == 2166){ // central, NOC via <E_clus-E>/E MC no OOB Pileup correction for MC
+    cuts.AddCutCalo("10110053","411790105ye30220000","0s331031000000d0"); // 00-10%
   // **********************************************************************************************************
   // ************************** EMC configurations PbPb run 2 2015 pass 3 semicent ****************************
   // **********************************************************************************************************
@@ -2149,6 +2229,10 @@ void AddTask_GammaCalo_PbPb(
     cuts.AddCutCalo("11310023","411790105te30220000","01331031000000d0"); // 10-30%
   } else if (trainConfig == 2314){ // semicent, with mean N matched tracks per cluster MC no OOB Pileup correction for MC with added signal (copy for pi0 + eta)
     cuts.AddCutCalo("11310023","411790105te30220000","01331031000000d0"); // 10-30%
+  } else if (trainConfig == 2315){ // semicent NOC via <E_clus-E>/E data
+    cuts.AddCutCalo("11310e03","411790105ye30220000","01331031000000d0"); // 10-30%
+  } else if (trainConfig == 2316){ // semicent, NOC via <E_clus-E>/E MC no OOB Pileup correction for MC
+    cuts.AddCutCalo("11310053","411790105ye30220000","01331031000000d0"); // 10-30%
   // with rotation background
   } else if (trainConfig == 2350){ // semicent
     cuts.AddCutCalo("11310e03","411790105ke30220000","0s331031000000d0"); // 10-30%
@@ -2180,6 +2264,10 @@ void AddTask_GammaCalo_PbPb(
     cuts.AddCutCalo("11310023","411790105te30220000","0s331031000000d0"); // 10-30%
   } else if (trainConfig == 2364){ // semicent, with mean N matched tracks per cluster MC no OOB Pileup correction for MC with added signal (copy for pi0 + eta)
     cuts.AddCutCalo("11310023","411790105te30220000","0s331031000000d0"); // 10-30%
+  } else if (trainConfig == 2365){ // semicent NOC via <E_clus-E>/E data
+    cuts.AddCutCalo("11310e03","411790105ye30220000","0s331031000000d0"); // 10-30%
+  } else if (trainConfig == 2366){ // semicent, NOC via <E_clus-E>/E MC no OOB Pileup correction for MC
+    cuts.AddCutCalo("11310053","411790105ye30220000","0s331031000000d0"); // 10-30%
   // **********************************************************************************************************
   // *********************** EMC configurations PbPb run 2 2015 pass 3 semiperipheral *************************
   // **********************************************************************************************************
@@ -2214,6 +2302,10 @@ void AddTask_GammaCalo_PbPb(
     cuts.AddCutCalo("13510023","411790105te30220000","01331031000000d0"); // 30-50%
   } else if (trainConfig == 2514){ // semiperipheral, with mean N matched tracks per cluster MC no OOB Pileup correction for MC with added signal (copy for pi0 + eta)
     cuts.AddCutCalo("13510023","411790105te30220000","01331031000000d0"); // 30-50%
+  } else if (trainConfig == 2515){ // semiperipheral NOC via <E_clus-E>/E data
+    cuts.AddCutCalo("13510e03","411790105ye30220000","01331031000000d0"); // 30-50%
+  } else if (trainConfig == 2516){ // semiperipheral, NOC via <E_clus-E>/E MC no OOB Pileup correction for MC
+    cuts.AddCutCalo("13510053","411790105ye30220000","01331031000000d0"); // 30-50%
   // with rotation background
   } else if (trainConfig == 2550){ // semiperipheral
     cuts.AddCutCalo("13510e03","411790105ke30220000","0s331031000000d0"); // 30-50%
@@ -2245,7 +2337,10 @@ void AddTask_GammaCalo_PbPb(
     cuts.AddCutCalo("13510023","411790105te30220000","0s331031000000d0"); // 30-50%
   } else if (trainConfig == 2564){ // semiperipheral, with mean N matched tracks per cluster MC no OOB Pileup correction for MC with added signal (copy for pi0 + eta)
     cuts.AddCutCalo("13510023","411790105te30220000","0s331031000000d0"); // 30-50%
-  
+  } else if (trainConfig == 2565){ // semiperipheral NOC via <E_clus-E>/E data
+    cuts.AddCutCalo("13510e03","411790105ye30220000","0s331031000000d0"); // 30-50%
+  } else if (trainConfig == 2566){ // semiperipheral, NOC via <E_clus-E>/E MC no OOB Pileup correction for MC
+    cuts.AddCutCalo("13510053","411790105ye30220000","0s331031000000d0"); // 30-50%
   // **********************************************************************************************************
   // ************************* EMC configurations PbPb run 2 2015 pass 3 peripheral ***************************
   // **********************************************************************************************************
@@ -2280,6 +2375,10 @@ void AddTask_GammaCalo_PbPb(
     cuts.AddCutCalo("15910023","411790105te30220000","01331031000000d0"); // 50-90%
   } else if (trainConfig == 2914){ // peripheral, with mean N matched tracks per cluster MC no OOB Pileup correction for MC with added signal (copy for pi0 + eta)
     cuts.AddCutCalo("15910023","411790105te30220000","01331031000000d0"); // 50-90%
+  } else if (trainConfig == 2915){ // peripheral NOC via <E_clus-E>/E data
+    cuts.AddCutCalo("15910e03","411790105ye30220000","01331031000000d0"); // 50-90%
+  } else if (trainConfig == 2916){ // peripheral, NOC via <E_clus-E>/E MC no OOB Pileup correction for MC
+    cuts.AddCutCalo("15910053","411790105ye30220000","01331031000000d0"); // 50-90%
   // with rotation background
   } else if (trainConfig == 2950){ // peripheral
     cuts.AddCutCalo("15910e03","411790105ke30220000","0s331031000000d0"); // 50-90%
@@ -2311,7 +2410,10 @@ void AddTask_GammaCalo_PbPb(
     cuts.AddCutCalo("15910023","411790105te30220000","0s331031000000d0"); // 50-90%
   } else if (trainConfig == 2964){ // peripheral, with mean N matched tracks per cluster MC no OOB Pileup correction for MC with added signal (copy for pi0 + eta)
     cuts.AddCutCalo("15910023","411790105te30220000","0s331031000000d0"); // 50-90%
-
+  } else if (trainConfig == 2965){ // peripheral NOC via <E_clus-E>/E data
+    cuts.AddCutCalo("15910e03","411790105ye30220000","0s331031000000d0"); // 50-90%
+  } else if (trainConfig == 2966){ // peripheral, NOC via <E_clus-E>/E MC no OOB Pileup correction for MC
+    cuts.AddCutCalo("15910053","411790105ye30220000","0s331031000000d0"); // 50-90%
 
   } else {
     Error(Form("GammaConvCalo_%i",trainConfig), "wrong trainConfig variable no cuts have been specified for the configuration");

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_PbPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_PbPb.C
@@ -1409,6 +1409,16 @@ void AddTask_GammaConvCalo_PbPb(
     cuts.AddCutPCMCalo("11310023","0dm00009ab770c00amd0404000","411790105te30220000","0133103100000010"); // 10-30%
     cuts.AddCutPCMCalo("13530023","0dm00009ab770c00amd0404000","411790105te30220000","0133103100000010"); // 30-50%
     cuts.AddCutPCMCalo("15910023","0dm00009ab770c00amd0404000","411790105te30220000","0133103100000010"); // 50-90%
+  } else if (trainConfig == 1015){ // 4 cents with mean N matched tracks per cluster data
+    cuts.AddCutPCMCalo("10130e03","0dm00009ab770c00amd0404000","411790105ye30220000","0133103100000010"); // 00-10%
+    cuts.AddCutPCMCalo("11310e03","0dm00009ab770c00amd0404000","411790105ye30220000","0133103100000010"); // 10-30%
+    cuts.AddCutPCMCalo("13530e03","0dm00009ab770c00amd0404000","411790105ye30220000","0133103100000010"); // 30-50%
+    cuts.AddCutPCMCalo("15910e03","0dm00009ab770c00amd0404000","411790105ye30220000","0133103100000010"); // 50-90%
+  } else if (trainConfig == 1016){ // 4 cents, with mean N matched tracks per cluster MC no OOB Pileup correction for MC
+    cuts.AddCutPCMCalo("10130053","0dm00009ab770c00amd0404000","411790105ye30220000","0133103100000010"); // 00-10%
+    cuts.AddCutPCMCalo("11310053","0dm00009ab770c00amd0404000","411790105ye30220000","0133103100000010"); // 10-30%
+    cuts.AddCutPCMCalo("13530053","0dm00009ab770c00amd0404000","411790105ye30220000","0133103100000010"); // 30-50%
+    cuts.AddCutPCMCalo("15910053","0dm00009ab770c00amd0404000","411790105ye30220000","0133103100000010"); // 50-90%
   // with rotation background
   } else if (trainConfig == 1050){ // 4 cents
     cuts.AddCutPCMCalo("10130e03","0dm00009ab770c00amd0404000","411790105ke30220000","0s331031000000d0"); // 00-10%
@@ -1485,6 +1495,16 @@ void AddTask_GammaConvCalo_PbPb(
     cuts.AddCutPCMCalo("11310023","0dm00009ab770c00amd0404000","411790105te30220000","0s331031000000d0"); // 10-30%
     cuts.AddCutPCMCalo("13530023","0dm00009ab770c00amd0404000","411790105te30220000","0s331031000000d0"); // 30-50%
     cuts.AddCutPCMCalo("15910023","0dm00009ab770c00amd0404000","411790105te30220000","0s331031000000d0"); // 50-90%
+  } else if (trainConfig == 1065){ // 4 cents with mean N matched tracks per cluster data
+    cuts.AddCutPCMCalo("10130e03","0dm00009ab770c00amd0404000","411790105ye30220000","0s33103100000010"); // 00-10%
+    cuts.AddCutPCMCalo("11310e03","0dm00009ab770c00amd0404000","411790105ye30220000","0s33103100000010"); // 10-30%
+    cuts.AddCutPCMCalo("13530e03","0dm00009ab770c00amd0404000","411790105ye30220000","0s33103100000010"); // 30-50%
+    cuts.AddCutPCMCalo("15910e03","0dm00009ab770c00amd0404000","411790105ye30220000","0s33103100000010"); // 50-90%
+  } else if (trainConfig == 1066){ // 4 cents, with mean N matched tracks per cluster MC no OOB Pileup correction for MC
+    cuts.AddCutPCMCalo("10130053","0dm00009ab770c00amd0404000","411790105ye30220000","0s33103100000010"); // 00-10%
+    cuts.AddCutPCMCalo("11310053","0dm00009ab770c00amd0404000","411790105ye30220000","0s33103100000010"); // 10-30%
+    cuts.AddCutPCMCalo("13530053","0dm00009ab770c00amd0404000","411790105ye30220000","0s33103100000010"); // 30-50%
+    cuts.AddCutPCMCalo("15910053","0dm00009ab770c00amd0404000","411790105ye30220000","0s33103100000010"); // 50-90%
   // **********************************************************************************************************
   // **************************** PCM-EMC configurations PbPb run 2 2018 pass 3 cent ******************************
   // **********************************************************************************************************
@@ -1519,6 +1539,10 @@ void AddTask_GammaConvCalo_PbPb(
     cuts.AddCutPCMCalo("10130023","0dm00009ab770c00amd0404000","411790105te30220000","0133103100000010"); // 00-10%
   } else if (trainConfig == 1114){ // central, with mean N matched tracks per cluster MC no OOB Pileup correction for MC with added signal (copy for pi0 + eta)
     cuts.AddCutPCMCalo("10130023","0dm00009ab770c00amd0404000","411790105te30220000","0133103100000010"); // 00-10%
+  } else if (trainConfig == 1115){ // central with mean N matched tracks per cluster data
+    cuts.AddCutPCMCalo("10130e03","0dm00009ab770c00amd0404000","411790105ye30220000","0133103100000010"); // 00-10%
+  } else if (trainConfig == 1116){ // central, with mean N matched tracks per cluster MC no OOB Pileup correction for MC
+    cuts.AddCutPCMCalo("10130053","0dm00009ab770c00amd0404000","411790105ye30220000","0133103100000010"); // 00-10%
   // with rotation background
   } else if (trainConfig == 1150){ // central
     cuts.AddCutPCMCalo("10130e03","0dm00009ab770c00amd0404000","411790105ke30220000","0s331031000000d0"); // 00-10%
@@ -1550,6 +1574,10 @@ void AddTask_GammaConvCalo_PbPb(
     cuts.AddCutPCMCalo("10130023","0dm00009ab770c00amd0404000","411790105te30220000","0s331031000000d0"); // 00-10%
   } else if (trainConfig == 1164){ // central, with mean N matched tracks per cluster MC no OOB Pileup correction for MC with added signal (copy for pi0 + eta)
     cuts.AddCutPCMCalo("10130023","0dm00009ab770c00amd0404000","411790105te30220000","0s331031000000d0"); // 00-10%
+  } else if (trainConfig == 1165){ // central with mean N matched tracks per cluster data
+    cuts.AddCutPCMCalo("10130e03","0dm00009ab770c00amd0404000","411790105ye30220000","0s33103100000010"); // 00-10%
+  } else if (trainConfig == 1166){ // central, with mean N matched tracks per cluster MC no OOB Pileup correction for MC
+    cuts.AddCutPCMCalo("10130053","0dm00009ab770c00amd0404000","411790105ye30220000","0s33103100000010"); // 00-10%
   // **********************************************************************************************************
   // ************************** PCM-EMC configurations PbPb run 2 2018 pass 3 semicent ****************************
   // **********************************************************************************************************
@@ -1584,6 +1612,10 @@ void AddTask_GammaConvCalo_PbPb(
     cuts.AddCutPCMCalo("11310023","0dm00009ab770c00amd0404000","411790105te30220000","0133103100000010"); // 10-30%
   } else if (trainConfig == 1314){ // semicent, with mean N matched tracks per cluster MC no OOB Pileup correction for MC with added signal (copy for pi0 + eta)
     cuts.AddCutPCMCalo("11310023","0dm00009ab770c00amd0404000","411790105te30220000","0133103100000010"); // 10-30%
+  } else if (trainConfig == 1315){ // semicent with mean N matched tracks per cluster data
+    cuts.AddCutPCMCalo("11310e03","0dm00009ab770c00amd0404000","411790105ye30220000","0133103100000010"); // 10-30%
+  } else if (trainConfig == 1316){ // semicent, with mean N matched tracks per cluster MC no OOB Pileup correction for MC
+    cuts.AddCutPCMCalo("11310053","0dm00009ab770c00amd0404000","411790105ye30220000","0133103100000010"); // 10-30%
   // with rotation background
   } else if (trainConfig == 1350){ // semicent
     cuts.AddCutPCMCalo("11310e03","0dm00009ab770c00amd0404000","411790105ke30220000","0s33103100000010"); // 10-30%
@@ -1615,6 +1647,10 @@ void AddTask_GammaConvCalo_PbPb(
     cuts.AddCutPCMCalo("11310023","0dm00009ab770c00amd0404000","411790105te30220000","0s33103100000010"); // 10-30%
   } else if (trainConfig == 1364){ // semicent, with mean N matched tracks per cluster MC no OOB Pileup correction for MC with added signal (copy for pi0 + eta)
     cuts.AddCutPCMCalo("11310023","0dm00009ab770c00amd0404000","411790105te30220000","0s33103100000010"); // 10-30%
+  } else if (trainConfig == 1365){ // semicent with mean N matched tracks per cluster data
+    cuts.AddCutPCMCalo("11310e03","0dm00009ab770c00amd0404000","411790105ye30220000","0s33103100000010"); // 10-30%
+  } else if (trainConfig == 1366){ // semicent, with mean N matched tracks per cluster MC no OOB Pileup correction for MC
+    cuts.AddCutPCMCalo("11310053","0dm00009ab770c00amd0404000","411790105ye30220000","0s33103100000010"); // 10-30%
   // **********************************************************************************************************
   // *********************** PCM-EMC configurations PbPb run 2 2018 pass 3 semiperipheral *************************
   // **********************************************************************************************************
@@ -1649,6 +1685,10 @@ void AddTask_GammaConvCalo_PbPb(
     cuts.AddCutPCMCalo("13530023","0dm00009ab770c00amd0404000","411790105te30220000","0133103100000010"); // 30-50%
   } else if (trainConfig == 1514){ // semiperipheral, with mean N matched tracks per cluster MC no OOB Pileup correction for MC with added signal (copy for pi0 + eta)
     cuts.AddCutPCMCalo("13530023","0dm00009ab770c00amd0404000","411790105te30220000","0133103100000010"); // 30-50%
+  } else if (trainConfig == 1515){ // semiperipheral with mean N matched tracks per cluster data
+    cuts.AddCutPCMCalo("13530e03","0dm00009ab770c00amd0404000","411790105ye30220000","0133103100000010"); // 30-50%
+  } else if (trainConfig == 1516){ // semiperipheral, with mean N matched tracks per cluster MC no OOB Pileup correction for MC
+    cuts.AddCutPCMCalo("13530053","0dm00009ab770c00amd0404000","411790105ye30220000","0133103100000010"); // 30-50%
   // with rotation background
   } else if (trainConfig == 1550){ // semiperipheral
     cuts.AddCutPCMCalo("13530e03","0dm00009ab770c00amd0404000","411790105ke30220000","0s33103100000010"); // 30-50%
@@ -1680,6 +1720,10 @@ void AddTask_GammaConvCalo_PbPb(
     cuts.AddCutPCMCalo("13530023","0dm00009ab770c00amd0404000","411790105te30220000","0s33103100000010"); // 30-50%
   } else if (trainConfig == 1564){ // semiperipheral, with mean N matched tracks per cluster MC no OOB Pileup correction for MC with added signal (copy for pi0 + eta)
     cuts.AddCutPCMCalo("13530023","0dm00009ab770c00amd0404000","411790105te30220000","0s33103100000010"); // 30-50%
+  } else if (trainConfig == 1565){ // semiperipheral with mean N matched tracks per cluster data
+    cuts.AddCutPCMCalo("13530e03","0dm00009ab770c00amd0404000","411790105ye30220000","0s33103100000010"); // 30-50%
+  } else if (trainConfig == 1566){ // semiperipheral, with mean N matched tracks per cluster MC no OOB Pileup correction for MC
+    cuts.AddCutPCMCalo("13530053","0dm00009ab770c00amd0404000","411790105ye30220000","0s33103100000010"); // 30-50%
   // **********************************************************************************************************
   // ************************* PCM-EMC configurations PbPb run 2 2018 pass 3 peripheral ***************************
   // **********************************************************************************************************
@@ -1714,6 +1758,10 @@ void AddTask_GammaConvCalo_PbPb(
     cuts.AddCutPCMCalo("15910023","0dm00009ab770c00amd0404000","411790105te30220000","0133103100000010"); // 50-90%
   } else if (trainConfig == 1914){ // peripheral, with mean N matched tracks per cluster MC no OOB Pileup correction for MC with added signal (copy for pi0 + eta)
     cuts.AddCutPCMCalo("15910023","0dm00009ab770c00amd0404000","411790105te30220000","0133103100000010"); // 50-90%
+  } else if (trainConfig == 1915){ // peripheral with mean N matched tracks per cluster data
+    cuts.AddCutPCMCalo("15910e03","0dm00009ab770c00amd0404000","411790105ye30220000","0133103100000010"); // 50-90%
+  } else if (trainConfig == 1916){ // peripheral, with mean N matched tracks per cluster MC no OOB Pileup correction for MC
+    cuts.AddCutPCMCalo("15910053","0dm00009ab770c00amd0404000","411790105ye30220000","0133103100000010"); // 50-90%
   // with rotation background
   } else if (trainConfig == 1950){ // peripheral
     cuts.AddCutPCMCalo("15910e03","0dm00009ab770c00amd0404000","411790105ke30220000","0s33103100000010"); // 50-90%
@@ -1745,6 +1793,10 @@ void AddTask_GammaConvCalo_PbPb(
     cuts.AddCutPCMCalo("15910023","0dm00009ab770c00amd0404000","411790105te30220000","0s33103100000010"); // 50-90%
   } else if (trainConfig == 1964){ // peripheral, with mean N matched tracks per cluster MC no OOB Pileup correction for MC with added signal (copy for pi0 + eta)
     cuts.AddCutPCMCalo("15910023","0dm00009ab770c00amd0404000","411790105te30220000","0s33103100000010"); // 50-90%
+  } else if (trainConfig == 1965){ // peripheral with mean N matched tracks per cluster data
+    cuts.AddCutPCMCalo("15910e03","0dm00009ab770c00amd0404000","411790105ye30220000","0s33103100000010"); // 50-90%
+  } else if (trainConfig == 1966){ // peripheral, with mean N matched tracks per cluster MC no OOB Pileup correction for MC
+    cuts.AddCutPCMCalo("15910053","0dm00009ab770c00amd0404000","411790105ye30220000","0s33103100000010"); // 50-90%
 
   // **********************************************************************************************************
   // ***************************** PCM-EMC configurations PbPb run 2 2015 pass 3 *******************************
@@ -1825,6 +1877,16 @@ void AddTask_GammaConvCalo_PbPb(
     cuts.AddCutPCMCalo("11310023","0dm00009ab770c00amd0404000","411790105te30220000","0133103100000010"); // 10-30%
     cuts.AddCutPCMCalo("13510023","0dm00009ab770c00amd0404000","411790105te30220000","0133103100000010"); // 30-50%
     cuts.AddCutPCMCalo("15910023","0dm00009ab770c00amd0404000","411790105te30220000","0133103100000010"); // 50-90%
+  } else if (trainConfig == 2015){ // 4 cents with mean N matched tracks per cluster data
+    cuts.AddCutPCMCalo("10110e03","0dm00009ab770c00amd0404000","411790105ye30220000","0133103100000010"); // 00-10%
+    cuts.AddCutPCMCalo("11310e03","0dm00009ab770c00amd0404000","411790105ye30220000","0133103100000010"); // 10-30%
+    cuts.AddCutPCMCalo("13510e03","0dm00009ab770c00amd0404000","411790105ye30220000","0133103100000010"); // 30-50%
+    cuts.AddCutPCMCalo("15910e03","0dm00009ab770c00amd0404000","411790105ye30220000","0133103100000010"); // 50-90%
+  } else if (trainConfig == 2016){ // 4 cents, with mean N matched tracks per cluster MC no OOB Pileup correction for MC
+    cuts.AddCutPCMCalo("10110053","0dm00009ab770c00amd0404000","411790105ye30220000","0133103100000010"); // 00-10%
+    cuts.AddCutPCMCalo("11310053","0dm00009ab770c00amd0404000","411790105ye30220000","0133103100000010"); // 10-30%
+    cuts.AddCutPCMCalo("13510053","0dm00009ab770c00amd0404000","411790105ye30220000","0133103100000010"); // 30-50%
+    cuts.AddCutPCMCalo("15910053","0dm00009ab770c00amd0404000","411790105ye30220000","0133103100000010"); // 50-90%
   // with rotation background
   } else if (trainConfig == 2050){ // 4 cents
     cuts.AddCutPCMCalo("10110e03","0dm00009ab770c00amd0404000","411790105ke30220000","0s331031000000d0"); // 00-10%
@@ -1901,6 +1963,16 @@ void AddTask_GammaConvCalo_PbPb(
     cuts.AddCutPCMCalo("11310023","0dm00009ab770c00amd0404000","411790105te30220000","0s331031000000d0"); // 10-30%
     cuts.AddCutPCMCalo("13510023","0dm00009ab770c00amd0404000","411790105te30220000","0s331031000000d0"); // 30-50%
     cuts.AddCutPCMCalo("15910023","0dm00009ab770c00amd0404000","411790105te30220000","0s331031000000d0"); // 50-90%
+  } else if (trainConfig == 2065){ // 4 cents with mean N matched tracks per cluster data
+    cuts.AddCutPCMCalo("10110e03","0dm00009ab770c00amd0404000","411790105ye30220000","0s33103100000010"); // 00-10%
+    cuts.AddCutPCMCalo("11310e03","0dm00009ab770c00amd0404000","411790105ye30220000","0s33103100000010"); // 10-30%
+    cuts.AddCutPCMCalo("13510e03","0dm00009ab770c00amd0404000","411790105ye30220000","0s33103100000010"); // 30-50%
+    cuts.AddCutPCMCalo("15910e03","0dm00009ab770c00amd0404000","411790105ye30220000","0s33103100000010"); // 50-90%
+  } else if (trainConfig == 2066){ // 4 cents, with mean N matched tracks per cluster MC no OOB Pileup correction for MC
+    cuts.AddCutPCMCalo("10110053","0dm00009ab770c00amd0404000","411790105ye30220000","0s33103100000010"); // 00-10%
+    cuts.AddCutPCMCalo("11310053","0dm00009ab770c00amd0404000","411790105ye30220000","0s33103100000010"); // 10-30%
+    cuts.AddCutPCMCalo("13510053","0dm00009ab770c00amd0404000","411790105ye30220000","0s33103100000010"); // 30-50%
+    cuts.AddCutPCMCalo("15910053","0dm00009ab770c00amd0404000","411790105ye30220000","0s33103100000010"); // 50-90%
   // **********************************************************************************************************
   // **************************** PCM-EMC configurations PbPb run 2 2015 pass 3 cent ******************************
   // **********************************************************************************************************
@@ -1935,6 +2007,10 @@ void AddTask_GammaConvCalo_PbPb(
     cuts.AddCutPCMCalo("10110023","0dm00009ab770c00amd0404000","411790105te30220000","0133103100000010"); // 00-10%
   } else if (trainConfig == 2114){ // central, with mean N matched tracks per cluster MC no OOB Pileup correction for MC with added signal (copy for pi0 + eta)
     cuts.AddCutPCMCalo("10110023","0dm00009ab770c00amd0404000","411790105te30220000","0133103100000010"); // 00-10%
+  } else if (trainConfig == 2115){ // central with mean N matched tracks per cluster data
+    cuts.AddCutPCMCalo("10110e03","0dm00009ab770c00amd0404000","411790105ye30220000","0133103100000010"); // 00-10%
+  } else if (trainConfig == 2116){ // central, with mean N matched tracks per cluster MC no OOB Pileup correction for MC
+    cuts.AddCutPCMCalo("10110053","0dm00009ab770c00amd0404000","411790105ye30220000","0133103100000010"); // 00-10%
   // with rotation background
   } else if (trainConfig == 2150){ // central
     cuts.AddCutPCMCalo("10110e03","0dm00009ab770c00amd0404000","411790105ke30220000","0s331031000000d0"); // 00-10%
@@ -1966,6 +2042,10 @@ void AddTask_GammaConvCalo_PbPb(
     cuts.AddCutPCMCalo("10110023","0dm00009ab770c00amd0404000","411790105te30220000","0s331031000000d0"); // 00-10%
   } else if (trainConfig == 2164){ // central, with mean N matched tracks per cluster MC no OOB Pileup correction for MC with added signal (copy for pi0 + eta)
     cuts.AddCutPCMCalo("10110023","0dm00009ab770c00amd0404000","411790105te30220000","0s331031000000d0"); // 00-10%
+  } else if (trainConfig == 2165){ // central with mean N matched tracks per cluster data
+    cuts.AddCutPCMCalo("10110e03","0dm00009ab770c00amd0404000","411790105ye30220000","0s33103100000010"); // 00-10%
+  } else if (trainConfig == 2166){ // central, with mean N matched tracks per cluster MC no OOB Pileup correction for MC
+    cuts.AddCutPCMCalo("10110053","0dm00009ab770c00amd0404000","411790105ye30220000","0s33103100000010"); // 00-10%
   // **********************************************************************************************************
   // ************************** PCM-EMC configurations PbPb run 2 2015 pass 3 semicent ****************************
   // **********************************************************************************************************
@@ -2000,6 +2080,10 @@ void AddTask_GammaConvCalo_PbPb(
     cuts.AddCutPCMCalo("11310023","0dm00009ab770c00amd0404000","411790105te30220000","0133103100000010"); // 10-30%
   } else if (trainConfig == 2314){ // semicent, with mean N matched tracks per cluster MC no OOB Pileup correction for MC with added signal (copy for pi0 + eta)
     cuts.AddCutPCMCalo("11310023","0dm00009ab770c00amd0404000","411790105te30220000","0133103100000010"); // 10-30%
+  } else if (trainConfig == 2315){ // semicent with mean N matched tracks per cluster data
+    cuts.AddCutPCMCalo("11310e03","0dm00009ab770c00amd0404000","411790105ye30220000","0133103100000010"); // 10-30%
+  } else if (trainConfig == 2316){ // semicent, with mean N matched tracks per cluster MC no OOB Pileup correction for MC
+    cuts.AddCutPCMCalo("11310053","0dm00009ab770c00amd0404000","411790105ye30220000","0133103100000010"); // 10-30%
   // with rotation background
   } else if (trainConfig == 2350){ // semicent
     cuts.AddCutPCMCalo("11310e03","0dm00009ab770c00amd0404000","411790105ke30220000","0s33103100000010"); // 10-30%
@@ -2031,6 +2115,10 @@ void AddTask_GammaConvCalo_PbPb(
     cuts.AddCutPCMCalo("11310023","0dm00009ab770c00amd0404000","411790105te30220000","0s33103100000010"); // 10-30%
   } else if (trainConfig == 2364){ // semicent, with mean N matched tracks per cluster MC no OOB Pileup correction for MC with added signal (copy for pi0 + eta)
     cuts.AddCutPCMCalo("11310023","0dm00009ab770c00amd0404000","411790105te30220000","0s33103100000010"); // 10-30%
+  } else if (trainConfig == 2365){ // semicent with mean N matched tracks per cluster data
+    cuts.AddCutPCMCalo("11310e03","0dm00009ab770c00amd0404000","411790105ye30220000","0s33103100000010"); // 10-30%
+  } else if (trainConfig == 2366){ // semicent, with mean N matched tracks per cluster MC no OOB Pileup correction for MC
+    cuts.AddCutPCMCalo("11310053","0dm00009ab770c00amd0404000","411790105ye30220000","0s33103100000010"); // 10-30%
   // **********************************************************************************************************
   // *********************** PCM-EMC configurations PbPb run 2 2015 pass 3 semiperipheral *************************
   // **********************************************************************************************************
@@ -2065,6 +2153,10 @@ void AddTask_GammaConvCalo_PbPb(
     cuts.AddCutPCMCalo("13510023","0dm00009ab770c00amd0404000","411790105te30220000","0133103100000010"); // 30-50%
   } else if (trainConfig == 2514){ // semiperipheral, with mean N matched tracks per cluster MC no OOB Pileup correction for MC with added signal (copy for pi0 + eta)
     cuts.AddCutPCMCalo("13510023","0dm00009ab770c00amd0404000","411790105te30220000","0133103100000010"); // 30-50%
+  } else if (trainConfig == 2515){ // semiperipheral with mean N matched tracks per cluster data
+    cuts.AddCutPCMCalo("13510e03","0dm00009ab770c00amd0404000","411790105ye30220000","0133103100000010"); // 30-50%
+  } else if (trainConfig == 2515){ // semiperipheral, with mean N matched tracks per cluster MC no OOB Pileup correction for MC
+    cuts.AddCutPCMCalo("13510053","0dm00009ab770c00amd0404000","411790105ye30220000","0133103100000010"); // 30-50%
   // with rotation background
   } else if (trainConfig == 2550){ // semiperipheral
     cuts.AddCutPCMCalo("13510e03","0dm00009ab770c00amd0404000","411790105ke30220000","0s33103100000010"); // 30-50%
@@ -2096,6 +2188,10 @@ void AddTask_GammaConvCalo_PbPb(
     cuts.AddCutPCMCalo("13510023","0dm00009ab770c00amd0404000","411790105te30220000","0s33103100000010"); // 30-50%
   } else if (trainConfig == 2564){ // semiperipheral, with mean N matched tracks per cluster MC no OOB Pileup correction for MC with added signal (copy for pi0 + eta)
     cuts.AddCutPCMCalo("13510023","0dm00009ab770c00amd0404000","411790105te30220000","0s33103100000010"); // 30-50%
+  } else if (trainConfig == 2565){ // semiperipheral with mean N matched tracks per cluster data
+    cuts.AddCutPCMCalo("13510e03","0dm00009ab770c00amd0404000","411790105ye30220000","0s33103100000010"); // 30-50%
+  } else if (trainConfig == 2565){ // semiperipheral, with mean N matched tracks per cluster MC no OOB Pileup correction for MC
+    cuts.AddCutPCMCalo("13510053","0dm00009ab770c00amd0404000","411790105ye30220000","0s33103100000010"); // 30-50%
   // **********************************************************************************************************
   // ************************* PCM-EMC configurations PbPb run 2 2015 pass 3 peripheral ***************************
   // **********************************************************************************************************
@@ -2130,6 +2226,10 @@ void AddTask_GammaConvCalo_PbPb(
     cuts.AddCutPCMCalo("15910023","0dm00009ab770c00amd0404000","411790105te30220000","0133103100000010"); // 50-90%
   } else if (trainConfig == 2914){ // peripheral, with mean N matched tracks per cluster MC no OOB Pileup correction for MC with added signal (copy for pi0 + eta)
     cuts.AddCutPCMCalo("15910023","0dm00009ab770c00amd0404000","411790105te30220000","0133103100000010"); // 50-90%
+  } else if (trainConfig == 2915){ // peripheral with mean N matched tracks per cluster data
+    cuts.AddCutPCMCalo("15910e03","0dm00009ab770c00amd0404000","411790105ye30220000","0133103100000010"); // 50-90%
+  } else if (trainConfig == 2916){ // peripheral, with mean N matched tracks per cluster MC no OOB Pileup correction for MC
+    cuts.AddCutPCMCalo("15910053","0dm00009ab770c00amd0404000","411790105ye30220000","0133103100000010"); // 50-90%
   // with rotation background
   } else if (trainConfig == 2950){ // peripheral
     cuts.AddCutPCMCalo("15910e03","0dm00009ab770c00amd0404000","411790105ke30220000","0s33103100000010"); // 50-90%
@@ -2161,7 +2261,10 @@ void AddTask_GammaConvCalo_PbPb(
     cuts.AddCutPCMCalo("15910023","0dm00009ab770c00amd0404000","411790105te30220000","0s33103100000010"); // 50-90%
   } else if (trainConfig == 2964){ // peripheral, with mean N matched tracks per cluster MC no OOB Pileup correction for MC with added signal (copy for pi0 + eta)
     cuts.AddCutPCMCalo("15910023","0dm00009ab770c00amd0404000","411790105te30220000","0s33103100000010"); // 50-90%
-
+  } else if (trainConfig == 2965){ // peripheral with mean N matched tracks per cluster data
+    cuts.AddCutPCMCalo("15910e03","0dm00009ab770c00amd0404000","411790105ye30220000","0s33103100000010"); // 50-90%
+  } else if (trainConfig == 2966){ // peripheral, with mean N matched tracks per cluster MC no OOB Pileup correction for MC
+    cuts.AddCutPCMCalo("15910053","0dm00009ab770c00amd0404000","411790105ye30220000","0s33103100000010"); // 50-90%
   
   } else {
     Error(Form("GammaConvCalo_%i",trainConfig), "wrong trainConfig variable no cuts have been specified for the configuration");

--- a/PWGGA/GammaConvBase/AliCaloPhotonCuts.h
+++ b/PWGGA/GammaConvBase/AliCaloPhotonCuts.h
@@ -415,6 +415,11 @@ class AliCaloPhotonCuts : public AliAnalysisCuts {
     Double_t    CorrectEnergyForOverlap(float meanCent, float E = 0);
     Int_t       GetDoEnergyCorrectionForOverlap()               {return fDoEnergyCorrectionForOverlap;}
     Double_t    GetMeanEForOverlap(Double_t cent, Double_t* par);
+    Double_t    GetNOCParameter0(Double_t cent, Double_t* par);
+    Double_t    GetNOCParameter1(Double_t cent, Double_t* par);
+    Double_t    GetNOCParameter2(Double_t cent, Double_t* par);
+    Double_t    GetNOCParameter3(Double_t cent, Double_t* par);
+    Double_t    GetNOCParameter4(Double_t cent, Double_t* par);
 
     // modify acceptance via histogram with cellID
     void        SetHistoToModifyAcceptance(TH1S* histAcc)       {fHistoModifyAcc  = histAcc; return;}
@@ -612,8 +617,14 @@ class AliCaloPhotonCuts : public AliAnalysisCuts {
     TF1*      fFuncPoissonParamCent;                    // TF1 to describe the poisson parameter that you get from fitting a poisson dsitribution to the number of matched tracks per cluster as function of centrality
     TF1*      fFuncNMatchedTracks;                      // TF1 poisson distribution to describe the number of matched tracks per cluster for a specific centrality
     Double_t  fParamMeanTrackPt[3];                     // TF1 distribution to describe the mean pT of tracks as function of centrality. Half of this value is used as neutral energy overlap correction.
+    Double_t  fNOCParam0[2];                            // parameter for function [0]*exp(x*[1]+2) to describe 1st parameter as function of cent of the 5 params for the NOC
+    Double_t  fNOCParam1[3];                            // parameter for function [0]/(1+exp([1]*(x-[2]))) to describe 2nd parameter as function of cent of the 5 params for the NOC
+    Double_t  fNOCParam2[4];                            // parameter for function pol3 to describe 3rd parameter as function of cent of the 5 params for the NOC
+    Double_t  fNOCParam3[3];                            // parameter for function pol2 to describe 4th parameter as function of cent of the 5 params for the NOC
+    Double_t  fNOCParam4[3];                            // parameter for function pol2 to describe 5th parameter as function of cent of the 5 params for the NOC
     Float_t   fMeanNMatchedTracks;                      // Mean number of matched primary tracks, stored to reduce CPU time for neutral overlap correction
     TF1*      fFuncNOCMaxBoltz;                         // TF1 Maxwell Boltzmann to describe the neutral overlap correction for a specific centrality
+
 
     //vector
     std::vector<Int_t> fVectorMatchedClusterIDs;        // vector with cluster IDs that have been matched to tracks in merged cluster analysis
@@ -768,7 +779,7 @@ class AliCaloPhotonCuts : public AliAnalysisCuts {
 
   private:
 
-    ClassDef(AliCaloPhotonCuts,135)
+    ClassDef(AliCaloPhotonCuts,136)
 };
 
 #endif


### PR DESCRIPTION
- Add new NOC correction to CaloPhotonCuts as cut `y` for trackmatching cuts
- Add new train configs for ConvCalo and Calo PbPb AddTasks to include the new NOC
- Add the histogram that was used to get this correction to ConvCalo
- Changed the histogram to be <E_clus-E_y>/E_y vs E_clus (was<E_clus-E_y>/E_y vs NMatched tracks vs p_T,clus)