### PR TITLE
Fix errors when building in debug mode

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.cxx
@@ -490,7 +490,6 @@ Bool_t AliEMCALRecoUtils::AcceptCalibrateCell(Int_t absID, Int_t bc,
     //____________________________________
     } else if (fUseAdditionalScale == 4) { // Run1 special values: SM with TRD in front (+ with/without Support structure) and SM without TRD in front (+ with/without Support structure)
       Int_t iCol = ieta;
-      bool behindSupport = false;
       // select columns with TRD support in front
       if( (imod > 11 && imod < 18) && imod%2) iCol+= 65;
       else if (imod%2) iCol+=49;

--- a/PWG/EMCAL/EMCALbase/AliTrackContainer.cxx
+++ b/PWG/EMCAL/EMCALbase/AliTrackContainer.cxx
@@ -516,12 +516,13 @@ Bool_t AliTrackContainer::CheckArrayConsistency() const {
 
   // Now check whehter tracks are stored in the same indices:
   if(teststatus){
-    int nmatch(0), nfail(0);
+    // int nmatch(0);
+    int nfail(0);
     for(int i = 0; i < fClArray->GetEntries(); i++) {
       AliVTrack *trackAll = dynamic_cast<AliVTrack *>(fClArray->At(i));
       AliVTrack *trackSel = dynamic_cast<AliVTrack *>(selected->At(i));
       if(trackSel == trackAll) {
-        nmatch++;    
+        // nmatch++;    
       } else {
         std::cout << "Mismatch in array position: " << i << std::endl;
         nfail++;

--- a/PWG/EMCAL/EMCALtasks/AliAnalysisTaskEmcalTriggerPatchClusterMatch.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliAnalysisTaskEmcalTriggerPatchClusterMatch.cxx
@@ -290,7 +290,7 @@ void AliAnalysisTaskEmcalTriggerPatchClusterMatch::ExtractMainPatch() {
   Int_t nPatch = fTriggerPatchInfo->GetEntriesFast();
 
   //loop over patches to define trigger type of event
-  Int_t nG1 = 0, nG2 = 0, nJ1 = 0, nJ2 = 0, nL0 = 0;
+  // Int_t nG1 = 0, nG2 = 0, nJ1 = 0, nJ2 = 0, nL0 = 0;
 
   // see if event was selected
   UInt_t trig = ((AliInputEventHandler*)(AliAnalysisManager::GetAnalysisManager()->GetInputEventHandler()))->IsEventSelected();
@@ -306,11 +306,11 @@ void AliAnalysisTaskEmcalTriggerPatchClusterMatch::ExtractMainPatch() {
     if (!patch) continue;
 
     // count trigger types
-    if (patch->IsGammaHigh()) nG1++;
-    if (patch->IsGammaLow())  nG2++;
-    if (patch->IsJetHigh()) nJ1++;
-    if (patch->IsJetLow())  nJ2++;
-    if (patch->IsLevel0())  nL0++;
+    // if (patch->IsGammaHigh()) nG1++;
+    // if (patch->IsGammaLow())  nG2++;
+    // if (patch->IsJetHigh()) nJ1++;
+    // if (patch->IsJetLow())  nJ2++;
+    // if (patch->IsLevel0())  nL0++;
 
     // fill Energy spectra of recalculated Jet and GA patches
     if(patch->IsRecalcGamma()) { fhRecalcGammaPatchEnergy->Fill(patch->GetPatchE()); }

--- a/PWG/EMCAL/EMCALtasks/AliEMCALClusterParams.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEMCALClusterParams.cxx
@@ -754,7 +754,7 @@ Double_t AliEMCALClusterParams::GetWeightedDispersionX() const
   UShort_t *celllist;
   celllist=fCluster->GetCellsAbsId();
 
-  Int_t ncell=0;//cell counter
+  // Int_t ncell=0;//cell counter
   
   for (Int_t i=0;i<nclusfCells;i++) {
     Int_t iSupMod = -1;
@@ -768,7 +768,7 @@ Double_t AliEMCALClusterParams::GetWeightedDispersionX() const
     fGeom->GetCellIndex(celllist[i],iSupMod,iTower,iIphi,iIeta);
     fGeom->GetCellPhiEtaIndexInSModule(iSupMod,iTower,iIphi,iIeta, iphi,ieta);
 
-    ncell++;
+    // ncell++;
     
     etai=(Double_t)ieta+1.;
     w = TMath::Max(0.,logWeight+TMath::Log(amp/totalFClusterEnergy )); //Calc weight
@@ -783,7 +783,7 @@ Double_t AliEMCALClusterParams::GetWeightedDispersionX() const
 
   // Calculate dispersion
   // Loop over fCells in the newly created fCluster
-  Int_t ncell1=0;//cell counter
+  // Int_t ncell1=0;//cell counter
   nstat=0;
 
   for (Int_t i=0;i<nclusfCells;i++) {
@@ -798,7 +798,7 @@ Double_t AliEMCALClusterParams::GetWeightedDispersionX() const
     fGeom->GetCellIndex(celllist[i],iSupMod,iTower,iIphi,iIeta);
     fGeom->GetCellPhiEtaIndexInSModule(iSupMod,iTower,iIphi,iIeta, iphi,ieta);
 
-    ncell1++;
+    // ncell1++;
     etai=(Double_t)ieta+1.;
     w = TMath::Max(0.,logWeight+TMath::Log(amp/totalFClusterEnergy));
     
@@ -833,7 +833,7 @@ Double_t AliEMCALClusterParams::GetWeightedDispersionY() const
   UShort_t *celllist;
   celllist=fCluster->GetCellsAbsId();
 
-  Int_t ncell=0;//cell counter
+  // Int_t ncell=0;//cell counter
   
   for (Int_t i=0;i<nclusfCells;i++) {
     Int_t iSupMod = -1;
@@ -847,7 +847,7 @@ Double_t AliEMCALClusterParams::GetWeightedDispersionY() const
     fGeom->GetCellIndex(celllist[i],iSupMod,iTower,iIphi,iIeta);
     fGeom->GetCellPhiEtaIndexInSModule(iSupMod,iTower,iIphi,iIeta, iphi,ieta);
 
-    ncell++;
+    // ncell++;
     
     phii=(Double_t)iphi+1.;
     w = TMath::Max(0.,logWeight+TMath::Log(amp/totalFClusterEnergy )); //Calc weight
@@ -862,7 +862,7 @@ Double_t AliEMCALClusterParams::GetWeightedDispersionY() const
 
   // Calculate dispersion
   // Loop over fCells in the newly created fCluster
-  Int_t ncell1=0;//cell counter
+  // Int_t ncell1=0;//cell counter
   nstat=0;
   for (Int_t i=0;i<nclusfCells;i++) {
     Int_t iSupMod = -1;
@@ -876,7 +876,7 @@ Double_t AliEMCALClusterParams::GetWeightedDispersionY() const
     fGeom->GetCellIndex(celllist[i],iSupMod,iTower,iIphi,iIeta);
     fGeom->GetCellPhiEtaIndexInSModule(iSupMod,iTower,iIphi,iIeta, iphi,ieta);
 
-    ncell1++;
+    // ncell1++;
 
     phii=(Double_t)iphi+1.;
     w = TMath::Max(0.,logWeight+TMath::Log(amp/totalFClusterEnergy));
@@ -920,7 +920,7 @@ void AliEMCALClusterParams::GetWeightedEllipseParameters(Double_t &param1, Doubl
 	
   Double_t etai =0, phii=0, w=0; 
 
-  Int_t ncell=0;//cell counter
+  // Int_t ncell=0;//cell counter
 
   Double_t totalFClusterEnergy=fCluster->E();
   Int_t nclusfCells=fCluster->GetNCells();
@@ -936,7 +936,7 @@ void AliEMCALClusterParams::GetWeightedEllipseParameters(Double_t &param1, Doubl
     Int_t ieta    = -1;
     Double_t amp=fCells->GetCellAmplitude(celllist[i]);
 
-    ncell++;
+    // ncell++;
     etai = phii = 0.; 
     fGeom->GetCellIndex(celllist[i],iSupMod,iTower,iIphi,iIeta);
     fGeom->GetCellPhiEtaIndexInSModule(iSupMod,iTower,iIphi,iIeta, iphi,ieta);
@@ -986,7 +986,7 @@ Double_t AliEMCALClusterParams::GetWeightedDispersion(Double_t &dispersionback) 
   Double_t etai, phii, etaMean=0.0, phiMean=0.0; 
 
   // Calculate mean values
-  Int_t ncell=0;//cell counter
+  // Int_t ncell=0;//cell counter
 
   Double_t totalFClusterEnergy=fCluster->E();
   Int_t nclusfCells=fCluster->GetNCells();
@@ -1002,7 +1002,7 @@ Double_t AliEMCALClusterParams::GetWeightedDispersion(Double_t &dispersionback) 
     Int_t ieta    = -1;
     Double_t amp=fCells->GetCellAmplitude(celllist[i]);
 
-    ncell++;
+    // ncell++;
     etai = phii = 0.; 
     fGeom->GetCellIndex(celllist[i],iSupMod,iTower,iIphi,iIeta);
     fGeom->GetCellPhiEtaIndexInSModule(iSupMod,iTower,iIphi,iIeta, iphi,ieta);
@@ -1024,7 +1024,7 @@ Double_t AliEMCALClusterParams::GetWeightedDispersion(Double_t &dispersionback) 
   }
 
   // Calculate dispersion
-  Int_t ncell1=0;//cell counter
+  // Int_t ncell1=0;//cell counter
   nstat=0;
 
   for (Int_t i=0;i<nclusfCells;i++) {
@@ -1036,7 +1036,7 @@ Double_t AliEMCALClusterParams::GetWeightedDispersion(Double_t &dispersionback) 
     Int_t ieta    = -1;
     Double_t amp=fCells->GetCellAmplitude(celllist[i]);
 
-    ncell1++;
+    // ncell1++;
     etai = phii = 0.; 
     fGeom->GetCellIndex(celllist[i],iSupMod,iTower,iIphi,iIeta);
     fGeom->GetCellPhiEtaIndexInSModule(iSupMod,iTower,iIphi,iIeta, iphi,ieta);

--- a/PWG/EMCAL/EMCALtasks/AliEmcalAodTrackFilterTask.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalAodTrackFilterTask.cxx
@@ -32,14 +32,14 @@ AliEmcalAodTrackFilterTask::AliEmcalAodTrackFilterTask() :
   fAttemptProp(kFALSE),
   fAttemptPropMatch(kFALSE),
   fKeepInvMassTag(kFALSE),
+  fTrackEfficiencyOnlyForEmbedding(kFALSE),
   fDist(440),
   fTrackEfficiency(0),
+  fTracksIn(0),
+  fTracksOut(0),
   fTrackEfficiencyHistogram(nullptr),
   fApplyPtDependentTrackingEfficiency(kFALSE),
-  fTrackEfficiencyOnlyForEmbedding(kFALSE),
-  fYAMLConfig(),
-  fTracksIn(0),
-  fTracksOut(0)
+  fYAMLConfig()
 {
   // Constructor.
 
@@ -61,14 +61,14 @@ AliEmcalAodTrackFilterTask::AliEmcalAodTrackFilterTask(const char *name) :
   fAttemptProp(kFALSE),
   fAttemptPropMatch(kFALSE),
   fKeepInvMassTag(kFALSE),
+  fTrackEfficiencyOnlyForEmbedding(kFALSE),
   fDist(440),
   fTrackEfficiency(0),
+  fTracksIn(0),
+  fTracksOut(0),
   fTrackEfficiencyHistogram(nullptr),
   fApplyPtDependentTrackingEfficiency(kFALSE),
-  fTrackEfficiencyOnlyForEmbedding(kFALSE),
-  fYAMLConfig(),
-  fTracksIn(0),
-  fTracksOut(0)
+  fYAMLConfig()
 {
   // Constructor.
 
@@ -201,7 +201,7 @@ AliEmcalAodTrackFilterTask* AliEmcalAodTrackFilterTask::AddTaskEmcalAodTrackFilt
       delete arr;
     } else {
   
-    if (!runPeriod.IsNull())::Warning("AddTaskEmcalAodTrackFilter", Form("Run period %s not known. It will use IsHybridGlobalConstrainedGlobal.",runPeriod.Data()));
+    if (!runPeriod.IsNull())::Warning("AddTaskEmcalAodTrackFilter", "%s", Form("Run period %s not known. It will use IsHybridGlobalConstrainedGlobal.",runPeriod.Data()));
         }
 
     aodTask->SetIncludeNoITS(includeNoITS);

--- a/PWG/EMCAL/EMCALtasks/AliEmcalPatchFromCellMaker.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalPatchFromCellMaker.cxx
@@ -201,12 +201,12 @@ Bool_t AliEmcalPatchFromCellMaker::Run()
 
   RunSimpleOfflineTrigger();
 
-  Double_t sum = 0.;
-  for (Int_t i = 0; i < kPatchCols; i++) {
-    for (Int_t j = 0; j < kPatchRows; j++) {
-      sum+=fPatchESimple[i][j];
-    }
-  }
+  // Double_t sum = 0.;
+  // for (Int_t i = 0; i < kPatchCols; i++) {
+  //   for (Int_t j = 0; j < kPatchRows; j++) {
+  //     sum+=fPatchESimple[i][j];
+  //   }
+  // }
 
   return kTRUE;
 }

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerDecisionContainer.cxx
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerDecisionContainer.cxx
@@ -101,7 +101,7 @@ bool AliEmcalTriggerDecisionContainer::IsEventSelected(EMCAL_STRINGVIEW name)  c
     }
     auto selectclasses = parseSelectionString(name, separator);
     bool selectionStatus = (mode == SeparatorMode::kSetIntersect) ? true : false;
-    for(const auto trgclass : selectclasses) {
+    for(const auto& trgclass : selectclasses) {
       auto triggerClassResult = IsEventSelected(trgclass.data());
       if((mode == SeparatorMode::kSetIntersect) && !triggerClassResult) {
         // All classes required - event rejection if one class is not present

--- a/PWG/Tools/THistManager.h
+++ b/PWG/Tools/THistManager.h
@@ -112,10 +112,13 @@ public:
    * THashList. The iterator is implemented as bidirectional
    * iterator, providing forward and backward iteration.
    */
-  class iterator :  public std::iterator<std::bidirectional_iterator_tag,
-                                                 TObject, std::ptrdiff_t,
-                                                 TObject **, TObject *&>{
+  class iterator{
   public:
+		using iterator_category = std::bidirectional_iterator_tag;
+    using value_type = TObject;
+    using difference_type = std::ptrdiff_t;
+    using pointer = TObject**;
+    using reference = TObject*&;
     /**
      * @enum THMIDirection_t
      * @brief Direction for the iteration

--- a/PWG/Tools/yaml-cpp/include/yaml-cpp/node/detail/iterator.h
+++ b/PWG/Tools/yaml-cpp/include/yaml-cpp/node/detail/iterator.h
@@ -19,8 +19,14 @@ namespace detail {
 struct iterator_value;
 
 template <typename V>
-class iterator_base : public std::iterator<std::forward_iterator_tag, V,
-                                           std::ptrdiff_t, V*, V> {
+class iterator_base{
+  public:
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = V;
+    using difference_type = std::ptrdiff_t;
+    using pointer = V*;
+    using reference = V&;
+
 
  private:
   template <typename>
@@ -37,7 +43,7 @@ class iterator_base : public std::iterator<std::forward_iterator_tag, V,
   };
 
  public:
-  typedef typename iterator_base::value_type value_type;
+  // typedef typename iterator_base::value_type value_type;
 
  public:
   iterator_base() : m_iterator(), m_pMemory() {}

--- a/PWG/Tools/yaml-cpp/include/yaml-cpp/node/detail/node_iterator.h
+++ b/PWG/Tools/yaml-cpp/include/yaml-cpp/node/detail/node_iterator.h
@@ -52,10 +52,17 @@ struct node_iterator_type<const V> {
 };
 
 template <typename V>
-class node_iterator_base
-    : public std::iterator<std::forward_iterator_tag, node_iterator_value<V>,
-                           std::ptrdiff_t, node_iterator_value<V>*,
-                           node_iterator_value<V>> {
+class node_iterator_base{
+    public:
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = node_iterator_value<V>;
+    using difference_type = std::ptrdiff_t;
+    using pointer = node_iterator_value<V>*;
+    using reference = node_iterator_value<V>&;
+
+    // std::iterator<std::forward_iterator_tag, node_iterator_value<V>,
+    //                        std::ptrdiff_t, node_iterator_value<V>*,
+    //                        node_iterator_value<V>> {
  private:
   struct enabler {};
 
@@ -70,7 +77,7 @@ class node_iterator_base
  public:
   typedef typename node_iterator_type<V>::seq SeqIter;
   typedef typename node_iterator_type<V>::map MapIter;
-  typedef node_iterator_value<V> value_type;
+  // typedef node_iterator_value<V> value_type;
 
   node_iterator_base()
       : m_type(iterator_type::NoneType), m_seqIt(), m_mapIt(), m_mapEnd() {}


### PR DESCRIPTION
This PR aims to fix all error messages that appear when building in debug mode and would hence prevent building in debug mode.

**PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.cxx:**
- remove unsused variable `bool behindSupport = false;` PWG/EMCAL/EMCALbase/AliTrackContainer.cxx:
- comment out unsused varaible `// int nmatch(0);`
---
**PWG/EMCAL/EMCALtasks/AliAnalysisTaskEmcalTriggerPatchClusterMatch.cxx:**
- comment out unused variables `Int_t nG1 = 0, nG2 = 0, nJ1 = 0, nJ2 = 0, nL0 = 0;` 
---
**PWG/EMCAL/EMCALtasks/AliEmcalAodTrackFilterTask.cxx:**
- changed order of variables in constructor to match order in header file
- Fixed Warning message to get message via `"%s"` to be secure (Error: format string is not a string literal) 
 ---
**PWG/EMCAL/EMCALtasks/AliEMCALClusterParams.cxx:**
- remove unused variables `ncell` and `ncell1` 
---
**PWG/EMCAL/EMCALtasks/AliEmcalPatchFromCellMaker.cxx**:
- remove unsused variable `sum` and a double nested loop which was not needed since it only added values to `sum`, but as stated `sum` is unused.
---
**PWG/EMCAL/EMCALtrigger/AliEmcalTriggerDecisionContainer.cxx:**
- change for loop from access by value, to access by reference `for(const auto& trgclass : selectclasses) {` 
---
**PWG/Tools/THistManager.h:**
- change `iterator` because std::iterator is deprecated
---
**PWG/Tools/yaml-cpp/include/yaml-cpp/node/detail/iterator.h:**
- change `iterator_base` because std::iterator is deprecated 
---
**PWG/Tools/yaml-cpp/include/yaml-cpp/node/detail/node_iterator.h:**
- change `node_iterator_base` because std::iterator is deprecated