### PR TITLE
PWGGA/GammaConv: add functionality for calculating pT-weights in variant (=!invariant) mode

### DIFF
--- a/PWGGA/GammaConv/macros/AddTask_GammaConvV1_PbPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvV1_PbPb.C
@@ -54,7 +54,7 @@ void AddTask_GammaConvV1_PbPb(
   Bool_t    enableChargedPrimary          = kFALSE,
   Bool_t    enablePlotVsCentrality        = kFALSE,
   Bool_t    processAODcheckForV0s         = kFALSE,   // flag for AOD check if V0s contained in AliAODs.root and AliAODGammaConversion.root
-  
+  bool      theUseGetMesonWeightNew       = false,
   // subwagon config
   TString   additionalTrainConfig         = "0")       // additional counter for trainconfig + special settings
   {
@@ -103,8 +103,8 @@ void AddTask_GammaConvV1_PbPb(
     return ;
   }
 
-  if (doWeightingPart<0) {
-    Error(Form("%s_%i", addTaskName.Data(),  trainConfig), "No negative values allowed for doWeightingPart");
+  if (acceptedAddedParticles<0) {
+    Error(Form("%s_%i", addTaskName.Data(),  trainConfig), "No negative values allowed for acceptedAddedParticles");
     return;
   }
 
@@ -3795,6 +3795,8 @@ void AddTask_GammaConvV1_PbPb(
       cuts.AddCutPCM("11310023", "0d200009ab770c00amd0404000", "0152101500000000"); // 10-30%
       cuts.AddCutPCM("13530023", "0d200009ab770c00amd0404000", "0152101500000000"); // 30-50%
       cuts.AddCutPCM("15910023", "0d200009ab770c00amd0404000", "0152101500000000"); // 50-90%
+  } else if (trainConfig == 998){ //____________________-___
+      cuts.AddCutPCM("10130023", "0d200009ab770c00amd0404000", "0152101500000000"); // 0-10%
 //****************************************************************************************************
 
   } else if (trainConfig == 1001){
@@ -4147,40 +4149,40 @@ void AddTask_GammaConvV1_PbPb(
     TObjString *Header1 = new TObjString("PARAM");
     HeaderList->Add(Header1);
   } else if (generatorName.CompareTo("LHC14a1a")==0){
-    if (doWeightingPart == 1){
+    if (acceptedAddedParticles == 1){
       TObjString *Header1 = new TObjString("pi0_1");
       HeaderList->Add(Header1);
-    } else if (doWeightingPart == 2){
+    } else if (acceptedAddedParticles == 2){
       TObjString *Header1 = new TObjString("eta_2");
       HeaderList->Add(Header1);
-    } else if (doWeightingPart == 3){
+    } else if (acceptedAddedParticles == 3){
       TString nameHeaders[2]    = { "pi0_1", "eta_2" };
       for (Int_t iHead = 0; iHead < 2; iHead++ ){
         TObjString *Header = new TObjString(nameHeaders[iHead]);
         HeaderList->Add(Header);
       }
-    } else if (doWeightingPart == 4){
+    } else if (acceptedAddedParticles == 4){
       TObjString *Header1 = new TObjString("pi0EMC_3");
       HeaderList->Add(Header1);
-    } else if (doWeightingPart == 5){
+    } else if (acceptedAddedParticles == 5){
       TObjString *Header1 = new TObjString("etaEMC_5");
       HeaderList->Add(Header1);
-    } else if (doWeightingPart == 6){
+    } else if (acceptedAddedParticles == 6){
       TString nameHeaders[2]    = { "pi0EMC_3", "etaEMC_5" };
       for (Int_t iHead = 0; iHead < 2; iHead++ ){
         TObjString *Header = new TObjString(nameHeaders[iHead]);
         HeaderList->Add(Header);
       }
-    } else if (doWeightingPart == 7){
+    } else if (acceptedAddedParticles == 7){
       TString nameHeaders[4]    = { "pi0_1", "eta_2", "pi0EMC_3", "etaEMC_5" };
       for (Int_t iHead = 0; iHead < 4; iHead++ ){
         TObjString *Header = new TObjString(nameHeaders[iHead]);
         HeaderList->Add(Header);
       }
-    } else if (doWeightingPart == 8){
+    } else if (acceptedAddedParticles == 8){
       TObjString *Header1 = new TObjString("gEMCPhoton_7");
       HeaderList->Add(Header1);
-    } else if (doWeightingPart == 9){
+    } else if (acceptedAddedParticles == 9){
       TString nameHeaders[10]   = { "Pythia_Jets_PtHard_1_10", "Pythia_Jets_PtHard_2_10", "Pythia_Jets_PtHard_3_10", "Pythia_Jets_PtHard_4_10", "Pythia_Jets_PtHard_5_10",
         "Pythia_Jets_PtHard_6_10", "Pythia_Jets_PtHard_7_10", "Pythia_Jets_PtHard_8_10", "Pythia_Jets_PtHard_9_10", "Pythia_Jets_PtHard_10_10"
       };
@@ -4188,10 +4190,10 @@ void AddTask_GammaConvV1_PbPb(
         TObjString *Header = new TObjString(nameHeaders[iHead]);
         HeaderList->Add(Header);
       }
-    } else if (doWeightingPart == 10){
+    } else if (acceptedAddedParticles == 10){
       TObjString *Header1 = new TObjString("pythia_bele_10_10");
       HeaderList->Add(Header1);
-    } else if (doWeightingPart == 11){
+    } else if (acceptedAddedParticles == 11){
       TString nameHeaders[34]   = { "Pythia_Jets_PtHard_1_10", "Pythia_Jets_PtHard_2_10", "Pythia_Jets_PtHard_3_10", "Pythia_Jets_PtHard_4_10", "Pythia_Jets_PtHard_5_10",
         "Pythia_Jets_PtHard_6_10", "Pythia_Jets_PtHard_7_10", "Pythia_Jets_PtHard_8_10", "Pythia_Jets_PtHard_9_10", "Pythia_Jets_PtHard_10_10",
         "gEMCPhoton_7", "flat pt kstar_8", "flat pt kstarbar_9", "pythia_cele_10_10", "pythia_cele_18_10",
@@ -4204,13 +4206,13 @@ void AddTask_GammaConvV1_PbPb(
         TObjString *Header = new TObjString(nameHeaders[iHead]);
         HeaderList->Add(Header);
       }
-    } else if (doWeightingPart == 12){
+    } else if (acceptedAddedParticles == 12){
       TObjString *Header1 = new TObjString("pi0PHS_4");
       HeaderList->Add(Header1);
-    } else if (doWeightingPart == 13){
+    } else if (acceptedAddedParticles == 13){
       TObjString *Header1 = new TObjString("etaPHS_6");
       HeaderList->Add(Header1);
-    } else if (doWeightingPart == 14){
+    } else if (acceptedAddedParticles == 14){
       TString nameHeaders[2]    = { "pi0PHS_4", "etaPHS_6" };
       for (Int_t iHead = 0; iHead < 2; iHead++ ){
         TObjString *Header = new TObjString(nameHeaders[iHead]);
@@ -4224,21 +4226,21 @@ void AddTask_GammaConvV1_PbPb(
       }
     }
   } else if (generatorName.CompareTo("LHC14a1b")==0 || generatorName.CompareTo("LHC14a1c")==0){
-    if (doWeightingPart == 1 || doWeightingPart == 2 || doWeightingPart == 3 ){
+    if (acceptedAddedParticles == 1 || acceptedAddedParticles == 2 || acceptedAddedParticles == 3 ){
       TObjString *Header1 = new TObjString("BOX");
       HeaderList->Add(Header1);
-    } if (doWeightingPart == 4 || doWeightingPart == 5 || doWeightingPart == 6 ){
+    } if (acceptedAddedParticles == 4 || acceptedAddedParticles == 5 || acceptedAddedParticles == 6 ){
       TObjString *Header1 = new TObjString("PARAM_EMC");
       HeaderList->Add(Header1);
-    } if (doWeightingPart == 12 || doWeightingPart == 13 || doWeightingPart == 14 ){
+    } if (acceptedAddedParticles == 12 || acceptedAddedParticles == 13 || acceptedAddedParticles == 14 ){
       TObjString *Header1 = new TObjString("PARAM_PHOS");
       HeaderList->Add(Header1);
     }
   } else if (generatorName.CompareTo("LHC16h4")==0 || generatorName.CompareTo("LHC19h3")==0){
-    if (doWeightingPart == 1){
+    if (acceptedAddedParticles == 1){
       TObjString *Header1 = new TObjString("Injector (pi0)_1");
       HeaderList->Add(Header1);
-    } else if (doWeightingPart == 2){
+    } else if (acceptedAddedParticles == 2){
       TObjString *Header1 = new TObjString("Injector (eta)_2");
       HeaderList->Add(Header1);
     } else {
@@ -4267,12 +4269,12 @@ void AddTask_GammaConvV1_PbPb(
       for (Size_t i=theStart; i<=theInclEnd; ++i) { fillSingle(i); }
     };
 
-    if      (doWeightingPart == 0)  { fillFromTo(1, 9); }            // all
-    else if (doWeightingPart <= 9)  { fillSingle(doWeightingPart); } // a single one
-    else if (doWeightingPart == 10) { fillFromTo(1, 5); }            // pi0) + pi0x)
-    else if (doWeightingPart == 11) { fillFromTo(2, 5); }            // all pi0x)
-    else if (doWeightingPart == 12) { fillFromTo(6, 7); }            // eta) + etaa)
-    else if (doWeightingPart == 13) {                                // pi0) + eta)
+    if      (acceptedAddedParticles == 0)  { fillFromTo(1, 9); }            // all
+    else if (acceptedAddedParticles <= 9)  { fillSingle(acceptedAddedParticles); } // a single one
+    else if (acceptedAddedParticles == 10) { fillFromTo(1, 5); }            // pi0) + pi0x)
+    else if (acceptedAddedParticles == 11) { fillFromTo(2, 5); }            // all pi0x)
+    else if (acceptedAddedParticles == 12) { fillFromTo(6, 7); }            // eta) + etaa)
+    else if (acceptedAddedParticles == 13) {                                // pi0) + eta)
       fillSingle(1);
       fillSingle(6);
     }
@@ -4312,7 +4314,7 @@ void AddTask_GammaConvV1_PbPb(
     TString mcInputMultHisto    = "";
     if (enableMultiplicityWeighting){
       cout << "INFO enableling mult weighting" << endl;
-      if(periodNameAnchor.CompareTo("LHC15o")==0 || periodNameAnchor.CompareTo("LHC18q")==0){
+      if(periodNameAnchor.BeginsWith("LHC15o")==0 || periodNameAnchor.CompareTo("LHC18q")==0){
         TString cutNumber = cuts.GetEventCut(i);
         TString centCut = cutNumber(0,3);  // first three digits of event cut
         dataInputMultHisto = Form("%s_%s", periodNameAnchor.Data(), centCut.Data());
@@ -4351,7 +4353,8 @@ void AddTask_GammaConvV1_PbPb(
     if (intPtWeightsCalculationMethod)
     {
       printf("AddTask_GammaConvV1_PbPb.C: INFO: intPtWeightsCalculationMethod = %d\n", intPtWeightsCalculationMethod);
-      if (periodNameAnchor.CompareTo("LHC15o") == 0 || periodNameAnchor.CompareTo("LHC18q") == 0)
+      if (periodNameAnchor.BeginsWith("LHC15o") || 
+          periodNameAnchor.BeginsWith("LHC18q"))
       {
         TString eventCutString = cuts.GetEventCut(i);
         TString eventCutShort = eventCutString(0, 6);                                                // first six digits
@@ -4363,94 +4366,95 @@ void AddTask_GammaConvV1_PbPb(
       analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(
           intPtWeightsCalculationMethod /*pi0reweight*/,
           intPtWeightsCalculationMethod /*etareweight*/,
-          intPtWeightsCalculationMethod /*k0sreweight*/,
+          0 /*need to switch off manually of here for now todo: <-*/ /*k0sreweight*/,
           fileNamePtWeights,
           histoNameMCPi0PT, histoNameMCEtaPT, histoNameMCK0sPT,
           fitNamePi0PT, fitNameEtaPT, fitNameK0sPT);
+      analysisEventCuts[i]->SetUseGetWeightForMesonNew(theUseGetMesonWeightNew);    
     }
 
     if (  trainConfig == 1   || trainConfig == 5   || trainConfig == 9   || trainConfig == 13   || trainConfig == 17   ||
         trainConfig == 21   || trainConfig == 25   || trainConfig == 29   || trainConfig == 33   || trainConfig == 37  ||
         trainConfig == 300 || trainConfig == 302 || trainConfig == 304){
-      if (i == 0 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kFALSE, kFALSE, fileNamePtWeights, "Pi0_Hijing_LHC13d2_PbPb_2760GeV_0005TPC", "", "","Pi0_Fit_Data_PbPb_2760GeV_0005V0M");
-      if (i == 1 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kFALSE, kFALSE, fileNamePtWeights, "Pi0_Hijing_LHC13d2_PbPb_2760GeV_0510TPC", "", "","Pi0_Fit_Data_PbPb_2760GeV_0510V0M");
-      if (i == 2 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kFALSE, kFALSE, fileNamePtWeights, "Pi0_Hijing_LHC13d2_PbPb_2760GeV_0010TPC", "", "","Pi0_Fit_Data_PbPb_2760GeV_0010V0M");
-      if (i == 3 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kFALSE, kFALSE,fileNamePtWeights, "Pi0_Hijing_LHC13d2_PbPb_2760GeV_1020TPC", "", "","Pi0_Fit_Data_PbPb_2760GeV_1020V0M");
-      if (i == 4 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kFALSE, kFALSE,fileNamePtWeights, "Pi0_Hijing_LHC13d2_PbPb_2760GeV_0020TPC", "", "","Pi0_Fit_Data_PbPb_2760GeV_0020V0M");
+      if (i == 0 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kFALSE, kFALSE, fileNamePtWeights, "Pi0_Hijing_LHC13d2_PbPb_2760GeV_0005TPC", "", "","Pi0_Fit_Data_PbPb_2760GeV_0005V0M");
+      if (i == 1 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kFALSE, kFALSE, fileNamePtWeights, "Pi0_Hijing_LHC13d2_PbPb_2760GeV_0510TPC", "", "","Pi0_Fit_Data_PbPb_2760GeV_0510V0M");
+      if (i == 2 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kFALSE, kFALSE, fileNamePtWeights, "Pi0_Hijing_LHC13d2_PbPb_2760GeV_0010TPC", "", "","Pi0_Fit_Data_PbPb_2760GeV_0010V0M");
+      if (i == 3 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kFALSE, kFALSE,fileNamePtWeights, "Pi0_Hijing_LHC13d2_PbPb_2760GeV_1020TPC", "", "","Pi0_Fit_Data_PbPb_2760GeV_1020V0M");
+      if (i == 4 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kFALSE, kFALSE,fileNamePtWeights, "Pi0_Hijing_LHC13d2_PbPb_2760GeV_0020TPC", "", "","Pi0_Fit_Data_PbPb_2760GeV_0020V0M");
     } else if (  trainConfig == 2   || trainConfig == 6   || trainConfig == 10   || trainConfig == 14   || trainConfig == 18   ||
           trainConfig == 22   || trainConfig == 26   || trainConfig == 30   || trainConfig == 34   || trainConfig == 38  ||
           trainConfig == 301 || trainConfig == 303 || trainConfig == 305){
-      if (i == 0 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kFALSE, kFALSE, fileNamePtWeights, "Pi0_Hijing_LHC13d2_PbPb_2760GeV_2040TPC", "", "","Pi0_Fit_Data_PbPb_2760GeV_2040V0M");
-      if (i == 1 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kFALSE, kFALSE, fileNamePtWeights, "Pi0_Hijing_LHC13d2_PbPb_2760GeV_4060TPC", "", "","Pi0_Fit_Data_PbPb_2760GeV_4060V0M");
-      if (i == 2 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kFALSE, kFALSE, fileNamePtWeights, "Pi0_Hijing_LHC13d2_PbPb_2760GeV_6080TPC", "", "","Pi0_Fit_Data_PbPb_2760GeV_6080V0M");
-      if (i == 3 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kFALSE, kFALSE, fileNamePtWeights, "Pi0_Hijing_LHC13d2_PbPb_2760GeV_4080TPC", "", "","Pi0_Fit_Data_PbPb_2760GeV_4080V0M");
+      if (i == 0 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kFALSE, kFALSE, fileNamePtWeights, "Pi0_Hijing_LHC13d2_PbPb_2760GeV_2040TPC", "", "","Pi0_Fit_Data_PbPb_2760GeV_2040V0M");
+      if (i == 1 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kFALSE, kFALSE, fileNamePtWeights, "Pi0_Hijing_LHC13d2_PbPb_2760GeV_4060TPC", "", "","Pi0_Fit_Data_PbPb_2760GeV_4060V0M");
+      if (i == 2 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kFALSE, kFALSE, fileNamePtWeights, "Pi0_Hijing_LHC13d2_PbPb_2760GeV_6080TPC", "", "","Pi0_Fit_Data_PbPb_2760GeV_6080V0M");
+      if (i == 3 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kFALSE, kFALSE, fileNamePtWeights, "Pi0_Hijing_LHC13d2_PbPb_2760GeV_4080TPC", "", "","Pi0_Fit_Data_PbPb_2760GeV_4080V0M");
     } else if ( trainConfig == 3   || trainConfig == 7    || trainConfig == 11   || trainConfig == 15  || trainConfig == 19   ||
           trainConfig == 23   || trainConfig == 27   || trainConfig == 31   || trainConfig == 35   || trainConfig == 39){
-      if (i == 0 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kFALSE, kFALSE, fileNamePtWeights, "Pi0_Hijing_LHC13d2_addSig_PbPb_2760GeV_0005TPC", "", "","Pi0_Fit_Data_PbPb_2760GeV_0005V0M");
-      if (i == 1 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kFALSE, kFALSE, fileNamePtWeights, "Pi0_Hijing_LHC13d2_addSig_PbPb_2760GeV_0510TPC", "", "","Pi0_Fit_Data_PbPb_2760GeV_0510V0M");
-      if (i == 2 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kFALSE, kFALSE, fileNamePtWeights, "Pi0_Hijing_LHC13d2_addSig_PbPb_2760GeV_0010TPC", "", "","Pi0_Fit_Data_PbPb_2760GeV_0010V0M");
-      if (i == 3 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kFALSE, kFALSE, fileNamePtWeights, "Pi0_Hijing_LHC13d2_addSig_PbPb_2760GeV_1020TPC", "", "","Pi0_Fit_Data_PbPb_2760GeV_1020V0M");
-      if (i == 0 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kFALSE, kFALSE, fileNamePtWeights, "Pi0_Hijing_LHC13d2_addSig_PbPb_2760GeV_0020TPC", "", "","Pi0_Fit_Data_PbPb_2760GeV_0020V0M");
+      if (i == 0 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kFALSE, kFALSE, fileNamePtWeights, "Pi0_Hijing_LHC13d2_addSig_PbPb_2760GeV_0005TPC", "", "","Pi0_Fit_Data_PbPb_2760GeV_0005V0M");
+      if (i == 1 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kFALSE, kFALSE, fileNamePtWeights, "Pi0_Hijing_LHC13d2_addSig_PbPb_2760GeV_0510TPC", "", "","Pi0_Fit_Data_PbPb_2760GeV_0510V0M");
+      if (i == 2 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kFALSE, kFALSE, fileNamePtWeights, "Pi0_Hijing_LHC13d2_addSig_PbPb_2760GeV_0010TPC", "", "","Pi0_Fit_Data_PbPb_2760GeV_0010V0M");
+      if (i == 3 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kFALSE, kFALSE, fileNamePtWeights, "Pi0_Hijing_LHC13d2_addSig_PbPb_2760GeV_1020TPC", "", "","Pi0_Fit_Data_PbPb_2760GeV_1020V0M");
+      if (i == 0 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kFALSE, kFALSE, fileNamePtWeights, "Pi0_Hijing_LHC13d2_addSig_PbPb_2760GeV_0020TPC", "", "","Pi0_Fit_Data_PbPb_2760GeV_0020V0M");
     } else if (  trainConfig == 4   ||trainConfig == 8     || trainConfig == 12   || trainConfig == 16   || trainConfig == 20   ||
           trainConfig == 24   || trainConfig == 28   || trainConfig == 32   || trainConfig == 36   || trainConfig == 40){
-      if (i == 0 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kFALSE, kFALSE, fileNamePtWeights, "Pi0_Hijing_LHC13d2_addSig_PbPb_2760GeV_2040TPC", "", "","Pi0_Fit_Data_PbPb_2760GeV_2040V0M");
-      if (i == 1 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kFALSE, kFALSE, fileNamePtWeights, "Pi0_Hijing_LHC13d2_addSig_PbPb_2760GeV_4060TPC", "", "","Pi0_Fit_Data_PbPb_2760GeV_4060V0M");
-      if (i == 2 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kFALSE, kFALSE, fileNamePtWeights, "Pi0_Hijing_LHC13d2_addSig_PbPb_2760GeV_6080TPC", "", "","Pi0_Fit_Data_PbPb_2760GeV_6080V0M");
-      if (i == 3 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kFALSE, kFALSE, fileNamePtWeights, "Pi0_Hijing_LHC13d2_addSig_PbPb_2760GeV_4080TPC", "", "","Pi0_Fit_Data_PbPb_2760GeV_4080V0M");
+      if (i == 0 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kFALSE, kFALSE, fileNamePtWeights, "Pi0_Hijing_LHC13d2_addSig_PbPb_2760GeV_2040TPC", "", "","Pi0_Fit_Data_PbPb_2760GeV_2040V0M");
+      if (i == 1 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kFALSE, kFALSE, fileNamePtWeights, "Pi0_Hijing_LHC13d2_addSig_PbPb_2760GeV_4060TPC", "", "","Pi0_Fit_Data_PbPb_2760GeV_4060V0M");
+      if (i == 2 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kFALSE, kFALSE, fileNamePtWeights, "Pi0_Hijing_LHC13d2_addSig_PbPb_2760GeV_6080TPC", "", "","Pi0_Fit_Data_PbPb_2760GeV_6080V0M");
+      if (i == 3 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kFALSE, kFALSE, fileNamePtWeights, "Pi0_Hijing_LHC13d2_addSig_PbPb_2760GeV_4080TPC", "", "","Pi0_Fit_Data_PbPb_2760GeV_4080V0M");
     }
 
     if (trainConfig == 56 ){
       if (generatorName.CompareTo("LHC14a1a") ==0 || generatorName.CompareTo("LHC14a1b") ==0 || generatorName.CompareTo("LHC14a1c") ==0 ){
-        if ( i == 0 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_0005TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_0005TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_0005V0M","Eta_Fit_Data_PbPb_2760GeV_0005V0M");
-        if ( i == 1 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_0510TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_0510TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_0510V0M","Eta_Fit_Data_PbPb_2760GeV_0510V0M");
-        if ( i == 2 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_0010TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_0010TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_0010V0M","Eta_Fit_Data_PbPb_2760GeV_0010V0M");
-        if ( i == 3 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_1020TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_1020TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_1020V0M","Eta_Fit_Data_PbPb_2760GeV_1020V0M");
-        if ( i == 4 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_0020TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_0020TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_0020V0M","Eta_Fit_Data_PbPb_2760GeV_0020V0M");
+        if ( i == 0 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_0005TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_0005TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_0005V0M","Eta_Fit_Data_PbPb_2760GeV_0005V0M");
+        if ( i == 1 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_0510TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_0510TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_0510V0M","Eta_Fit_Data_PbPb_2760GeV_0510V0M");
+        if ( i == 2 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_0010TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_0010TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_0010V0M","Eta_Fit_Data_PbPb_2760GeV_0010V0M");
+        if ( i == 3 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_1020TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_1020TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_1020V0M","Eta_Fit_Data_PbPb_2760GeV_1020V0M");
+        if ( i == 4 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_0020TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_0020TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_0020V0M","Eta_Fit_Data_PbPb_2760GeV_0020V0M");
       }
     }
     if (trainConfig == 57 ){
       if (generatorName.CompareTo("LHC14a1a") ==0 || generatorName.CompareTo("LHC14a1b") ==0 || generatorName.CompareTo("LHC14a1c") ==0 ){
-        if ( i == 0 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_0005TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_0005TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_0005V0M","Eta_Fit_Data_PbPb_2760GeV_0005V0M");
-        if ( i == 1 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_0510TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_0510TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_0510V0M","Eta_Fit_Data_PbPb_2760GeV_0510V0M");
-        if ( i == 2 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_0010TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_0010TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_0010V0M","Eta_Fit_Data_PbPb_2760GeV_0010V0M");
-        if ( i == 3 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_1020TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_1020TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_1020V0M","Eta_Fit_Data_PbPb_2760GeV_1020V0M");
-        if ( i == 4 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_0020TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_0020TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_0020V0M","Eta_Fit_Data_PbPb_2760GeV_0020V0M");
+        if ( i == 0 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_0005TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_0005TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_0005V0M","Eta_Fit_Data_PbPb_2760GeV_0005V0M");
+        if ( i == 1 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_0510TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_0510TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_0510V0M","Eta_Fit_Data_PbPb_2760GeV_0510V0M");
+        if ( i == 2 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_0010TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_0010TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_0010V0M","Eta_Fit_Data_PbPb_2760GeV_0010V0M");
+        if ( i == 3 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_1020TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_1020TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_1020V0M","Eta_Fit_Data_PbPb_2760GeV_1020V0M");
+        if ( i == 4 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_0020TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_0020TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_0020V0M","Eta_Fit_Data_PbPb_2760GeV_0020V0M");
       }
     }
     if (trainConfig == 58 ){
       if (generatorName.CompareTo("LHC14a1a") ==0 || generatorName.CompareTo("LHC14a1b") ==0 || generatorName.CompareTo("LHC14a1c") ==0 ){
-        if ( i == 0 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_2040TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_2040TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_2040V0M","Eta_Fit_Data_PbPb_2760GeV_2040V0M");
-        if ( i == 1 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_4060TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_4060TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_4060V0M","Eta_Fit_Data_PbPb_2760GeV_4060V0M");
-        if ( i == 2 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_6080TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_6080TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_6080V0M","Eta_Fit_Data_PbPb_2760GeV_6080V0M");
-        if ( i == 3 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_4080TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_4080TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_1020V0M","Eta_Fit_Data_PbPb_2760GeV_1020V0M");
-        if ( i == 4 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_3050TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_3050TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_3050V0M","Eta_Fit_Data_PbPb_2760GeV_3050V0M");
+        if ( i == 0 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_2040TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_2040TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_2040V0M","Eta_Fit_Data_PbPb_2760GeV_2040V0M");
+        if ( i == 1 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_4060TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_4060TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_4060V0M","Eta_Fit_Data_PbPb_2760GeV_4060V0M");
+        if ( i == 2 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_6080TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_6080TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_6080V0M","Eta_Fit_Data_PbPb_2760GeV_6080V0M");
+        if ( i == 3 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_4080TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_4080TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_1020V0M","Eta_Fit_Data_PbPb_2760GeV_1020V0M");
+        if ( i == 4 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_3050TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_3050TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_3050V0M","Eta_Fit_Data_PbPb_2760GeV_3050V0M");
       }
     }
     if (trainConfig == 59 ){
       if (generatorName.CompareTo("LHC14a1a") ==0 || generatorName.CompareTo("LHC14a1b") ==0 || generatorName.CompareTo("LHC14a1c") ==0 ){
-        if ( i == 0 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_2040TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_2040TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_2040V0M","Eta_Fit_Data_PbPb_2760GeV_2040V0M");
-        if ( i == 1 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_4060TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_4060TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_4060V0M","Eta_Fit_Data_PbPb_2760GeV_4060V0M");
-        if ( i == 2 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_6080TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_6080TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_6080V0M","Eta_Fit_Data_PbPb_2760GeV_6080V0M");
-        if ( i == 3 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_4080TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_4080TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_1020V0M","Eta_Fit_Data_PbPb_2760GeV_1020V0M");
-        if ( i == 4 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_3050TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_3050TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_3050V0M","Eta_Fit_Data_PbPb_2760GeV_3050V0M");
+        if ( i == 0 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_2040TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_2040TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_2040V0M","Eta_Fit_Data_PbPb_2760GeV_2040V0M");
+        if ( i == 1 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_4060TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_4060TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_4060V0M","Eta_Fit_Data_PbPb_2760GeV_4060V0M");
+        if ( i == 2 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_6080TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_6080TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_6080V0M","Eta_Fit_Data_PbPb_2760GeV_6080V0M");
+        if ( i == 3 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_4080TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_4080TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_1020V0M","Eta_Fit_Data_PbPb_2760GeV_1020V0M");
+        if ( i == 4 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_3050TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_3050TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_3050V0M","Eta_Fit_Data_PbPb_2760GeV_3050V0M");
       }
     }
     if (trainConfig == 60 ){
       if (generatorName.CompareTo("LHC14a1a") ==0 || generatorName.CompareTo("LHC14a1b") ==0 || generatorName.CompareTo("LHC14a1c") ==0 ){
-        if ( i == 0 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_2030TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_2030TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_2030V0M","Eta_Fit_Data_PbPb_2760GeV_2030V0M");
-        if ( i == 1 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_3040TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_3040TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_3040V0M","Eta_Fit_Data_PbPb_2760GeV_3040V0M");
-        if ( i == 2 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_4050TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_4050TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_4050V0M","Eta_Fit_Data_PbPb_2760GeV_4050V0M");
-        if ( i == 3 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_5060TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_5060TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_5060V0M","Eta_Fit_Data_PbPb_2760GeV_5060V0M");
-        if ( i == 4 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_2050TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_2050TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_2050V0M","Eta_Fit_Data_PbPb_2760GeV_2050V0M");
+        if ( i == 0 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_2030TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_2030TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_2030V0M","Eta_Fit_Data_PbPb_2760GeV_2030V0M");
+        if ( i == 1 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_3040TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_3040TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_3040V0M","Eta_Fit_Data_PbPb_2760GeV_3040V0M");
+        if ( i == 2 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_4050TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_4050TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_4050V0M","Eta_Fit_Data_PbPb_2760GeV_4050V0M");
+        if ( i == 3 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_5060TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_5060TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_5060V0M","Eta_Fit_Data_PbPb_2760GeV_5060V0M");
+        if ( i == 4 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_2050TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_2050TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_2050V0M","Eta_Fit_Data_PbPb_2760GeV_2050V0M");
       }
     }
     if (trainConfig == 61 ){
       if (generatorName.CompareTo("LHC14a1a") ==0 || generatorName.CompareTo("LHC14a1b") ==0 || generatorName.CompareTo("LHC14a1c") ==0 ){
-        if ( i == 0 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_2030TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_2030TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_2030V0M","Eta_Fit_Data_PbPb_2760GeV_2030V0M");
-        if ( i == 1 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_3040TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_3040TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_3040V0M","Eta_Fit_Data_PbPb_2760GeV_3040V0M");
-        if ( i == 2 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_4050TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_4050TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_4050V0M","Eta_Fit_Data_PbPb_2760GeV_4050V0M");
-        if ( i == 3 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_5060TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_5060TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_5060V0M","Eta_Fit_Data_PbPb_2760GeV_5060V0M");
-        if ( i == 4 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_2050TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_2050TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_2050V0M","Eta_Fit_Data_PbPb_2760GeV_2050V0M");
+        if ( i == 0 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_2030TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_2030TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_2030V0M","Eta_Fit_Data_PbPb_2760GeV_2030V0M");
+        if ( i == 1 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_3040TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_3040TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_3040V0M","Eta_Fit_Data_PbPb_2760GeV_3040V0M");
+        if ( i == 2 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_4050TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_4050TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_4050V0M","Eta_Fit_Data_PbPb_2760GeV_4050V0M");
+        if ( i == 3 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_5060TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_5060TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_5060V0M","Eta_Fit_Data_PbPb_2760GeV_5060V0M");
+        if ( i == 4 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_2050TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_2050TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_2050V0M","Eta_Fit_Data_PbPb_2760GeV_2050V0M");
       }
     }
 
@@ -4468,11 +4472,11 @@ void AddTask_GammaConvV1_PbPb(
         trainConfig == 234   || trainConfig == 236   || trainConfig == 238   || trainConfig == 240  || trainConfig == 242  ||
         trainConfig == 244   || trainConfig == 357   || trainConfig == 358   ){
       if (generatorName.CompareTo("LHC14a1a") ==0 || generatorName.CompareTo("LHC14a1b") ==0 || generatorName.CompareTo("LHC14a1c") ==0 ){
-        if ( i == 0 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_0005TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_0005TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_0005V0M","Eta_Fit_Data_PbPb_2760GeV_0005V0M");
-        if ( i == 1 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_0510TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_0510TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_0510V0M","Eta_Fit_Data_PbPb_2760GeV_0510V0M");
-        if ( i == 2 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_0010TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_0010TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_0010V0M","Eta_Fit_Data_PbPb_2760GeV_0010V0M");
-        if ( i == 3 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_2040TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_2040TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_2040V0M","Eta_Fit_Data_PbPb_2760GeV_2040V0M");
-        if ( i == 4 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_2050TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_2050TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_2050V0M","Eta_Fit_Data_PbPb_2760GeV_2050V0M");
+        if ( i == 0 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_0005TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_0005TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_0005V0M","Eta_Fit_Data_PbPb_2760GeV_0005V0M");
+        if ( i == 1 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_0510TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_0510TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_0510V0M","Eta_Fit_Data_PbPb_2760GeV_0510V0M");
+        if ( i == 2 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_0010TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_0010TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_0010V0M","Eta_Fit_Data_PbPb_2760GeV_0010V0M");
+        if ( i == 3 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_2040TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_2040TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_2040V0M","Eta_Fit_Data_PbPb_2760GeV_2040V0M");
+        if ( i == 4 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_2050TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_2050TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_2050V0M","Eta_Fit_Data_PbPb_2760GeV_2050V0M");
       }
     }
 
@@ -4490,23 +4494,23 @@ void AddTask_GammaConvV1_PbPb(
         trainConfig == 235   || trainConfig == 237   || trainConfig == 239   || trainConfig == 241  || trainConfig == 243  ||
         trainConfig == 245){
       if (generatorName.CompareTo("LHC14a1a") ==0 || generatorName.CompareTo("LHC14a1b") ==0 || generatorName.CompareTo("LHC14a1c") ==0 ){
-        if ( i == 0 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_0005TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_0005TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_0005V0M","Eta_Fit_Data_PbPb_2760GeV_0005V0M");
-        if ( i == 1 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_0510TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_0510TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_0510V0M","Eta_Fit_Data_PbPb_2760GeV_0510V0M");
-        if ( i == 2 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_0010TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_0010TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_0010V0M","Eta_Fit_Data_PbPb_2760GeV_0010V0M");
-        if ( i == 3 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_2040TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_2040TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_2040V0M","Eta_Fit_Data_PbPb_2760GeV_2040V0M");
-        if ( i == 4 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_2050TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_2050TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_2050V0M","Eta_Fit_Data_PbPb_2760GeV_2050V0M");
+        if ( i == 0 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_0005TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_0005TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_0005V0M","Eta_Fit_Data_PbPb_2760GeV_0005V0M");
+        if ( i == 1 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_0510TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_0510TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_0510V0M","Eta_Fit_Data_PbPb_2760GeV_0510V0M");
+        if ( i == 2 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_0010TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_0010TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_0010V0M","Eta_Fit_Data_PbPb_2760GeV_0010V0M");
+        if ( i == 3 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_2040TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_2040TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_2040V0M","Eta_Fit_Data_PbPb_2760GeV_2040V0M");
+        if ( i == 4 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_2050TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_2050TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_2050V0M","Eta_Fit_Data_PbPb_2760GeV_2050V0M");
       }
     }
 
     if (trainConfig == 186   || trainConfig == 187 || trainConfig == 190   || trainConfig == 191 || trainConfig == 359   || trainConfig == 360){
       if (generatorName.CompareTo("LHC14a1a") ==0 || generatorName.CompareTo("LHC14a1b") ==0 || generatorName.CompareTo("LHC14a1c") ==0 ){
-        if ( i == 0 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_0010TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_0010TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_0010V0M","Eta_Fit_Data_PbPb_2760GeV_0010V0M");
+        if ( i == 0 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_0010TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_0010TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_0010V0M","Eta_Fit_Data_PbPb_2760GeV_0010V0M");
       }
     }
     if (trainConfig == 188   || trainConfig == 189 || trainConfig == 192   || trainConfig == 193 || trainConfig == 361   || trainConfig == 362){
       if (generatorName.CompareTo("LHC14a1a") ==0 || generatorName.CompareTo("LHC14a1b") ==0 || generatorName.CompareTo("LHC14a1c") ==0 ){
-        if ( i == 0 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_2040TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_2040TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_2040V0M","Eta_Fit_Data_PbPb_2760GeV_2040V0M");
-        if ( i == 1 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_2050TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_2050TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_2050V0M","Eta_Fit_Data_PbPb_2760GeV_2050V0M");
+        if ( i == 0 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_2040TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_2040TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_2040V0M","Eta_Fit_Data_PbPb_2760GeV_2040V0M");
+        if ( i == 1 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_2050TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_2050TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_2050V0M","Eta_Fit_Data_PbPb_2760GeV_2050V0M");
       }
     }
 
@@ -4515,8 +4519,8 @@ void AddTask_GammaConvV1_PbPb(
         trainConfig == 218 || trainConfig == 219 || trainConfig == 222 || trainConfig == 223 || trainConfig == 226 || trainConfig == 227 ||
         trainConfig == 230 || trainConfig == 231){
       if (generatorName.CompareTo("LHC14a1a") ==0 || generatorName.CompareTo("LHC14a1b") ==0 || generatorName.CompareTo("LHC14a1c") ==0 ){
-        if ( i == 0 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_0010TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_0010TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_0010V0M","Eta_Fit_Data_PbPb_2760GeV_0010V0M");
-        if ( i == 1 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_0010TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_0010TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_0010V0M","Eta_Fit_Data_PbPb_2760GeV_0010V0M");
+        if ( i == 0 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_0010TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_0010TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_0010V0M","Eta_Fit_Data_PbPb_2760GeV_0010V0M");
+        if ( i == 1 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_0010TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_0010TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_0010V0M","Eta_Fit_Data_PbPb_2760GeV_0010V0M");
       }
     }
     if (trainConfig == 196 || trainConfig == 197 || trainConfig == 200 || trainConfig == 201 || trainConfig == 204 || trainConfig == 205 ||
@@ -4524,22 +4528,22 @@ void AddTask_GammaConvV1_PbPb(
         trainConfig == 220 || trainConfig == 221 || trainConfig == 224 || trainConfig == 225 || trainConfig == 228 || trainConfig == 229 ||
         trainConfig == 232 || trainConfig == 233){
     if (generatorName.CompareTo("LHC14a1a") ==0 || generatorName.CompareTo("LHC14a1b") ==0 || generatorName.CompareTo("LHC14a1c") ==0 ){
-        if ( i == 0 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_2040TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_2040TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_2040V0M","Eta_Fit_Data_PbPb_2760GeV_2040V0M");
-        if ( i == 1 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_2040TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_2040TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_2040V0M","Eta_Fit_Data_PbPb_2760GeV_2040V0M");
-        if ( i == 2 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_2050TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_2050TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_2050V0M","Eta_Fit_Data_PbPb_2760GeV_2050V0M");
-        if ( i == 3 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_2050TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_2050TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_2050V0M","Eta_Fit_Data_PbPb_2760GeV_2050V0M");
+        if ( i == 0 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_2040TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_2040TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_2040V0M","Eta_Fit_Data_PbPb_2760GeV_2040V0M");
+        if ( i == 1 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_2040TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_2040TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_2040V0M","Eta_Fit_Data_PbPb_2760GeV_2040V0M");
+        if ( i == 2 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_2050TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_2050TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_2050V0M","Eta_Fit_Data_PbPb_2760GeV_2050V0M");
+        if ( i == 3 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_2050TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_2050TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_2050V0M","Eta_Fit_Data_PbPb_2760GeV_2050V0M");
       }
     }
 
     if (trainConfig == 313   || trainConfig == 314 || trainConfig == 317   || trainConfig == 318 || trainConfig == 363   || trainConfig == 364){
       if (generatorName.CompareTo("LHC14a1a") ==0 || generatorName.CompareTo("LHC14a1b") ==0 || generatorName.CompareTo("LHC14a1c") ==0 ){
-        if ( i == 0 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_0010TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_0010TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_0010V0M","Eta_Fit_Data_PbPb_2760GeV_0010V0M");
+        if ( i == 0 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_0010TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_0010TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_0010V0M","Eta_Fit_Data_PbPb_2760GeV_0010V0M");
       }
     }
     if (trainConfig == 315   || trainConfig == 316 || trainConfig == 319   || trainConfig == 320 || trainConfig == 365   || trainConfig == 366){
       if (generatorName.CompareTo("LHC14a1a") ==0 || generatorName.CompareTo("LHC14a1b") ==0 || generatorName.CompareTo("LHC14a1c") ==0 ){
-        if ( i == 0 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_2040TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_2040TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_2040V0M","Eta_Fit_Data_PbPb_2760GeV_2040V0M");
-        if ( i == 1 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_2050TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_2050TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_2050V0M","Eta_Fit_Data_PbPb_2760GeV_2050V0M");
+        if ( i == 0 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_2040TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_2040TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_2040V0M","Eta_Fit_Data_PbPb_2760GeV_2040V0M");
+        if ( i == 1 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_2050TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_2050TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_2050V0M","Eta_Fit_Data_PbPb_2760GeV_2050V0M");
       }
     }
 
@@ -4547,47 +4551,47 @@ void AddTask_GammaConvV1_PbPb(
         trainConfig == 333 || trainConfig == 334 || trainConfig == 337 || trainConfig == 338 || trainConfig == 341 || trainConfig == 342 ||
         trainConfig == 345 || trainConfig == 346 || trainConfig == 349 || trainConfig == 350 || trainConfig == 353 || trainConfig == 354){
       if (generatorName.CompareTo("LHC14a1a") ==0 || generatorName.CompareTo("LHC14a1b") ==0 || generatorName.CompareTo("LHC14a1c") ==0 ){
-        if ( i == 0 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_0010TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_0010TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_0010V0M","Eta_Fit_Data_PbPb_2760GeV_0010V0M");
-        if ( i == 1 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_0010TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_0010TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_0010V0M","Eta_Fit_Data_PbPb_2760GeV_0010V0M");
+        if ( i == 0 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_0010TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_0010TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_0010V0M","Eta_Fit_Data_PbPb_2760GeV_0010V0M");
+        if ( i == 1 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_0010TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_0010TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_0010V0M","Eta_Fit_Data_PbPb_2760GeV_0010V0M");
     }
     }
     if (trainConfig == 323 || trainConfig == 324 || trainConfig == 327 || trainConfig == 328 || trainConfig == 331 || trainConfig == 332 ||
         trainConfig == 335 || trainConfig == 336 || trainConfig == 339 || trainConfig == 340 || trainConfig == 343 || trainConfig == 344 ||
         trainConfig == 347 || trainConfig == 348 || trainConfig == 351 || trainConfig == 352 || trainConfig == 355 || trainConfig == 356){
     if (generatorName.CompareTo("LHC14a1a") ==0 || generatorName.CompareTo("LHC14a1b") ==0 || generatorName.CompareTo("LHC14a1c") ==0 ){
-        if ( i == 0 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_2040TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_2040TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_2040V0M","Eta_Fit_Data_PbPb_2760GeV_2040V0M");
-        if ( i == 1 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_2040TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_2040TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_2040V0M","Eta_Fit_Data_PbPb_2760GeV_2040V0M");
-        if ( i == 2 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_2050TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_2050TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_2050V0M","Eta_Fit_Data_PbPb_2760GeV_2050V0M");
-        if ( i == 3 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_2050TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_2050TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_2050V0M","Eta_Fit_Data_PbPb_2760GeV_2050V0M");
+        if ( i == 0 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_2040TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_2040TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_2040V0M","Eta_Fit_Data_PbPb_2760GeV_2040V0M");
+        if ( i == 1 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_2040TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_2040TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_2040V0M","Eta_Fit_Data_PbPb_2760GeV_2040V0M");
+        if ( i == 2 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_2050TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_2050TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_2050V0M","Eta_Fit_Data_PbPb_2760GeV_2050V0M");
+        if ( i == 3 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_2050TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_2050TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_2050V0M","Eta_Fit_Data_PbPb_2760GeV_2050V0M");
       }
     }
 
     if(trainConfig == 367 || trainConfig == 368){
       if (generatorName.CompareTo("LHC14a1a") ==0 || generatorName.CompareTo("LHC14a1b") ==0 || generatorName.CompareTo("LHC14a1c") ==0 ){
-        if ( i == 0 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_2030TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_2030TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_2030V0M","Eta_Fit_Data_PbPb_2760GeV_2030V0M");
-        if ( i == 1 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_3040TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_3040TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_3040V0M","Eta_Fit_Data_PbPb_2760GeV_3040V0M");
-        if ( i == 2 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_3050TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_3050TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_3050V0M","Eta_Fit_Data_PbPb_2760GeV_3050V0M");
+        if ( i == 0 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_2030TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_2030TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_2030V0M","Eta_Fit_Data_PbPb_2760GeV_2030V0M");
+        if ( i == 1 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_3040TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_3040TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_3040V0M","Eta_Fit_Data_PbPb_2760GeV_3040V0M");
+        if ( i == 2 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_3050TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_3050TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_3050V0M","Eta_Fit_Data_PbPb_2760GeV_3050V0M");
       }
     }
     if (trainConfig == 369   || trainConfig == 370){
       if (generatorName.CompareTo("LHC14a1a") ==0 || generatorName.CompareTo("LHC14a1b") ==0 || generatorName.CompareTo("LHC14a1c") ==0 ){
-        if ( i == 0 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_2030TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_2030TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_2030V0M","Eta_Fit_Data_PbPb_2760GeV_2030V0M");
-        if ( i == 1 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_3040TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_3040TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_3040V0M","Eta_Fit_Data_PbPb_2760GeV_3040V0M");
-        if ( i == 2 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_3050TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_3050TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_3050V0M","Eta_Fit_Data_PbPb_2760GeV_3050V0M");
+        if ( i == 0 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_2030TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_2030TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_2030V0M","Eta_Fit_Data_PbPb_2760GeV_2030V0M");
+        if ( i == 1 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_3040TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_3040TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_3040V0M","Eta_Fit_Data_PbPb_2760GeV_3040V0M");
+        if ( i == 2 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_3050TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_3050TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_3050V0M","Eta_Fit_Data_PbPb_2760GeV_3050V0M");
       }
     }
     if(trainConfig == 371 || trainConfig == 372){
       if (generatorName.CompareTo("LHC14a1a") ==0 || generatorName.CompareTo("LHC14a1b") ==0 || generatorName.CompareTo("LHC14a1c") ==0 ){
-        if ( i == 0 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_0005TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_0005TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_0005V0M","Eta_Fit_Data_PbPb_2760GeV_0005V0M");
-        if ( i == 1 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_0510TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_0510TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_0510V0M","Eta_Fit_Data_PbPb_2760GeV_0510V0M");
-        if ( i == 2 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_1020TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_1020TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_1020V0M","Eta_Fit_Data_PbPb_2760GeV_1020V0M");
+        if ( i == 0 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_0005TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_0005TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_0005V0M","Eta_Fit_Data_PbPb_2760GeV_0005V0M");
+        if ( i == 1 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_0510TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_0510TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_0510V0M","Eta_Fit_Data_PbPb_2760GeV_0510V0M");
+        if ( i == 2 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_PbPb_2760GeV_1020TPC",generatorName.Data()), Form("Eta_Hijing_%s_PbPb_2760GeV_1020TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_1020V0M","Eta_Fit_Data_PbPb_2760GeV_1020V0M");
       }
     }
     if (trainConfig == 373   || trainConfig == 374){
       if (generatorName.CompareTo("LHC14a1a") ==0 || generatorName.CompareTo("LHC14a1b") ==0 || generatorName.CompareTo("LHC14a1c") ==0 ){
-        if ( i == 0 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_0005TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_0005TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_0005V0M","Eta_Fit_Data_PbPb_2760GeV_0005V0M");
-        if ( i == 1 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_0510TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_0510TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_0510V0M","Eta_Fit_Data_PbPb_2760GeV_0510V0M");
-        if ( i == 2 && enablePtWeighting)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_1020TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_1020TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_1020V0M","Eta_Fit_Data_PbPb_2760GeV_1020V0M");
+        if ( i == 0 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_0005TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_0005TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_0005V0M","Eta_Fit_Data_PbPb_2760GeV_0005V0M");
+        if ( i == 1 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_0510TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_0510TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_0510V0M","Eta_Fit_Data_PbPb_2760GeV_0510V0M");
+        if ( i == 2 && intPtWeightsCalculationMethod)  analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(kTRUE, kTRUE, kFALSE,fileNamePtWeights, Form("Pi0_Hijing_%s_addSig_PbPb_2760GeV_1020TPC",generatorName.Data()), Form("Eta_Hijing_%s_addSig_PbPb_2760GeV_1020TPC",generatorName.Data()), "","Pi0_Fit_Data_PbPb_2760GeV_1020V0M","Eta_Fit_Data_PbPb_2760GeV_1020V0M");
       }
     }
 
@@ -4610,8 +4614,8 @@ void AddTask_GammaConvV1_PbPb(
     analysisEventCuts[i]->SetLightOutput(enableLightOutput);
     analysisEventCuts[i]->InitializeCutsFromCutString((cuts.GetEventCut(i)).Data());
     if (generatorName.CompareTo("LHC14a1b") ==0 || generatorName.CompareTo("LHC14a1c") ==0 ){
-      if (doWeightingPart == 1 || doWeightingPart == 4 || doWeightingPart == 12 ) analysisEventCuts[i]->SetAddedSignalPDGCode(111);
-      if (doWeightingPart == 2 || doWeightingPart == 5 || doWeightingPart == 13 ) analysisEventCuts[i]->SetAddedSignalPDGCode(221);
+      if (acceptedAddedParticles == 1 || acceptedAddedParticles == 4 || acceptedAddedParticles == 12 ) analysisEventCuts[i]->SetAddedSignalPDGCode(111);
+      if (acceptedAddedParticles == 2 || acceptedAddedParticles == 5 || acceptedAddedParticles == 13 ) analysisEventCuts[i]->SetAddedSignalPDGCode(221);
     }
     EventCutList->Add(analysisEventCuts[i]);
     if (trainConfig == 37 || trainConfig == 38){

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvV1_PbPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvV1_PbPb.C
@@ -122,7 +122,7 @@ void AddTask_GammaConvV1_PbPb(
   for(Int_t i = 0; i<rmaxFacPtHardSetting->GetEntries() ; i++){
     TObjString* tempObjStrPtHardSetting     = (TObjString*) rmaxFacPtHardSetting->At(i);
     TString strTempSetting                  = tempObjStrPtHardSetting->GetString();
-    if(strTempSetting.BeginsWith("MINPTHFAC:")){
+    if(strTempSetting.("MINPTHFAC:")){
       strTempSetting.Replace(0,10,"");
       minFacPtHard               = strTempSetting.Atof();
       cout << "running with min pT hard jet fraction of: " << minFacPtHard << endl;
@@ -4314,7 +4314,7 @@ void AddTask_GammaConvV1_PbPb(
     TString mcInputMultHisto    = "";
     if (enableMultiplicityWeighting){
       cout << "INFO enableling mult weighting" << endl;
-      if(periodNameAnchor.BeginsWith("LHC15o")==0 || periodNameAnchor.CompareTo("LHC18q")==0){
+      if(periodNameAnchor.BeginsWith("LHC15o") || periodNameAnchor.BeginsWith("LHC18q")){
         TString cutNumber = cuts.GetEventCut(i);
         TString centCut = cutNumber(0,3);  // first three digits of event cut
         dataInputMultHisto = Form("%s_%s", periodNameAnchor.Data(), centCut.Data());
@@ -4353,8 +4353,8 @@ void AddTask_GammaConvV1_PbPb(
     if (intPtWeightsCalculationMethod)
     {
       printf("AddTask_GammaConvV1_PbPb.C: INFO: intPtWeightsCalculationMethod = %d\n", intPtWeightsCalculationMethod);
-      if (periodNameAnchor.BeginsWith("LHC15o") || 
-          periodNameAnchor.BeginsWith("LHC18q"))
+      if (periodNameAnchor.("LHC15o") || 
+          periodNameAnchor.("LHC18q"))
       {
         TString eventCutString = cuts.GetEventCut(i);
         TString eventCutShort = eventCutString(0, 6);                                                // first six digits

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvV1_PbPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvV1_PbPb.C
@@ -3797,6 +3797,8 @@ void AddTask_GammaConvV1_PbPb(
       cuts.AddCutPCM("15910023", "0d200009ab770c00amd0404000", "0152101500000000"); // 50-90%
   } else if (trainConfig == 998){ //____________________-___
       cuts.AddCutPCM("10130023", "0d200009ab770c00amd0404000", "0152101500000000"); // 0-10%
+  } else if (trainConfig == 999){ //____________________-___
+      cuts.AddCutPCM("13530023", "0d200009ab770c00amd0404000", "0152101500000000"); // 0-10%
 //****************************************************************************************************
 
   } else if (trainConfig == 1001){
@@ -4364,9 +4366,15 @@ void AddTask_GammaConvV1_PbPb(
         fitNameEtaPT = Form("Eta_Data_5TeV_%s", eventCutShort.Data());
       }
       analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(
-          intPtWeightsCalculationMethod /*pi0reweight*/,
-          intPtWeightsCalculationMethod /*etareweight*/,
-          0 /*need to switch off manually of here for now todo: <-*/ /*k0sreweight*/,
+          HeaderList->FindObject("Injector (pi0)") 
+            ? intPtWeightsCalculationMethod /*pi0reweight*/
+            : 0,
+          HeaderList->FindObject("Injector (eta)") 
+            ? intPtWeightsCalculationMethod /*etareweight*/
+            : 0,
+          HeaderList->FindObject("Injector (K0s)") 
+            ? intPtWeightsCalculationMethod /*k0sreweight*/
+            : 0,
           fileNamePtWeights,
           histoNameMCPi0PT, histoNameMCEtaPT, histoNameMCK0sPT,
           fitNamePi0PT, fitNameEtaPT, fitNameK0sPT);

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvV1_PbPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvV1_PbPb.C
@@ -122,7 +122,7 @@ void AddTask_GammaConvV1_PbPb(
   for(Int_t i = 0; i<rmaxFacPtHardSetting->GetEntries() ; i++){
     TObjString* tempObjStrPtHardSetting     = (TObjString*) rmaxFacPtHardSetting->At(i);
     TString strTempSetting                  = tempObjStrPtHardSetting->GetString();
-    if(strTempSetting.("MINPTHFAC:")){
+    if(strTempSetting.BeginsWith("MINPTHFAC:")){
       strTempSetting.Replace(0,10,"");
       minFacPtHard               = strTempSetting.Atof();
       cout << "running with min pT hard jet fraction of: " << minFacPtHard << endl;
@@ -4353,8 +4353,8 @@ void AddTask_GammaConvV1_PbPb(
     if (intPtWeightsCalculationMethod)
     {
       printf("AddTask_GammaConvV1_PbPb.C: INFO: intPtWeightsCalculationMethod = %d\n", intPtWeightsCalculationMethod);
-      if (periodNameAnchor.("LHC15o") || 
-          periodNameAnchor.("LHC18q"))
+      if (periodNameAnchor.BeginsWith("LHC15o") || 
+          periodNameAnchor.BeginsWith("LHC18q"))
       {
         TString eventCutString = cuts.GetEventCut(i);
         TString eventCutShort = eventCutString(0, 6);                                                // first six digits

--- a/PWGGA/GammaConvBase/AliConvEventCuts.cxx
+++ b/PWGGA/GammaConvBase/AliConvEventCuts.cxx
@@ -7920,7 +7920,6 @@ Float_t AliConvEventCuts::GetWeightForMeson(Int_t index, AliMCEvent *mcEvent, Al
 }
 
 // todo: thinkg of using the return value of this function for more signaling purposes.
-// At the moment it returns 1 for any error case.
 //_________________________________________________________________________
 Float_t AliConvEventCuts::GetWeightForMesonNew(Int_t index, AliMCEvent *mcEvent, AliVEvent *event)
 {

--- a/PWGGA/GammaConvBase/AliConvEventCuts.cxx
+++ b/PWGGA/GammaConvBase/AliConvEventCuts.cxx
@@ -171,12 +171,12 @@ AliConvEventCuts::AliConvEventCuts(const char *name,const char *title) :
   hTriggerClass(NULL),
   hTriggerClassSelected(NULL),
   hTriggerClassesCorrelated(NULL),
-  hReweightMCHistPi0(NULL),
-  hReweightMCHistEta(NULL),
-  hReweightMCHistK0s(NULL),
-  fFitDataPi0(NULL),
-  fFitDataEta(NULL),
-  fFitDataK0s(NULL),
+  hReweightMCHistPi0_inv(NULL),
+  hReweightMCHistEta_inv(NULL),
+  hReweightMCHistK0s_inv(NULL),
+  fFitDataPi0_inv(NULL),
+  fFitDataEta_inv(NULL),
+  fFitDataK0s_inv(NULL),
   hReweightMCHistGamma(NULL),
   hReweightDataHistGamma(NULL),
   fAddedSignalPDGCode(0),
@@ -320,12 +320,12 @@ AliConvEventCuts::AliConvEventCuts(const AliConvEventCuts &ref) :
   hTriggerClass(NULL),
   hTriggerClassSelected(NULL),
   hTriggerClassesCorrelated(NULL),
-  hReweightMCHistPi0(ref.hReweightMCHistPi0),
-  hReweightMCHistEta(ref.hReweightMCHistEta),
-  hReweightMCHistK0s(ref.hReweightMCHistK0s),
-  fFitDataPi0(ref.fFitDataPi0),
-  fFitDataEta(ref.fFitDataEta),
-  fFitDataK0s(ref.fFitDataK0s),
+  hReweightMCHistPi0_inv(ref.hReweightMCHistPi0_inv),
+  hReweightMCHistEta_inv(ref.hReweightMCHistEta_inv),
+  hReweightMCHistK0s_inv(ref.hReweightMCHistK0s_inv),
+  fFitDataPi0_inv(ref.fFitDataPi0_inv),
+  fFitDataEta_inv(ref.fFitDataEta_inv),
+  fFitDataK0s_inv(ref.fFitDataK0s_inv),
   hReweightMCHistGamma(ref.hReweightMCHistGamma),
   hReweightDataHistGamma(ref.hReweightDataHistGamma),
   fAddedSignalPDGCode(ref.fAddedSignalPDGCode),
@@ -438,17 +438,17 @@ void AliConvEventCuts::InitCutHistograms(TString name, Bool_t preCut){
     else fHistograms->SetName(Form("%s_%s",name.Data(),GetCutNumber().Data()));
   }
 
-  if (hReweightMCHistPi0){
-    hReweightMCHistPi0->SetName("MCInputForWeightingPi0");
-    fHistograms->Add(hReweightMCHistPi0);
+  if (hReweightMCHistPi0_inv){
+    hReweightMCHistPi0_inv->SetName("MCInputForWeightingPi0");
+    fHistograms->Add(hReweightMCHistPi0_inv);
   }
-  if (hReweightMCHistEta){
-    hReweightMCHistEta->SetName("MCInputForWeightingEta");
-    fHistograms->Add(hReweightMCHistEta);
+  if (hReweightMCHistEta_inv){
+    hReweightMCHistEta_inv->SetName("MCInputForWeightingEta");
+    fHistograms->Add(hReweightMCHistEta_inv);
   }
-  if (hReweightMCHistK0s){
-    hReweightMCHistK0s->SetName("MCInputForWeightingK0s");
-    fHistograms->Add(hReweightMCHistK0s);
+  if (hReweightMCHistK0s_inv){
+    hReweightMCHistK0s_inv->SetName("MCInputForWeightingK0s");
+    fHistograms->Add(hReweightMCHistK0s_inv);
   }
 
   if (hReweightMCHistGamma){
@@ -953,54 +953,54 @@ void AliConvEventCuts::LoadReweightingHistosMCFromFile() {
     cout << "I have to find: " <<  fNameHistoReweightingPi0.Data() << endl;
     TH1D *hReweightMCHistPi0temp = (TH1D*)f->Get(fNameHistoReweightingPi0.Data());
     if(hReweightMCHistPi0temp){
-      hReweightMCHistPi0 = new TH1D(*hReweightMCHistPi0temp);
-      hReweightMCHistPi0->SetDirectory(0);
+      hReweightMCHistPi0_inv = new TH1D(*hReweightMCHistPi0temp);
+      hReweightMCHistPi0_inv->SetDirectory(0);
       AliInfo(Form("%s has been loaded from %s", fNameHistoReweightingPi0.Data(),fPathTrFReweighting.Data() ));
     } else AliWarning(Form("%s not found in %s", fNameHistoReweightingPi0.Data() ,fPathTrFReweighting.Data()));
   }
   if (fNameFitDataPi0.CompareTo("") != 0 && fDoReweightHistoMCPi0 ){
     cout << "I have to find: " <<  fNameFitDataPi0.Data() << endl;
-    TF1 *fFitDataPi0temp = (TF1*)f->Get(fNameFitDataPi0.Data());
-    if(fFitDataPi0temp){
-      fFitDataPi0 = new TF1(*fFitDataPi0temp);
+    TF1 *fFitDataPi0_inv_temp = (TF1*)f->Get(fNameFitDataPi0.Data());
+    if(fFitDataPi0_inv_temp){
+      fFitDataPi0_inv = new TF1(*fFitDataPi0_inv_temp);
       AliInfo(Form("%s has been loaded from %s", fNameFitDataPi0.Data(),fPathTrFReweighting.Data() ));
     } else AliWarning(Form("%s not found in %s",fPathTrFReweighting.Data(), fNameFitDataPi0.Data() ));
   }
 
   if (fNameHistoReweightingEta.CompareTo("") != 0 && fDoReweightHistoMCEta){
     cout << "I have to find: " <<  fNameHistoReweightingEta.Data() << endl;
-    TH1D *hReweightMCHistEtatemp = (TH1D*)f->Get(fNameHistoReweightingEta.Data());
-    if(hReweightMCHistEtatemp){
-      hReweightMCHistEta = new TH1D(*hReweightMCHistEtatemp);
-      hReweightMCHistEta->SetDirectory(0);
+    TH1D *hReweightMCHistEta_inv_temp = (TH1D*)f->Get(fNameHistoReweightingEta.Data());
+    if(hReweightMCHistEta_inv_temp){
+      hReweightMCHistEta_inv = new TH1D(*hReweightMCHistEta_inv_temp);
+      hReweightMCHistEta_inv->SetDirectory(0);
       AliInfo(Form("%s has been loaded from %s", fNameHistoReweightingEta.Data(),fPathTrFReweighting.Data() ));
     } else AliWarning(Form("%s not found in %s", fNameHistoReweightingEta.Data(),fPathTrFReweighting.Data() ));
   }
 
   if (fNameFitDataEta.CompareTo("") != 0 && fDoReweightHistoMCEta){
     cout << "I have to find: " <<  fNameFitDataEta.Data() << endl;
-    TF1 *fFitDataEtatemp = (TF1*)f->Get(fNameFitDataEta.Data());
-    if(fFitDataEtatemp){
-      fFitDataEta = new TF1(*fFitDataEtatemp);
+    TF1 *fFitDataEta_inv_temp = (TF1*)f->Get(fNameFitDataEta.Data());
+    if(fFitDataEta_inv_temp){
+      fFitDataEta_inv = new TF1(*fFitDataEta_inv_temp);
       AliInfo(Form("%s has been loaded from %s", fNameFitDataEta.Data(),fPathTrFReweighting.Data() ));
     } else AliWarning(Form("%s not found in %s", fNameFitDataEta.Data(),fPathTrFReweighting.Data() ));
 
   }
   if (fNameHistoReweightingK0s.CompareTo("") != 0 && fDoReweightHistoMCK0s){
     cout << "I have to find: " <<  fNameHistoReweightingK0s.Data() << endl;
-    TH1D *hReweightMCHistK0stemp = (TH1D*)f->Get(fNameHistoReweightingK0s.Data());
-    if(hReweightMCHistK0stemp){
-      hReweightMCHistK0s = new TH1D(*hReweightMCHistK0stemp);
-      hReweightMCHistK0s->SetDirectory(0);
+    TH1D *hReweightMCHistK0s_inv_temp = (TH1D*)f->Get(fNameHistoReweightingK0s.Data());
+    if(hReweightMCHistK0s_inv_temp){
+      hReweightMCHistK0s_inv = new TH1D(*hReweightMCHistK0s_inv_temp);
+      hReweightMCHistK0s_inv->SetDirectory(0);
       AliInfo(Form("%s has been loaded from %s", fNameHistoReweightingK0s.Data(),fPathTrFReweighting.Data() ));
     } else AliWarning(Form("%s not found in %s", fNameHistoReweightingK0s.Data(),fPathTrFReweighting.Data() ));
   }
 
   if (fNameFitDataK0s.CompareTo("") != 0 && fDoReweightHistoMCK0s){
     cout << "I have to find: " <<  fNameFitDataK0s.Data() << endl;
-    TF1 *fFitDataK0stemp = (TF1*)f->Get(fNameFitDataK0s.Data());
-    if(fFitDataK0stemp){
-      fFitDataK0s = new TF1(*fFitDataK0stemp);
+    TF1 *fFitDataK0s_inv_temp = (TF1*)f->Get(fNameFitDataK0s.Data());
+    if(fFitDataK0s_inv_temp){
+      fFitDataK0s_inv = new TF1(*fFitDataK0s_inv_temp);
       AliInfo(Form("%s has been loaded from %s", fNameFitDataK0s.Data(),fPathTrFReweighting.Data() ));
     } else AliWarning(Form("%s not found in %s", fNameFitDataK0s.Data(),fPathTrFReweighting.Data() ));
   }
@@ -7861,26 +7861,26 @@ Float_t AliConvEventCuts::GetWeightForMeson(Int_t index, AliMCEvent *mcEvent, Al
 
   // get MC value
   Float_t functionResultMC = 1.;
-  if ( PDGCode ==  111 && fDoReweightHistoMCPi0 && hReweightMCHistPi0!= 0x0){
-    functionResultMC = hReweightMCHistPi0->Interpolate(mesonPt);
+  if ( PDGCode ==  111 && fDoReweightHistoMCPi0 && hReweightMCHistPi0_inv!= 0x0){
+    functionResultMC = hReweightMCHistPi0_inv->Interpolate(mesonPt);
   }
-  if ( PDGCode ==  221 && fDoReweightHistoMCEta && hReweightMCHistEta!= 0x0){
-    functionResultMC = hReweightMCHistEta->Interpolate(mesonPt);
+  if ( PDGCode ==  221 && fDoReweightHistoMCEta && hReweightMCHistEta_inv!= 0x0){
+    functionResultMC = hReweightMCHistEta_inv->Interpolate(mesonPt);
   }
-  if ( PDGCode ==  310 && fDoReweightHistoMCK0s && hReweightMCHistK0s!= 0x0){
-    functionResultMC = hReweightMCHistK0s->Interpolate(mesonPt);
+  if ( PDGCode ==  310 && fDoReweightHistoMCK0s && hReweightMCHistK0s_inv!= 0x0){
+    functionResultMC = hReweightMCHistK0s_inv->Interpolate(mesonPt);
   }
 
   // get data value
   Float_t functionResultData = 1;
-  if ( PDGCode ==  111 && fDoReweightHistoMCPi0 && fFitDataPi0!= 0x0){
-    functionResultData = fFitDataPi0->Eval(mesonPt);
+  if ( PDGCode ==  111 && fDoReweightHistoMCPi0 && fFitDataPi0_inv!= 0x0){
+    functionResultData = fFitDataPi0_inv->Eval(mesonPt);
   }
-  if ( PDGCode ==  221 && fDoReweightHistoMCEta && fFitDataEta!= 0x0){
-    functionResultData = fFitDataEta->Eval(mesonPt);
+  if ( PDGCode ==  221 && fDoReweightHistoMCEta && fFitDataEta_inv!= 0x0){
+    functionResultData = fFitDataEta_inv->Eval(mesonPt);
   }
-  if ( PDGCode ==  310 && fDoReweightHistoMCK0s && fFitDataK0s!= 0x0){
-    functionResultData = fFitDataK0s->Eval(mesonPt);
+  if ( PDGCode ==  310 && fDoReweightHistoMCK0s && fFitDataK0s_inv!= 0x0){
+    functionResultData = fFitDataK0s_inv->Eval(mesonPt);
   }
 
   // calculate weight from data and MC
@@ -7890,12 +7890,12 @@ Float_t AliConvEventCuts::GetWeightForMeson(Int_t index, AliMCEvent *mcEvent, Al
       weight = functionResultData/functionResultMC;
       if ( kCaseGen == 3){   // never true ?
         if (PDGCode ==  111){
-      if (!(fDoReweightHistoMCPi0 && hReweightMCHistPi0!= 0x0 && PDGCode ==  111)){
+      if (!(fDoReweightHistoMCPi0 && hReweightMCHistPi0_inv!= 0x0 && PDGCode ==  111)){
         weight = 1.;
       }
         }
         if (PDGCode ==  221){
-      if (!(fDoReweightHistoMCEta && hReweightMCHistEta!= 0x0 && PDGCode ==  221)){
+      if (!(fDoReweightHistoMCEta && hReweightMCHistEta_inv!= 0x0 && PDGCode ==  221)){
         weight = 1.;
       }
         }

--- a/PWGGA/GammaConvBase/AliConvEventCuts.cxx
+++ b/PWGGA/GammaConvBase/AliConvEventCuts.cxx
@@ -8071,13 +8071,8 @@ Float_t AliConvEventCuts::GetWeightForMesonNew(Int_t index, AliMCEvent *mcEvent,
     return checkSanitizeAndReturnWeight(lWeight);
   };
 
-  bool lCaseEtaPi0 = (PDGCode == 111) || (PDGCode == 221);
-  double lResult = lCaseEtaPi0
-             ? calcWeight()
-             : checkSanitizeAndReturnWeight(lDenomMC);
-
-  // AliInfo(Form("INFO: end of function. Return value = %f\n", 
-  //        lResult));
+  double lResult = calcWeight();
+  // AliInfo(Form("INFO: end of function. Return value = %f\n", lResult));
   return lResult;
 }
 

--- a/PWGGA/GammaConvBase/AliConvEventCuts.cxx
+++ b/PWGGA/GammaConvBase/AliConvEventCuts.cxx
@@ -141,9 +141,9 @@ AliConvEventCuts::AliConvEventCuts(const char *name,const char *title) :
   fDoCentralityFlat(0),
   fPathWeightsFlatCent(""),
   fNameHistoNotFlatCentrality(""),
-  fDoReweightHistoMCPi0(kFALSE),
-  fDoReweightHistoMCEta(kFALSE),
-  fDoReweightHistoMCK0s(kFALSE),
+  fDoReweightHistoMCPi0(kOff),
+  fDoReweightHistoMCEta(kOff),
+  fDoReweightHistoMCK0s(kOff),
   fPathTrFReweighting(""),
   fNameHistoReweightingPi0(""),
   fNameHistoReweightingEta(""),
@@ -221,7 +221,8 @@ AliConvEventCuts::AliConvEventCuts(const char *name,const char *title) :
   hReweightMultData(NULL),
   hReweightMultMC(NULL),
   fPHOSTrigger(kPHOSAny),
-  fDebugLevel(0)
+  fDebugLevel(0),
+  fMapPtWeightsAccessObjects()
 {
   for(Int_t jj=0;jj<kNCuts;jj++){fCuts[jj]=0;}
   fCutString=new TObjString((GetCutNumber()).Data());
@@ -370,7 +371,8 @@ AliConvEventCuts::AliConvEventCuts(const AliConvEventCuts &ref) :
   hReweightMultData(ref.hReweightMultData),
   hReweightMultMC(ref.hReweightMultMC),
   fPHOSTrigger(kPHOSAny),
-  fDebugLevel(ref.fDebugLevel)
+  fDebugLevel(ref.fDebugLevel),
+  fMapPtWeightsAccessObjects(ref.fMapPtWeightsAccessObjects)
 {
   // Copy Constructor
   for(Int_t jj=0;jj<kNCuts;jj++){fCuts[jj]=ref.fCuts[jj];}
@@ -1041,6 +1043,70 @@ void AliConvEventCuts::LoadGammaPtReweightingHistosMCFromFile() {
   delete f;
 }
 
+// todo: check if I need to delete objects from heap
+///________________________________________________________________________
+int AliConvEventCuts::InitializeMapPtWeightsAccessObjects()
+{
+  auto multiplyTH1ByBinCenters = [](TH1 const &theH) -> TH1 &
+  {
+    TH1 &lResult = dynamic_cast<TH1 &>(*theH.Clone(Form("%s_multByBinCenters", theH.GetName())));
+    for (int i = 1; i <= lResult.GetNbinsX(); ++i)
+    {
+      Double_t center = lResult.GetBinCenter(i);
+      lResult.SetBinContent(i, lResult.GetBinContent(i) * center);
+      if (lResult.GetSumw2N())
+      {
+        lResult.SetBinError(i, lResult.GetBinError(i) * center);
+      }
+    }
+    return lResult;
+  };
+
+  auto calculateVariantSpectraAndInsert = [&](int thePDGCode,
+                                              EnumPtWeights theWhich,
+                                              TF1 const &theDataTF1_inv,
+                                              TH1D const &theMCTH1_inv)
+  {
+    TF1 const *lDataTF1 = (theWhich == kOff)
+                              ? nullptr
+                          : (theWhich == kInvariant)
+                              ? &theDataTF1_inv
+                              : new TF1(Form("%s_multByX", theDataTF1_inv.GetName()),
+                                        Form("x*(%s)", theDataTF1_inv.GetTitle()),
+                                        theDataTF1_inv.GetXmin(), theDataTF1_inv.GetXmax());
+
+    TH1 const *lMCTH1 = (theWhich == kOff)
+                            ? nullptr
+                        : (theWhich == kInvariant)
+                            ? &theMCTH1_inv
+                            : &multiplyTH1ByBinCenters(theMCTH1_inv);
+    if (!fMapPtWeightsAccessObjects.insert({thePDGCode, PtWeightsBundle{theWhich, lDataTF1, lMCTH1}}).second)
+    {
+      AliError(Form("AliConvEventCuts::InitializeMapPtWeightsAccessObjects(): failed to insert:\n"
+                    "\tthePDGCode: %d\n"
+                    "\ttheWhich: %d\n"
+                    "\ttheDataTF1_inv: %s\n"
+                    "\ttheMCTH1_inv: %s\n",
+                    thePDGCode, static_cast<int>(theWhich), theDataTF1_inv.GetName(), theMCTH1_inv.GetName()));
+      return false;
+    }
+    return true;
+  };
+
+  // execution starts here
+  AliInfo("AliConvEventCuts::InitializeMapPtWeightsAccessObjects(): start.\n");
+  bool lSuccess = true;
+  lSuccess &= calculateVariantSpectraAndInsert(111, fDoReweightHistoMCPi0, *fFitDataPi0_inv, *hReweightMCHistPi0_inv);
+  lSuccess &= calculateVariantSpectraAndInsert(211, fDoReweightHistoMCEta, *fFitDataEta_inv, *hReweightMCHistEta_inv);
+  lSuccess &= calculateVariantSpectraAndInsert(310, fDoReweightHistoMCEta, *fFitDataEta_inv, *hReweightMCHistEta_inv);
+
+  if (!lSuccess)
+  {
+    AliError("AliConvEventCuts::InitializeMapPtWeightsAccessObjects(): failed to initialize map.");
+    return 0;
+  }
+  return 1.;
+}
 
 ///________________________________________________________________________
 Bool_t AliConvEventCuts::InitializeCutsFromCutString(const TString analysisCutSelection ) {
@@ -1060,6 +1126,7 @@ Bool_t AliConvEventCuts::InitializeCutsFromCutString(const TString analysisCutSe
   if(fDoReweightHistoMCPi0 || fDoReweightHistoMCEta || fDoReweightHistoMCK0s) {
     AliInfo("Particle Weighting was enabled");
     LoadReweightingHistosMCFromFile();
+    InitializeMapPtWeightsAccessObjects();
   }
 
   if(fDoReweightHistoMCGamma) {
@@ -7910,6 +7977,117 @@ Float_t AliConvEventCuts::GetWeightForMeson(Int_t index, AliMCEvent *mcEvent, Al
   return weight;
 }
 
+// todo: thinkg of using the return value of this function for more signaling purposes.
+// At the moment it returns 1 for any error case.
+//_________________________________________________________________________
+Float_t AliConvEventCuts::GetWeightForMesonNew(Int_t index, AliMCEvent *mcEvent, AliVEvent *event)
+{
+  // todo: check why I need to capture everything in order for it work
+  // returns 1 if function evaluation is to be continued
+  auto indexIsValidAndParticleIsToBeWeighted = [&]()
+  {
+    Int_t kCaseGen = 0;
+    if (fPeriodEnum == kLHC13d2 || fPeriodEnum == kLHC13d2b ||                                                           // LHC10h MCs
+        fPeriodEnum == kLHC14a1a || fPeriodEnum == kLHC14a1b || fPeriodEnum == kLHC14a1c ||                              // LHC11h MCs
+        fPeriodEnum == kLHC13e7 || fPeriodEnum == kLHC13b2_efix || fPeriodEnum == kLHC14b2 || fPeriodEnum == kLHC18j5 || // LHC13bc MCs
+        fPeriodEnum == kLHC14e2b ||                                                                                      // LHC12[a-i] pass 1 MCs
+        fPeriodEnum == kLHC12f1a || fPeriodEnum == kLHC12f1b || fPeriodEnum == kLHC12i3 ||                               // LHC11a MCs
+        fPeriodEnum == kLHC16h4 || fPeriodEnum == kLHC19h3 || fPeriodEnum == kLHC20g10 || fPeriodEnum == kLHC24a1)       // LHC15o, LHC18qr pass1, LHC18qr pass3  MCs
+    {
+      kCaseGen = 1;
+    } // = added signal productions                                                                                                                                                                                                                                                                                                                                                             // added particles MC
+
+    else if (fPeriodEnum == kLHC18e1 || fPeriodEnum == kLHC18e1a || fPeriodEnum == kLHC18e1b || fPeriodEnum == kLHC18e1c || fPeriodEnum == kLHC16i1a || fPeriodEnum == kLHC16i1b || fPeriodEnum == kLHC16i1c || fPeriodEnum == kLHC16i2a || fPeriodEnum == kLHC16i2b || fPeriodEnum == kLHC16i2c || fPeriodEnum == kLHC16i3a || fPeriodEnum == kLHC16i3b || fPeriodEnum == kLHC16i3c || // LHC15o MCs
+             fPeriodEnum == kLHC12P2JJ || fPeriodEnum == kLHC16h3 || fPeriodEnum == kLHC18b8 || fPeriodEnum == kLHC16rP1JJ || fPeriodEnum == kLHC16sP1JJ || fPeriodEnum == kLHC16rsGJ || fPeriodEnum == kLHC16rsP2GJ || fPeriodEnum == kLHC16rsP2JJLow || fPeriodEnum == kLHC16rsP2JJHigh || fPeriodEnum == kLHC17g8a ||
+             fPeriodEnum == kLHC18f3 ||                                                                                          // LHC16qt MCs
+             fPeriodEnum == kLHC17l3b || fPeriodEnum == kLHC18j2 ||                                                              // LHC17pq MCs
+             fPeriodEnum == kLHC18l8a || fPeriodEnum == kLHC18l8b || fPeriodEnum == kLHC18l8c ||                                 // LHC18qr MC
+             fPeriodEnum == kLHC19h2a || fPeriodEnum == kLHC19h2b || fPeriodEnum == kLHC19h2c ||                                 // LHC18qr MC
+             fPeriodEnum == kLHC20e3a || fPeriodEnum == kLHC20e3b || fPeriodEnum == kLHC20e3c || fPeriodEnum == kLHC22b5 ||      // LHC18qr MC pass3 GenPurpose MCs
+             fPeriodEnum == kLHC20g2a_2 || fPeriodEnum == kLHC20g2b_2 || fPeriodEnum == kLHC20k6c || fPeriodEnum == kLHC23d8b || // LHC18qr MC pass3	other PWGs injected Particles MCs
+             fPeriodEnum == kLHC20j6a || fPeriodEnum == kLHC20j6b || fPeriodEnum == kLHC20j6c || fPeriodEnum == kLHC20j6d)       // LHC15o pass2 MCs
+    {
+      kCaseGen = 2; // regular MC
+    }
+    return (index > 0) && kCaseGen && IsParticleFromBGEvent(index, mcEvent, event);
+  };
+
+  if (!indexIsValidAndParticleIsToBeWeighted())
+  {
+    return 1.;
+  }
+
+  Double_t mesonPt = 0;
+  Int_t PDGCode = 0;
+  // todo: check why I need to capture everything in order for it work
+  auto getPDGCodeAndMesonPt = [&]()
+  {
+    if (!event || event->IsA() == AliESDEvent::Class())
+    {
+      mesonPt = ((AliMCParticle *)mcEvent->GetTrack(index))->Pt();
+      PDGCode = ((AliMCParticle *)mcEvent->GetTrack(index))->PdgCode();
+    }
+    else if (event->IsA() == AliAODEvent::Class())
+    {
+      if (!fAODMCTrackArray)
+        fAODMCTrackArray = dynamic_cast<TClonesArray *>(event->FindListObject(AliAODMCParticle::StdBranchName()));
+      if (fAODMCTrackArray)
+      {
+        AliAODMCParticle *aodMCParticle = static_cast<AliAODMCParticle *>(fAODMCTrackArray->At(index));
+        mesonPt = aodMCParticle->Pt();
+        PDGCode = aodMCParticle->GetPdgCode();
+      }
+      else
+      {
+        return 0;
+      }
+    }
+    return 1;
+  };
+
+  if (!getPDGCodeAndMesonPt())
+  {
+    return 1.;
+  }
+
+  auto checkSanitizeAndReturnWeight = [&](Double_t theWeight)
+  {
+    if ((theWeight < 0) || !isfinite(theWeight))
+    {
+      theWeight = 1.;
+      AliWarning(Form("checkSanitizeAndReturnWeight(): WARNING: Weight for meson %d is negative or not finite: %f. It was set back to 1.\n"
+                      "This points to a severe problem - investigate!\n",
+                      PDGCode, theWeight));
+    }
+    return theWeight;
+  };
+
+  // catch cases with invalid PDGCode
+  auto const &lConstIt = fMapPtWeightsAccessObjects.find(PDGCode);
+  if (lConstIt == fMapPtWeightsAccessObjects.cend())
+  {
+    AliWarning(Form("GetWeightForMesonNew(): WARNING: PDGCode %d not found in fMapPtWeightsAccessObjects. Returning 1.\n", PDGCode));
+    return 1.;
+  }
+
+  Double_t lNomData = lConstIt->second.fData->Eval(mesonPt);
+  Double_t lDenomMC = lConstIt->second.hMC->Interpolate(mesonPt);
+  auto calcWeight = [&checkSanitizeAndReturnWeight, &lNomData, &lDenomMC]()
+  {
+    Double_t lWeight = lDenomMC
+                           ? (lNomData > 0.)
+                                 ? lNomData / lDenomMC
+                                 : lNomData // to signal problem
+                           : -1.;           // to signal problem
+    // will reset to 1 and throw a warning if weight is not >=0 and finite
+    return checkSanitizeAndReturnWeight(lWeight);
+  };
+
+  bool lCaseEtaPi0 = (PDGCode == 111) || (PDGCode == 221);
+  return lCaseEtaPi0
+             ? calcWeight()
+             : checkSanitizeAndReturnWeight(lDenomMC);
+}
 
 //_________________________________________________________________________
 Float_t AliConvEventCuts::GetWeightForGamma(Int_t index, Double_t gammaPTrec, AliMCEvent *mcEvent, AliVEvent *event){

--- a/PWGGA/GammaConvBase/AliConvEventCuts.cxx
+++ b/PWGGA/GammaConvBase/AliConvEventCuts.cxx
@@ -7990,7 +7990,7 @@ Float_t AliConvEventCuts::GetWeightForMesonNew(Int_t index, AliMCEvent *mcEvent,
                            ? (lNomData > 0.)
                                  ? lNomData / lDenomMC
                                  : lNomData // to signal problem
-                           : -1.;           // to signal problem
+                           : 0.;          
     // will reset to 1 and throw a warning if weight is not >=0 and finite
     return checkSanitizeAndReturnWeight(lWeight);
   };

--- a/PWGGA/GammaConvBase/AliConvEventCuts.h
+++ b/PWGGA/GammaConvBase/AliConvEventCuts.h
@@ -896,7 +896,7 @@ class AliConvEventCuts : public AliAnalysisCuts {
   private:
 
       /// \cond CLASSIMP
-      ClassDef(AliConvEventCuts,93)
+      ClassDef(AliConvEventCuts,94)
       /// \endcond
 };
 

--- a/PWGGA/GammaConvBase/AliConvEventCuts.h
+++ b/PWGGA/GammaConvBase/AliConvEventCuts.h
@@ -813,12 +813,12 @@ class AliConvEventCuts : public AliAnalysisCuts {
       TH1F*                       hTriggerClass;                          ///< fired offline trigger class
       TH1F*                       hTriggerClassSelected;                  ///< selected fired offline trigger class
       TH1F*                       hTriggerClassesCorrelated;              ///< selected trigger class correlation with others
-      TH1D*                       hReweightMCHistPi0;                     ///< histogram input for reweighting Pi0
-      TH1D*                       hReweightMCHistEta;                     ///< histogram input for reweighting Eta
-      TH1D*                       hReweightMCHistK0s;                     ///< histogram input for reweighting K0s
-      TF1*                        fFitDataPi0;                            ///< fit to pi0 spectrum in Data
-      TF1*                        fFitDataEta;                            ///< fit to eta spectrum in Data
-      TF1*                        fFitDataK0s;                            ///< fit to K0s spectrum in Data
+      TH1D*                       hReweightMCHistPi0_inv;                 ///< histogram input for reweighting Pi0 in pt invariant form
+      TH1D*                       hReweightMCHistEta_inv;                 ///< histogram input for reweighting Eta in pt invariant form
+      TH1D*                       hReweightMCHistK0s_inv;                 ///< histogram input for reweighting K0s in pt invariant form
+      TF1*                        fFitDataPi0_inv;                        ///< fit to pi0 spectrum in Data
+      TF1*                        fFitDataEta_inv;                        ///< fit to eta spectrum in Data
+      TF1*                        fFitDataK0s_inv;                        ///< fit to K0s spectrum in Data
       TH1D*                       hReweightMCHistGamma;                   ///< histogram MC   input for reweighting Gamma
       TH1D*                       hReweightDataHistGamma;                 ///< histogram data input for reweighting Gamma
       Int_t                       fAddedSignalPDGCode;

--- a/PWGGA/GammaConvBase/AliConvEventCuts.h
+++ b/PWGGA/GammaConvBase/AliConvEventCuts.h
@@ -523,10 +523,11 @@ class AliConvEventCuts : public AliAnalysisCuts {
                                                                                       AliInfo(Form("setting custom trigger mimic OADB from file: %s",pathOADB.Data()));
                                                                                       fPathTriggerMimicSpecialInput=pathOADB                                ;
                                                                                     }
-      void    SetUseReweightingWithHistogramFromFile( Bool_t pi0reweight=kTRUE,
-                                Bool_t etareweight=kFALSE,
-                                Bool_t k0sreweight=kFALSE,
-                                                              TString path="$ALICE_PHYSICS/PWGGA/GammaConv/MCSpectraInput.root",
+      void    SetUseReweightingWithHistogramFromFile( 
+                                int pi0reweight = 0,
+                                int etareweight = 0,
+                                int k0sreweight = 0,
+                                TString path="$ALICE_PHYSICS/PWGGA/GammaConv/MCSpectraInput.root",
                                 TString histoNamePi0 = "",
                                 TString histoNameEta = "",
                                 TString histoNameK0s = "",

--- a/PWGGA/GammaConvBase/AliConvEventCuts.h
+++ b/PWGGA/GammaConvBase/AliConvEventCuts.h
@@ -427,6 +427,30 @@ class AliConvEventCuts : public AliAnalysisCuts {
         kEtaEMCf  = 13    //!< Injected Eta in DCal acceptance
       };
 
+      // ============ BEGIN section for pt weights in variant calculation form =====
+      /**
+       * @enum EnumPtWeights
+       * @brief two options for calculating pt weights. Invariant (historic) and variant
+       */
+      enum EnumPtWeights
+      {
+        kOff,
+        kInvariant,
+        kVariant
+      };
+
+      /**
+       * @struct PtWeightsBundle
+       * @brief for a meson: define invariant OR variant pt weights along with data and mc objects to compute them
+       */
+      struct PtWeightsBundle
+      {
+        EnumPtWeights eWhich;
+        TF1 const *fData;
+        TH1 const *hMC;
+      };
+      std::map<int, PtWeightsBundle> fMapPtWeightsAccessObjects; //!<! map of meson pdg code to PtWeightsBundle
+      // ============ END section for pt weights in variant calculation form =====
 
       AliConvEventCuts(const char *name="EventCuts", const char * title="Event Cuts");
       AliConvEventCuts(const AliConvEventCuts&);
@@ -511,9 +535,9 @@ class AliConvEventCuts : public AliAnalysisCuts {
                                 TString fitNameK0s ="" )
                                                                                     {
                                                                                       AliInfo(Form("enabled reweighting for: pi0 : %i, eta: %i, K0s: %i",pi0reweight, etareweight, k0sreweight));
-                                                                                      fDoReweightHistoMCPi0 = pi0reweight                       ;
-                                                                                      fDoReweightHistoMCEta = etareweight                       ;
-                                                                                      fDoReweightHistoMCK0s = k0sreweight                       ;
+                                                                                      fDoReweightHistoMCPi0 = static_cast<EnumPtWeights>(pi0reweight);
+                                                                                      fDoReweightHistoMCEta = static_cast<EnumPtWeights>(etareweight);
+                                                                                      fDoReweightHistoMCK0s = static_cast<EnumPtWeights>(k0sreweight);
                                                                                       fPathTrFReweighting=path                                  ;
                                                                                       fNameHistoReweightingPi0 =histoNamePi0                    ;
                                                                                       fNameHistoReweightingEta =histoNameEta                    ;
@@ -602,6 +626,7 @@ class AliConvEventCuts : public AliAnalysisCuts {
       Float_t   GetWeightForCentralityFlattening(AliVEvent *event = 0x0);
       Float_t   GetWeightForMultiplicity(Int_t mult);
       Float_t   GetWeightForMeson( Int_t index, AliMCEvent *mcEvent, AliVEvent *event = 0x0);
+      Float_t   GetWeightForMesonNew(Int_t index, AliMCEvent *mcEvent, AliVEvent *event = 0x0);
       Float_t   GetWeightForGamma( Int_t index, Double_t gammaPTrec, AliMCEvent *mcEvent, AliVEvent *event = 0x0);
       Float_t   GetCentrality(AliVEvent *event);
       Int_t     GetEMCalClusterMultiplicity(AliVEvent* event);
@@ -669,7 +694,8 @@ class AliConvEventCuts : public AliAnalysisCuts {
                                                  AliVEvent              *theInputEvent,
                                                  AliAODConversionPhoton &thePhoton,
                                                  Bool_t                 &theIsFromSelectedHeader); // future todo: make this const
-
+      
+      int     InitializeMapPtWeightsAccessObjects();
       void    LoadWeightingFlatCentralityFromFile ();
       void    LoadWeightingMultiplicityFromFile ();
       void    LoadReweightingHistosMCFromFile ();
@@ -781,9 +807,9 @@ class AliConvEventCuts : public AliAnalysisCuts {
       Int_t                       fDoCentralityFlat;                      ///<
       TString                     fPathWeightsFlatCent;                   ///<
       TString                     fNameHistoNotFlatCentrality;            ///<
-      Bool_t                      fDoReweightHistoMCPi0;                  ///< Flag for reweighting Pi0 input with histogram
-      Bool_t                      fDoReweightHistoMCEta;                  ///< Flag for reweighting Eta input with histogram
-      Bool_t                      fDoReweightHistoMCK0s;                  ///< Flag for reweighting K0s input with histogram
+      EnumPtWeights               fDoReweightHistoMCPi0;                  ///< Flag for reweighting Pi0 input with histogram
+      EnumPtWeights               fDoReweightHistoMCEta;                  ///< Flag for reweighting Eta input with histogram
+      EnumPtWeights               fDoReweightHistoMCK0s;                  ///< Flag for reweighting K0s input with histogram
       TString                     fPathTrFReweighting;                    ///< Path for file used in reweighting
       TString                     fNameHistoReweightingPi0;               ///< Histogram name for reweighting Pi0
       TString                     fNameHistoReweightingEta;               ///< Histogram name for reweighting Eta

--- a/PWGGA/GammaConvBase/AliConvEventCuts.h
+++ b/PWGGA/GammaConvBase/AliConvEventCuts.h
@@ -449,7 +449,10 @@ class AliConvEventCuts : public AliAnalysisCuts {
         TF1 const *fData;
         TH1 const *hMC;
       };
-      std::map<int, PtWeightsBundle> fMapPtWeightsAccessObjects; //!<! map of meson pdg code to PtWeightsBundle
+      std::map<int, PtWeightsBundle> fMapPtWeightsAccessObjects; //!<  map of meson pdg code to PtWeightsBundle
+      bool fMapPtWeightsIsFilledAndSane;                         //!<  flag to indicate if fMapPtWeightsAccessObjects is filled and sane
+      // this flag will removed as soon the functionality has been checked against the old method
+      bool fUseGetWeightForMesonNew;                             //!<  flag to indicate if new method for getting pt weights is used
       // ============ END section for pt weights in variant calculation form =====
 
       AliConvEventCuts(const char *name="EventCuts", const char * title="Event Cuts");
@@ -547,6 +550,7 @@ class AliConvEventCuts : public AliAnalysisCuts {
                                                                                       fNameFitDataEta =fitNameEta                               ;
                                                                                       fNameFitDataK0s =fitNameK0s                               ;
                                                                                     }
+      void    SetUseGetWeightForMesonNew(Bool_t useNewMethod)                       { fUseGetWeightForMesonNew = useNewMethod                    ; }                                                                                       
       void    SetUseWeightMultiplicityFromFile( Int_t doWeighting = 0,
                                                 TString pathC="$ALICE_PHYSICS/PWGGA/GammaConv/MultiplicityInput.root",
                                                 TString nameHistoMultData="",
@@ -628,6 +632,7 @@ class AliConvEventCuts : public AliAnalysisCuts {
       Float_t   GetWeightForMultiplicity(Int_t mult);
       Float_t   GetWeightForMeson( Int_t index, AliMCEvent *mcEvent, AliVEvent *event = 0x0);
       Float_t   GetWeightForMesonNew(Int_t index, AliMCEvent *mcEvent, AliVEvent *event = 0x0);
+      Float_t   GetWeightForMesonOld(Int_t index, AliMCEvent *mcEvent, AliVEvent *event = 0x0);
       Float_t   GetWeightForGamma( Int_t index, Double_t gammaPTrec, AliMCEvent *mcEvent, AliVEvent *event = 0x0);
       Float_t   GetCentrality(AliVEvent *event);
       Int_t     GetEMCalClusterMultiplicity(AliVEvent* event);

--- a/PWGGA/GammaConvBase/AliConvEventCuts.h
+++ b/PWGGA/GammaConvBase/AliConvEventCuts.h
@@ -453,6 +453,8 @@ class AliConvEventCuts : public AliAnalysisCuts {
       bool fMapPtWeightsIsFilledAndSane;                         //!<  flag to indicate if fMapPtWeightsAccessObjects is filled and sane
       // this flag will removed as soon the functionality has been checked against the old method
       bool fUseGetWeightForMesonNew;                             //!<  flag to indicate if new method for getting pt weights is used
+      TH1 *fHistoRelDiffNewOldMesonWeights;                   //!<  histo to store differences between new and old method for pt weights
+      TH1 *fHistoRelDiffNewOldMesonWeights_fine;              //!<  histo to store differences between new and old method for pt weights
       // ============ END section for pt weights in variant calculation form =====
 
       AliConvEventCuts(const char *name="EventCuts", const char * title="Event Cuts");


### PR DESCRIPTION
As is, this change does not alter any functionality. It only adds one member function 'Float_t AliConvEventCuts::GetWeightForMesonNew...)' without ever calling it. The function allows to compute the pt weights from variant spectra in contrast to invariant spectra that were used up to now.  There will be another commit in short, that will add functionality for calling the function.