### PR TITLE
MC PDG study

### DIFF
--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliAnalysisTaskNanoFromAODLambdaPion.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliAnalysisTaskNanoFromAODLambdaPion.cxx
@@ -340,6 +340,37 @@ void AliAnalysisTaskNanoFromAODLambdaPion::UserExec(Option_t *)
           continue;
         }
       }
+      
+      if (fMC && fDoTrackMothers) {
+        AliAODMCParticle *mcPart = (AliAODMCParticle *)fMC->GetTrack(fLambda->GetID());
+        if (!mcPart) continue;
+
+        // Set mother PDG to the PDG of the particle (if it does not change, the particle 
+        // is primary)
+        int momAbsPdg = std::abs(mcPart->GetPdgCode());
+        AliAODMCParticle *firstMom = (AliAODMCParticle *)fMC->GetTrack(mcPart->GetMother());
+        if (!firstMom) continue;
+
+        // The PDG of the mother is updated only if its direct mother is an hadron
+        int nextMomPdg = std::abs(firstMom->GetPdgCode());
+        while(IsHadronPdg(nextMomPdg)) {
+          momAbsPdg = std::abs(firstMom->GetPdgCode());
+          AliAODMCParticle *secondMom = (AliAODMCParticle *)fMC->GetTrack(firstMom->GetMother());
+          if (!secondMom) break;
+          nextMomPdg = std::abs(secondMom->GetPdgCode());
+          
+          // Skip diquarks, there can be processes where hadron --> diquarks --> hadrons
+          while(IsDiquarkPdg(nextMomPdg)) {
+            AliAODMCParticle *diquarkMom = (AliAODMCParticle *)fMC->GetTrack(secondMom->GetMother());
+            nextMomPdg = std::abs(diquarkMom->GetPdgCode());
+            secondMom = diquarkMom;
+          }
+
+          // Update the particle from which the PDG will be taken
+          firstMom = secondMom;
+        }
+        fLambda->SetMotherPDG(momAbsPdg); 
+      }
 
       Lambdas.push_back(*fLambda);
     }
@@ -357,6 +388,30 @@ void AliAnalysisTaskNanoFromAODLambdaPion::UserExec(Option_t *)
         if (std::find(fExcludedMothers.begin(), fExcludedMothers.end(), momAbsPdg) != fExcludedMothers.end()) {
           continue;
         }
+      }
+
+      if (fMC && fDoTrackMothers) {
+        // std::cout << "------------------------" << std::endl; 
+        // std::cout << "Taking mother ID lambda" << std::endl;
+        AliAODMCParticle *mcPart = (AliAODMCParticle *)fMC->GetTrack(fLambda->GetID());
+        if (!mcPart) continue;
+        int momAbsPdg = std::abs(mcPart->GetPdgCode());
+        AliAODMCParticle *firstMom = (AliAODMCParticle *)fMC->GetTrack(mcPart->GetMother());
+        if (!firstMom) continue;
+        int nextMomPdg = std::abs(firstMom->GetPdgCode());
+        while(IsHadronPdg(nextMomPdg)) {
+          momAbsPdg = std::abs(firstMom->GetPdgCode());
+          AliAODMCParticle *secondMom = (AliAODMCParticle *)fMC->GetTrack(firstMom->GetMother());
+          if (!secondMom) break;
+          nextMomPdg = std::abs(secondMom->GetPdgCode());
+          while(IsDiquarkPdg(nextMomPdg)) {
+            AliAODMCParticle *diquarkMom = (AliAODMCParticle *)fMC->GetTrack(secondMom->GetMother());
+            nextMomPdg = std::abs(diquarkMom->GetPdgCode());
+            secondMom = diquarkMom;
+          }
+          firstMom = secondMom;
+        }
+        fLambda->SetMotherPDG(momAbsPdg); 
       }
 
       AntiLambdas.push_back(*fLambda);
@@ -391,6 +446,28 @@ void AliAnalysisTaskNanoFromAODLambdaPion::UserExec(Option_t *)
         }
       }
 
+      if (fMC && fDoTrackMothers) {
+        AliAODMCParticle *mcPart = (AliAODMCParticle *)fMC->GetTrack(fTrack->GetID());
+        if (!mcPart) continue;
+        int momAbsPdg = std::abs(mcPart->GetPdgCode());
+        AliAODMCParticle *firstMom = (AliAODMCParticle *)fMC->GetTrack(mcPart->GetMother());
+        if (!firstMom) continue;
+        int nextMomPdg = std::abs(firstMom->GetPdgCode());
+        while(IsHadronPdg(nextMomPdg)) {
+          momAbsPdg = std::abs(firstMom->GetPdgCode());
+          AliAODMCParticle *secondMom = (AliAODMCParticle *)fMC->GetTrack(firstMom->GetMother());
+          if (!secondMom) break;
+          nextMomPdg = std::abs(secondMom->GetPdgCode());
+          while(IsDiquarkPdg(nextMomPdg)) {
+            AliAODMCParticle *diquarkMom = (AliAODMCParticle *)fMC->GetTrack(secondMom->GetMother());
+            nextMomPdg = std::abs(diquarkMom->GetPdgCode());
+            secondMom = diquarkMom;
+          }
+          firstMom = secondMom;
+        }
+        fTrack->SetMotherPDG(momAbsPdg); 
+      }
+
       PionPlus.push_back(*fTrack);
     }
     if (fNegPionCuts->isSelected(fTrack))
@@ -407,6 +484,28 @@ void AliAnalysisTaskNanoFromAODLambdaPion::UserExec(Option_t *)
         if (std::find(fExcludedMothers.begin(), fExcludedMothers.end(), momAbsPdg) != fExcludedMothers.end()) {
           continue;
         }
+      }
+
+      if (fMC && fDoTrackMothers) {
+        AliAODMCParticle *mcPart = (AliAODMCParticle *)fMC->GetTrack(fTrack->GetID());
+        if (!mcPart) continue;
+        int momAbsPdg = std::abs(mcPart->GetPdgCode());
+        AliAODMCParticle *firstMom = (AliAODMCParticle *)fMC->GetTrack(mcPart->GetMother());
+        if (!firstMom) continue;
+        int nextMomPdg = std::abs(firstMom->GetPdgCode());
+        while(IsHadronPdg(nextMomPdg)) {
+          momAbsPdg = std::abs(firstMom->GetPdgCode());
+          AliAODMCParticle *secondMom = (AliAODMCParticle *)fMC->GetTrack(firstMom->GetMother());
+          if (!secondMom) break;
+          nextMomPdg = std::abs(secondMom->GetPdgCode());
+          while(IsDiquarkPdg(nextMomPdg)) {
+            AliAODMCParticle *diquarkMom = (AliAODMCParticle *)fMC->GetTrack(secondMom->GetMother());
+            nextMomPdg = std::abs(diquarkMom->GetPdgCode());
+            secondMom = diquarkMom;
+          }
+          firstMom = secondMom;
+        }
+        fTrack->SetMotherPDG(momAbsPdg); 
       }
 
       PionMinus.push_back(*fTrack);
@@ -547,3 +646,21 @@ void AliAnalysisTaskNanoFromAODLambdaPion::StoreGlobalTrackReference(AliVTrack *
   }
   (fGTI[trackID]) = track;
 }
+
+bool AliAnalysisTaskNanoFromAODLambdaPion::IsDiquarkPdg(int pdg) {
+  std::vector<int> diquarkPdgs = {1103, 2101, 2103, 2203, 3101, 3103, 3201,
+                                  3203, 3303, 4101, 4103, 4201, 4203, 4301,
+                                  4303, 4403, 5101, 5103, 5201, 5203, 5301,
+                                  5401, 5403, 5503};                       
+  if (std::find(diquarkPdgs.begin(), diquarkPdgs.end(), pdg) != diquarkPdgs.end()) {
+    return true;
+  }
+  return false;
+} 
+
+bool AliAnalysisTaskNanoFromAODLambdaPion::IsHadronPdg(int pdg) {
+  if(pdg < 100 || IsDiquarkPdg(pdg)) {
+    return false;
+  }
+  return true;
+} 

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliAnalysisTaskNanoFromAODLambdaPion.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliAnalysisTaskNanoFromAODLambdaPion.h
@@ -57,6 +57,11 @@ public:
   {
     fUseEvtNoLambda = usenolambdaevt;
   }
+  void SetDoTrackMothers(bool doIt)
+  {
+    // std::cout << "Set track mothers to " << doIt << std::endl;
+    fDoTrackMothers = doIt;
+  }
   void SetExcludeDausOf(std::vector<UInt_t> motherList) {
     fExcludedMothers = motherList;
   }
@@ -66,6 +71,9 @@ public:
   }
   void SetTrigger(UInt_t trigger) { fTrigger = trigger; }
 
+  bool IsHadronPdg(int pdg);
+  bool IsDiquarkPdg(int pdg);
+
 private:
   AliAnalysisTaskNanoFromAODLambdaPion(const AliAnalysisTaskNanoFromAODLambdaPion &);
   AliAnalysisTaskNanoFromAODLambdaPion &operator=(const AliAnalysisTaskNanoFromAODLambdaPion &);
@@ -74,6 +82,7 @@ private:
   bool fIsMC;                             //
   bool fUseOMixing;                       //
   bool fUseEvtNoLambda;                   //
+  bool fDoTrackMothers;                   //
   std::vector<UInt_t> fExcludedMothers;   // Only valid if run on MC
   PCSettings fPCSettings;                 //
   UInt_t fTrigger;                        //

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCollConfig.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCollConfig.cxx
@@ -331,8 +331,7 @@ void AliFemtoDreamCollConfig::SetMinKRel(std::vector<float> minKRel)
 }
 std::vector<float> AliFemtoDreamCollConfig::GetMinKRel()
 {
-  if (fCoutVariables)
-  {
+  if (fCoutVariables) {
     for (auto it : fMinK_rel)
     {
       std::cout << "Stored kMin for your Analysis " << it << std::endl;

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCollConfig.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCollConfig.h
@@ -154,6 +154,10 @@ public:
   {
     fMinimalBookingSample = doIt;
   };
+  void SetDoTrackMothers(bool doIt)
+  {
+    fDoTrackMothers = doIt;
+  };
   void SetMultiplicityEstimator(AliFemtoDreamEvent::MultEstimator est)
   {
     fEst = est;
@@ -227,6 +231,10 @@ public:
   {
     return fRemoveAncestorsResonances;
   }
+  bool GetDoTrackMothers()
+  {
+    return fDoTrackMothers;
+  };
   bool GetDopTOnepTTwokStarPlotsmT()
   {
     return fpTOnepTTwokStarPlotsmT;
@@ -407,6 +415,7 @@ private:
   AliFemtoDreamEvent::MultEstimator fEst;          //
   bool fAncestors;                                 //
   bool fRemoveAncestorsResonances;                 //
+  bool fDoTrackMothers;                            //
   bool fpTOnepTTwokStarPlotsmT;                    //
   float fpTOnepTTwokStarCut;                       //
   float fDeltaEtaMax;                              //

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCorrHists.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCorrHists.cxx
@@ -83,6 +83,9 @@ ClassImp(AliFemtoDreamCorrHists)
       fEffMixingDepth(nullptr),
       fSameEventDistCommon(nullptr),
       fSameEventDistNonCommon(nullptr),
+      fTrackPDGMothersCommon(nullptr),
+      fTrackPDGMothersNonCommon(nullptr),
+      fTrackPDGMothersMixed(nullptr),
       fdEtadPhiSECommon(nullptr),
       fdEtadPhiSENonCommon(nullptr),
       fSameEventMultDistCommon(nullptr),
@@ -108,6 +111,7 @@ ClassImp(AliFemtoDreamCorrHists)
       fPhiEtaPlotsSmallK(false),
       fmTDetaDPhi(false),
       fAncestors(false),
+      fDoTrackMothers(false),
       fRemoveAncestorsResonances(false),
       fpTOnepTTwokStarPlotsmT(false),
       fpTOnepTTwokStarCutOff(3.),
@@ -189,7 +193,10 @@ AliFemtoDreamCorrHists::AliFemtoDreamCorrHists(
       fdEtadPhiMEmT(hists.fdEtadPhiMEmT),
       fEffMixingDepth(hists.fEffMixingDepth),
       fSameEventDistCommon(hists.fSameEventDistCommon),
-      fSameEventDistNonCommon(hists.fSameEventDistCommon),
+      fSameEventDistNonCommon(hists.fSameEventDistNonCommon),
+      fTrackPDGMothersCommon(hists.fTrackPDGMothersCommon),
+      fTrackPDGMothersNonCommon(hists.fTrackPDGMothersNonCommon),
+      fTrackPDGMothersMixed(hists.fTrackPDGMothersMixed),
       fdEtadPhiSECommon(hists.fdEtadPhiSECommon),
       fdEtadPhiSENonCommon(hists.fdEtadPhiSENonCommon),
       fSameEventMultDistCommon(hists.fSameEventMultDistCommon),
@@ -215,6 +222,7 @@ AliFemtoDreamCorrHists::AliFemtoDreamCorrHists(
       fPhiEtaPlotsSmallK(hists.fPhiEtaPlotsSmallK),
       fmTDetaDPhi(hists.fmTDetaDPhi),
       fAncestors(hists.fAncestors),
+      fDoTrackMothers(hists.fDoTrackMothers),
       fRemoveAncestorsResonances(hists.fRemoveAncestorsResonances),
       fpTOnepTTwokStarPlotsmT(hists.fpTOnepTTwokStarPlotsmT),
       fpTOnepTTwokStarCutOff(hists.fpTOnepTTwokStarCutOff),
@@ -297,6 +305,9 @@ AliFemtoDreamCorrHists::AliFemtoDreamCorrHists(AliFemtoDreamCollConfig *conf,
       fEffMixingDepth(nullptr),
       fSameEventDistCommon(nullptr),
       fSameEventDistNonCommon(nullptr),
+      fTrackPDGMothersCommon(nullptr),
+      fTrackPDGMothersNonCommon(nullptr),
+      fTrackPDGMothersMixed(nullptr),
       fdEtadPhiSECommon(nullptr),
       fdEtadPhiSENonCommon(nullptr),
       fSameEventMultDistCommon(nullptr),
@@ -322,6 +333,7 @@ AliFemtoDreamCorrHists::AliFemtoDreamCorrHists(AliFemtoDreamCollConfig *conf,
       fPhiEtaPlotsSmallK(false),
       fmTDetaDPhi(false),
       fAncestors(false),
+      fDoTrackMothers(false),
       fRemoveAncestorsResonances(false),
       fpTOnepTTwokStarPlotsmT(false),
       fpTOnepTTwokStarCutOff(3.),
@@ -350,6 +362,7 @@ AliFemtoDreamCorrHists::AliFemtoDreamCorrHists(AliFemtoDreamCollConfig *conf,
   fPhiEtaPlotsSmallK = conf->GetdPhidEtaPlotsSmallK();
   fmTDetaDPhi = conf->GetdPhidEtamTPlots();
   fAncestors = conf->GetDoAncestorsPlots();
+  fDoTrackMothers = conf->GetDoTrackMothers();
   fRemoveAncestorsResonances = conf->GetRemoveAncestorResonances();
   fpTOnepTTwokStarPlotsmT = conf->GetDopTOnepTTwokStarPlotsmT();
   fpTOnepTTwokStarCutOff = conf->GetDopTOnepTTwokStarCutOff();
@@ -694,6 +707,13 @@ AliFemtoDreamCorrHists::AliFemtoDreamCorrHists(AliFemtoDreamCollConfig *conf,
       fSameEventmTMultDistCommon = new TH2F **[nHists];
       fSameEventmTMultDistNonCommon = new TH2F **[nHists];
     }
+    if (fDoTrackMothers) 
+    {
+      fTrackPDGMothersCommon = new TH3F *[nHists];
+      fTrackPDGMothersNonCommon = new TH3F *[nHists];
+      fTrackPDGMothersMixed = new TH3F *[nHists];
+    }
+
   }
   else
   {
@@ -707,6 +727,10 @@ AliFemtoDreamCorrHists::AliFemtoDreamCorrHists(AliFemtoDreamCollConfig *conf,
     fSameEventmTDistNonCommon = nullptr;
     fSameEventmTMultDistCommon = nullptr;
     fSameEventmTMultDistNonCommon = nullptr;
+    fTrackPDGMothersCommon = nullptr;
+    fTrackPDGMothersNonCommon = nullptr;
+    fTrackPDGMothersMixed = nullptr;
+
   }
 
   if (fpTOnepTTwokStarPlotsmT)
@@ -1072,6 +1096,60 @@ AliFemtoDreamCorrHists::AliFemtoDreamCorrHists(AliFemtoDreamCollConfig *conf,
                                                     SameEventNameNonCommon.Data(), *itNBins,
                                                     *itKMin, *itKMax);
         fPairs[Counter]->Add(fSameEventDistNonCommon[Counter]);
+
+        if (fDoTrackMothers)
+        {
+          TString TrackMothersCommonName =
+            TString::Format("TrackMothersCommon_Particle%d_Particle%d", iPar1, iPar2);
+          fTrackPDGMothersCommon[Counter] = new TH3F(TrackMothersCommonName.Data(), 
+                                                     TrackMothersCommonName.Data(), 
+                                                     250, 0, 1., 100, 0, 100, 100, 0, 100);
+          fPairs[Counter]->Add(fTrackPDGMothersCommon[Counter]);
+          
+          TString TrackMothersNonCommonName =
+            TString::Format("TrackMothersNonCommon_Particle%d_Particle%d", iPar1, iPar2);
+          fTrackPDGMothersNonCommon[Counter] = new TH3F(TrackMothersNonCommonName.Data(),         
+                                                        TrackMothersNonCommonName.Data(), 
+                                                        250, 0, 1., 100, 0, 100, 100, 0, 100);
+          fPairs[Counter]->Add(fTrackPDGMothersNonCommon[Counter]);
+
+          TString TrackMothersMixedName =
+            TString::Format("TrackMothersMixed_Particle%d_Particle%d", iPar1, iPar2);
+          fTrackPDGMothersMixed[Counter] = new TH3F(TrackMothersMixedName.Data(),         
+                                                    TrackMothersMixedName.Data(), 
+                                                    250, 0, 1., 120, 0, 120, 120, 0, 120);
+          fPairs[Counter]->Add(fTrackPDGMothersMixed[Counter]);
+
+          // Set axis labels
+          TString part0Label = TString::Format("PDG mothers Particle%d", iPar1);
+          TString part1Label = TString::Format("PDG mothers Particle%d", iPar2);
+          fTrackPDGMothersCommon[Counter]->GetYaxis()->SetTitle(part0Label.Data());
+          fTrackPDGMothersCommon[Counter]->GetZaxis()->SetTitle(part1Label.Data());
+          fTrackPDGMothersNonCommon[Counter]->GetYaxis()->SetTitle(part0Label.Data());
+          fTrackPDGMothersNonCommon[Counter]->GetZaxis()->SetTitle(part1Label.Data());
+          fTrackPDGMothersMixed[Counter]->GetYaxis()->SetTitle(part0Label.Data());
+          fTrackPDGMothersMixed[Counter]->GetZaxis()->SetTitle(part1Label.Data());
+                    
+          // Set bin labels to "0", these will be progressively changed with the PDG codes of the mothers
+          fTrackPDGMothersCommon[Counter]->GetYaxis()->SetAlphanumeric();
+          fTrackPDGMothersCommon[Counter]->GetZaxis()->SetAlphanumeric();
+          fTrackPDGMothersNonCommon[Counter]->GetYaxis()->SetAlphanumeric();
+          fTrackPDGMothersNonCommon[Counter]->GetZaxis()->SetAlphanumeric();
+          fTrackPDGMothersMixed[Counter]->GetYaxis()->SetAlphanumeric();
+          fTrackPDGMothersMixed[Counter]->GetZaxis()->SetAlphanumeric();
+          for(int iBin1=0; iBin1<fTrackPDGMothersCommon[Counter]->GetYaxis()->GetNbins(); iBin1++) {
+            fTrackPDGMothersCommon[Counter]->GetYaxis()->SetBinLabel(iBin1+1, "0");
+            fTrackPDGMothersCommon[Counter]->GetZaxis()->SetBinLabel(iBin1+1, "0");
+          }
+          for(int iBin2=0; iBin2<fTrackPDGMothersNonCommon[Counter]->GetYaxis()->GetNbins(); iBin2++) {
+            fTrackPDGMothersNonCommon[Counter]->GetYaxis()->SetBinLabel(iBin2+1, "0");
+            fTrackPDGMothersNonCommon[Counter]->GetZaxis()->SetBinLabel(iBin2+1, "0");
+          } 
+          for(int iBin3=0; iBin3<fTrackPDGMothersMixed[Counter]->GetYaxis()->GetNbins(); iBin3++) {
+            fTrackPDGMothersMixed[Counter]->GetYaxis()->SetBinLabel(iBin3+1, "0");
+            fTrackPDGMothersMixed[Counter]->GetZaxis()->SetBinLabel(iBin3+1, "0");
+          } 
+        }
 
         if (fDoMultBinning)
         {
@@ -1704,6 +1782,9 @@ AliFemtoDreamCorrHists &AliFemtoDreamCorrHists::operator=(
     this->fEffMixingDepth = hists.fEffMixingDepth;
     this->fSameEventDistCommon = hists.fSameEventDistCommon;
     this->fSameEventDistNonCommon = hists.fSameEventDistNonCommon;
+    this->fTrackPDGMothersCommon = hists.fTrackPDGMothersCommon;
+    this->fTrackPDGMothersNonCommon = hists.fTrackPDGMothersNonCommon;
+    this->fTrackPDGMothersMixed = hists.fTrackPDGMothersMixed;
     this->fdEtadPhiSECommon = hists.fdEtadPhiSECommon;
     this->fdEtadPhiSENonCommon = hists.fdEtadPhiSENonCommon;
     this->fSameEventMultDistCommon = hists.fSameEventMultDistCommon;
@@ -1874,6 +1955,21 @@ AliFemtoDreamCorrHists::~AliFemtoDreamCorrHists()
   {
     delete[] fSameEventDistNonCommon;
     delete fSameEventDistNonCommon;
+  }
+  if (fTrackPDGMothersCommon)
+  {
+    delete[] fTrackPDGMothersCommon;
+    delete fTrackPDGMothersCommon;
+  }
+  if (fTrackPDGMothersNonCommon)
+  {
+    delete[] fTrackPDGMothersNonCommon;
+    delete fTrackPDGMothersNonCommon;
+  }
+  if (fTrackPDGMothersMixed)
+  {
+    delete[] fTrackPDGMothersMixed;
+    delete fTrackPDGMothersMixed;
   }
   if (fdEtadPhiSECommon)
   {
@@ -2206,3 +2302,77 @@ void AliFemtoDreamCorrHists::FillSameEventmTMultDistNonCommon(int iHist, float m
     }
   }
 }
+
+void AliFemtoDreamCorrHists::FillTrackPDGMothersNonCommon(int i, float RelK, int PDG1, int PDG2)
+{
+  if (!fMinimalBooking)
+  {
+    if (fDoTrackMothers) {
+      int bin1(0);
+      int bin2(0);
+
+      // The function FindFixBin of the class TAxis returns -1 if the argument does not match any of the 
+      // current axis labels, the default for all axis labels is "0"
+      int label1Idx = fTrackPDGMothersNonCommon[i]->GetYaxis()->FindFixBin(std::to_string(PDG1).c_str());
+      int label2Idx = fTrackPDGMothersNonCommon[i]->GetZaxis()->FindFixBin(std::to_string(PDG2).c_str());
+      
+      // This means that we still haven't encountered this mother, thus we set the first bin that is keeping 
+      // the default setting to the new PDG code found
+      if(label1Idx == -1) {
+        fTrackPDGMothersNonCommon[i]->GetYaxis()->SetBinLabel(fTrackPDGMothersNonCommon[i]->GetYaxis()->FindFixBin("0"),
+                                                           std::to_string(PDG1).c_str());
+      }
+      if(label2Idx == -1) {
+        fTrackPDGMothersNonCommon[i]->GetZaxis()->SetBinLabel(fTrackPDGMothersNonCommon[i]->GetZaxis()->FindFixBin("0"),
+                                                           std::to_string(PDG2).c_str());
+      }
+
+      // Fill the histogram specifying the y and z bins with their label, i.e. the PDG of the mother
+      fTrackPDGMothersNonCommon[i]->Fill(static_cast<Double_t>(RelK), std::to_string(PDG1).c_str(), std::to_string(PDG2).c_str(), 1);
+    }
+  }
+};
+
+void AliFemtoDreamCorrHists::FillTrackPDGMothersCommon(int i, float RelK, int PDG1, int PDG2)
+{
+  if (!fMinimalBooking)
+  {
+    if (fDoTrackMothers) {
+      int bin1(0);
+      int bin2(0);
+      int label1Idx = fTrackPDGMothersCommon[i]->GetYaxis()->FindFixBin(std::to_string(PDG1).c_str());
+      int label2Idx = fTrackPDGMothersCommon[i]->GetZaxis()->FindFixBin(std::to_string(PDG2).c_str());
+      if(label1Idx == -1) {
+        fTrackPDGMothersCommon[i]->GetYaxis()->SetBinLabel(fTrackPDGMothersCommon[i]->GetYaxis()->FindFixBin("0"),
+                                                           std::to_string(PDG1).c_str());
+      }
+      if(label2Idx == -1) {
+        fTrackPDGMothersCommon[i]->GetZaxis()->SetBinLabel(fTrackPDGMothersCommon[i]->GetZaxis()->FindFixBin("0"),
+                                                           std::to_string(PDG2).c_str());
+      }
+      fTrackPDGMothersCommon[i]->Fill(static_cast<Double_t>(RelK), std::to_string(PDG1).c_str(), std::to_string(PDG2).c_str(), 1);
+    }
+  }
+};
+
+void AliFemtoDreamCorrHists::FillTrackPDGMothersMixed(int i, float RelK, int PDG1, int PDG2)
+{
+  if (!fMinimalBooking)
+  {
+    if (fDoTrackMothers) {
+      int bin1(0);
+      int bin2(0);
+      int label1Idx = fTrackPDGMothersMixed[i]->GetYaxis()->FindFixBin(std::to_string(PDG1).c_str());
+      int label2Idx = fTrackPDGMothersMixed[i]->GetZaxis()->FindFixBin(std::to_string(PDG2).c_str());
+      if(label1Idx == -1) {
+        fTrackPDGMothersMixed[i]->GetYaxis()->SetBinLabel(fTrackPDGMothersMixed[i]->GetYaxis()->FindFixBin("0"),
+                                                           std::to_string(PDG1).c_str());
+      }
+      if(label2Idx == -1) {
+        fTrackPDGMothersMixed[i]->GetZaxis()->SetBinLabel(fTrackPDGMothersMixed[i]->GetZaxis()->FindFixBin("0"),
+                                                           std::to_string(PDG2).c_str());
+      }
+      fTrackPDGMothersMixed[i]->Fill(static_cast<Double_t>(RelK), std::to_string(PDG1).c_str(), std::to_string(PDG2).c_str(), 1);
+    }
+  }
+};

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCorrHists.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCorrHists.h
@@ -93,6 +93,10 @@ public:
   {
     return fAncestors;
   }
+  bool GetDoTrackMothers()
+  {
+    return fDoTrackMothers;
+  }
   bool GetDoRemoveAncestorsResonances()
   {
     return fRemoveAncestorsResonances;
@@ -463,6 +467,10 @@ public:
       fEffMixingDepth[iHist]->Fill(iDepth);
   }
 
+  void FillTrackPDGMothersCommon(int i, float RelK, int PDG1, int PDG2);
+  void FillTrackPDGMothersNonCommon(int i, float RelK, int PDG1, int PDG2);
+  void FillTrackPDGMothersMixed(int i, float RelK, int PDG1, int PDG2);
+
   void FillSameEventDistCommon(int i, float RelK)
   {
     if (!fMinimalBooking)
@@ -604,6 +612,10 @@ private:
   TH2F ***fSameEventpTOnepTTwokStar; // to-do: change back to THnSparseF for more dimensions
   TH2F ***fMixedEventpTOnepTTwokStar;
 
+  TH3F **fTrackPDGMothersCommon;
+  TH3F **fTrackPDGMothersNonCommon;
+  TH3F **fTrackPDGMothersMixed;
+  
   bool fDoMinvKtandRelativeKBinning;
   bool fDoMultBinning;
   bool fDoCentBinning;
@@ -621,6 +633,7 @@ private:
   bool fmTDetaDPhi;
   bool fAncestors;
   bool fRemoveAncestorsResonances;
+  bool fDoTrackMothers;
   bool fpTOnepTTwokStarPlotsmT;
   double fpTOnepTTwokStarCutOff;
   std::vector<int> fPDGCode;

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamHigherPairMath.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamHigherPairMath.cxx
@@ -324,7 +324,7 @@ float AliFemtoDreamHigherPairMath::FillSameEvent(int iHC, int Mult, float cent,
 
       if (isAlabama)
       {
-
+        // std::cout << "MC pair detected" << std::endl;
         if (fHists->GetDoRemoveAncestorsResonances() && CommonMotherResonance(part1, part2))
         {
           // do nothing
@@ -344,6 +344,10 @@ float AliFemtoDreamHigherPairMath::FillSameEvent(int iHC, int Mult, float cent,
           {
             fHists->FillSameEventmTMultDistCommon(iHC, RelativePairmT(PartOne, PartTwo), Mult + 1, RelativeK);
           }
+          if (fHists->GetDoTrackMothers())
+          {
+            fHists->FillTrackPDGMothersCommon(iHC, RelativeK, part1.GetMotherPDG(), part2.GetMotherPDG());
+          }
         }
       }
       else
@@ -360,6 +364,10 @@ float AliFemtoDreamHigherPairMath::FillSameEvent(int iHC, int Mult, float cent,
         if (fHists->GetDomTMultPlots())
         {
           fHists->FillSameEventmTMultDistNonCommon(iHC, RelativePairmT(PartOne, PartTwo), Mult + 1, RelativeK);
+        }
+        if (fHists->GetDoTrackMothers())
+        {
+          fHists->FillTrackPDGMothersNonCommon(iHC, RelativeK, part1.GetMotherPDG(), part2.GetMotherPDG());
         }
       }
     }
@@ -499,6 +507,10 @@ float AliFemtoDreamHigherPairMath::FillMixedEvent(
 
     fHists->FillKstarPtMEOneQADist(iHC, RelativeK, Part1Momentum.Pt());
     fHists->FillKstarPtMETwoQADist(iHC, RelativeK, Part2Momentum.Pt());
+  }
+  if (fHists->GetDoTrackMothers())
+  {
+    fHists->FillTrackPDGMothersMixed(iHC, RelativeK, part1.GetMotherPDG(), part2.GetMotherPDG());
   }
   return RelativeK;
 }

--- a/PWGCF/FEMTOSCOPY/macros/AddTaskFemtoNanoFromAODLambdaPion.C
+++ b/PWGCF/FEMTOSCOPY/macros/AddTaskFemtoNanoFromAODLambdaPion.C
@@ -16,11 +16,11 @@ AliAnalysisTaskSE *AddTaskFemtoNanoFromAODLambdaPion(bool isMC = true,          
                                                      AliAnalysisTaskNanoFromAODLambdaPion::PCSettings pcsettings = AliAnalysisTaskNanoFromAODLambdaPion::PCSettings::NoPC,  // choose pair cleaner
                                                      bool usenolambdaevt = true,            // true to discard events with neither Lambda or AntiLambda
                                                      double dauPIDCut = 2,
+                                                     bool doTrackMothers = false,  // works only with MC Ancestors, studies the mother PDG of each LPi
                                                      const char *cutVariation = "0")
 {
   TString suffix = TString::Format("%s", cutVariation);
   bool IsSystematics = suffix != "0";
-
   AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
 
   if (!mgr)
@@ -236,7 +236,18 @@ AliAnalysisTaskSE *AddTaskFemtoNanoFromAODLambdaPion(bool isMC = true,          
     config->SetMomentumResolution(true);
     if (DoAncestors)
     {
+      std::cout << "Set doing ancestors" << std::endl;
+      config->SetMinimalBookingME(false);
       config->SetAncestors(true);
+      if (doTrackMothers) {
+        config->SetDoTrackMothers(true);
+        config->SetPtQA(false);
+        config->SetMassQA(false);
+        config->SetkTBinning(false);
+        config->SetMultBinning(false);
+        config->SetDomTMultBinning(false);
+        config->SetmTBinning(false);
+      }
       config->GetDoAncestorsPlots();
     }
   }
@@ -1342,6 +1353,7 @@ AliAnalysisTaskSE *AddTaskFemtoNanoFromAODLambdaPion(bool isMC = true,          
   // other histograms specific for MC
   if (isMC)
   {
+    std::cout << "Adding MC histos!" << std::endl;
     AliAnalysisDataContainer *coutputv0CutsMC;
     TString v0CutsMCName = Form("%sv0CutsMC%s", addon.Data(), suffix.Data());
     coutputv0CutsMC = mgr->CreateContainer(


### PR DESCRIPTION
Implemented TH3F to store kstar, PDGpart1, PDGpart2 for MC SE distributions Common and NonCommon ancestor and MC ME distribution. Other histograms are not filled with this configuration to reduce the memory consumption and the runtime.