### PR TITLE
PWGGA/GammaConv: Change header selection for `rejection == 1 || rejec…

### DIFF
--- a/PWGGA/GammaConvBase/AliCaloPhotonCuts.cxx
+++ b/PWGGA/GammaConvBase/AliCaloPhotonCuts.cxx
@@ -5525,7 +5525,7 @@ Bool_t AliCaloPhotonCuts::SetTimingCut(Int_t timing)
 
     printf("AliCaloPhotonCuts:Period name has been set to %s, period-enum: %o\n",fPeriodName.Data(),fCurrentMC ) ;
   }
-  if(fCurrentMC == kPbPb5T18HIJING){
+  if(fCurrentMC == kPbPb5T18HIJING || fCurrentMC == kPbPb5T15HIJING){
     fOffsetTimeMC = 61.6e-8;
     if (!fUseTimeDiffMC) fUseTimeDiffMC=1;
   }


### PR DESCRIPTION
…tion == 3` case

- When one selected the cut to rejected any signal except MB (rejection == 1) what would happen is, that the first header avaible in the list of headers was chosen. However, this is not always the MB header. This commit aims to fix that by looping over all headers and comparing them with hijing, pythia, mb and minimumbias and uses the first matching header.
- Also fixes bug introduced in [PR #23471](https://github.com/alisw/AliPhysics/pull/23471) where not setting  `fUseGetWeightForMesonNew` to true would lead to a crash since two histograms were always tried to be filled which only exist if the variable was set to true.