### PR TITLE
PWGGA/GammaConv: Updated MC Header handling

### DIFF
--- a/PWGGA/GammaConv/macros/AddTask_GammaCalo_PbPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaCalo_PbPb.C
@@ -2674,11 +2674,6 @@ void AddTask_GammaCalo_PbPb(
       Error(Form("%s_%i", addTaskName.Data(),  trainConfig), "No valid header selection");
       return;
     }
-  }  else if ( generatorName.BeginsWith("LHC20j6") || generatorName.BeginsWith("LHC22b") || generatorName.BeginsWith("LHC20e3") ){
-    HeaderList->Add(new TObjString("Hijing"));
-    HeaderList->Add(new TObjString("Pileup"));
-  } else if ( generatorName.BeginsWith("LHC18e1") || generatorName.BeginsWith("LHC19h2") || generatorName.BeginsWith("LHC18l8") ){
-    HeaderList->Add(new TObjString("Hijing"));
   }
 
 

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_PbPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_PbPb.C
@@ -2525,11 +2525,6 @@ void AddTask_GammaConvCalo_PbPb(
       Error(Form("%s_%i", addTaskName.Data(),  trainConfig), "No valid header selection");
       return;
     }
-  } else if ( generatorName.BeginsWith("LHC20j6") || generatorName.BeginsWith("LHC22b") || generatorName.BeginsWith("LHC20e3") ){
-    HeaderList->Add(new TObjString("Hijing"));
-    HeaderList->Add(new TObjString("Pileup"));
-  } else if ( generatorName.BeginsWith("LHC18e1") || generatorName.BeginsWith("LHC19h2") || generatorName.BeginsWith("LHC18l8") ){
-    HeaderList->Add(new TObjString("Hijing"));
   }
 
   EventCutList->SetOwner(kTRUE);

--- a/PWGGA/GammaConvBase/AliConvEventCuts.h
+++ b/PWGGA/GammaConvBase/AliConvEventCuts.h
@@ -802,6 +802,7 @@ class AliConvEventCuts : public AliAnalysisCuts {
       PeriodVar                   fPeriodEnum;                            ///< period selector
       EnergyVar                   fEnergyEnum;                            ///< energy selector
       AliTimeRangeCut             fTimeRangeCut;                          //!
+      Bool_t                      fHasMBNotFirst;                         //< bool to tell if the header of the MC has the minimum bias header not at first place
 
       TObjString*                 fCutString;                             ///< cut number used for analysis
       TString                     fCutStringRead;                         ///<
@@ -904,7 +905,7 @@ class AliConvEventCuts : public AliAnalysisCuts {
   private:
 
       /// \cond CLASSIMP
-      ClassDef(AliConvEventCuts,94)
+      ClassDef(AliConvEventCuts,95)
       /// \endcond
 };
 


### PR DESCRIPTION
- New bool variable `fHasMBNotFirst` to check if the minimum bias head is NOT first in the list of headers. If that is the case it will be set in `SetPeriodEnum` to true for the corresponding MC. This is currently only impemented for the few known Hijing MCs which are from 2020 or newer. Everyone whos working with MCs that include pile up need to check this and possibly set the variable to true for their used MC.
- Fixed a bug which made it necessary to have a headerlist in the AddTask when running only min bias header or exclude pile up. (See changes to code where `fHeaderMap` is used)
- Thanks to that bug fix some header lists in the AddTask could be removed.