### PR TITLE
PWGGA/GammaConv: Add configs for NonLin studies

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskConvCaloCalibration.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskConvCaloCalibration.cxx
@@ -575,16 +575,15 @@ void AliAnalysisTaskConvCaloCalibration::UserCreateOutputObjects(){
     Double_t *arrQAPtBinning    = new Double_t[1200];
     Double_t *arrClusPtBinning  = new Double_t[1200];
     if(fMesonRecoMode < 2 && fDoMesonQA == 0){
-      nBinsPt                   = 235;
+      nBinsPt                   = 240;
       minPt                     = 0;
       maxPt                     = 50;
       binWidthPt                = 0.05;
       for(Int_t i=0; i<nBinsPt+1;i++){
-        if (i < 1) arrPtBinning[i]              = 0.3*i;
-        else if(i<55) arrPtBinning[i]           = 0.3+0.05*(i-1);
-        else if(i<125) arrPtBinning[i]          = 3.+0.1*(i-55);
-        else if(i<185) arrPtBinning[i]          = 10.+0.25*(i-125);
-        else if(i<235) arrPtBinning[i]          = 25.+0.5*(i-185);
+        if(i<60) arrPtBinning[i]                = 0.05*i;
+        else if(i<130) arrPtBinning[i]          = 3.+0.1*(i-60);
+        else if(i<190) arrPtBinning[i]          = 10.+0.25*(i-130);
+        else if(i<240) arrPtBinning[i]          = 25.+0.5*(i-190);
         else  arrPtBinning[i]                   = maxPt;
       }
       nBinsQAPt                 = 221;
@@ -597,61 +596,57 @@ void AliAnalysisTaskConvCaloCalibration::UserCreateOutputObjects(){
         else if(i<221) arrQAPtBinning[i]        = 40.+1.0*(i-210);
         else arrQAPtBinning[i]                  = maxQAPt;
       }
-      nBinsClusterPt            = 351;
+      nBinsClusterPt            = 256;
       maxClusterPt              = 50;
       for(Int_t i=0; i<nBinsClusterPt+1;i++){
-        if (i < 1) arrClusPtBinning[i]          = 0.3*i;
-        else if(i<55) arrClusPtBinning[i]       = 0.3+0.05*(i-1);
-        else if(i<125) arrClusPtBinning[i]      = 3.+0.1*(i-55);
-        else if(i<155) arrClusPtBinning[i]      = 10.+0.2*(i-125);
-        else if(i<211) arrClusPtBinning[i]      = 16.+0.25*(i-155);
-        else if(i<251) arrClusPtBinning[i]      = 30.+0.5*(i-211);
+        if(i<60) arrClusPtBinning[i]            = 0.05*i;
+        else if(i<130) arrClusPtBinning[i]      = 3.+0.1*(i-60);
+        else if(i<160) arrClusPtBinning[i]      = 10.+0.2*(i-130);
+        else if(i<216) arrClusPtBinning[i]      = 16.+0.25*(i-160);
+        else if(i<256) arrClusPtBinning[i]      = 30.+0.5*(i-216);
         else arrClusPtBinning[i]                = maxClusterPt;
     }
 
   } else if(fMesonRecoMode == 2 && fDoMesonQA == 0){
-        nBinsPt                   = 165;
-        minPt                     = 0;
-        maxPt                     = 20;
-        binWidthPt                = 0.05;
-        for(Int_t i=0; i<nBinsPt+1;i++){
-          if (i < 1) arrPtBinning[i]              = 0.3*i;
-          else if(i<55) arrPtBinning[i]           = 0.3+0.05*(i-1);
-          else if(i<125) arrPtBinning[i]          = 3.+0.1*(i-55);
-          else if(i<165) arrPtBinning[i]          = 10.+0.25*(i-125);
-          else  arrPtBinning[i]                   = maxPt;
-        }
-        nBinsQAPt                 = 210;
-        maxQAPt                   = 20;
-        for(Int_t i=0; i<nBinsQAPt+1;i++){
-          if(i<60) arrQAPtBinning[i]              = 0.05*i;
-          else if(i<130) arrQAPtBinning[i]        = 3.+0.1*(i-60);
-          else if(i<170) arrQAPtBinning[i]        = 10.+0.25*(i-130);
-          else arrQAPtBinning[i]                  = maxQAPt;
-        }
-        nBinsClusterPt            = 171;
-        maxClusterPt              = 20;
-        for(Int_t i=0; i<nBinsClusterPt+1;i++){
-          if (i < 1) arrClusPtBinning[i]          = 0.3*i;
-          else if(i<55) arrClusPtBinning[i]       = 0.3+0.05*(i-1);
-          else if(i<125) arrClusPtBinning[i]      = 3.+0.1*(i-55);
-          else if(i<155) arrClusPtBinning[i]      = 10.+0.2*(i-125);
-          else if(i<171) arrClusPtBinning[i]      = 16.+0.25*(i-155);
-          else arrClusPtBinning[i]                = maxClusterPt;
-        }
+      nBinsPt                   = 170;
+      minPt                     = 0;
+      maxPt                     = 20;
+      binWidthPt                = 0.05;
+      for(Int_t i=0; i<nBinsPt+1;i++){
+        if(i<60) arrPtBinning[i]                = 0.05*i;
+        else if(i<130) arrPtBinning[i]          = 3.+0.1*(i-60);
+        else if(i<170) arrPtBinning[i]          = 10.+0.25*(i-130);
+        else  arrPtBinning[i]                   = maxPt;
+      }
+      nBinsQAPt                 = 170;
+      maxQAPt                   = 20;
+      for(Int_t i=0; i<nBinsQAPt+1;i++){
+        if(i<60) arrQAPtBinning[i]              = 0.05*i;
+        else if(i<130) arrQAPtBinning[i]        = 3.+0.1*(i-60);
+        else if(i<170) arrQAPtBinning[i]        = 10.+0.25*(i-130);
+        else arrQAPtBinning[i]                  = maxQAPt;
+      }
+      nBinsClusterPt            = 176;
+      maxClusterPt              = 20;
+      for(Int_t i=0; i<nBinsClusterPt+1;i++){
+        if(i<60) arrClusPtBinning[i]            = 0.05*i;
+        else if(i<130) arrClusPtBinning[i]      = 3.+0.1*(i-60);
+        else if(i<160) arrClusPtBinning[i]      = 10.+0.2*(i-130);
+        else if(i<176) arrClusPtBinning[i]      = 16.+0.25*(i-160);
+        else arrClusPtBinning[i]                = maxClusterPt;
+      }
               // default binning
     } else {
-      nBinsPt                   = 310;
+      nBinsPt                   = 312;
       minPt                     = 0;
       maxPt                     = 100;
       binWidthPt                = 0.1;
       for(Int_t i=0; i<nBinsPt+1;i++){
-        if (i < 1) arrPtBinning[i]              = 0.3*i;
-        else if(i<198) arrPtBinning[i]          = 0.3+0.1*(i-1);
-        else if(i<238) arrPtBinning[i]          = 20.+0.25*(i-198);
-        else if(i<278) arrPtBinning[i]          = 30.+0.5*(i-238);
-        else if(i<298) arrPtBinning[i]          = 50.+1.0*(i-278);
-        else if(i<310) arrPtBinning[i]          = 70.+2.5*(i-298);
+        if(i<200) arrPtBinning[i]               = 0.1*i;
+        else if(i<240) arrPtBinning[i]          = 20.+0.25*(i-200);
+        else if(i<280) arrPtBinning[i]          = 30.+0.5*(i-240);
+        else if(i<300) arrPtBinning[i]          = 50.+1.0*(i-280);
+        else if(i<312) arrPtBinning[i]          = 70.+2.5*(i-300);
         else  arrPtBinning[i]                   = maxPt;
       }
       nBinsQAPt                 = 240;
@@ -663,15 +658,14 @@ void AliAnalysisTaskConvCaloCalibration::UserCreateOutputObjects(){
         else if(i<240) arrQAPtBinning[i]        = 40.+1.0*(i-180);
         else arrQAPtBinning[i]                  = maxQAPt;
       }
-      nBinsClusterPt            = 310;
+      nBinsClusterPt            = 312;
       maxClusterPt              = 100;
       for(Int_t i=0; i<nBinsClusterPt+1;i++){
-        if (i < 1) arrClusPtBinning[i]          = 0.3*i;
-        else if(i<198) arrClusPtBinning[i]      = 0.3+0.1*(i-1);
-        else if(i<238) arrClusPtBinning[i]      = 20.+0.25*(i-198);
-        else if(i<278) arrClusPtBinning[i]      = 30.+0.5*(i-238);
-        else if(i<298) arrClusPtBinning[i]      = 50.+1.0*(i-278);
-        else if(i<310) arrClusPtBinning[i]      = 70.+2.5*(i-298);
+        if(i<200) arrClusPtBinning[i]           = 0.1*i;
+        else if(i<240) arrClusPtBinning[i]      = 20.+0.25*(i-200);
+        else if(i<280) arrClusPtBinning[i]      = 30.+0.5*(i-240);
+        else if(i<300) arrClusPtBinning[i]      = 50.+1.0*(i-280);
+        else if(i<312) arrClusPtBinning[i]      = 70.+2.5*(i-300);
         else  arrClusPtBinning[i]               = maxClusterPt;
       }
     }

--- a/PWGGA/GammaConv/macros/AddTask_ConvCaloCalibration_CaloMode_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_ConvCaloCalibration_CaloMode_pp.C
@@ -445,6 +445,24 @@ void AddTask_ConvCaloCalibration_CaloMode_pp(
   } else if (trainConfig == 112){
     cuts.AddCutCalo("0008d113","411790109fe30230000","0s631031000000d0");  // EG1 no TM
 
+
+  // Cell scale studies
+  } else if (trainConfig == 120) { // No NL, minE = 700MeV
+    cuts.AddCutCalo("00010113","411790009fe32220000","0s631031000000d0"); // INT7
+    cuts.AddCutCalo("00010113","411790009fe30220000","0s631031000000d0"); // INT7, no NCell
+  } else if (trainConfig == 121) { // No NL, minE = 500MeV
+    cuts.AddCutCalo("00010113","411790009fe22220000","0s631031000000d0"); // INT7
+    cuts.AddCutCalo("00010113","411790009fe20220000","0s631031000000d0"); // INT7, no NCell
+  } else if (trainConfig == 122) { // No NL, minE = 400MeV
+    cuts.AddCutCalo("00010113","411790009fe82220000","0s631031000000d0"); // INT7
+    cuts.AddCutCalo("00010113","411790009fe80220000","0s631031000000d0"); // INT7, no NCell
+  } else if (trainConfig == 123) { // No NL, minE = 100MeV
+    cuts.AddCutCalo("00010113","411790009fe02220000","0s631031000000d0"); // INT7
+    cuts.AddCutCalo("00010113","411790009fe00220000","0s631031000000d0"); // INT7, no NCell
+  } else if (trainConfig == 124) { // No NL, minE = 200MeV
+    cuts.AddCutCalo("00010113","411790009fei2220000","0s631031000000d0"); // INT7
+    cuts.AddCutCalo("00010113","411790009fei0220000","0s631031000000d0"); // INT7, no NCell
+
   // Cuts to compare with PbPbs
   } else if (trainConfig == 201){
     cuts.AddCutCalo("00010113","4117901057e30220000","0s631031000000d0");  // INT7 pT dependent track matching w/o E/p

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvCaloCalibration_MixedMode_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvCaloCalibration_MixedMode_pp.C
@@ -387,6 +387,22 @@ void AddTask_GammaConvCaloCalibration_MixedMode_pp(
     cuts.AddCutPCMCalo("00010113","0dm00089f9730000iih0404000","411799609f030000000","0r63103100000010"); // INT7 without M02/exotic cut, no FT
 
 
+  } else if (trainConfig == 120){ // minE = 700 MeV, noNL
+    cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411790009fe30220000","0163103100000010"); // no NCell cut
+    cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411790009fe32220000","0163103100000010"); // NCell >= 2 cut
+  } else if (trainConfig == 121){ // minE = 500 MeV, noNL
+    cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411790009fe20220000","0163103100000010"); // no NCell cut
+    cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411790009fe22220000","0163103100000010"); // NCell >= 2 cut
+  } else if (trainConfig == 122){ // minE = 400 MeV, noNL
+    cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411790009fe80220000","0163103100000010"); // no NCell cut
+    cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411790009fe82220000","0163103100000010"); // NCell >= 2 cut
+  } else if (trainConfig == 123){ // minE = 100 MeV, noNL
+    cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411790009fe00220000","0163103100000010"); // no NCell cut
+    cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411790009fe02220000","0163103100000010"); // NCell >= 2 cut
+  } else if (trainConfig == 124){ // minE = 200 MeV, noNL
+    cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411790009fei0220000","0163103100000010"); // no NCell cut
+    cuts.AddCutPCMCalo("00010113","0dm00009f9730000dge0404000","411790009fei2220000","0163103100000010"); // NCell >= 2 cut
+
   } else {
     Error(Form("AddTask_GammaConvCaloCalibration_MixedMode_pp%i",trainConfig), "wrong trainConfig variable no cuts have been specified for the configuration");
     return;

--- a/PWGGA/GammaConvBase/AliConversionMesonCuts.cxx
+++ b/PWGGA/GammaConvBase/AliConversionMesonCuts.cxx
@@ -391,7 +391,7 @@ void AliConversionMesonCuts::InitCutHistograms(TString name, Bool_t additionalHi
 
   // Meson Cuts
   if (fIsMergedClusterCut == 1){
-    fHistoMesonCuts=new TH2F(Form("MesonCuts %s",GetCutNumber().Data()),"MesonCuts vs Pt",9,-0.5,8.5, 500, 0, 100);
+    fHistoMesonCuts=new TH2F(Form("MesonCuts %s",GetCutNumber().Data()),"MesonCuts vs Pt",10,-0.5,9.5, 500, 0, 100);
     fHistoMesonCuts->GetXaxis()->SetBinLabel(1,"in");
     fHistoMesonCuts->GetXaxis()->SetBinLabel(2,"undef rapidity");
     fHistoMesonCuts->GetXaxis()->SetBinLabel(3,"rapidity cut");
@@ -400,10 +400,11 @@ void AliConversionMesonCuts::InitCutHistograms(TString name, Bool_t additionalHi
     fHistoMesonCuts->GetXaxis()->SetBinLabel(6,"alpha max");
     fHistoMesonCuts->GetXaxis()->SetBinLabel(7,"alpha min");
     fHistoMesonCuts->GetXaxis()->SetBinLabel(8,"pT min");
-    fHistoMesonCuts->GetXaxis()->SetBinLabel(9,"out");
+    fHistoMesonCuts->GetXaxis()->SetBinLabel(9,"quality");
+    fHistoMesonCuts->GetXaxis()->SetBinLabel(10,"out");
     fHistograms->Add(fHistoMesonCuts);
   } else if (fIsMergedClusterCut == 2){
-    fHistoMesonCuts=new TH2F(Form("MesonCuts %s",GetCutNumber().Data()),"MesonCuts vs Pt",9,-0.5,8.5, 250, 0, 50);
+    fHistoMesonCuts=new TH2F(Form("MesonCuts %s",GetCutNumber().Data()),"MesonCuts vs Pt",10,-0.5,9.5, 250, 0, 50);
     fHistoMesonCuts->GetXaxis()->SetBinLabel(1,"in");
     fHistoMesonCuts->GetXaxis()->SetBinLabel(2,"undef rapidity");
     fHistoMesonCuts->GetXaxis()->SetBinLabel(3,"rapidity cut");
@@ -412,10 +413,11 @@ void AliConversionMesonCuts::InitCutHistograms(TString name, Bool_t additionalHi
     fHistoMesonCuts->GetXaxis()->SetBinLabel(6,"alpha max");
     fHistoMesonCuts->GetXaxis()->SetBinLabel(7,"alpha min");
     fHistoMesonCuts->GetXaxis()->SetBinLabel(8,"pT min");
-    fHistoMesonCuts->GetXaxis()->SetBinLabel(9,"out");
+    fHistoMesonCuts->GetXaxis()->SetBinLabel(9,"quality");
+    fHistoMesonCuts->GetXaxis()->SetBinLabel(10,"out");
     fHistograms->Add(fHistoMesonCuts);
 
-    fHistoMesonBGCuts=new TH2F(Form("MesonBGCuts %s",GetCutNumber().Data()),"MesonBGCuts vs Pt",9,-0.5,8.5, 250, 0, 50);
+    fHistoMesonBGCuts=new TH2F(Form("MesonBGCuts %s",GetCutNumber().Data()),"MesonBGCuts vs Pt",10,-0.5,9.5, 250, 0, 50);
     fHistoMesonBGCuts->GetXaxis()->SetBinLabel(1,"in");
     fHistoMesonBGCuts->GetXaxis()->SetBinLabel(2,"undef rapidity");
     fHistoMesonBGCuts->GetXaxis()->SetBinLabel(3,"rapidity cut");
@@ -424,7 +426,8 @@ void AliConversionMesonCuts::InitCutHistograms(TString name, Bool_t additionalHi
     fHistoMesonBGCuts->GetXaxis()->SetBinLabel(6,"alpha max");
     fHistoMesonBGCuts->GetXaxis()->SetBinLabel(7,"alpha min");
     fHistoMesonBGCuts->GetXaxis()->SetBinLabel(8,"pT min");
-    fHistoMesonBGCuts->GetXaxis()->SetBinLabel(9,"out");
+    fHistoMesonBGCuts->GetXaxis()->SetBinLabel(9,"quality");
+    fHistoMesonBGCuts->GetXaxis()->SetBinLabel(10,"out");
     fHistograms->Add(fHistoMesonBGCuts);
   } else {
     fHistoMesonCuts=new TH2F(Form("MesonCuts %s",GetCutNumber().Data()),"MesonCuts vs Pt",12,-0.5,11.5, 250, 0, 50);


### PR DESCRIPTION
- Changed binning down to pt = 0
- Added configs with different minimum energy requirements
- Adjusted MesonQuality histogram to match the code (Previously, "out" component was not visible as MesonQuality was filled instead of "out")