### PR TITLE
PWGGA/GammaConv: Add option for cluster efficiency application

### DIFF
--- a/PWGGA/GammaConv/macros/AddTask_ConvCaloCalibration_CaloMode_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_ConvCaloCalibration_CaloMode_pp.C
@@ -484,6 +484,10 @@ void AddTask_ConvCaloCalibration_CaloMode_pp(
   } else if (trainConfig == 162){
     cuts.AddCutCalo("00010113","4117911097e3n220000","0r631031000000d0");  // with NCell efficiency
 
+  // cluster efficiency application
+  } else if (trainConfig == 170){
+    cuts.AddCutCalo("00010113","4117901097e302200a0","0r631031000000d0");  // std cuts
+
   // Cuts to compare with PbPbs
   } else if (trainConfig == 201){
     cuts.AddCutCalo("00010113","4117901057e30220000","0s631031000000d0");  // INT7 pT dependent track matching w/o E/p

--- a/PWGGA/GammaConv/macros/AddTask_GammaCalo_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaCalo_pp.C
@@ -2127,6 +2127,13 @@ void AddTask_GammaCalo_pp(
     cuts.AddCutCalo("r0a78113","411790109fe309v0000","bs631031000000d0"); // transverse
     cuts.AddCutCalo("r0a78113","411790109fe309v0000","cs631031000000d0"); // away
 
+
+  // EMCAL experimental settings with cluster efficiency
+  } else if (trainConfig == 1750){  // 
+    cuts.AddCutCalo("00010113","411790109fe309v00a0","0s631031000000d0"); // No NCell cut
+    cuts.AddCutCalo("00010113","411790109fe3n9v00a0","0s631031000000d0"); // With NCell efficiency
+
+
     //---------------------------------------
     // pp 13 TeV systematic cut var multiplicity dependent
     //---------------------------------------

--- a/PWGGA/GammaConvBase/AliCaloPhotonCuts.h
+++ b/PWGGA/GammaConvBase/AliCaloPhotonCuts.h
@@ -604,7 +604,7 @@ class AliCaloPhotonCuts : public AliAnalysisCuts {
     Float_t   fConvRejMaxOpenAngle;                     // maximum opening angle of a cluster pair to be considerd to be a conversion from the same photon
     Int_t     fUseRecConv;                              // flag to switch on conversion recovery
     Double_t  fMaxDispersion;                           // maximum dispersion
-    Bool_t    fUseDispersion;                           // flag for switching on dispersion cut
+    int       fUseDispersion;                           // flag for switching on dispersion cut. If set to two, this acts as the cluster efficiency (cut is overloaded from cutID=10 onwards)
     Int_t     fMinNLM;                                  // minimum number of local maxima in cluster
     Int_t     fMaxNLM;                                  // maximum number of local maxima in cluster
     Bool_t    fUseNLM;                                  // flag for switching on NLM cut
@@ -626,6 +626,9 @@ class AliCaloPhotonCuts : public AliAnalysisCuts {
     Double_t  fNOCParam4[3];                            // parameter for function pol2 to describe 5th parameter as function of cent of the 5 params for the NOC
     Float_t   fMeanNMatchedTracks;                      // Mean number of matched primary tracks, stored to reduce CPU time for neutral overlap correction
     TF1*      fFuncNOCMaxBoltz;                         // TF1 Maxwell Boltzmann to describe the neutral overlap correction for a specific centrality
+    // for cluster efficiency application in data
+    bool      fApplyClusterEffOnData;                   // switch weather cluster efficiency should be applied on data or MC
+    TF1*      fClusterEfficiencyFunc;                   // function giveing the probability a cluster should survive the cuts as function of energy
 
 
     //vector
@@ -786,7 +789,7 @@ class AliCaloPhotonCuts : public AliAnalysisCuts {
 
   private:
 
-    ClassDef(AliCaloPhotonCuts,138)
+    ClassDef(AliCaloPhotonCuts,139)
 };
 
 #endif


### PR DESCRIPTION
- Cluster efficiency to match efficiencies between data and MC found with matched electrons
- Overloads the Dispersion cut: From cut ID 10 onwards (a in the cutstring), the efficiency for clusters is used
- TF1 is implemented that gives the difference between data and MC and randomly rejects clusters depending on their energy
- Experimental setting!! Dont use it for your analysis