### PR TITLE
PWGGA/GammaConv: Fix particleFromBGEvent bug

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.cxx
@@ -3779,7 +3779,6 @@ void AliAnalysisTaskGammaCalo::ProcessClusters()
       particleFromBGEvent = ((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsParticleFromBGEvent(PhotonCandidate->GetCaloPhotonMCLabel(0), fMCEvent, fInputEvent);
       if ( particleFromBGEvent == 2 && ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetSignalRejection() == 4) tempPhotonWeight = 1;
       if ( particleFromBGEvent == 0) fIsFromDesiredHeader = kFALSE;
-      if ( particleFromBGEvent == 2) fIsFromDesiredHeader = kFALSE;
       if (clus->GetNLabels()>1){
         Int_t* mclabelsCluster = clus->GetLabels();
         if (fLocalDebugFlag > 1)   cout << "testing if other labels in cluster belong to different header, need to test " << (Int_t)clus->GetNLabels()-1 << " additional labels" << endl;

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvCalo.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvCalo.cxx
@@ -3535,7 +3535,7 @@ void AliAnalysisTaskGammaConvCalo::ProcessClusters(){
     // test whether largest contribution to cluster orginates in added signals
     if (fIsMC>0 && ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetSignalRejection() > 0){
       particleFromBGEvent = ((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsParticleFromBGEvent(PhotonCandidate->GetCaloPhotonMCLabel(0), fMCEvent, fInputEvent);
-      if ( particleFromBGEvent == 0 || particleFromBGEvent == 2){
+      if ( particleFromBGEvent == 0){
         fIsFromDesiredHeader = kFALSE;
       }
       if (clus->GetNLabels()>1){


### PR DESCRIPTION
Currently particles which are coming from the MB header where marked as 2 from `IsParticleFromBGEvent`. For some reason particles that have 2 returned from that function which is only the case if they are MB AND ACCEPTED, they are marked as `fIsFromDesiredHeader = false`, so not from desired Header. This seems outdated, so I removed the case where particles from MB header are marked as `fIsFromDesiredHeader = false`