### PR TITLE
PWGGA/GammaConv: Additions to electron to cluster matching studies

### DIFF
--- a/PWGGA/GammaConv/macros/AddTask_ConvCaloCalibration_CaloMode_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_ConvCaloCalibration_CaloMode_pp.C
@@ -482,6 +482,19 @@ void AddTask_ConvCaloCalibration_CaloMode_pp(
     cuts.AddCutCalo("00010113","411790109fe30220000","0r631031000000d0");  // TM cuts, with E/p
     cuts.AddCutCalo("00010113","4117901092e30220000","0r631031000000d0");  // TM cuts, no energy dependence
 
+  } else if (trainConfig == 156){ // open cuts, TM variation
+    cuts.AddCutCalo("00010113","4117901092e10200000","0r631031000000d0");  // 500 MeV cluster threshold, TM cuts, no energy dependence
+    cuts.AddCutCalo("00010113","411790109fe10200000","0r631031000000d0");  // 500 MeV cluster threshold, TM cuts, E/p > 1.75
+    cuts.AddCutCalo("00010113","411790109he10200000","0r631031000000d0");  // 500 MeV cluster threshold, TM cuts, E/p > 1.25
+  } else if (trainConfig == 157){ // open cuts, TM variation
+    cuts.AddCutCalo("00010113","4117901092e10200000","0r631031000000d0");  // 500 MeV cluster threshold, TM cuts, no energy dependence
+    cuts.AddCutCalo("00010113","411790109fe10200000","0r631031000000d0");  // 500 MeV cluster threshold, TM cuts, E/p > 1.75
+    cuts.AddCutCalo("00010113","411790109he10200000","0r631031000000d0");  // 500 MeV cluster threshold, TM cuts, E/p > 1.25
+  } else if (trainConfig == 158){ // open cuts, TM variation
+    cuts.AddCutCalo("00010113","4117901092e10200000","0r631031000000d0");  // 500 MeV cluster threshold, TM cuts, no energy dependence
+    cuts.AddCutCalo("00010113","411790109fe10200000","0r631031000000d0");  // 500 MeV cluster threshold, TM cuts, E/p > 1.75
+    cuts.AddCutCalo("00010113","411790109he10200000","0r631031000000d0");  // 500 MeV cluster threshold, TM cuts, E/p > 1.25
+
   // configs without cell scale
   } else if (trainConfig == 160){
     cuts.AddCutCalo("00010113","4117911097e30220000","0r631031000000d0");  // std cuts

--- a/PWGGA/GammaConvBase/AliCaloPhotonCuts.cxx
+++ b/PWGGA/GammaConvBase/AliCaloPhotonCuts.cxx
@@ -355,6 +355,10 @@ AliCaloPhotonCuts::AliCaloPhotonCuts(Int_t isMC, const char *name,const char *ti
   fHistElectronPositronClusterMatchVsEta(NULL),
   fHistElectronPositronClusterMatchDoubleCount(NULL),
   fHistElectronClusterMatchM02(NULL),
+  fHistElectronPositronOnEMCCellMixing(NULL),
+  fHistElectronPositronOnEMCCellMatchedMixing(NULL),
+  fHistElectronPositronClusterMatchEoverPMixing(NULL),
+  vecElectronMixing({}),
   fHistInvMassDiCluster(NULL),
   fHistInvMassConvFlagging(NULL),
   fHistDiClusterAngle(NULL),
@@ -631,6 +635,10 @@ AliCaloPhotonCuts::AliCaloPhotonCuts(const AliCaloPhotonCuts &ref) :
   fHistElectronPositronClusterMatchVsEta(NULL),
   fHistElectronPositronClusterMatchDoubleCount(NULL),
   fHistElectronClusterMatchM02(NULL),
+  fHistElectronPositronOnEMCCellMixing(NULL),
+  fHistElectronPositronOnEMCCellMatchedMixing(NULL),
+  fHistElectronPositronClusterMatchEoverPMixing(NULL),
+  vecElectronMixing({}),
   fHistInvMassDiCluster(NULL),
   fHistInvMassConvFlagging(NULL),
   fHistDiClusterAngle(NULL),
@@ -2027,28 +2035,34 @@ void AliCaloPhotonCuts::InitCutHistograms(TString name){
     fHistograms->Add(fHistElectronPositronClusterMatchSub);
 
     fHistElectronPositronClusterMatchEoverP = new TH2F(Form("MatchedElectronPositronEOverP %s",GetCutNumber().Data()), "Matched Electron Positron tracks with P on EMC E over track P",
-                                                      300,0,1.5,500,0,50.);
+                                                      150,0,3.,nBinsClusterE, arrClusEBinning);
     fHistElectronPositronClusterMatchEoverP->GetXaxis()->SetTitle("E_{cl} / P_{track, EMC}");
     fHistElectronPositronClusterMatchEoverP->GetYaxis()->SetTitle("P_{T} (GeV)");
     fHistograms->Add(fHistElectronPositronClusterMatchEoverP);
 
     fHistElectronPositronClusterMatchEoverPonVtx = new TH2F(Form("MatchedElectronPositronEOverPonVtx %s",GetCutNumber().Data()), "Matched Electron Positron tracks with P on Vtx E over track P",
-                                                      300,0,1.5,500,0,50.);
+                                                      150,0,3.,nBinsClusterE, arrClusEBinning);
     fHistElectronPositronClusterMatchEoverPonVtx->GetXaxis()->SetTitle("E_{cl} / P_{track, Vtx}");
     fHistElectronPositronClusterMatchEoverPonVtx->GetYaxis()->SetTitle("P_{T} (GeV)");
     fHistograms->Add(fHistElectronPositronClusterMatchEoverPonVtx);
 
     fHistElectronPositronClusterMatchEoverPVsE = new TH2F(Form("MatchedElectronPositronEOverPVsE %s",GetCutNumber().Data()), "Matched Electron Positron tracks with P on EMC E over track P",
-                                                      300,0,1.5,500,0,50.);
+                                                      150,0,3.,nBinsClusterE, arrClusEBinning);
     fHistElectronPositronClusterMatchEoverPVsE->GetXaxis()->SetTitle("E_{cl} / P_{track, EMC}");
     fHistElectronPositronClusterMatchEoverPVsE->GetYaxis()->SetTitle("E_{cl} (GeV)");
     fHistograms->Add(fHistElectronPositronClusterMatchEoverPVsE);
 
     fHistElectronPositronClusterMatchEoverPonVtxVsE = new TH2F(Form("MatchedElectronPositronEOverPonVtxVsE %s",GetCutNumber().Data()), "Matched Electron Positron tracks with P on Vtx E over track P",
-                                                      300,0,1.5,500,0,50.);
+                                                      150,0,3.,nBinsClusterE, arrClusEBinning);
     fHistElectronPositronClusterMatchEoverPonVtxVsE->GetXaxis()->SetTitle("E_{cl} / P_{track, Vtx}");
     fHistElectronPositronClusterMatchEoverPonVtxVsE->GetYaxis()->SetTitle("E_{cl} (GeV)");
     fHistograms->Add(fHistElectronPositronClusterMatchEoverPonVtxVsE);
+
+    fHistElectronPositronClusterMatchEoverPMixing = new TH2F(Form("MatchedElectronPositronEOverPMixing %s",GetCutNumber().Data()), "Matched Electron Positron tracks with P on EMC E over track P Mixing",
+                                                      150,0,3.,nBinsClusterE, arrClusEBinning);
+    fHistElectronPositronClusterMatchEoverPMixing->GetXaxis()->SetTitle("E_{cl} / P_{track, EMC}");
+    fHistElectronPositronClusterMatchEoverPMixing->GetYaxis()->SetTitle("P_{T} (GeV)");
+    fHistograms->Add(fHistElectronPositronClusterMatchEoverPMixing);
 
     if(fExtendedMatchAndQA > 1 ){
       fHistElectronClusterMatch = new TH2F(Form("MatchedElectronTrackPClusE %s",GetCutNumber().Data()), "Matched Electron tracks with P on EMC",
@@ -2104,6 +2118,16 @@ void AliCaloPhotonCuts::InitCutHistograms(TString name){
       fHistElectronClusterMatchM02->GetXaxis()->SetTitle("P_{track, EMC} (GeV/c)");
       fHistElectronClusterMatchM02->GetYaxis()->SetTitle("M_{02}");
       fHistograms->Add(fHistElectronClusterMatchM02);
+
+      fHistElectronPositronOnEMCCellMixing = new TH1F(Form("VerifiedMatchedElectronPositronTrackPMixing %s",GetCutNumber().Data()), "Verified Matched Electron Positron tracks with P on EMC mixed electrons (incl. no matches)",
+                                                      nBinsClusterE, arrClusEBinning);
+      fHistElectronPositronOnEMCCellMixing->GetXaxis()->SetTitle("P_{track, EMC} (GeV/c)");
+      fHistograms->Add(fHistElectronPositronOnEMCCellMixing);
+
+      fHistElectronPositronOnEMCCellMatchedMixing = new TH1F(Form("VerifiedMatchedElectronPositronTrackPMatchedMixing %s",GetCutNumber().Data()), "Verified Matched Electron Positron tracks with P on EMC mixed electrons (only matches)",
+                                                      nBinsClusterE, arrClusEBinning);
+      fHistElectronPositronOnEMCCellMatchedMixing->GetXaxis()->SetTitle("P_{track, EMC} (GeV/c)");
+      fHistograms->Add(fHistElectronPositronOnEMCCellMatchedMixing);
     }
 
 
@@ -2176,6 +2200,8 @@ void AliCaloPhotonCuts::InitCutHistograms(TString name){
         fHistElectronPositronClusterMatchVsEta->Sumw2();
         fHistElectronPositronClusterMatchDoubleCount->Sumw2();
         fHistElectronClusterMatchM02->Sumw2();
+        fHistElectronPositronOnEMCCellMixing->Sumw2();
+        fHistElectronPositronOnEMCCellMatchedMixing->Sumw2();
       }
     }
 
@@ -4771,7 +4797,7 @@ void AliCaloPhotonCuts::MatchElectronTracksToClusters(AliVEvent* event, AliMCEve
         fHistElectronPositronClusterMatch->Fill(cluster->E(), inTrack->GetTrackPOnEMCal(), weight);
         fHistElectronPositronClusterMatchSub->Fill(cluster->E(), cluster->E() - inTrack->GetTrackPOnEMCal(), weight);
         if(inTrack->GetTrackPOnEMCal() > 0) {
-          fHistElectronPositronClusterMatchEoverP->Fill(cluster->E() / inTrack->GetTrackPOnEMCal(), inTrack->Pt(), weight);
+          fHistElectronPositronClusterMatchEoverP->Fill(cluster->E() / inTrack->GetTrackPOnEMCal(), inTrack->GetTrackPOnEMCal(), weight);
           fHistElectronPositronClusterMatchEoverPVsE->Fill(cluster->E() / inTrack->GetTrackPOnEMCal(), cluster->E(), weight);
         }
         if(inTrack->P() > 0) {
@@ -4810,6 +4836,73 @@ void AliCaloPhotonCuts::MatchElectronTracksToClusters(AliVEvent* event, AliMCEve
       }
     }
   }
+
+  for(const auto & etr : vecElectronMixing){
+    // fill all electron tracks
+    fHistElectronPositronOnEMCCellMixing->Fill(etr.momOnCalo, weight);
+    for(unsigned int icl = 0; icl < vCluster.size(); icl++){
+      AliVCluster* cluster = vCluster[icl];
+      if(!cluster){
+        continue;
+      }
+      
+      float clusPos[3]={0,0,0};
+      cluster->GetPosition(clusPos);
+      TVector3 clusterVector(clusPos[0],clusPos[1],clusPos[2]);
+      double etaCluster = clusterVector.Eta();
+      double phiCluster = clusterVector.Phi();
+      if (phiCluster < 0) phiCluster += 2*TMath::Pi();
+      float dEta = std::abs(etr.etaCalo - etaCluster); 
+      float dPhi = std::abs(etr.phiCalo - phiCluster);
+
+      
+
+      bool match_dEta = (std::abs(dEta) < fMaxDistTrackToClusterEta) ? kTRUE : kFALSE;
+      bool match_dPhi = kFALSE;
+      // Bool_t vetoEOverP = kFALSE;
+
+      if( (etr.charge > 0) && (dPhi > fMinDistTrackToClusterPhi) && (dPhi < fMaxDistTrackToClusterPhi) ) match_dPhi = kTRUE;
+      else if( (etr.charge < 0) && (dPhi < -fMinDistTrackToClusterPhi) && (dPhi > -fMaxDistTrackToClusterPhi) ) match_dPhi = kTRUE;
+
+      if(fUsePtDepTrackToCluster == 1){
+        if( std::abs(dEta) < fFuncPtDepEta->Eval(etr.pT)) match_dEta = kTRUE;
+        else match_dEta = kFALSE;
+
+        if( std::abs(dPhi) < fFuncPtDepPhi->Eval(etr.pT)) match_dPhi = kTRUE;
+        else match_dPhi = kFALSE;
+      }
+
+      // matched
+      if(match_dEta && match_dPhi){
+        fHistElectronPositronOnEMCCellMatchedMixing->Fill(etr.momOnCalo, weight);
+        fHistElectronPositronClusterMatchEoverPMixing->Fill(cluster->E() / etr.momOnCalo, etr.momOnCalo, weight);
+      } // end matched condition
+    } // end cluster loop
+  } // end track loop
+
+  // Refill the mixing vector
+  vecElectronMixing.clear();
+  //loop over all electron candidates
+  for (UInt_t itr=0;itr<vElectronTracks.size();itr++){
+    AliVTrack *inTrack = 0x0;
+    if(esdev){
+      inTrack = esdev->GetTrack(vElectronTracks[itr]);
+      if(!inTrack) continue;
+    } else if(aodev) {
+      inTrack = dynamic_cast<AliVTrack*>(aodev->GetTrack(vElectronTracks[itr]));
+      if(!inTrack) {cout<<"track not valid..."<<endl; continue;}
+    }
+    if(inTrack->GetTrackPOnEMCal() > 0){
+      // Check if the track actually hit a good cell
+      double trackPhiEMC = inTrack->GetTrackPhiOnEMCal();
+      if(trackPhiEMC < 0) trackPhiEMC += TMath::Pi()*2;
+      double trackEtaEMC = inTrack->GetTrackEtaOnEMCal();
+      if( GetCaloCellIdFromEtaPhi(trackEtaEMC, trackPhiEMC) >= 0 ) {
+        vecElectronMixing.push_back(ElectronMixing(trackPhiEMC, trackPhiEMC, inTrack->GetTrackPOnEMCal(), inTrack->Pt(), inTrack->Charge()));
+      }
+    }
+  }
+
 }
 
 //________________________________________________________________________

--- a/PWGGA/GammaConvBase/AliCaloPhotonCuts.h
+++ b/PWGGA/GammaConvBase/AliCaloPhotonCuts.h
@@ -23,6 +23,7 @@
 #include "AliAnalysisManager.h"
 #include "AliCaloTrackMatcher.h"
 #include "AliPhotonIsolation.h"
+#include "AliGammaConvEventMixing.h"
 #include <vector>
 
 class AliESDEvent;
@@ -492,6 +493,7 @@ class AliCaloPhotonCuts : public AliAnalysisCuts {
     AliEMCALGeometry* GetGeomEMCAL(){return fGeomEMCAL;}
     AliPHOSGeometry*  GetGeomPHOS() {return fGeomPHOS;}
 
+
   protected:
     TList      *fHistograms;
     TList      *fHistExtQA;
@@ -783,6 +785,11 @@ class AliCaloPhotonCuts : public AliAnalysisCuts {
     TH2F*     fHistElectronPositronClusterMatchVsEta;           // track momentum for matched electron and positron tracks vs. eta of cluster
     TH1F*     fHistElectronPositronClusterMatchDoubleCount;     // track momentum for matched electron and positron tracks if matched to multiple clusters
     TH2F*     fHistElectronClusterMatchM02;                     // track momentum for matched electron and positron tracks vs M02 of matched cluster
+    TH1F*     fHistElectronPositronOnEMCCellMixing;             // Electron/Positron P for all tracks in EMCal acceptance and that hit a good cell
+    TH1F*     fHistElectronPositronOnEMCCellMatchedMixing;      // Electron/Positron P for all tracks in EMCal acceptance and that hit a good cell and matched to a cluster
+    TH2F*     fHistElectronPositronClusterMatchEoverPMixing;    // Electron/Positron P for all tracks in EMCal acceptance and that hit a good cell and matched to a cluster vs E/p
+    std::vector<ElectronMixing> vecElectronMixing;              //! vector holding information on electron tracks for electron mixing 
+
 
     // histogram for conv candidate rejection
     TH2F*     fHistInvMassDiCluster;                    // histogram for monitoring di-cluster mass
@@ -794,7 +801,7 @@ class AliCaloPhotonCuts : public AliAnalysisCuts {
 
   private:
 
-    ClassDef(AliCaloPhotonCuts,142)
+    ClassDef(AliCaloPhotonCuts,143)
 };
 
 #endif

--- a/PWGGA/GammaConvBase/AliGammaConvEventMixing.h
+++ b/PWGGA/GammaConvBase/AliGammaConvEventMixing.h
@@ -164,4 +164,17 @@ class EventMixPoolMesonJets
 
 };
 
+struct ElectronMixing{
+  ElectronMixing(double eta, double phi, double p, double pt, short ch) : etaCalo(eta), phiCalo(phi), momOnCalo(p), pT(pt), charge(ch)
+  {
+  
+  }
+  ElectronMixing() : etaCalo(0.), phiCalo(0.), momOnCalo(0.), pT(0.), charge(0)
+  {
+
+  }
+  double etaCalo, phiCalo, momOnCalo, pT;
+  short charge;
+};
+
 #endif


### PR DESCRIPTION
- Add M02 dependent histograms for detailed studies on the M02 cut
- Add electron mixing to estimate the background (fake matches) in data and MC