### PR TITLE
PWGGA/GammaConv: fix a pt weights related bug that I introduced with my latest commit.

### DIFF
--- a/PWGGA/GammaConv/macros/AddTask_GammaConvV1_PbPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvV1_PbPb.C
@@ -4366,18 +4366,10 @@ void AddTask_GammaConvV1_PbPb(
         fitNameEtaPT = Form("Eta_Data_5TeV_%s", eventCutShort.Data());
       }
       analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(
-          HeaderList->FindObject("Injector (pi0)") 
-            ? intPtWeightsCalculationMethod /*pi0reweight*/
-            : 0,
-          HeaderList->FindObject("Injector (eta)") 
-            ? intPtWeightsCalculationMethod /*etareweight*/
-            : 0,
-          HeaderList->FindObject("Injector (K0s)") 
-            ? intPtWeightsCalculationMethod /*k0sreweight*/
-            : 0,
-          fileNamePtWeights,
-          histoNameMCPi0PT, histoNameMCEtaPT, histoNameMCK0sPT,
-          fitNamePi0PT, fitNameEtaPT, fitNameK0sPT);
+        intPtWeightsCalculationMethod, intPtWeightsCalculationMethod, intPtWeightsCalculationMethod, 
+        fileNamePtWeights, 
+        histoNameMCPi0PT, histoNameMCEtaPT, histoNameMCK0sPT, 
+        fitNamePi0PT, fitNameEtaPT, fitNameK0sPT);
       analysisEventCuts[i]->SetUseGetWeightForMesonNew(theUseGetMesonWeightNew);    
     }
 


### PR DESCRIPTION
 The effect of the bug was, that for the MBMC productions for LHCh15o and LHC18qr pt weighting could not be enabled because for these MCs we don't explicitly name the accepted particle headers (since we take all particles)