### PR TITLE
PWGGA/GammaConv: CalibTask: Add histograms for cluster width studies

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskConvCaloCalibration.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskConvCaloCalibration.h
@@ -209,6 +209,8 @@ protected:
   TH1F***                 fHistoClusHighPtTrackdPhiSM;                        //! array of histos with dPhi between track (above 5GeV) and cluster
   TH2F**                  fHistoEVsM02;                                       //! array of histos with cluster E vs M02
   TH2F**                  fHistoEVsM02NCell4;                                 //! array of histos with cluster E vs M02 for NCell > 4
+  TH2F**                  fHistoClusterLeadingFractionVsEClus;                //! array of histos with cluster E vs fraction of leading cell in the cluster to total energy of the cluster
+  TH2F**                  fHistoClusterSigmaVsEClus;                          //! array of histos with cluster E vs sigma of the cluster (similar to M02 but accounting for both axes)
   TH1F**                  fHistoMotherInvMassRejected;                        //! array of histos with invariant mass pairs which were rejected
   TH1F**                  fHistoNEvents;                                      //! array of histos with event information
   TH1F**                  fHistoNEventsWOWeight;                              //! array of histos with event information without event weights
@@ -272,7 +274,7 @@ private:
   AliAnalysisTaskConvCaloCalibration(const AliAnalysisTaskConvCaloCalibration&); // Prevent copy-construction
   AliAnalysisTaskConvCaloCalibration &operator=(const AliAnalysisTaskConvCaloCalibration&); // Prevent assignment
 
-  ClassDef(AliAnalysisTaskConvCaloCalibration, 12);
+  ClassDef(AliAnalysisTaskConvCaloCalibration, 13);
 };
 
 #endif // AliAnalysisTaskConvCaloCalibration_H


### PR DESCRIPTION
- Width of the cluster might affect the rec. efficiency for clusters
- If clusters are wider, the seed threshold is not as easily reached as for narrower cluster
- To compare data and MC, two histograms are implemented: Fractional energy of leading cell of the cluster to the whole cluster, and the width of the cluster (standard deviation)