### PR TITLE
Improve AliFJWrapper/Add Functionality To SoftDropUtility/Add to analysis task

### DIFF
--- a/PWGJE/EMCALJetTasks/AliEmcalJetUtilitySoftDrop.h
+++ b/PWGJE/EMCALJetTasks/AliEmcalJetUtilitySoftDrop.h
@@ -34,6 +34,9 @@ class AliEmcalJetUtilitySoftDrop : public AliEmcalJetUtility
   void Prepare(AliFJWrapper& fjw);
   void ProcessJet(AliEmcalJet* jet, Int_t ij, AliFJWrapper& fjw);
   void Terminate(AliFJWrapper& fjw);
+  void SetZCut(Double_t zCut) {fZCut = zCut;}
+  void SetBeta(Double_t beta) {fBeta = beta;}
+  void SetRecursiveDepth(Int_t n) {fRecursiveDepth = n;}
 
  protected:
 
@@ -44,6 +47,10 @@ class AliEmcalJetUtilitySoftDrop : public AliEmcalJetUtility
   TString                fRhomName;                           ///< name of rhom
   Double_t               fRho;                                ///< pT background density
   Double_t               fRhom;                               ///< mT background density
+    // condition to stop the grooming (rejection of soft splitting) z > fZCut theta^fBeta
+  Double_t               fZCut;                              //< fZCut = 0.1                
+  Double_t               fBeta;                              //< fBeta = 0
+  Int_t                  fRecursiveDepth;                    //< 0: No Soft Drop; 1: Apply once; -1: Apply until the condition stops the grooming
 
   TClonesArray          *fGroomedJets;                        //!<! groomed jet collection
   TClonesArray          *fGroomedJetParticles;                       //!<! groomed particle collection

--- a/PWGJE/EMCALJetTasks/AliEmcalJetUtilitySoftDrop.h
+++ b/PWGJE/EMCALJetTasks/AliEmcalJetUtilitySoftDrop.h
@@ -57,6 +57,6 @@ class AliEmcalJetUtilitySoftDrop : public AliEmcalJetUtility
   AliRhoParameter       *fRhoParam;                           //!<! event rho
   AliRhoParameter       *fRhomParam;                          //!<! event rhom
 
-  ClassDef(AliEmcalJetUtilitySoftDrop, 1) // Emcal jet utility that implements the constituent subtractor form the fastjet contrib
+  ClassDef(AliEmcalJetUtilitySoftDrop, 2) // Emcal jet utility that implements the constituent subtractor form the fastjet contrib
 };
 #endif

--- a/PWGJE/EMCALJetTasks/AliFJWrapper.h
+++ b/PWGJE/EMCALJetTasks/AliFJWrapper.h
@@ -401,6 +401,7 @@ void AliFJWrapper::CopySettingsFrom(const AliFJWrapper& wrapper)
   fUseArea4Vector   = wrapper.fUseArea4Vector;
   fZcut             = wrapper.fZcut;
   fBeta             = wrapper.fBeta;
+  fRecursiveDepth   = wrapper.fRecursiveDepth;
   fLegacyMode       = wrapper.fLegacyMode;
   fUseExternalBkg   = wrapper.fUseExternalBkg;
   fRho              = wrapper.fRho;

--- a/PWGJE/EMCALJetTasks/AliFJWrapper.h
+++ b/PWGJE/EMCALJetTasks/AliFJWrapper.h
@@ -143,7 +143,9 @@ class AliFJWrapper
   void SetEventSub(Bool_t b) {fEventSub = b;}
   void SetMaxDelR(Double_t r)  {fMaxDelR = r;}
   void SetAlpha(Double_t a)  {fAlpha = a;}
-
+  void SetRecursiveDepth(Int_t n) {fRecursiveDepth = n;}
+  void SetZCut(Double_t zCut) {fZcut = zCut;}
+  void SetBeta(Double_t beta) {fBeta = beta;}
 
  protected:
   TString                                fName;               //!
@@ -192,6 +194,7 @@ class AliFJWrapper
   // condition to stop the grooming (rejection of soft splitting) z > fZcut theta^fBeta
   Double_t                               fZcut;               // fZcut = 0.1                
   Double_t                               fBeta;               // fBeta = 0
+  Int_t                                  fRecursiveDepth;
   Bool_t                                 fEventSub;
   Double_t                               fMaxDelR;
   Double_t                               fAlpha;
@@ -201,7 +204,7 @@ class AliFJWrapper
   fastjet::contrib::GenericSubtractor     *fGenSubtractor;    //!
   fastjet::contrib::ConstituentSubtractor *fConstituentSubtractor;    //!
   fastjet::contrib::ConstituentSubtractor *fEventConstituentSubtractor;    //!
-  fastjet::contrib::SoftDrop              *fSoftDrop;        //!
+  fastjet::contrib::RecursiveSoftDrop              *fSoftDrop;        //!
   std::vector<fastjet::contrib::GenericSubtractorInfo> fGenSubtractorInfoJetMass;        //!
   std::vector<fastjet::contrib::GenericSubtractorInfo> fGenSubtractorInfoGRNum;          //!
   std::vector<fastjet::contrib::GenericSubtractorInfo> fGenSubtractorInfoGRDen;          //!
@@ -298,6 +301,7 @@ AliFJWrapper::AliFJWrapper(const char *name, const char *title)
   , fUseArea4Vector    (kFALSE)
   , fZcut(0.1)
   , fBeta(0)
+  , fRecursiveDepth(1)
   , fEventSub          (kFALSE)
   , fMaxDelR           (-1)
   , fAlpha             (0)
@@ -1280,6 +1284,7 @@ Int_t AliFJWrapper::DoSoftDrop() {
   //fSoftDrop->set_input_jet_is_subtracted(false); //??
   
   for (unsigned i = 0; i < fInclusiveJets.size(); i++) {
+    fInclusiveJets[i].set_user_index(i);
     fj::PseudoJet groomed_jet(0.,0.,0.,0.);
     if(fInclusiveJets[i].perp()>0.){
       groomed_jet = (*fSoftDrop)(fInclusiveJets[i]);
@@ -1300,7 +1305,7 @@ Int_t AliFJWrapper::CreateSoftDrop() {
   #ifdef FASTJET_VERSION
   if (fSoftDrop) { delete fSoftDrop; } // protect against memory leaks
   
-  fSoftDrop   = new fj::contrib::SoftDrop(fBeta,fZcut);
+  fSoftDrop   = new fj::contrib::RecursiveSoftDrop(fBeta,fZcut,fRecursiveDepth);
   fSoftDrop->set_verbose_structure(kTRUE);
   
   #endif

--- a/PWGJE/EMCALJetTasks/AliFJWrapper.h
+++ b/PWGJE/EMCALJetTasks/AliFJWrapper.h
@@ -143,9 +143,9 @@ class AliFJWrapper
   void SetEventSub(Bool_t b) {fEventSub = b;}
   void SetMaxDelR(Double_t r)  {fMaxDelR = r;}
   void SetAlpha(Double_t a)  {fAlpha = a;}
-  void SetRecursiveDepth(Int_t n) {fRecursiveDepth = n;}
   void SetZCut(Double_t zCut) {fZcut = zCut;}
   void SetBeta(Double_t beta) {fBeta = beta;}
+  void SetRecursiveDepth(Int_t n) {fRecursiveDepth = n;}
 
  protected:
   TString                                fName;               //!
@@ -299,9 +299,9 @@ AliFJWrapper::AliFJWrapper(const char *name, const char *title)
   , fPluginAlgor       (0)
   , fMedUsedForBgSub   (0)
   , fUseArea4Vector    (kFALSE)
-  , fZcut(0.1)
-  , fBeta(0)
-  , fRecursiveDepth(1)
+  , fZcut              (0.1)
+  , fBeta              (0)
+  , fRecursiveDepth    (1)
   , fEventSub          (kFALSE)
   , fMaxDelR           (-1)
   , fAlpha             (0)

--- a/PWGJE/EMCALJetTasks/FJ_includes.h
+++ b/PWGJE/EMCALJetTasks/FJ_includes.h
@@ -29,6 +29,7 @@
 #include <fastjet/contrib/Njettiness.hh>
 #include <fastjet/contrib/NjettinessPlugin.hh>
 #include <fastjet/contrib/SoftDrop.hh>
+#include <fastjet/contrib/RecursiveSoftDrop.hh>
 #endif
 #endif
 

--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskIDFragmentationFunction.cxx
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskIDFragmentationFunction.cxx
@@ -1599,7 +1599,6 @@ Bool_t AliAnalysisTaskIDFragmentationFunction::FillHistograms()
         break;         
     }
   }
-  return kTRUE;
 
   AliDebugStream(2) << "Process Underlying event..." << std::endl;
   if (fUseJetUEPIDtask && jetContainer && !isPileUpForAllJetUEPIDTasks && !fUseFastSimulations) {

--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskIDFragmentationFunction.cxx
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskIDFragmentationFunction.cxx
@@ -48,6 +48,7 @@
 #include "AliGenHijingEventHeader.h"
 #include "AliInputEventHandler.h"
 #include "AliJetContainer.h"
+#include "AliEmcalJetTask.h"
 
 #include "AliAnalysisHelperJetTasks.h"
 #include "AliAnalysisManager.h"
@@ -146,9 +147,6 @@ AliAnalysisTaskIDFragmentationFunction::AliAnalysisTaskIDFragmentationFunction()
    ,fUseJetUEPIDtask(kFALSE)
    ,fIsPP(kFALSE)
    ,fFillDCA(kFALSE)
-   ,fDoGroomedJets(kFALSE)
-   ,fBetaSoftDrop(0.0)
-   ,fZSoftDrop(0.1)
    ,fUseFastSimulations(kFALSE)
    ,fastSimulationParameters("")
    ,fEffFunctions(0x0)
@@ -244,9 +242,6 @@ AliAnalysisTaskIDFragmentationFunction::AliAnalysisTaskIDFragmentationFunction(c
   ,fUseJetUEPIDtask(kFALSE)
   ,fIsPP(kFALSE)
   ,fFillDCA(kFALSE)
-  ,fDoGroomedJets(kFALSE)
-  ,fBetaSoftDrop(0.0)
-  ,fZSoftDrop(0.1)
   ,fUseFastSimulations(kFALSE) 
   ,fastSimulationParameters("")
   ,fEffFunctions(0x0)
@@ -1544,57 +1539,17 @@ Bool_t AliAnalysisTaskIDFragmentationFunction::FillHistograms()
   }
 
   AliJetContainer* jetContainer = GetJetContainer(GetNameJetContainer());
-  
-  if (GetDoGroomedJets() && trackContainer) {
-    AliFJWrapper* wrapper = new AliFJWrapper("wrapper","wrapper");
-    SetUpFastJetWrapperWithOriginalValues(wrapper);    
-    AliTrackIterableMomentumContainer itcont = trackContainer->accepted_momentum();
-    for (AliTrackIterableMomentumContainer::iterator it = itcont.begin(); it != itcont.end(); it++) {
-      TLorentzVector pvec(it->first.Px(), it->first.Py(), it->first.Pz(), it->first.E());
-      wrapper->AddInputVector(pvec.Px(), pvec.Py(), pvec.Pz(), pvec.E(), it.current_index());
-    }
-    wrapper->Run();
-    wrapper->DoSoftDrop();
-    std::vector<fastjet::PseudoJet> jets = wrapper->GetInclusiveJets();
-    std::vector<fastjet::PseudoJet> groomedJets = wrapper->GetGroomedJets();
-    for (UInt_t j=0;j<jets.size();++j) {
-      if (jets[j].perp() < 5.0 || TMath::Abs(jets[j].eta()) > 0.5)
-        continue;
-      else {
-        fh1nRecJetsCuts->Fill(jets[j].perp());
-      }
-    }
-    for (UInt_t j=0;j<groomedJets.size();++j) {
-      if (groomedJets[j].perp() < 5.0 || TMath::Abs(groomedJets[j].eta()) > 0.5)
-        continue;
-      else {
-        fh1nRecJetsCutsGroomed->Fill(groomedJets[j].perp());
-//         std::vector<fastjet::PseudoJet> constituents = groomedJets[j].constituents();
-//         cout << "Groomed Jet: " << jets[j].perp() << " " << constituents.size() << endl;
-/*        for (Int_t i=0;i<constituents.size();++i) {
-          Int_t uid = constituents[i].user_index();
-          if (uid == -1)    //Ghost particle
-            continue;
-          cout << uid << endl;
-        }  */      
-      }
-    }    
-  }
-  
-  
+
   if (jetContainer && !fUseFastSimulations) { 
     if (fOnlyLeadingJets)
       jetContainer->SortArray();
     for (auto jet : jetContainer->accepted()) {
-      if (!jet)
-        continue;
-      
       Float_t jetPt   = jet->Pt();
       
       if (jetContainer->GetRhoParameter())
         jetPt = jetPt - jetContainer->GetRhoVal() * jet->Area();
       
-//       fh1nRecJetsCuts->Fill(jetPt);
+      fh1nRecJetsCuts->Fill(jetPt);
       
       fh1TotJetEnergy->Fill(0.5,jetPt);
       
@@ -1609,7 +1564,7 @@ Bool_t AliAnalysisTaskIDFragmentationFunction::FillHistograms()
         if (!isPileUpJetPIDtask[i])
           fJetPIDtask[i]->FillRecJets(centPercent, jetPt);
       }
-      
+
       for(Int_t j=0; j<jet->GetNumberOfTracks(); ++j) {
         AliVTrack *track  = dynamic_cast<AliVTrack*>(jet->Track(j));
         if (!track)
@@ -1644,7 +1599,8 @@ Bool_t AliAnalysisTaskIDFragmentationFunction::FillHistograms()
         break;         
     }
   }
-  
+  return kTRUE;
+
   AliDebugStream(2) << "Process Underlying event..." << std::endl;
   if (fUseJetUEPIDtask && jetContainer && !isPileUpForAllJetUEPIDTasks && !fUseFastSimulations) {
     for (Int_t i=0;i<fNumJetUEPIDtasks;++i) {
@@ -2404,14 +2360,19 @@ void AliAnalysisTaskIDFragmentationFunction::FillDCA(AliVTrack* track, AliMCPart
 }
 
 void AliAnalysisTaskIDFragmentationFunction::SetUpFastJetWrapperWithOriginalValues(AliFJWrapper* wrapper) {
+  AliJetContainer* jetContainer = GetJetContainer(GetNameJetContainer());
+
   wrapper->SetAreaType(fastjet::active_area_explicit_ghosts);
   wrapper->SetGhostArea(0.005);
   wrapper->SetR(TMath::Abs(GetFFRadius()));
   //Currently not working, including AliEmcalJetTask fails
-  //wrapper->SetAlgorithm(AliEmcalJetTask::ConvertToFJAlgo(jetContainer->GetJetAlgorithm()));
-  //wrapper->SetRecombScheme(AliEmcalJetTask::ConvertToFJRecoScheme(jetContainer->GetRecombinationScheme()));
-  wrapper->SetAlgorithm(fastjet::antikt_algorithm);
-  wrapper->SetRecombScheme(fastjet::pt_scheme);
+  if (jetContainer) {
+    wrapper->SetAlgorithm(AliEmcalJetTask::ConvertToFJAlgo(jetContainer->GetJetAlgorithm()));
+    wrapper->SetRecombScheme(AliEmcalJetTask::ConvertToFJRecoScheme(jetContainer->GetRecombinationScheme())); 
+  } else {
+    wrapper->SetAlgorithm(fastjet::antikt_algorithm);
+    wrapper->SetRecombScheme(fastjet::pt_scheme);
+  }
   wrapper->SetMaxRap(1);    
 }
 

--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskIDFragmentationFunction.h
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskIDFragmentationFunction.h
@@ -291,10 +291,6 @@ public:
   Bool_t fIsPP;                             // Is pp collision system? -> If yes, centrality will be set to -1
   
   Bool_t fFillDCA;                          //Shall the DCA histograms be filled?
-
-  // Changed jets analysis
-  Double_t fBetaSoftDrop;
-  Double_t fZSoftDrop;
   
   // Fast simulation parameters
   Bool_t fUseFastSimulations;

--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskIDFragmentationFunction.h
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskIDFragmentationFunction.h
@@ -310,7 +310,7 @@ private:
   AliAnalysisTaskIDFragmentationFunction(const  AliAnalysisTaskIDFragmentationFunction&);   //Not implemented in AliAnalysisTaskEmcalJet
   AliAnalysisTaskIDFragmentationFunction& operator=(const  AliAnalysisTaskIDFragmentationFunction);   //Not implemented AliAnalysisTaskEmcalJet
   
-  ClassDef(AliAnalysisTaskIDFragmentationFunction, 26);
+  ClassDef(AliAnalysisTaskIDFragmentationFunction, 27);
 };
 
 

--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskIDFragmentationFunction.h
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskIDFragmentationFunction.h
@@ -86,15 +86,6 @@ public:
   virtual Bool_t GetFillDCA() const { return fFillDCA; }
   virtual void SetFillDCA(Bool_t flag) { fFillDCA = flag; }  
   
-  virtual Bool_t GetDoGroomedJets() const { return fDoGroomedJets; }
-  virtual void SetDoGroomedJets(Bool_t flag) { fDoGroomedJets = flag; } 
-  
-  virtual Double_t GetBetaSoftDrop() const { return fBetaSoftDrop; }   // Does not influence the analysis, since this is hardcoded in AliFJWrapper
-  virtual void SetBetaSoftDrop(Double_t value) { fBetaSoftDrop = value; }
-  
-  virtual Double_t GetZSoftDrop() const { return fZSoftDrop; }    // Does not influence the analysis, since this is hardcoded in AliFJWrapper
-  virtual void SetZSoftDrop(Double_t value) { fZSoftDrop = value; }  
-  
   virtual Bool_t GetUseFastSimulations() const { return fUseFastSimulations; }
   virtual void SetUseFastSimulations(Bool_t value) { fUseFastSimulations = value; } 
   
@@ -302,7 +293,6 @@ public:
   Bool_t fFillDCA;                          //Shall the DCA histograms be filled?
 
   // Changed jets analysis
-  Bool_t fDoGroomedJets;                    //! Use groomed jets
   Double_t fBetaSoftDrop;
   Double_t fZSoftDrop;
   

--- a/PWGJE/macros/AddTaskIDFragmentationFunction.C
+++ b/PWGJE/macros/AddTaskIDFragmentationFunction.C
@@ -216,14 +216,16 @@ AliAnalysisTaskIDFragmentationFunction *AddTaskIDFragmentationFunction(
 		if (groomingParameters != "") {
 			TObjArray* groomingParametersArray = groomingParameters.Tokenize(";");
 			if (groomingParametersArray->GetEntriesFast() != 3) {
-				AliError("Wrong parameter count for grooming parameters");
+				::Error("AddTaskIDFragmentationFunction", "Wrong parameter count for grooming parameters");
 				return NULL;
 			}
-			Double_t zCut = ((TObjString*)(groomingParametersArray->At(0)))->GetString().Atof();
-			Double_t beta = ((TObjString*)(groomingParametersArray->At(1)))->GetString().Atof();
-			Int_t recursiveDepth = ((TObjString*)(groomingParametersArray->At(1)))->GetString().Atoi();
-
-			AliInfo("Use Grooming with zCut = %f, beta = %f and recursive depth of %d", zCut, beta, recursiveDepth);
+		                  
+			Double_t zCut = ((TObjString*)(groomingParametersArray->At(0)))->GetString().Atof(); // fZCut = 0.1  standard
+			Double_t beta = ((TObjString*)(groomingParametersArray->At(1)))->GetString().Atof(); // fBeta = 0 standard
+			// 0: No Soft Drop; 1: Apply once; -1: Apply until the condition stops the grooming
+			Int_t recursiveDepth = ((TObjString*)(groomingParametersArray->At(2)))->GetString().Atoi(); 
+			
+			Printf("Use Grooming with zCut = %f, beta = %f and recursive depth of %d", zCut, beta, recursiveDepth);
 
 			softDropUtility = new AliEmcalJetUtilitySoftDrop("MTFPID");
 			softDropUtility->SetGroomedJetsName("GroomedJets");
@@ -362,6 +364,7 @@ AliAnalysisTaskIDFragmentationFunction *AddTaskIDFragmentationFunction(
 	}
 	 
 	 AliJetContainer** jetContainer = new AliJetContainer*[nJetContainer];
+	 TString* jetContainerNames = new TString[nJetContainer];
 	
 	if (useJets) {
 		for (Int_t i=0;i<nJetContainer;++i) {


### PR DESCRIPTION
Replace SoftDrop in AliFJWrapper with RecursiveSoftDrop, standard value for recursive depth is N=1 which corresponds to standard soft drop. Add settings for recursive depth, zCut and beta in the soft drop functionality

Recursive Soft Drop with N=1 corresponds to standard soft drop: https://phab.hepforge.org/source/fastjetsvn/browse/contrib/contribs/RecursiveTools/trunk/README