### PR TITLE
PWGGA/GammaConv: Add option to apply prefilter (for eta meson)

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.h
@@ -64,6 +64,7 @@ class AliAnalysisTaskGammaCalo : public AliAnalysisTaskSE {
     void ProcessTrueMesonCandidates( AliAODConversionMother *Pi0Candidate, AliAODConversionPhoton *TrueGammaCandidate0, AliAODConversionPhoton *TrueGammaCandidate1);
     void ProcessTrueMesonCandidatesAOD(AliAODConversionMother *Pi0Candidate, AliAODConversionPhoton *TrueGammaCandidate0, AliAODConversionPhoton *TrueGammaCandidate1);
     void ProcessAODSphericityParticles();
+    void ApplyPrefilterForClusters();
 
     // switches for additional analysis streams or outputs
     void SetLightOutput(Int_t flag){fDoLightOutput = flag;}
@@ -180,6 +181,7 @@ class AliAnalysisTaskGammaCalo : public AliAnalysisTaskSE {
     Int_t*                fDDLRange_HistoClusGamma;                             //! Min and Max Value for Modules in PHOS for fHistoClusGamma E and Pt
     AliCaloTriggerMimicHelper**     fCaloTriggerMimicHelper;                    //!Array wich points to AliCaloTriggerMimicHelper for each Event Cut
     map<TString, Bool_t>  fSetEventCutsOutputlist;                              //! Store, if Output list for Event Cut has already been added
+    bool                  fDoApplyPrefilter;                                    //! Switch to apply prefilter or not
 
     //histograms for mesons reconstructed quantities
     TH2F**                fHistoMotherInvMassPt;                                //! array of histogram with signal + BG for same event photon pairs, inv Mass, pt
@@ -534,7 +536,7 @@ class AliAnalysisTaskGammaCalo : public AliAnalysisTaskSE {
     AliAnalysisTaskGammaCalo(const AliAnalysisTaskGammaCalo&);                  // Prevent copy-construction
     AliAnalysisTaskGammaCalo &operator=(const AliAnalysisTaskGammaCalo&);       // Prevent assignment
 
-    ClassDef(AliAnalysisTaskGammaCalo, 97);
+    ClassDef(AliAnalysisTaskGammaCalo, 98);
 };
 
 #endif

--- a/PWGGA/GammaConv/macros/AddTask_GammaCalo_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaCalo_pp.C
@@ -4824,6 +4824,11 @@ void AddTask_GammaCalo_pp(
     cuts.AddCutCalo("00010113","411799909fegr9v0000","0s631031000000d0"); // min E = 300 MeV, NCell >= 2 with effi r
     cuts.AddCutCalo("00010113","411799909fegm9v0000","0s631031000000d0"); // min E = 300 MeV, NCell >= 2 with effi m
     cuts.AddCutCalo("00010113","411799909fegl9v0000","0s631031000000d0"); // min E = 300 MeV, NCell >= 2 with effi l
+  
+  // eta prefilter
+  } else if (trainConfig == 3310){  
+    cuts.AddCutCalo("00010113","411799909feg09v0000","0s63103u000000d0"); // min E = 300 MeV, NCell = 0, prefilter 0-160 MeV
+    cuts.AddCutCalo("00010113","411799909feg09v0000","0s63103v000000d0"); // min E = 300 MeV, NCell = 0, prefilter 100-160 MeV
 
   //////////////////////    Mult slices  PHOS pp 13 TeV   //////////////////////////////////
 // INT7 trigger	V0M high mult	EG2	EG1	SPD high mult

--- a/PWGGA/GammaConvBase/AliConversionMesonCuts.cxx
+++ b/PWGGA/GammaConvBase/AliConversionMesonCuts.cxx
@@ -192,7 +192,8 @@ AliConversionMesonCuts::AliConversionMesonCuts(const char *name,const char *titl
   fNDaughterEnergyCut(0),
   fSingleDaughterMinE(0.),
   fInLeadTrackDir(0),
-  fLeadTrackMinPt(4.)
+  fLeadTrackMinPt(4.),
+  fDoApplyPrefilter(false)
 {
   for(Int_t jj=0;jj<kNCuts;jj++){fCuts[jj]=0;}
   fCutString=new TObjString((GetCutNumber()).Data());
@@ -324,7 +325,8 @@ AliConversionMesonCuts::AliConversionMesonCuts(const AliConversionMesonCuts &ref
   fNDaughterEnergyCut(0),
   fSingleDaughterMinE(0.),
   fInLeadTrackDir(ref.fInLeadTrackDir),
-  fLeadTrackMinPt(ref.fLeadTrackMinPt)
+  fLeadTrackMinPt(ref.fLeadTrackMinPt),
+  fDoApplyPrefilter(false)
 
 {
   // Copy Constructor
@@ -2492,7 +2494,16 @@ Bool_t AliConversionMesonCuts::SetSelectionWindowCut(Int_t selectionCut){
       fSelectionHigh      = 0.145;
       fAcceptMesonMass    = kTRUE;
       fUseGammaSelection  = kTRUE;
-
+      break;
+    case 30: // u EMC-EMC prefilter
+      fDoApplyPrefilter   = true;
+      fSelectionLow       = 0.;
+      fSelectionHigh      = 0.16;
+      break;
+    case 31: // v EMC-EMC prefilter
+      fDoApplyPrefilter   = true;
+      fSelectionLow       = 0.1;
+      fSelectionHigh      = 0.16;
       break;
     default:
       cout<<"Warning: SelectionCut not defined "<<selectionCut<<endl;

--- a/PWGGA/GammaConvBase/AliConversionMesonCuts.h
+++ b/PWGGA/GammaConvBase/AliConversionMesonCuts.h
@@ -247,6 +247,7 @@ class AliConversionMesonCuts : public AliAnalysisCuts {
     Bool_t   MesonLeadTrackSelectionAODMC(AliVEvent* curEvent, AliAODMCParticle* curmeson);
     Bool_t   MesonLeadTrackSelection(AliVEvent* curEvent, AliAODConversionMother* curmeson);
     Bool_t   MesonLeadTrackSelectionBase(AliVEvent* curEvent, TVector3 curmeson);
+    bool     GetDoApplyPrefilter() const {return fDoApplyPrefilter;}
 
     // Jet specific function
     Bool_t  IsParticleInJet(std::vector<Double_t> vectorJetEta, std::vector<Double_t> vectorJetPhi, Double_t JetRadius, Double_t partEta, Double_t partPhi, Int_t &matchedJet, Double_t &RJetPi0Cand);
@@ -378,6 +379,8 @@ class AliConversionMesonCuts : public AliAnalysisCuts {
     Float_t     fSingleDaughterMinE;            ///< if above is enabled, at least fNDaughterEnergyCut daughter contributing to neutral meson needs to fulfill fMinSingleDaughterE
     Int_t       fInLeadTrackDir;                ///< switch to Analyse mesons (not) in direction of highest pT track
     Double_t    fLeadTrackMinPt;                ///< min pT for leading track
+
+    bool        fDoApplyPrefilter;              ///< set to true in case the selection window with this option enabled is chosen. This cuts away all gamma pairs with a mass in the specified window
 
   private:
 


### PR DESCRIPTION
- Cut away cluster pairs that have a mass in the pi0 mass region.
- This should allow to reduce the background in the eta measurement
- Can be activated in the MesonCuts with 2 new cuts added