### PR TITLE
PWGGA/GammaConv: fix for var. ptW in AddTask_GammaConvV1_PbPb.C

### DIFF
--- a/PWGGA/GammaConv/macros/AddTask_GammaConvV1_PbPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvV1_PbPb.C
@@ -4508,7 +4508,7 @@ void AddTask_GammaConvV1_PbPb(
         fitNameEtaPT = Form("Eta_Data_5TeV_%s", eventCutShort.Data());
       }
       analysisEventCuts[i]->SetUseReweightingWithHistogramFromFile(
-        intPtWeightsCalculationMethod, intPtWeightsCalculationMethod, intPtWeightsCalculationMethod, 
+        intPtWeightsCalculationMethod, intPtWeightsCalculationMethod, kFALSE, 
         fileNamePtWeights, 
         histoNameMCPi0PT, histoNameMCEtaPT, histoNameMCK0sPT, 
         fitNamePi0PT, fitNameEtaPT, fitNameK0sPT);


### PR DESCRIPTION
small fix. The issue was that even when the new pt weights method (= pt variantly calculated pt weights) was specified, the old was method was used.