### PR TITLE
PWGJE/EMCAL: Fix cluster efficiency application in jet task

### DIFF
--- a/PWGJE/EMCALJetTasks/AliEmcalJetTask.cxx
+++ b/PWGJE/EMCALJetTasks/AliEmcalJetTask.cxx
@@ -354,7 +354,7 @@ Int_t AliEmcalJetTask::FindJets()
         }
         if(clusterEff < 1.) {
           Double_t rnd = fRandom.Rndm();
-          if (fClusterEfficiency < rnd) {
+          if (clusterEff < rnd) {
             AliDebug(2,Form("Cluster %d rejected due to artificial tracking inefficiency", it.current_index()));
             continue;
           } 


### PR DESCRIPTION
- Dcerease cluster efficiency by rejecting clusters according to a predefined function
- The random value was compared to the wrong variable. This is now fixed