### PR TITLE
[RUN3, PWGGA] Fix circle dependency

### DIFF
--- a/PWGCF/FEMTOSCOPY/FemtoDream/CMakeLists.txt
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/CMakeLists.txt
@@ -20,6 +20,7 @@ add_definitions(-D_MODULE_="${MODULE}")
 # Module include folder
 include_directories(${AliPhysics_SOURCE_DIR}/PWGCF/FEMTOSCOPY/FemtoDream
                     ${AliPhysics_SOURCE_DIR}/PWGGA/GammaConvBase
+                    ${AliPhysics_SOURCE_DIR}/PWGGA/Common
                     ${AliPhysics_SOURCE_DIR}/PWG/DevNanoAOD)
 
 # Additional includes - alphabetical order except ROOT

--- a/PWGGA/CMakeLists.txt
+++ b/PWGGA/CMakeLists.txt
@@ -14,6 +14,7 @@
 # **************************************************************************
 
 add_subdirectory(CaloTrackCorrelations)
+add_subdirectory(Common)
 add_subdirectory(EMCALTasks)
 add_subdirectory(GammaConv)
 add_subdirectory(GammaConvBase)

--- a/PWGGA/Common/AliAODRelabelInterface.cxx
+++ b/PWGGA/Common/AliAODRelabelInterface.cxx
@@ -1,0 +1,2 @@
+#include "AliAODRelabelInterface.h"
+// Empty file to ensure CMake generates the library.

--- a/PWGGA/Common/AliAODRelabelInterface.h
+++ b/PWGGA/Common/AliAODRelabelInterface.h
@@ -1,0 +1,19 @@
+#ifndef ALIAODRELABELINTERFACE_H
+#define ALIAODRELABELINTERFACE_H
+
+#include "AliAnalysisTaskSE.h"
+
+// Interface for AOD relabeling that can happen in the V0Reader and RUN3/AliAnalysisTaskAO2Dconverter
+class AliAODRelabelInterface : public AliAnalysisTaskSE {
+public:
+  AliAODRelabelInterface(const char* name) : AliAnalysisTaskSE(name) {}
+  virtual ~AliAODRelabelInterface() = default;
+
+  // Pure virtual functions for required methods
+  virtual bool AreAODsRelabeled() const = 0;
+  virtual int IsReaderPerformingRelabeling() const = 0;
+
+  ClassDef(AliAODRelabelInterface, 1);
+};
+
+#endif // ALIAODRELABELINTERFACE_H

--- a/PWGGA/Common/CMakeLists.txt
+++ b/PWGGA/Common/CMakeLists.txt
@@ -14,61 +14,58 @@
 # **************************************************************************
 
 # Module
-set(MODULE RUN3)
+set(MODULE PWGGACommon)
 add_definitions(-D_MODULE_="${MODULE}")
 
 # Module include folder
-include_directories(${AliPhysics_SOURCE_DIR}/RUN3
-                    ${AliPhysics_SOURCE_DIR}/OADB
-                    ${AliPhysics_SOURCE_DIR}/PWGGA/Common
-                    ${AliPhysics_SOURCE_DIR}/PWGGA/GammaConvBase
-)
-
-# Additional include folders in alphabetical order except ROOT
-include_directories(${ROOT_INCLUDE_DIRS})
+include_directories(${AliPhysics_SOURCE_DIR}/PWGGA/Common)
 
 # Sources in alphabetical order
-set(SRCS AliAnalysisTaskAO2Dconverter.cxx benchmark/AliAnalysisTaskHistogram.cxx)
+set(SRCS
+    AliAODRelabelInterface.cxx
+   )
 
 # Headers from sources
 string(REPLACE ".cxx" ".h" HDRS "${SRCS}")
-
+set(HDRS ${HDRS})
 # Generate the dictionary
 # It will create G_ARG1.cxx and G_ARG1.h / ARG1 = function first argument
 get_directory_property(incdirs INCLUDE_DIRECTORIES)
 generate_dictionary("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
 
-set(ROOT_DEPENDENCIES Core EG Gpad Hist MathCore Physics RIO Spectrum)
-set(ALIROOT_DEPENDENCIES ANALYSIS ESD OADB STEERBase ANALYSISalice STEER EMCALUtils)
+set(ROOT_DEPENDENCIES Core EG GenVector Geom Gpad Hist MathCore Matrix Net Physics RIO Tree)
+set(ALIROOT_DEPENDENCIES ANALYSIS ANALYSISalice AOD PWGEMCALtasks PWGEMCALbase PWGEMCALtrigger)
+set(ALIPHYSICS_DEPENDENCIES EMCALbase PWGCaloTrackCorrBase PWGCaloTrackCorrBase OADB)
 
 # Generate the ROOT map
 # Dependecies
-set(LIBDEPS ${ALIROOT_DEPENDENCIES} ${ROOT_DEPENDENCIES} PWGGACommon)
+set(LIBDEPS ${ALIROOT_DEPENDENCIES} ${ALIPHYSICS_DEPENDENCIES} ${ROOT_DEPENDENCIES})
 generate_rootmap("${MODULE}" "${LIBDEPS}" "${CMAKE_CURRENT_SOURCE_DIR}/${MODULE}LinkDef.h")
 
 # Generate a PARfile target for this library
 add_target_parfile(${MODULE} "${SRCS}" "${HDRS}" "${MODULE}LinkDef.h" "${LIBDEPS}")
 
-# Create an object to be reused in case of static libraries 
+# Create an object to be reused in case of static libraries
 # Otherwise the sources will be compiled twice
 add_library(${MODULE}-object OBJECT ${SRCS} G__${MODULE}.cxx)
+
 # Add a library to the project using the object
 add_library_tested(${MODULE} SHARED $<TARGET_OBJECTS:${MODULE}-object>)
-target_link_libraries(${MODULE} ${ALIROOT_DEPENDENCIES} ${ROOT_DEPENDENCIES} PWGGACommon)
+target_link_libraries(${MODULE} ${LIBDEPS})
 
 # Setting the correct headers for the object as gathered from the dependencies
 target_include_directories(${MODULE}-object PUBLIC $<TARGET_PROPERTY:${MODULE},INCLUDE_DIRECTORIES>)
 set_target_properties(${MODULE}-object PROPERTIES COMPILE_DEFINITIONS $<TARGET_PROPERTY:${MODULE},COMPILE_DEFINITIONS>)
 
 # Public include folders that will be propagated to the dependecies
-target_include_directories(${MODULE} PUBLIC ${incdirs})
+target_include_directories(${MODULE} PUBLIC ${incdirs} INTERFACE)
 
 set(MODULE_COMPILE_FLAGS)
 set(MODULE_LINK_FLAGS)
 
 if(DATE_FOUND)
-  set(MODULE_COMPILE_FLAGS "${DATE_CFLAGS}")
-  set(MODULE_LINK_FLAGS "${DATE_LDFLAGS} ${DATE_LIBS}")
+    set(MODULE_COMPILE_FLAGS "${DATE_CFLAGS}")
+    set(MODULE_LINK_FLAGS "${DATE_LDFLAGS} ${DATE_LIBS}")
 endif(DATE_FOUND)
 
 # Additional compilation and linking flags
@@ -76,12 +73,10 @@ set(MODULE_COMPILE_FLAGS " ${MODULE_COMPILE_FLAGS}")
 
 # System dependent: Modify the way the library is build
 if(${CMAKE_SYSTEM} MATCHES Darwin)
-  set(MODULE_LINK_FLAGS "-undefined dynamic_lookup ${MODULE_LINK_FLAGS}")
+    set(MODULE_LINK_FLAGS "-undefined dynamic_lookup ${MODULE_LINK_FLAGS}")
 endif(${CMAKE_SYSTEM} MATCHES Darwin)
 
-# Setting compilation flags for the object
 set_target_properties(${MODULE}-object PROPERTIES COMPILE_FLAGS "${MODULE_COMPILE_FLAGS}")
-
 # Setting the linking flags for the library
 set_target_properties(${MODULE} PROPERTIES LINK_FLAGS "${MODULE_LINK_FLAGS}")
 
@@ -91,7 +86,3 @@ install(TARGETS ${MODULE}
         LIBRARY DESTINATION lib)
 
 install(FILES ${HDRS} DESTINATION include)
-
-# Install the macros
-install(DIRECTORY . DESTINATION RUN3 FILES_MATCHING PATTERN "*.C")
-install(DIRECTORY . DESTINATION RUN3 FILES_MATCHING PATTERN "benchmark/*.C")

--- a/PWGGA/Common/PWGGACommonLinkDef.h
+++ b/PWGGA/Common/PWGGACommonLinkDef.h
@@ -1,0 +1,8 @@
+#ifdef __CINT__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+#pragma link C++ class AliAODRelabelInterface+;
+#endif

--- a/PWGGA/GammaConv/CMakeLists.txt
+++ b/PWGGA/GammaConv/CMakeLists.txt
@@ -40,7 +40,7 @@ include_directories(${ROOT_INCLUDE_DIRS}
                     ${AliPhysics_SOURCE_DIR}/PWGGA/PHOSTasks/PHOS_PbPb
                     ${AliPhysics_SOURCE_DIR}/PWGGA/PWGGAUtils
                     ${AliPhysics_SOURCE_DIR}/PWGGA/GammaConvBase
-                    ${AliPhysics_SOURCE_DIR}/RUN3
+                    ${AliPhysics_SOURCE_DIR}/PWGGA/Common
                    )
 
 # Sources in alphabetical order

--- a/PWGGA/GammaConvBase/AliConversionPhotonCuts.h
+++ b/PWGGA/GammaConvBase/AliConversionPhotonCuts.h
@@ -18,6 +18,7 @@
 #include "AliAnalysisManager.h"
 #include "AliDalitzAODESDMC.h"
 #include "AliDalitzEventMC.h"
+#include "AliAODRelabelInterface.h"
 
 
 class AliESDEvent;

--- a/PWGGA/GammaConvBase/AliV0ReaderV1.h
+++ b/PWGGA/GammaConvBase/AliV0ReaderV1.h
@@ -1,7 +1,7 @@
 #ifndef ALIV0READERV1_H
 #define ALIV0READERV1_H
 
-#include "AliAnalysisTaskSE.h"
+#include "AliAODRelabelInterface.h"
 #include "AliAODv0.h"
 #include "AliESDv0.h"
 #include "AliConversionPhotonCuts.h"
@@ -27,7 +27,6 @@ class TClonesArray;
 class TH1F;
 class TH2F;
 class AliAODConversionPhoton;
-class AliAnalysisTaskAO2Dconverter;
 
 #if (__GNUC__ >= 3) && !defined(__INTEL_COMPILER)
 // gcc warns in level Weffc++ about non-virtual destructor
@@ -41,7 +40,7 @@ class AliAnalysisTaskAO2Dconverter;
 #pragma GCC diagnostic ignored "-Weffc++"
 #endif
 
-class AliV0ReaderV1 : public AliAnalysisTaskSE {
+class AliV0ReaderV1 : public AliAODRelabelInterface {
 
   public:
 
@@ -122,8 +121,8 @@ class AliV0ReaderV1 : public AliAnalysisTaskSE {
                                                                          return;}
 
     void               RelabelAODs(Bool_t relabel=kTRUE)                {fRelabelAODs=relabel; return;}
-    Bool_t             AreAODsRelabeled()                               {return fRelabelAODs;}
-    Int_t              IsReaderPerformingRelabeling()                   {return fPreviousV0ReaderPerformsAODRelabeling;}
+    bool               AreAODsRelabeled() const override                {return fRelabelAODs;}
+    int                IsReaderPerformingRelabeling() const override    {return fPreviousV0ReaderPerformsAODRelabeling;}
     Bool_t             RelabelAODPhotonCandidates(AliAODConversionPhoton *PhotonCandidate);
     Bool_t             GetErrorAODRelabeling()                          {return fErrorAODRelabeling;}
     void               SetPeriodName(TString name)                      {fPeriodName = name;
@@ -294,7 +293,7 @@ class AliV0ReaderV1 : public AliAnalysisTaskSE {
     AliV0ReaderV1 &operator=(const AliV0ReaderV1 &ref);
 
 
-    ClassDef(AliV0ReaderV1, 26)
+    ClassDef(AliV0ReaderV1, 27)
 
 };
 

--- a/PWGGA/GammaConvBase/CMakeLists.txt
+++ b/PWGGA/GammaConvBase/CMakeLists.txt
@@ -35,7 +35,7 @@ include_directories(${ROOT_INCLUDE_DIRS}
                     ${AliPhysics_SOURCE_DIR}/TENDER/TenderSupplies
                     ${AliPhysics_SOURCE_DIR}/PWGGA/PHOSTasks/ClusterSelection
                     ${AliPhysics_SOURCE_DIR}/PWGGA/PHOSTasks/PHOS_PbPb
-                    ${AliPhysics_SOURCE_DIR}/RUN3
+                    ${AliPhysics_SOURCE_DIR}/PWGGA/Common
                    )
 
 # the KF particle library support if required
@@ -96,7 +96,7 @@ set(ALIPHYSICS_DEPENDENCIES EMCALbase PWGCaloTrackCorrBase PWGCaloTrackCorrBase 
 
 # Generate the ROOT map
 # Dependecies
-set(LIBDEPS ${ALIROOT_DEPENDENCIES} ${ALIPHYSICS_DEPENDENCIES} ${ROOT_DEPENDENCIES})
+set(LIBDEPS ${ALIROOT_DEPENDENCIES} ${ALIPHYSICS_DEPENDENCIES} ${ROOT_DEPENDENCIES} PWGGACommon)
 if(USEKFLIBRARY)
     get_target_property(KFPARTICLE_LIBRARY KFParticle::KFParticle IMPORTED_LOCATION)
     set(LIBDEPS ${LIBDEPS} ${KFPARTICLE_LIBRARY})
@@ -112,7 +112,7 @@ add_library(${MODULE}-object OBJECT ${SRCS} G__${MODULE}.cxx)
 
 # Add a library to the project using the object
 add_library_tested(${MODULE} SHARED $<TARGET_OBJECTS:${MODULE}-object>)
-target_link_libraries(${MODULE} ${LIBDEPS})
+target_link_libraries(${MODULE} ${LIBDEPS} PWGGACommon)
 
 # Setting the correct headers for the object as gathered from the dependencies
 target_include_directories(${MODULE}-object PUBLIC $<TARGET_PROPERTY:${MODULE},INCLUDE_DIRECTORIES>)

--- a/RUN3/AliAnalysisTaskAO2Dconverter.h
+++ b/RUN3/AliAnalysisTaskAO2Dconverter.h
@@ -6,7 +6,7 @@
 #define AliAnalysisTaskAO2Dconverter_H
 
 #include "AliAnalysisFilter.h"
-#include "AliAnalysisTaskSE.h"
+#include "AliAODRelabelInterface.h"
 #include "AliESDMuonTrack.h"
 #include "AliEventCuts.h"
 #include "AliTriggerAnalysis.h"
@@ -68,7 +68,7 @@ class TH2I;
 class AliGenEventHeader;
 class V0Reader;
 
-class AliAnalysisTaskAO2Dconverter : public AliAnalysisTaskSE
+class AliAnalysisTaskAO2Dconverter : public AliAODRelabelInterface
 {
 public:
   AliAnalysisTaskAO2Dconverter() = default;
@@ -232,8 +232,8 @@ public:
 
   Bool_t GetAODConversionGammas();
   void FindDeltaAODBranchName();
-  Bool_t AreAODsRelabeled() {return fRelabelAODs;}
-  Int_t IsReaderPerformingRelabeling() {return fPreviousV0ReaderPerformsAODRelabeling;}
+  bool AreAODsRelabeled() const override {return fRelabelAODs;}
+  int IsReaderPerformingRelabeling() const override {return fPreviousV0ReaderPerformsAODRelabeling;}
   void SetDeltaAODBranchName(TString string)            {fDeltaAODBranchName = string;
                                                           fRelabelAODs = kTRUE;
                                                           AliInfo(Form("Set DeltaAOD BranchName to: %s",fDeltaAODBranchName.Data()));
@@ -825,7 +825,7 @@ private:
   FwdTrackPars MUONtoFwdTrack(AliESDMuonTrack&); // Converts MUON Tracks from ESD between RUN2 and RUN3 coordinates
   FwdTrackPars MUONtoFwdTrack(AliAODTrack&); // Converts MUON Tracks from AOD between RUN2 and RUN3 coordinates
 
-  ClassDef(AliAnalysisTaskAO2Dconverter, 33);
+  ClassDef(AliAnalysisTaskAO2Dconverter, 34);
 };
 
 #endif


### PR DESCRIPTION
The `AliAnalysisTaskAO2DConverter` needed to know of `AliV0ReaderV1` and vice versa. This commit adds the class `AliAODRelabelInterface` which is a new base class that inherits itself from the `AliAnalysisTaskSE` class and that `AliV0ReaderV1` and `AliAnalysisTaskAO2DConverter` inherit from. This way both classes only need the one new class and do not need to know from each other. Inside PWGGA/GammaConvBase/AliConversionPhotonCuts both classes were also needed because there in the function `GetTrack` one needs to check if the V0s are already relabeled.