### PR TITLE
[RUN3] Try to fix build crashing with undefined symbol: _ZTI22AliAODC…

### DIFF
--- a/RUN3/CMakeLists.txt
+++ b/RUN3/CMakeLists.txt
@@ -43,7 +43,7 @@ set(ALIROOT_DEPENDENCIES ANALYSIS ESD OADB STEERBase ANALYSISalice STEER EMCALUt
 
 # Generate the ROOT map
 # Dependecies
-set(LIBDEPS ${ALIROOT_DEPENDENCIES} ${ROOT_DEPENDENCIES} PWGGACommon)
+set(LIBDEPS ${ALIROOT_DEPENDENCIES} ${ROOT_DEPENDENCIES} PWGGACommon PWGGAGammaConvBase)
 generate_rootmap("${MODULE}" "${LIBDEPS}" "${CMAKE_CURRENT_SOURCE_DIR}/${MODULE}LinkDef.h")
 
 # Generate a PARfile target for this library
@@ -54,7 +54,7 @@ add_target_parfile(${MODULE} "${SRCS}" "${HDRS}" "${MODULE}LinkDef.h" "${LIBDEPS
 add_library(${MODULE}-object OBJECT ${SRCS} G__${MODULE}.cxx)
 # Add a library to the project using the object
 add_library_tested(${MODULE} SHARED $<TARGET_OBJECTS:${MODULE}-object>)
-target_link_libraries(${MODULE} ${ALIROOT_DEPENDENCIES} ${ROOT_DEPENDENCIES} PWGGACommon)
+target_link_libraries(${MODULE} ${ALIROOT_DEPENDENCIES} ${ROOT_DEPENDENCIES} PWGGACommon PWGGAGammaConvBase)
 
 # Setting the correct headers for the object as gathered from the dependencies
 target_include_directories(${MODULE}-object PUBLIC $<TARGET_PROPERTY:${MODULE},INCLUDE_DIRECTORIES>)


### PR DESCRIPTION
…onversionPhoton

- I assume the problem now is, that since we include the AliAODConversionPhoton class in RUN3 we need the PWGGA/GammaConvBase lib in RUN3 since AliAODConversionPhoton is defined there. Why multiple other builds worked without that fix, I do not know.
Should fix remaining issue seen in PR #23754 