### PR TITLE
RUN3: fix bumped table versions (O2trackextra, O2zdc, O2mccalolabel)

### DIFF
--- a/RUN3/AliAnalysisTaskAO2Dconverter.cxx
+++ b/RUN3/AliAnalysisTaskAO2Dconverter.cxx
@@ -1035,11 +1035,16 @@ void AliAnalysisTaskAO2Dconverter::InitTF(ULong64_t tfId)
   if (fTreeStatus[kZdc])
   {
     tZdc->Branch("fIndexBCs", &zdc.fIndexBCs, "fIndexBCs/I");
-    tZdc->Branch("fEnergy", &zdc.fEnergy);
-    tZdc->Branch("fChannelE", &zdc.fChannelE);
-    tZdc->Branch("fAmplitude", &zdc.fAmplitude);
-    tZdc->Branch("fTime", &zdc.fTime);
-    tZdc->Branch("fChannelT", &zdc.fChannelT);
+    tZdc->Branch("fEnergy_size", &zdc.fEnergy_size, "fEnergy_size/I");
+    tZdc->Branch("fEnergy", &zdc.fEnergy, "fEnergy[fEnergy_size]/F");
+    tZdc->Branch("fChannelE_size", &zdc.fChannelE_size, "fChannelE_size/I");
+    tZdc->Branch("fChannelE", &zdc.fChannelE, "fChannelE[fChannelE_size]/b");
+    tZdc->Branch("fAmplitude_size", &zdc.fAmplitude_size, "fAmplitude_size/I");
+    tZdc->Branch("fAmplitude", &zdc.fAmplitude, "fAmplitude[fAmplitude_size]/F");
+    tZdc->Branch("fTime_size", &zdc.fTime_size, "fTime_size/I");
+    tZdc->Branch("fTime", &zdc.fTime, "fTime[fTime_size]/F");
+    tZdc->Branch("fChannelT_size", &zdc.fChannelT_size, "fChannelT_size/I");
+    tZdc->Branch("fChannelT", &zdc.fChannelT, "fChannelT[fChannelT_size]/b");
     tZdc->SetBasketSize("*", fBasketSizeEvents);
   }
 
@@ -1237,8 +1242,10 @@ void AliAnalysisTaskAO2Dconverter::InitTF(ULong64_t tfId)
     TTree *tCaloLabels = CreateTree(kMcCaloLabel);
     if (fTreeStatus[kMcCaloLabel])
     {
-      tCaloLabels->Branch("fIndexMcParticles", &mccalolabel.fIndexMcParticles);
-      tCaloLabels->Branch("fAmplitudeFraction", &mccalolabel.fAmplitudeFraction);
+      tCaloLabels->Branch("fIndexMcParticles_size", &mccalolabel.fIndexMcParticles_size, "fIndexMcParticles_size/I");
+      tCaloLabels->Branch("fIndexMcParticles", &mccalolabel.fIndexMcParticles, "fIndexMcParticles[fIndexMcParticles_size]/I");
+      tCaloLabels->Branch("fAmplitudeFraction_size", &mccalolabel.fAmplitudeFraction_size, "fAmplitudeFraction_size/I");
+      tCaloLabels->Branch("fAmplitudeFraction", &mccalolabel.fAmplitudeFraction, "fAmplitudeFraction[fAmplitudeFraction_size]/F");
       tCaloLabels->SetBasketSize("*", fBasketSizeEvents);
     }
 
@@ -2246,11 +2253,11 @@ void AliAnalysisTaskAO2Dconverter::FillEventInTF()
     if (fTaskMode == kMC)
     {
       // Find the modified label
+      mccalolabel.fIndexMcParticles_size = 0;
+      mccalolabel.fAmplitudeFraction_size = 0;
       Int_t klabel = kineIndex[TMath::Abs(mclabel)];
-      mccalolabel.fIndexMcParticles.resize(1);
-      mccalolabel.fIndexMcParticles[0] = TMath::Abs(klabel) + fOffsetLabel;
-      mccalolabel.fAmplitudeFraction.resize(1);
-      mccalolabel.fAmplitudeFraction[0] = 1.f;
+      mccalolabel.fIndexMcParticles[mccalolabel.fIndexMcParticles_size++] = TMath::Abs(klabel) + fOffsetLabel;
+      mccalolabel.fAmplitudeFraction[mccalolabel.fAmplitudeFraction_size++] = 1.f;
 
       FillTree(kMcCaloLabel);
     }
@@ -2478,13 +2485,13 @@ void AliAnalysisTaskAO2Dconverter::FillEventInTF()
       nphoscells_filled++;
     if (fTaskMode == kMC)
     {
-      // Find the modified label
+      // Find the modified labe
+      mccalolabel.fIndexMcParticles_size = 0;
+      mccalolabel.fAmplitudeFraction_size = 0;
       if(mclabel>=0){  //label -1 == no primary
         Int_t klabel = kineIndex[mclabel];
-        mccalolabel.fIndexMcParticles.resize(1);
-        mccalolabel.fIndexMcParticles[0] = TMath::Abs(klabel) + fOffsetLabel;
-        mccalolabel.fAmplitudeFraction.resize(1);
-        mccalolabel.fAmplitudeFraction[0] = 1.f;
+        mccalolabel.fIndexMcParticles[mccalolabel.fIndexMcParticles_size++] = TMath::Abs(klabel) + fOffsetLabel;
+        mccalolabel.fAmplitudeFraction[mccalolabel.fAmplitudeFraction_size++] = 1.f;
 
         FillTree(kMcCaloLabel);
       }
@@ -2551,11 +2558,11 @@ void AliAnalysisTaskAO2Dconverter::FillEventInTF()
   zdc.fIndexBCs = fBCCount;
 
 
-  zdc.fEnergy.clear();
-  zdc.fChannelE.clear();
-  zdc.fAmplitude.clear();
-  zdc.fTime.clear();
-  zdc.fChannelT.clear();
+  zdc.fEnergy_size = 0;
+  zdc.fChannelE_size = 0;
+  zdc.fAmplitude_size = 0;
+  zdc.fTime_size = 0;
+  zdc.fChannelT_size = 0;
 
   // In the conversion between RUN2 data to RUN3 the ZDC energies and amplitudes
   // have the same content whereas in RUN3 they provide two different estimates
@@ -2613,151 +2620,151 @@ void AliAnalysisTaskAO2Dconverter::FillEventInTF()
     }
 
     // ZNA
-    zdc.fEnergy.emplace_back(esdzdc->GetZNATowerEnergy()[0]);
-    zdc.fChannelE.emplace_back(IdZNAC);
+    zdc.fEnergy[zdc.fEnergy_size++] = esdzdc->GetZNATowerEnergy()[0];
+    zdc.fChannelE[zdc.fChannelE_size++] = IdZNAC;
     if (zdcTime[0] < 12.5) {
-      zdc.fAmplitude.emplace_back(esdzdc->GetZNATowerEnergy()[0]); // WARNING: copy of the energy information
-      zdc.fTime.emplace_back(zdcTime[0]);
-      zdc.fChannelT.emplace_back(IdZNAC);
+      zdc.fAmplitude[zdc.fAmplitude_size++] = esdzdc->GetZNATowerEnergy()[0]; // WARNING: copy of the energy information
+      zdc.fTime[zdc.fTime_size++] = zdcTime[0];
+      zdc.fChannelT[zdc.fChannelT_size++] = IdZNAC;
     }
 
     // ZNA sectors
     for (Int_t ich = 0; ich < 4; ++ich) {
-      zdc.fEnergy.emplace_back(esdzdc->GetZNATowerEnergy()[ich + 1]);
-      zdc.fChannelE.emplace_back(IdZNA1 + ich);
+      zdc.fEnergy[zdc.fEnergy_size++] = esdzdc->GetZNATowerEnergy()[ich + 1];
+      zdc.fChannelE[zdc.fChannelE_size++] = IdZNA1 + ich;
     }
 
     // ZPA
-    zdc.fEnergy.emplace_back(esdzdc->GetZPATowerEnergy()[0]);
-    zdc.fChannelE.emplace_back(IdZPAC);
+    zdc.fEnergy[zdc.fEnergy_size++] = esdzdc->GetZPATowerEnergy()[0];
+    zdc.fChannelE[zdc.fChannelE_size++] = IdZPAC;
     if (zdcTime[2] < 12.5) {
-      zdc.fAmplitude.emplace_back(esdzdc->GetZPATowerEnergy()[0]); // WARNING: copy of the energy information
-      zdc.fTime.emplace_back(zdcTime[2]);
-      zdc.fChannelT.emplace_back(IdZPAC);
+      zdc.fAmplitude[zdc.fAmplitude_size++] = esdzdc->GetZPATowerEnergy()[0]; // WARNING: copy of the energy information
+      zdc.fTime[zdc.fTime_size++] = zdcTime[2];
+      zdc.fChannelT[zdc.fChannelT_size++] = IdZPAC;
     }
 
     // ZPA sectors
     for (Int_t ich = 0; ich < 4; ++ich) {
-      zdc.fEnergy.emplace_back(esdzdc->GetZPATowerEnergy()[ich + 1]);
-      zdc.fChannelE.emplace_back(IdZPA1 + ich);
+      zdc.fEnergy[zdc.fEnergy_size++] = esdzdc->GetZPATowerEnergy()[ich + 1];
+      zdc.fChannelE[zdc.fChannelE_size++] = IdZPA1 + ich;
     }
 
     // ZEM1
-    zdc.fEnergy.emplace_back(esdzdc->GetZEM1Energy());
-    zdc.fChannelE.emplace_back(IdZEM1);
+    zdc.fEnergy[zdc.fEnergy_size++] = esdzdc->GetZEM1Energy();
+    zdc.fChannelE[zdc.fChannelE_size++] = IdZEM1;
     if (zdcTime[4] < 12.5) {
-      zdc.fAmplitude.emplace_back(esdzdc->GetZEM1Energy()); // WARNING: copy of the energy information
-      zdc.fTime.emplace_back(zdcTime[4]);
-      zdc.fChannelT.emplace_back(IdZEM1);
+      zdc.fAmplitude[zdc.fAmplitude_size++] = esdzdc->GetZEM1Energy(); // WARNING: copy of the energy information
+      zdc.fTime[zdc.fTime_size++] = zdcTime[4];
+      zdc.fChannelT[zdc.fChannelT_size++] = IdZEM1;
     }
 
     // ZEM2
-    zdc.fEnergy.emplace_back(esdzdc->GetZEM2Energy());
-    zdc.fChannelE.emplace_back(IdZEM2);
+    zdc.fEnergy[zdc.fEnergy_size++] = esdzdc->GetZEM2Energy();
+    zdc.fChannelE[zdc.fChannelE_size++] = IdZEM2;
     if (zdcTime[5] < 12.5) {
-      zdc.fAmplitude.emplace_back(esdzdc->GetZEM2Energy()); // WARNING: copy of the energy information
-      zdc.fTime.emplace_back(zdcTime[5]);
-      zdc.fChannelT.emplace_back(IdZEM2);
+      zdc.fAmplitude[zdc.fAmplitude_size++] = esdzdc->GetZEM2Energy(); // WARNING: copy of the energy information
+      zdc.fTime[zdc.fTime_size++] = zdcTime[5];
+      zdc.fChannelT[zdc.fChannelT_size++] = IdZEM2;
     }
 
     // ZNC
-    zdc.fEnergy.emplace_back(esdzdc->GetZNCTowerEnergy()[0]);
-    zdc.fChannelE.emplace_back(IdZNCC);
+    zdc.fEnergy[zdc.fEnergy_size++] = esdzdc->GetZNCTowerEnergy()[0];
+    zdc.fChannelE[zdc.fChannelE_size++] = IdZNCC;
     if (zdcTime[1] < 12.5) {
-      zdc.fAmplitude.emplace_back(esdzdc->GetZNCTowerEnergy()[0]);  // WARNING: copy of the energy information
-      zdc.fTime.emplace_back(zdcTime[1]);
-      zdc.fChannelT.emplace_back(IdZNCC);
+      zdc.fAmplitude[zdc.fAmplitude_size++] = esdzdc->GetZNCTowerEnergy()[0];  // WARNING: copy of the energy information
+      zdc.fTime[zdc.fTime_size++] = zdcTime[1];
+      zdc.fChannelT[zdc.fChannelT_size++] = IdZNCC;
     }
 
     // ZNC sectors
     for (Int_t ich = 0; ich < 4; ++ich) {
-      zdc.fEnergy.emplace_back(esdzdc->GetZNCTowerEnergy()[ich + 1]);
-      zdc.fChannelE.emplace_back(IdZNC1 + ich);
+      zdc.fEnergy[zdc.fEnergy_size++] = esdzdc->GetZNCTowerEnergy()[ich + 1];
+      zdc.fChannelE[zdc.fChannelE_size++] = IdZNC1 + ich;
     }
 
     // ZPC
-    zdc.fEnergy.emplace_back(esdzdc->GetZPCTowerEnergy()[0]);
-    zdc.fChannelE.emplace_back(IdZPCC);
+    zdc.fEnergy[zdc.fEnergy_size++] = esdzdc->GetZPCTowerEnergy()[0];
+    zdc.fChannelE[zdc.fChannelE_size++] = IdZPCC;
     if (zdcTime[3] < 12.5) {
-      zdc.fAmplitude.emplace_back(esdzdc->GetZPCTowerEnergy()[0]);  // WARNING: copy of the energy information
-      zdc.fTime.emplace_back(zdcTime[3]);
-      zdc.fChannelT.emplace_back(IdZPCC);
+      zdc.fAmplitude[zdc.fAmplitude_size++] = esdzdc->GetZPCTowerEnergy()[0];  // WARNING: copy of the energy information
+      zdc.fTime[zdc.fTime_size++] = zdcTime[3];
+      zdc.fChannelT[zdc.fChannelT_size++] = IdZPCC;
     }
 
     // ZDC (P,N) sectors
     for (Int_t ich = 0; ich < 4; ++ich) {
-      zdc.fEnergy.emplace_back(esdzdc->GetZPCTowerEnergy()[ich + 1]);
-      zdc.fChannelE.emplace_back(IdZPC1 + ich);
+      zdc.fEnergy[zdc.fEnergy_size++] = esdzdc->GetZPCTowerEnergy()[ich + 1];
+      zdc.fChannelE[zdc.fChannelE_size++] = IdZPC1 + ich;
     }
 
   } else {
     // ZNA
-    zdc.fEnergy.emplace_back(aodzdc->GetZNATowerEnergy()[0]);
-    zdc.fChannelE.emplace_back(IdZNAC);
+    zdc.fEnergy[zdc.fEnergy_size++] = aodzdc->GetZNATowerEnergy()[0];
+    zdc.fChannelE[zdc.fChannelE_size++] = IdZNAC;
     if(aodzdc->GetZNATime() < 12.5){
-      zdc.fAmplitude.emplace_back(aodzdc->GetZNATowerEnergy()[0]); // WARNING: copy of the energy information
-      zdc.fTime.emplace_back(aodzdc->GetZNATime());
-      zdc.fChannelT.emplace_back(IdZNAC);
+      zdc.fAmplitude[zdc.fAmplitude_size++] = aodzdc->GetZNATowerEnergy()[0]; // WARNING: copy of the energy information
+      zdc.fTime[zdc.fTime_size++] = aodzdc->GetZNATime();
+      zdc.fChannelT[zdc.fChannelT_size++] = IdZNAC;
     }
 
     // ZNA sectors
     for (Int_t ich = 0; ich < 4; ++ich) {
-      zdc.fEnergy.emplace_back(aodzdc->GetZNATowerEnergy()[ich + 1]);
-      zdc.fChannelE.emplace_back(IdZNA1 + ich);
+      zdc.fEnergy[zdc.fEnergy_size++] = aodzdc->GetZNATowerEnergy()[ich + 1];
+      zdc.fChannelE[zdc.fChannelE_size++] = IdZNA1 + ich;
     }
 
     // ZPA
-    zdc.fEnergy.emplace_back(aodzdc->GetZPATowerEnergy()[0]);
-    zdc.fChannelE.emplace_back(IdZPAC);
+    zdc.fEnergy[zdc.fEnergy_size++] = aodzdc->GetZPATowerEnergy()[0];
+    zdc.fChannelE[zdc.fChannelE_size++] = IdZPAC;
     if(aodzdc->GetZPATime()<12.5){
-      zdc.fAmplitude.emplace_back(aodzdc->GetZPATowerEnergy()[0]); // WARNING: copy of the energy information
-      zdc.fTime.emplace_back(aodzdc->GetZPATime());
-      zdc.fChannelT.emplace_back(IdZPAC);
+      zdc.fAmplitude[zdc.fAmplitude_size++] = aodzdc->GetZPATowerEnergy()[0]; // WARNING: copy of the energy information
+      zdc.fTime[zdc.fTime_size++] = aodzdc->GetZPATime();
+      zdc.fChannelT[zdc.fChannelT_size++] = IdZPAC;
     }
 
     // ZPA sectors
     for (Int_t ich = 0; ich < 4; ++ich) {
-      zdc.fEnergy.emplace_back(aodzdc->GetZPATowerEnergy()[ich + 1]);
-      zdc.fChannelE.emplace_back(IdZPA1 + ich);
+      zdc.fEnergy[zdc.fEnergy_size++] = aodzdc->GetZPATowerEnergy()[ich + 1];
+      zdc.fChannelE[zdc.fChannelE_size++] = IdZPA1 + ich;
     }
 
     // ZEM1,2 times are not in AOD therefore we do not store amplitudes and times
     // ZEM1
-    zdc.fEnergy.emplace_back(aodzdc->GetZEM1Energy());
-    zdc.fChannelE.emplace_back(IdZEM1);
+    zdc.fEnergy[zdc.fEnergy_size++] = aodzdc->GetZEM1Energy();
+    zdc.fChannelE[zdc.fChannelE_size++] = IdZEM1;
 
     // ZEM2
-    zdc.fEnergy.emplace_back(aodzdc->GetZEM2Energy());
-    zdc.fChannelE.emplace_back(IdZEM2);
+    zdc.fEnergy[zdc.fEnergy_size++] = aodzdc->GetZEM2Energy();
+    zdc.fChannelE[zdc.fChannelE_size++] = IdZEM2;
 
     // ZNC
-    zdc.fEnergy.emplace_back(aodzdc->GetZNCTowerEnergy()[0]);
-    zdc.fChannelE.emplace_back(IdZNCC);
+    zdc.fEnergy[zdc.fEnergy_size++] = aodzdc->GetZNCTowerEnergy()[0];
+    zdc.fChannelE[zdc.fChannelE_size++] = IdZNCC;
     if(aodzdc->GetZNCTime() < 12.5){
-      zdc.fAmplitude.emplace_back(aodzdc->GetZNCTowerEnergy()[0]); // WARNING: copy of the energy information
-      zdc.fTime.emplace_back(aodzdc->GetZNCTime());
-      zdc.fChannelT.emplace_back(IdZNCC);
+      zdc.fAmplitude[zdc.fAmplitude_size++] = aodzdc->GetZNCTowerEnergy()[0]; // WARNING: copy of the energy information
+      zdc.fTime[zdc.fTime_size++] = aodzdc->GetZNCTime();
+      zdc.fChannelT[zdc.fChannelT_size++] = IdZNCC;
     }
 
     // ZNC sectors
     for (Int_t ich = 0; ich < 4; ++ich) {
-      zdc.fEnergy.emplace_back(aodzdc->GetZNCTowerEnergy()[ich + 1]);
-      zdc.fChannelE.emplace_back(IdZNC1 + ich);
+      zdc.fEnergy[zdc.fEnergy_size++] = aodzdc->GetZNCTowerEnergy()[ich + 1];
+      zdc.fChannelE[zdc.fChannelE_size++] = IdZNC1 + ich;
     }
 
     // ZPC
-    zdc.fEnergy.emplace_back(aodzdc->GetZPCTowerEnergy()[0]);
-    zdc.fChannelE.emplace_back(IdZPCC);
+    zdc.fEnergy[zdc.fEnergy_size++] = aodzdc->GetZPCTowerEnergy()[0];
+    zdc.fChannelE[zdc.fChannelE_size++] = IdZPCC;
     if(aodzdc->GetZPCTime() < 12.5){
-      zdc.fAmplitude.emplace_back(aodzdc->GetZPCTowerEnergy()[0]); // WARNING: copy of the energy information
-      zdc.fTime.emplace_back(aodzdc->GetZPCTime());
-      zdc.fChannelT.emplace_back(IdZPCC);
+      zdc.fAmplitude[zdc.fAmplitude_size++] = aodzdc->GetZPCTowerEnergy()[0]; // WARNING: copy of the energy information
+      zdc.fTime[zdc.fTime_size++] = aodzdc->GetZPCTime();
+      zdc.fChannelT[zdc.fChannelT_size++] = IdZPCC;
     }
 
     // ZPC sectors
     for (Int_t ich = 0; ich < 4; ++ich) {
-      zdc.fEnergy.emplace_back(aodzdc->GetZPCTowerEnergy()[ich + 1]);
-      zdc.fChannelE.emplace_back(IdZPC1 + ich);
+      zdc.fEnergy[zdc.fEnergy_size++] = aodzdc->GetZPCTowerEnergy()[ich + 1];
+      zdc.fChannelE[zdc.fChannelE_size++] = IdZPC1 + ich;
     }
 
     // ZEM

--- a/RUN3/AliAnalysisTaskAO2Dconverter.cxx
+++ b/RUN3/AliAnalysisTaskAO2Dconverter.cxx
@@ -2609,19 +2609,19 @@ void AliAnalysisTaskAO2Dconverter::FillEventInTF()
       if (tZNA > -12.5 && tZNA < 12.5 && zdcTime[0] > 998){
         zdcTime[0] = tZNA;
       }
-      if (tZNC > -12.5 && tZNC < 12.5 && zdcTime[0] > 998){
+      if (tZNC > -12.5 && tZNC < 12.5 && zdcTime[1] > 998){
         zdcTime[1] = tZNC;
       }
-      if (tZPA > -12.5 && tZPA < 12.5 && zdcTime[1] > 998){
+      if (tZPA > -12.5 && tZPA < 12.5 && zdcTime[2] > 998){
         zdcTime[2] = tZPA;
       }
-      if (tZPC > -12.5 && tZPC < 12.5 && zdcTime[2] > 998){
+      if (tZPC > -12.5 && tZPC < 12.5 && zdcTime[3] > 998){
         zdcTime[3] = tZPC;
       }
-      if (tZEM1 > -12.5 && tZEM1 < 12.5 && zdcTime[3] > 998){
+      if (tZEM1 > -12.5 && tZEM1 < 12.5 && zdcTime[4] > 998){
         zdcTime[4] = tZEM1;
       }
-      if (tZEM2 > -12.5 && tZEM2 < 12.5 && zdcTime[4] > 998){
+      if (tZEM2 > -12.5 && tZEM2 < 12.5 && zdcTime[5] > 998){
         zdcTime[5] = tZEM2;
       }
     }

--- a/RUN3/AliAnalysisTaskAO2Dconverter.h
+++ b/RUN3/AliAnalysisTaskAO2Dconverter.h
@@ -288,7 +288,7 @@ private:
   int fBasketSizeEvents = 1000000;   // Maximum basket size of the trees for events
   int fBasketSizeTracks = 10000000;   // Maximum basket size of the trees for tracks
 
-  TaskModes fTaskMode = kStandard; // Running mode of the task. Useful to set for e.g. MC mode  
+  TaskModes fTaskMode = kStandard; // Running mode of the task. Useful to set for e.g. MC mode
 
   // Data structures
 
@@ -399,7 +399,7 @@ private:
     UInt_t fFlags = 0u;       /// Reconstruction status flags
 
     // Clusters and tracklets
-    UChar_t fITSClusterMap = 0u;   /// ITS map of clusters, one bit per a layer
+    UInt_t fITSClusterSizes = 0u;  /// ITS clusters sizes, four bits per a layer, starting from the innermost
     UChar_t fTPCNClsFindable = 0u; /// number of clusters that could be assigned in the TPC
     Char_t fTPCNClsFindableMinusFound = 0;       /// difference between foundable and found clusters
     Char_t fTPCNClsFindableMinusCrossedRows = 0; ///  difference between foundable clsuters and crossed rows
@@ -476,7 +476,7 @@ private:
   struct {
     /// Calo cluster label to find the corresponding MC particle
     std::vector<int> fIndexMcParticles = {-999};      ///< Calo label
-    std::vector<float> fAmplitudeFraction = {1.f};    ///< Amplitude fraction of deposited energy of the mc particle and the total cell 
+    std::vector<float> fAmplitudeFraction = {1.f};    ///< Amplitude fraction of deposited energy of the mc particle and the total cell
   } mccalolabel; ///<! Calo labels
 
   struct {
@@ -727,7 +727,7 @@ private:
     Int_t fIndexCollisions = -1; /// The index of the collision vertex in the TF, to which the track is attached
     Int_t fIndexTracksPos = -1; // Positive track ID
     Int_t fIndexTracksNeg = -1; // Negative track ID
-    uint8_t fV0Type = 0; //custom bitmap for selection (standard or photon) 
+    uint8_t fV0Type = 0; //custom bitmap for selection (standard or photon)
   } v0s;               //! structure to keep v0sinformation
 
   struct {

--- a/RUN3/AliAnalysisTaskAO2Dconverter.h
+++ b/RUN3/AliAnalysisTaskAO2Dconverter.h
@@ -475,8 +475,10 @@ private:
 
   struct {
     /// Calo cluster label to find the corresponding MC particle
-    std::vector<int> fIndexMcParticles = {-999};      ///< Calo label
-    std::vector<float> fAmplitudeFraction = {1.f};    ///< Amplitude fraction of deposited energy of the mc particle and the total cell
+    Int_t fIndexMcParticles_size = 0;         /// Calo label size
+    Int_t fIndexMcParticles[1] = {-999};      ///< Calo label
+    Int_t fAmplitudeFraction_size = 0;        /// Amplitude fraction size
+    Float_t fAmplitudeFraction[1] = {1.f};    ///< Amplitude fraction of deposited energy of the mc particle and the total cell
   } mccalolabel; ///<! Calo labels
 
   struct {
@@ -667,13 +669,18 @@ private:
   } fwdtracks; //! structure to keep forward tracks parameters and covariances
 
   struct {
-    Int_t   fIndexBCs = 0u;                 /// Index to BC table
-    std::vector<float> fEnergy = {};           ///< Energy of non-zero channels. The channel IDs are given in ChannelE (at the same index)
-    std::vector<uint8_t> fChannelE = {};       ///< Channel IDs which have reconstructed energy. There are at maximum 26 channels
-    std::vector<float> fAmplitude = {};        ///< Amplitudes of non-zero channels. The channel IDs are given in ChannelT (at the same index)
-    std::vector<float> fTime = {};             ///< Times of non-zero channels. The channel IDs are given in ChannelT (at the same index)
-    std::vector<uint8_t> fChannelT = {};       ///< Channel IDs which had non-zero amplitudes. There are at maximum 26 channels
-  } zdc;                                 //! structure to keep ZDC information
+    Int_t fIndexBCs = 0u;             /// Index to BC table
+    Int_t fEnergy_size = 0;           /// Size of fEnergy
+    Float_t fEnergy[26] = {0.f};      ///< Energy of non-zero channels. The channel IDs are given in ChannelE (at the same index)
+    Int_t fChannelE_size = 0;         /// Size of fChannelE
+    uint8_t fChannelE[26] = {0u};     ///< Channel IDs which have reconstructed energy. There are at maximum 26 channels
+    Int_t fAmplitude_size = 0;        /// Size of fAmplitude
+    Float_t fAmplitude[26] = {0.f};   ///< Amplitudes of non-zero channels. The channel IDs are given in ChannelT (at the same index)
+    Int_t fTime_size = 0;             /// Size of fTime
+    Float_t fTime[26] = {0.f};        ///< Times of non-zero channels. The channel IDs are given in ChannelT (at the same index)
+    Int_t fChannelT_size = 0;         /// Size of fChannelT
+    uint8_t fChannelT[26] = {0u};     ///< Channel IDs which had non-zero amplitudes. There are at maximum 26 channels
+  } zdc;                              //! structure to keep ZDC information
 
   struct {
     /// V0A  (32 cells in Run2, 48 cells in Run3)


### PR DESCRIPTION
Hi @pzhristov @ddobrigk @jgrosseo this PR fixes some bugs in O2trackextra_v001, O2zdc_v001, and O2mccalolabel_v001:
- Go from fITSClusterMap to fITSClusterSizes in the trackestra table
- Fix the streaming of std::vector columns for the zdc and mccalolabel tables by adding the "_size" columns
This version of the converted data is correctly read by O2