### PR TITLE
RUN3: increase converter class version

### DIFF
--- a/RUN3/AliAnalysisTaskAO2Dconverter.h
+++ b/RUN3/AliAnalysisTaskAO2Dconverter.h
@@ -833,7 +833,7 @@ private:
   FwdTrackPars MUONtoFwdTrack(AliESDMuonTrack&); // Converts MUON Tracks from ESD between RUN2 and RUN3 coordinates
   FwdTrackPars MUONtoFwdTrack(AliAODTrack&); // Converts MUON Tracks from AOD between RUN2 and RUN3 coordinates
 
-  ClassDef(AliAnalysisTaskAO2Dconverter, 34);
+  ClassDef(AliAnalysisTaskAO2Dconverter, 35);
 };
 
 #endif


### PR DESCRIPTION
@pzhristov @ddobrigk @jgrosseo there were a few warnings in the previous compilation that seem connected to the ClassDef macro, see for instance https://ali-ci.cern.ch/alice-build-logs/alisw/AliPhysics/23768/0de7954073758b13fce18d20ee393042bd1c749d/build_AliPhysics_root6/fullLog.txt

In file included from input_line_9:12:
/sw/SOURCES/AliPhysics/23768-slc7_x86-64/0/RUN3/AliAnalysisTaskAO2Dconverter.h:836:3: warning: 'CheckTObjectHashConsistency' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  ClassDef(AliAnalysisTaskAO2Dconverter, 34);

I increased the class version accordingly