### PR TITLE
RUN3: add default constructor to interface + increase class version

### DIFF
--- a/PWGGA/Common/AliAODRelabelInterface.h
+++ b/PWGGA/Common/AliAODRelabelInterface.h
@@ -6,6 +6,7 @@
 // Interface for AOD relabeling that can happen in the V0Reader and RUN3/AliAnalysisTaskAO2Dconverter
 class AliAODRelabelInterface : public AliAnalysisTaskSE {
 public:
+  AliAODRelabelInterface() = default;
   AliAODRelabelInterface(const char* name) : AliAnalysisTaskSE(name) {}
   virtual ~AliAODRelabelInterface() = default;
 

--- a/RUN3/AliAnalysisTaskAO2Dconverter.h
+++ b/RUN3/AliAnalysisTaskAO2Dconverter.h
@@ -833,7 +833,7 @@ private:
   FwdTrackPars MUONtoFwdTrack(AliESDMuonTrack&); // Converts MUON Tracks from ESD between RUN2 and RUN3 coordinates
   FwdTrackPars MUONtoFwdTrack(AliAODTrack&); // Converts MUON Tracks from AOD between RUN2 and RUN3 coordinates
 
-  ClassDef(AliAnalysisTaskAO2Dconverter, 34);
+  ClassDef(AliAnalysisTaskAO2Dconverter, 35);
 };
 
 #endif


### PR DESCRIPTION
@ddobrigk @pzhristov @jgrosseo I added an explicit default constructor to AliAODRelabelInterface since in the previous version this was missing and caused the default constructor of AliAnalysisTaskAO2DConverter to be implicitly deleted, see for instance the following lines from the log of a previous build https://ali-ci.cern.ch/alice-build-logs/alisw/AliPhysics/23768/0de7954073758b13fce18d20ee393042bd1c749d/build_AliPhysics_root6/fullLog.txt

```
In file included from input_line_9:12:
/sw/SOURCES/AliPhysics/23768-slc7_x86-64/0/RUN3/AliAnalysisTaskAO2Dconverter.h:74:3: warning: explicitly defaulted default constructor is implicitly deleted [-Wdefaulted-function-deleted]
  AliAnalysisTaskAO2Dconverter() = default;
  ^
/sw/SOURCES/AliPhysics/23768-slc7_x86-64/0/RUN3/AliAnalysisTaskAO2Dconverter.h:71:38: note: default constructor of 'AliAnalysisTaskAO2Dconverter' is implicitly deleted because base class 'AliAODRelabelInterface' has no default constructor
class AliAnalysisTaskAO2Dconverter : public AliAODRelabelInterface
```

Since the tag vAN-20241107, this caused the following error when running the analysis, for example PWGZZ/Run3_Conversion/497_20241118-1431:
`E-TClass::New: cannot create object of class AliAnalysisTaskAO2Dconverter`

This should fix the bug. Meanwhile I also incremented the version of the converter class