### PR TITLE
[RUN3] Rename V0otfs to Run2V0otfs

### DIFF
--- a/RUN3/AliAnalysisTaskAO2Dconverter.cxx
+++ b/RUN3/AliAnalysisTaskAO2Dconverter.cxx
@@ -111,7 +111,7 @@ const TString AliAnalysisTaskAO2Dconverter::TreeName[kTrees] = {
   "O2ft0",
   "O2fdd_001",
   "O2v0_002", // 002 added the V0Type (standard or photon)
-  "O2v0otf", // on the fly V0s for photon conversions
+  "O2run2v0otf", // on the fly V0s for photon conversions
   "O2cascade_001",
   "O2tof",
   "O2mcparticle_001",


### PR DESCRIPTION
- Renaming of the V0otfs table to Run2V0otfs to go hand in hand with the table name we want in the O2 framework.