### PR TITLE
Run 3 converter: add PMD 

### DIFF
--- a/RUN3/AliAnalysisTaskAO2Dconverter.cxx
+++ b/RUN3/AliAnalysisTaskAO2Dconverter.cxx
@@ -295,6 +295,10 @@ AliAnalysisTaskAO2Dconverter::AliAnalysisTaskAO2Dconverter(const char* name)
   {
     fTreeStatus[i] = kTRUE;
   }
+
+  // disable experimental features 
+  fTreeStatus[kPMD] = kFALSE;
+
 } // AliAnalysisTaskAO2Dconverter::AliAnalysisTaskAO2Dconverter(const char* name)
 
 

--- a/RUN3/AliAnalysisTaskAO2Dconverter.cxx
+++ b/RUN3/AliAnalysisTaskAO2Dconverter.cxx
@@ -995,6 +995,7 @@ void AliAnalysisTaskAO2Dconverter::InitTF(ULong64_t tfId)
   TTree* tPmdInfo = CreateTree(kPMD);
   if (fTreeStatus[kPMD]) {
     // PMD information
+    tPmdInfo->Branch("fIndexCollisions", &tracks.fIndexCollisions, "fIndexCollisions/I");
     tPmdInfo->Branch("fX", &pmdInfo.fX, "fX/F");
     tPmdInfo->Branch("fY", &pmdInfo.fY, "fY/F");
     tPmdInfo->Branch("fZ", &pmdInfo.fZ, "fZ/F");
@@ -3227,6 +3228,7 @@ void AliAnalysisTaskAO2Dconverter::FillEventInTF()
   // PMD information loop (to be adjusted as necessary)
   if(fESD){ // path from ESD only (check for AOD if needed)
 	  Int_t PMDTrackks = fESD->GetNumberOfPmdTracks();
+    pmdInfo.fIndexCollisions = fCollisionCount;
     for(Int_t trk = 0; trk < PMDTrackks; trk++){
       AliESDPmdTrack *pmdtr = fESD->GetPmdTrack(trk);
       pmdInfo.fX          = AliMathBase::TruncateFloatFraction(pmdtr->GetClusterX(), mPMDPositionPrecision);

--- a/RUN3/AliAnalysisTaskAO2Dconverter.cxx
+++ b/RUN3/AliAnalysisTaskAO2Dconverter.cxx
@@ -63,6 +63,7 @@
 #include "AliESDVZERO.h"
 #include "AliESDv0.h"
 #include "AliESDcascade.h"
+#include "AliESDPmdTrack.h"
 
 #include "AliMCEvent.h"
 #include "AliMCEventHandler.h"
@@ -130,7 +131,8 @@ const TString AliAnalysisTaskAO2Dconverter::TreeName[kTrees] = {
   "O2hepmcxsection",
   "O2hepmcpdfinfo",
   "O2hepmcheavyion",
-  "O2run2trackextra_001"
+  "O2run2trackextra_001",
+  "O2pmd"
 };
 
 const TString AliAnalysisTaskAO2Dconverter::TreeTitle[kTrees] = {
@@ -168,7 +170,8 @@ const TString AliAnalysisTaskAO2Dconverter::TreeTitle[kTrees] = {
   "O2 HepMc Cross Sections",
   "O2 HepMc Pdf Info",
   "O2 HepMc Heavy Ion",
-  "Barrel tracks Extra Run2"
+  "Barrel tracks Extra Run2",
+  "PMD info"
 };
 
 const TClass *AliAnalysisTaskAO2Dconverter::Generator[kGenerators] = {AliGenEventHeader::Class(), AliGenCocktailEventHeader::Class(), AliGenDPMjetEventHeader::Class(), AliGenEpos3EventHeader::Class(), AliGenEposEventHeader::Class(), AliGenEventHeaderTunedPbPb::Class(), AliGenGeVSimEventHeader::Class(), AliGenHepMCEventHeader::Class(), AliGenHerwigEventHeader::Class(), AliGenHijingEventHeader::Class(), AliGenPythiaEventHeader::Class(), AliGenToyEventHeader::Class()};
@@ -230,6 +233,10 @@ namespace
   UInt_t mV0otfMass = 0xFFFFFFFF;
   UInt_t mV0otfMomentum = 0xFFFFFFFF;
 
+  UInt_t mPMDPositionPrecision = 0xFFFFFFFF;
+  UInt_t mPMDEnergyPrecision = 0xFFFFFFFF;
+  UInt_t mPMDProbabilityPrecision = 0xFFFFFFFF;
+
   // No compression for ZDC for the moment
 
 } // namespace
@@ -278,6 +285,7 @@ AliAnalysisTaskAO2Dconverter::AliAnalysisTaskAO2Dconverter(const char* name)
     hf3Prong(),
     hfCascades(),
     hfDStar(),
+    pmdInfo(),
     fMetaData()
 
 {
@@ -424,6 +432,10 @@ void AliAnalysisTaskAO2Dconverter::UserCreateOutputObjects()
     mV0otfLength = 0xFFFFF000;  // 11 bits
     mV0otfMass = 0xFFFFF000;    // 11 bits but saved in MeV!
     mV0otfMomentum = 0xFFFFFC00; // 13 bits
+    
+    mPMDPositionPrecision = 0xFFFFF000;  // 11 bits
+    mPMDEnergyPrecision = 0xFFFFF000;  // 11 bits
+    mPMDProbabilityPrecision = 0xFFFFF000;  // 11 bits
   }
 
   // create output objects
@@ -978,6 +990,25 @@ void AliAnalysisTaskAO2Dconverter::InitTF(ULong64_t tfId)
     tCaloTrigger->Branch("fTriggerBits", &calotrigger.fTriggerBits, "fTriggerBits/I");
     tCaloTrigger->Branch("fCaloType", &calotrigger.fCaloType, "fCaloType/B");
     tCaloTrigger->SetBasketSize("*", fBasketSizeEvents);
+  }
+
+  TTree* tPmdInfo = CreateTree(kPMD);
+  if (fTreeStatus[kPMD]) {
+    // PMD information
+    tPmdInfo->Branch("fX", &pmdInfo.fX, "fX/F");
+    tPmdInfo->Branch("fY", &pmdInfo.fY, "fY/F");
+    tPmdInfo->Branch("fZ", &pmdInfo.fZ, "fZ/F");
+    tPmdInfo->Branch("fCluADC", &pmdInfo.fCluADC, "fCluADC/F");
+    tPmdInfo->Branch("fCluPID", &pmdInfo.fCluPID, "fCluPID/F");
+    tPmdInfo->Branch("fDet", &pmdInfo.fDet, "fDet/b");
+    tPmdInfo->Branch("fNcell", &pmdInfo.fNcell, "fNcell/b");
+    tPmdInfo->Branch("fSmn", &pmdInfo.fSmn, "fSmn/I");
+    tPmdInfo->Branch("fTrackNo", &pmdInfo.fTrackNo, "fTrackNo/I");
+    tPmdInfo->Branch("fTrackPid", &pmdInfo.fTrackPid, "fTrackPid/I");
+    tPmdInfo->Branch("fSigX", &pmdInfo.fSigX, "fSigX/F");
+    tPmdInfo->Branch("fSigY", &pmdInfo.fSigY, "fSigY/F");
+    tPmdInfo->Branch("fClMatching", &pmdInfo.fClMatching, "fClMatching/I");
+    tPmdInfo->SetBasketSize("*", fBasketSizeTracks);
   }
 
   // Associate FwdTrack branches for MUON tracks
@@ -3190,6 +3221,34 @@ void AliAnalysisTaskAO2Dconverter::FillEventInTF()
       delete[] v0Lookup;
     } // End if V0s
     eventextra.fNentries[kCascades] = ncascades_filled;
+  }
+
+  //---------------------------------------------------------------------------
+  // PMD information loop (to be adjusted as necessary)
+  if(fESD){ // path from ESD only (check for AOD if needed)
+	  Int_t PMDTrackks = fESD->GetNumberOfPmdTracks();
+    for(Int_t trk = 0; trk < PMDTrackks; trk++){
+      AliESDPmdTrack *pmdtr = fESD->GetPmdTrack(trk);
+      pmdInfo.fX          = AliMathBase::TruncateFloatFraction(pmdtr->GetClusterX(), mPMDPositionPrecision);
+      pmdInfo.fY          = AliMathBase::TruncateFloatFraction(pmdtr->GetClusterY(), mPMDPositionPrecision);
+      pmdInfo.fZ          = AliMathBase::TruncateFloatFraction(pmdtr->GetClusterZ(), mPMDPositionPrecision);
+      pmdInfo.fCluADC     = AliMathBase::TruncateFloatFraction(pmdtr->GetClusterADC(), mPMDEnergyPrecision);
+      pmdInfo.fCluPID     = AliMathBase::TruncateFloatFraction(pmdtr->GetClusterPID(), mPMDProbabilityPrecision);
+
+      pmdInfo.fSigX       = AliMathBase::TruncateFloatFraction(pmdtr->GetClusterSigmaX(), mPMDPositionPrecision);
+      pmdInfo.fSigY       = AliMathBase::TruncateFloatFraction(pmdtr->GetClusterSigmaY(), mPMDPositionPrecision);
+
+      pmdInfo.fDet        = pmdtr->GetDetector();
+      pmdInfo.fNcell      = pmdtr->GetClusterCells();
+
+      pmdInfo.fTrackNo    = pmdtr->GetClusterTrackNo();
+      pmdInfo.fTrackPid   = pmdtr->GetClusterTrackPid();
+      pmdInfo.fSmn        = pmdtr->GetSmn();
+
+      pmdInfo.fClMatching = pmdtr->GetClusterMatching();
+
+      FillTree(kPMD);
+    }
   }
 
   //---------------------------------------------------------------------------

--- a/RUN3/AliAnalysisTaskAO2Dconverter.cxx
+++ b/RUN3/AliAnalysisTaskAO2Dconverter.cxx
@@ -3243,7 +3243,7 @@ void AliAnalysisTaskAO2Dconverter::FillEventInTF()
       pmdInfo.fDet        = pmdtr->GetDetector();
       pmdInfo.fNcell      = pmdtr->GetClusterCells();
 
-      pmdInfo.fTrackNo    = pmdtr->GetClusterTrackNo();
+      pmdInfo.fTrackNo    = pmdtr->GetClusterTrackNo() + fOffsetLabel;
       pmdInfo.fTrackPid   = pmdtr->GetClusterTrackPid();
       pmdInfo.fSmn        = pmdtr->GetSmn();
 

--- a/RUN3/AliAnalysisTaskAO2Dconverter.h
+++ b/RUN3/AliAnalysisTaskAO2Dconverter.h
@@ -142,6 +142,7 @@ public:
     kHepMcPdfInfo,
     kHepMcHeavyIon,
     kRun2TrackExtras,
+    kPMD,
     kTrees
   };
   enum TaskModes { // Flag for the task operation mode
@@ -795,6 +796,23 @@ private:
     Int_t fIndexHf2Prongs = -1; /// D0 index
     Int_t fIndexTracks_0 = -1;  /// Track index of soft pion
   } hfDStar;                  //! structure for HF Dstar
+
+  struct {
+    // pmd information
+    Float_t fX = 0.0f;            /// Cluster X position
+    Float_t fY = 0.0f;            /// Cluster Y position
+    Float_t fZ = 0.0f;            /// Cluster Z position
+    Float_t fCluADC = 0.0f;       /// Cluster Energy in ADC
+    Float_t fCluPID = 0.0f;       ///[0.,1.,8] Cluster probability, 1: Photon, 0: Hadron
+    uint8_t fDet = 0;             /// Detector, 0:PRE, 1:CPV
+    uint8_t fNcell = 0;           /// Cluster cells
+    Int_t fSmn = 0;               /// Serial module number
+    Int_t fTrackNo = -1;          /// Track number assigned to the clus from simulation
+    Int_t fTrackPid = 0;          /// Track pid assigned to the clus from simulation
+    Float_t fSigX = 0.0f; /// Cluster x-width
+    Float_t fSigY = 0.0f; /// Cluster y-width
+    Int_t fClMatching = 0; ///Cluster of PRE matching with CPV
+  } pmdInfo;                    //! structure to hold PMD information
 
   /// Offsets to convert the IDs within one collision to global IDs
   Int_t fOffsetMuTrackID = 0; ///! Offset of MUON track  (used in the clusters)

--- a/RUN3/AliAnalysisTaskAO2Dconverter.h
+++ b/RUN3/AliAnalysisTaskAO2Dconverter.h
@@ -799,6 +799,7 @@ private:
 
   struct {
     // pmd information
+    Int_t fIndexCollisions = -1;      // stores information for collision association
     Float_t fX = 0.0f;            /// Cluster X position
     Float_t fY = 0.0f;            /// Cluster Y position
     Float_t fZ = 0.0f;            /// Cluster Z position


### PR DESCRIPTION
This PR adds an experimental path to save PMD information. It is disabled by default and unless specifically requested, will not be saved. It is intended for larger-scale tests of a solution that has been verified to be functional already in local testing.