### PR TITLE
Run 3 converter: bump up BC version to 001

### DIFF
--- a/RUN3/AliAnalysisTaskAO2Dconverter.cxx
+++ b/RUN3/AliAnalysisTaskAO2Dconverter.cxx
@@ -120,7 +120,7 @@ const TString AliAnalysisTaskAO2Dconverter::TreeName[kTrees] = {
   "O2mctracklabel",
   "O2mccalolabel_001", // changed the mask column to std::vector for the amplitude fraction
   "O2mccollisionlabel",
-  "O2bc",
+  "O2bc_001",
   "O2run2bcinfo",
   "O2origin",
   "O2hmpid_001", // now stores the position of the extrapolated track and HMPID cluster, cluster size, track
@@ -880,6 +880,7 @@ void AliAnalysisTaskAO2Dconverter::InitTF(ULong64_t tfId)
     tBC->Branch("fRunNumber", &bc.fRunNumber, "fRunNumber/I");
     tBC->Branch("fGlobalBC", &bc.fGlobalBC, "fGlobalBC/l");
     tBC->Branch("fTriggerMask", &bc.fTriggerMask, "fTriggerMask/l");
+    tBC->Branch("fInputMask", &bc.fInputMask, "fInputMask/l");
     tBC->SetBasketSize("*", fBasketSizeEvents);
   }
 

--- a/RUN3/AliAnalysisTaskAO2Dconverter.h
+++ b/RUN3/AliAnalysisTaskAO2Dconverter.h
@@ -331,6 +331,7 @@ private:
     int fRunNumber = -1;         /// Run number
     ULong64_t fGlobalBC = 0u;    /// Unique bunch crossing id. Contains period, orbit and bunch crossing numbers
     ULong64_t fTriggerMask = 0u; /// Trigger class mask
+    ULong64_t fInputMask = 0u;   /// Input mask (unused, stored compressed to avoid converter)
   } bc; //! structure to keep trigger-related info
 
   struct {


### PR DESCRIPTION
This commit bumps up the version of the BC table such that no BC 000 to 001 converter is necessary for it when analysing converted data from this point forward. 