### PR TITLE
PWGGA/GammaConv: Add option to apply weighting to jet repsonse matrix

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskMesonJetCorrelation.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskMesonJetCorrelation.h
@@ -172,6 +172,13 @@ class AliAnalysisTaskMesonJetCorrelation : public AliAnalysisTaskSE
     fMesonCutArray = CutArray;
   }
 
+  void SetParticleWeighting(const char * name, float minFracMom = 0.05){
+    fNameJetWeightingFile = name;
+    fMinFracMomForWeight = minFracMom;
+    fDoWeightGenParticles = true;
+  }
+  void InitializePartAbundanceWeighting();
+
  protected:
   //-------------------------------
   // GLobal settings
@@ -404,6 +411,7 @@ class AliAnalysisTaskMesonJetCorrelation : public AliAnalysisTaskSE
   std::vector<TH3F*> fHistoTrueJetPtVsMomFracVsLeadingPart;   //! vector of histos with true jet pt vs. particle enery fraction for different leading particles
   std::vector<TH2F*> fHistoTrueMatchedJetPtVsLeadingPart;     //! vector of histos with matched true jets for different leading particles
   std::vector<TH2F*> fHistoTrueJetPtVsLeadingPart;            //! vector of histos with true jets in acceptance for different leading particles
+  std::vector<TH2F*> fHistoTruevsRecJetPtWeighted;            //! vector of histos response matrix for jets weighted
   
   std::vector<TH1F*> fHistoMatchedPtJet;              //! vector of histos with pt of jets for jets that got matched with a true jet
   std::vector<TH1F*> fHistoUnMatchedPtJet;            //! vector of histos with pt of jets for jets that did not get matched with a true jet
@@ -521,6 +529,15 @@ class AliAnalysisTaskMesonJetCorrelation : public AliAnalysisTaskSE
   std::vector<TH3F*> fHistoMCJetPtVsMesonPtVsRadius;      //! vector of histos True jet pT vs. true meson pt vs jet-meson radius for particles originating from hard parton from Jet
   std::vector<TH3F*> fHistoMCJetPtVsMesonPtVsRadiusInAcc; //! vector of histos True jet pT vs. true meson pt vs jet-meson radius for particles originating from hard parton from Jet
 
+
+  //-------------------------------
+  // Jet weighting
+  //-------------------------------
+  bool fDoWeightGenParticles;
+  double fMinFracMomForWeight;
+  TString fNameJetWeightingFile;
+  std::vector<TH1F*> fHistWeightingPartAbundance;     //! vector of histos that contain a pT dependent weighting for different particle species (defined in GetParticleIndex). Has to be loaded from alien
+
   //-------------------------------
   // DCA tree for PCM pile-up estimation
   //-------------------------------
@@ -534,14 +551,13 @@ class AliAnalysisTaskMesonJetCorrelation : public AliAnalysisTaskSE
   bool fDCATree_isTrueMeson;       //! flag if meson is true meson or not
   float fDCATree_EvtWeight;        //! event weight for the tree in case of MC
 
-  std::map<int, int> tmpmap;
 
  private:
   static constexpr bool fLocalDebugFlag = false;
   AliAnalysisTaskMesonJetCorrelation(const AliAnalysisTaskMesonJetCorrelation&);            // Prevent copy-construction
   AliAnalysisTaskMesonJetCorrelation& operator=(const AliAnalysisTaskMesonJetCorrelation&); // Prevent assignment
 
-  ClassDef(AliAnalysisTaskMesonJetCorrelation, 23);
+  ClassDef(AliAnalysisTaskMesonJetCorrelation, 24);
 };
 
 #endif

--- a/PWGGA/GammaConv/macros/AddTask_MesonJetCorr_Calo.C
+++ b/PWGGA/GammaConv/macros/AddTask_MesonJetCorr_Calo.C
@@ -73,6 +73,7 @@ void AddTask_MesonJetCorr_Calo(
   TString fileNamePtWeights = cuts.GetSpecialFileNameFromString(fileNameExternalInputs, "FPTW:");
   TString fileNameMultWeights = cuts.GetSpecialFileNameFromString(fileNameExternalInputs, "FMUW:");
   TString fileNameCustomTriggerMimicOADB = cuts.GetSpecialFileNameFromString(fileNameExternalInputs, "FTRM:");
+  TString fileNameJetWeighting = cuts.GetSpecialFileNameFromString(fileNameExternalInputs, "FNJW:");
 
   TString corrTaskSetting = cuts.GetSpecialSettingFromAddConfig(additionalTrainConfig, "CF", "", addTaskName);
   if (corrTaskSetting.CompareTo(""))
@@ -550,6 +551,7 @@ void AddTask_MesonJetCorr_Calo(
   task->SetForcePi0Unstable(setPi0Unstable);
   task->SetUseMixedBackAdd(enableAddBackground);
   task->SetDoRadiusDependence(enableRadiusDep);
+  if(!fileNameJetWeighting.EqualTo(""))task->SetParticleWeighting(fileNameJetWeighting);
 
   //connect containers
   TString nameContainer = Form("MesonJetCorrelation_Calo_%i_%i%s%s", meson, trainConfig, corrTaskSetting.EqualTo("") == true ? "" : Form("_%s", corrTaskSetting.Data()), nameJetFinder.EqualTo("") == true ? "" : Form("_%s", nameJetFinder.Data()) );

--- a/PWGGA/GammaConvBase/AliGammaConvEventMixing.h
+++ b/PWGGA/GammaConvBase/AliGammaConvEventMixing.h
@@ -31,7 +31,8 @@
 #include <vector>
 #include "AliAODConversionPhoton.h"
 
-struct EventWithJetAxis {
+class EventWithJetAxis {
+  public:
   EventWithJetAxis(std::vector<AliAODConversionPhoton*> vecPhotons, bool isCalo, TVector3 jet) : caloPhotons(), convPhotons(), jetAxis()
   {
     if (isCalo) {
@@ -57,17 +58,8 @@ struct EventWithJetAxis {
   }
   EventWithJetAxis(const EventWithJetAxis&) = delete;
   EventWithJetAxis() = default;
-  ~EventWithJetAxis()
-  {
-    caloPhotons.clear();
-    convPhotons.clear();
-    // for(unsigned int i = 0; i < caloPhotons.size(); ++i){
-    //   if(caloPhotons[i] != nullptr) delete caloPhotons[i];
-    // }
-    // for(unsigned int i = 0; i < convPhotons.size(); ++i){
-    //   if(convPhotons[i] != nullptr) delete convPhotons[i];
-    // }
-  }
+  virtual ~EventWithJetAxis() = default;
+
   std::unique_ptr<AliAODConversionPhoton> getPhoton(int index, bool isCaloPhoton)
   {
     if (isCaloPhoton)
@@ -105,9 +97,12 @@ struct EventWithJetAxis {
       return caloPhotons.size();
     return convPhotons.size();
   }
-  std::vector<std::unique_ptr<AliAODConversionPhoton>> caloPhotons;
-  std::vector<std::unique_ptr<AliAODConversionPhoton>> convPhotons;
+  std::vector<std::unique_ptr<AliAODConversionPhoton>> caloPhotons;  //!
+  std::vector<std::unique_ptr<AliAODConversionPhoton>> convPhotons;  //!
   TVector3 jetAxis;
+
+  private:
+  ClassDef(EventWithJetAxis, 1);
 };
 
 class EventMixPoolMesonJets
@@ -117,7 +112,7 @@ class EventMixPoolMesonJets
   EventMixPoolMesonJets(std::vector<float> vec);
   EventMixPoolMesonJets(const EventMixPoolMesonJets&) = delete;
   EventMixPoolMesonJets(EventMixPoolMesonJets&&) = default;
-  ~EventMixPoolMesonJets();
+  virtual ~EventMixPoolMesonJets() = default;
 
   ///\brief Set new jet momentum classes for mixing pool
   ///\param vec vector with jet momenta
@@ -159,12 +154,15 @@ class EventMixPoolMesonJets
 
  private:
   std::vector<float> vecJetPClasses = {-1, 20, 40, 60, 100, 100000};
-  std::vector<std::vector<std::shared_ptr<EventWithJetAxis>>> mixingPool = {};
-  unsigned int poolDepth = 20;
+  std::vector<std::vector<std::shared_ptr<EventWithJetAxis>>> mixingPool = {}; //! 
+  unsigned int poolDepth = 20;  //!
+
+  ClassDef(EventMixPoolMesonJets, 1);
 
 };
 
-struct ElectronMixing{
+class ElectronMixing{
+  public:
   ElectronMixing(double eta, double phi, double p, double pt, short ch) : etaCalo(eta), phiCalo(phi), momOnCalo(p), pT(pt), charge(ch)
   {
   
@@ -173,8 +171,12 @@ struct ElectronMixing{
   {
 
   }
+  virtual ~ElectronMixing() = default;;
   double etaCalo, phiCalo, momOnCalo, pT;
   short charge;
+
+  private:
+  ClassDef(ElectronMixing, 1);
 };
 
 #endif

--- a/PWGGA/GammaConvBase/PWGGAGammaConvBaseLinkDef.h
+++ b/PWGGA/GammaConvBase/PWGGAGammaConvBaseLinkDef.h
@@ -30,6 +30,9 @@
 #pragma link C++ class AliPhotonIsolation+;
 #pragma link C++ class MatrixHandler4D+;
 #pragma link C++ class MatrixHandlerNDim+;
+#pragma link C++ class EventMixPoolMesonJets+;
+#pragma link C++ class EventWithJetAxis+;
+#pragma link C++ class ElectronMixing+;
 
 
 // User tasks


### PR DESCRIPTION
- Particle abundancies in the MC do not represent the ones in data. Hence, the jet response matrix is weighted according to the differences in particle abundancies between MC and data