### PR TITLE
PWGGA/GammaConv: Fix to enable cutstring beyond z

### DIFF
--- a/PWGGA/GammaConvBase/AliCaloPhotonCuts.cxx
+++ b/PWGGA/GammaConvBase/AliCaloPhotonCuts.cxx
@@ -5187,7 +5187,6 @@ Bool_t AliCaloPhotonCuts::InitializeCutsFromCutString(const TString analysisCutS
   }
 
   TString analysisCutSelectionLowerCase = Form("%s",analysisCutSelection.Data());
-  analysisCutSelectionLowerCase.ToLower();
   const char *cutSelection = analysisCutSelectionLowerCase.Data();
   #define ASSIGNARRAY(i) \
     fCuts[i] = \


### PR DESCRIPTION
- ToLower made it impossible to select cutstrings based on lower or upper case. 