### PR TITLE
removed PWGHFvertexingHF library dependency

### DIFF
--- a/PWGCF/Correlations/JCORRAN/Pro/CMakeLists.txt
+++ b/PWGCF/Correlations/JCORRAN/Pro/CMakeLists.txt
@@ -84,7 +84,7 @@ get_directory_property(incdirs INCLUDE_DIRECTORIES)
 generate_dictionary("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}" "${FASTJET_ROOTDICT_OPTS}")
 
 set(ROOT_DEPENDENCIES)
-set(ALIROOT_DEPENDENCIES ANALYSISalice CORRFW  EMCALUtils PHOSUtils PWGJETFW PWGCFCorrelationsJCORRAN PWGHFvertexingHF)
+set(ALIROOT_DEPENDENCIES ANALYSISalice CORRFW  EMCALUtils PHOSUtils PWGJETFW PWGCFCorrelationsJCORRAN)
 
 # Generate the ROOT map
 # Dependecies


### PR DESCRIPTION
AliPhysics builds normally without this library in the CMakeFiles, and removing it allows to run the AliAnalysisTaskSVtaskMCFilter which needs lib PWGHFvertexingHF 