### PR TITLE
[RUN3] AOD conversion: save hybrid tracks, event bits

### DIFF
--- a/RUN3/AliAnalysisTaskAO2Dconverter.cxx
+++ b/RUN3/AliAnalysisTaskAO2Dconverter.cxx
@@ -1814,7 +1814,7 @@ void AliAnalysisTaskAO2Dconverter::FillEventInTF()
         SETBIT(run2bcinfo.fEventCuts, kTRDHEE);
     }
   }
-  else {
+  else if (fAOD && fSaveEventBitsInAODConversion) {
     // // Get multiplicity selection
     // AliMultSelection *multSelection = (AliMultSelection*) fAOD->FindListObject("MultSelection");
     // AliMultSelection *multSelection = (AliMultSelection*) fVEvent->FindListObject("MultSelection");
@@ -2144,24 +2144,15 @@ void AliAnalysisTaskAO2Dconverter::FillEventInTF()
         AliVTrack * aodVTrack = fAOD->GetTrack(itrk);
         AliAODTrack * aodTrack = dynamic_cast<AliAODTrack *>(aodVTrack);
         if (!aodTrack) continue; // Should not happen
-        // Skip MUON tracks and constrained tracks
+        // Skip MUON tracks
         if (aodTrack->IsMuonTrack()) continue;
-        // if (aodTrack->IsTPCConstrained()) {
-        //   std::cout << "is a TPC constrained track" << std::endl;
-        //   continue;
-        // }
-        // if (aodTrack->IsGlobalConstrained()) {
-        //   std::cout << "is a global constrained track" << std::endl;
-        //   continue;
-        // }
-        // if (aodTrack->IsHybridGlobalConstrainedGlobal()) {
-        //   std::cout << "is a hybrid global constrained track" << std::endl;
-        //   continue;
-        // }
-        // if (aodTrack->IsHybridTPCConstrainedGlobal()) {
-        //   std::cout << "is a hybrid TPC constrained track" << std::endl;
-        //   continue;
-        // }
+        // Skip constrained tracks if relevant flag is off
+        if (!fSaveHybridTracksInAODConversion) {
+          if (aodTrack->IsTPCConstrained()) continue;
+          if (aodTrack->IsGlobalConstrained()) continue;
+          if (aodTrack->IsHybridGlobalConstrainedGlobal()) continue;
+          if (aodTrack->IsHybridTPCConstrainedGlobal()) continue;
+        }
 
         track = new AliESDtrack(aodVTrack);
         deleteTrack = kTRUE; // Since we use new, we have to delete at the end

--- a/RUN3/AliAnalysisTaskAO2Dconverter.cxx
+++ b/RUN3/AliAnalysisTaskAO2Dconverter.cxx
@@ -1817,6 +1817,7 @@ void AliAnalysisTaskAO2Dconverter::FillEventInTF()
   else {
     // // Get multiplicity selection
     // AliMultSelection *multSelection = (AliMultSelection*) fAOD->FindListObject("MultSelection");
+    // AliMultSelection *multSelection = (AliMultSelection*) fVEvent->FindListObject("MultSelection");
     // if (!multSelection)
     //   AliFatal("MultSelection not found in input event");
 
@@ -1831,6 +1832,56 @@ void AliAnalysisTaskAO2Dconverter::FillEventInTF()
 
     // if( multSelection->GetThisEventPassesTrackletVsCluster() )
     //   SETBIT (run2bcinfo.fEventCuts, kTrackletsVsClusters);
+
+    if( fAOD->GetPrimaryVertex()->GetNContributors()>0 )
+      SETBIT (run2bcinfo.fEventCuts, kNonZeroNContribs);
+
+    // if( multSelection->GetThisEventIsNotIncompleteDAQ() )
+    //   SETBIT (run2bcinfo.fEventCuts, kIncompleteDAQ);
+
+    if (fEventCuts.PassedCut(AliEventCuts::kPileUp))
+      SETBIT(run2bcinfo.fEventCuts, kPileUpMV);
+
+    if (fEventCuts.PassedCut(AliEventCuts::kTPCPileUp))
+      SETBIT(run2bcinfo.fEventCuts, kTPCPileUp);
+
+    if (fEventCuts.PassedCut(AliEventCuts::kTimeRangeCut))
+      SETBIT(run2bcinfo.fEventCuts, kTimeRangeCut);
+
+    if (fEventCuts.PassedCut(AliEventCuts::kEMCALEDCut))
+      SETBIT(run2bcinfo.fEventCuts, kEMCALEDCut);
+
+    if (fEventCuts.PassedCut(AliEventCuts::kAllCuts))
+      SETBIT(run2bcinfo.fEventCuts, kAliEventCutsAccepted);
+
+    if (fUseTriggerAnalysis) {
+      if (fTriggerAnalysis.IsSPDVtxPileup(fInputEvent))
+        SETBIT(run2bcinfo.fEventCuts, kIsPileupFromSPD);
+
+      if (fTriggerAnalysis.IsV0PFPileup(fInputEvent))
+        SETBIT(run2bcinfo.fEventCuts, kIsV0PFPileup);
+
+      if (fTriggerAnalysis.IsHVdipTPCEvent(fInputEvent))
+        SETBIT(run2bcinfo.fEventCuts, kIsTPCHVdip);
+
+      if (fTriggerAnalysis.IsLaserWarmUpTPCEvent(fInputEvent))
+        SETBIT(run2bcinfo.fEventCuts, kIsTPCLaserWarmUp);
+
+      if (fTriggerAnalysis.TRDTrigger(fInputEvent,AliTriggerAnalysis::kTRDHCO))
+        SETBIT(run2bcinfo.fEventCuts, kTRDHCO);
+
+      if (fTriggerAnalysis.TRDTrigger(fInputEvent,AliTriggerAnalysis::kTRDHJT))
+        SETBIT(run2bcinfo.fEventCuts, kTRDHJT);
+
+      if (fTriggerAnalysis.TRDTrigger(fInputEvent,AliTriggerAnalysis::kTRDHSE))
+        SETBIT(run2bcinfo.fEventCuts, kTRDHSE);
+
+      if (fTriggerAnalysis.TRDTrigger(fInputEvent,AliTriggerAnalysis::kTRDHQU))
+        SETBIT(run2bcinfo.fEventCuts, kTRDHQU);
+
+      if (fTriggerAnalysis.TRDTrigger(fInputEvent,AliTriggerAnalysis::kTRDHEE))
+        SETBIT(run2bcinfo.fEventCuts, kTRDHEE);
+    }
   }
 
   FillTree(kRun2BCInfo);
@@ -2082,7 +2133,6 @@ void AliAnalysisTaskAO2Dconverter::FillEventInTF()
   {
     Int_t ntrk = fVEvent->GetNumberOfTracks();
     Int_t ntofcls_filled = 0; // total number of TOF clusters filled per event
-
     for (Int_t itrk = 0; itrk < ntrk; itrk++)
     {
       AliESDtrack *track = nullptr;

--- a/RUN3/AliAnalysisTaskAO2Dconverter.cxx
+++ b/RUN3/AliAnalysisTaskAO2Dconverter.cxx
@@ -2096,10 +2096,22 @@ void AliAnalysisTaskAO2Dconverter::FillEventInTF()
         if (!aodTrack) continue; // Should not happen
         // Skip MUON tracks and constrained tracks
         if (aodTrack->IsMuonTrack()) continue;
-        if (aodTrack->IsTPCConstrained()) continue;
-        if (aodTrack->IsGlobalConstrained()) continue;
-        if (aodTrack->IsHybridGlobalConstrainedGlobal()) continue;
-        if (aodTrack->IsHybridTPCConstrainedGlobal()) continue;
+        // if (aodTrack->IsTPCConstrained()) {
+        //   std::cout << "is a TPC constrained track" << std::endl;
+        //   continue;
+        // }
+        // if (aodTrack->IsGlobalConstrained()) {
+        //   std::cout << "is a global constrained track" << std::endl;
+        //   continue;
+        // }
+        // if (aodTrack->IsHybridGlobalConstrainedGlobal()) {
+        //   std::cout << "is a hybrid global constrained track" << std::endl;
+        //   continue;
+        // }
+        // if (aodTrack->IsHybridTPCConstrainedGlobal()) {
+        //   std::cout << "is a hybrid TPC constrained track" << std::endl;
+        //   continue;
+        // }
 
         track = new AliESDtrack(aodVTrack);
         deleteTrack = kTRUE; // Since we use new, we have to delete at the end

--- a/RUN3/AliAnalysisTaskAO2Dconverter.h
+++ b/RUN3/AliAnalysisTaskAO2Dconverter.h
@@ -103,6 +103,8 @@ public:
   void SetEMCALTriggerReducedPayload(Bool_t reduced) { fEMCALReducedTriggerPayload = reduced; }
   void SetUsePHOSTriggerMap(Bool_t toUse=kTRUE) { fUsePHOSBadMap = toUse; }
   void SetReadTR(Bool_t readTR = true) {fReadTR = readTR;};
+  void SetSaveEventBitsInAODConversion(Bool_t saveEventBitsInAODConversion = kTRUE) {fSaveEventBitsInAODConversion = saveEventBitsInAODConversion;};
+  void SetSaveHybridTracksInAODConversion(Bool_t saveHybridTracksInAODConversion = kTRUE) {fSaveHybridTracksInAODConversion = saveHybridTracksInAODConversion;};
 
   void SetDisableEMCAL(bool flag = true) { fDisableEMCAL = flag; }
 
@@ -271,6 +273,8 @@ public:
 private:
   Bool_t fUseEventCuts = kFALSE;         // Use or not event cuts
   Bool_t fUseTriggerAnalysis = kTRUE;    // Use or not trigger analysis
+  Bool_t fSaveEventBitsInAODConversion = kFALSE;
+  Bool_t fSaveHybridTracksInAODConversion = kFALSE;
   Bool_t fReadTR = false;
   Int_t fCollSystem;            // 0 - pp, 1 - PbPb, 2 pPb, 29 UPC
   AliEventCuts fEventCuts;      // Standard event cuts


### PR DESCRIPTION
- Save hybrid tracks in AOD -> AO2D conversions
- Save event bit information in AOD -> AO2D conversions
- Implement flags to turn hybrid track and event bit saving on (the saving is off by default)

tagging also @ddobrigk 