### PR TITLE
PWG/EMCAL: Add option to use custom measureable particle definition

### DIFF
--- a/PWG/EMCAL/EMCALtasks/AliEmcalMCTrackSelector.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalMCTrackSelector.cxx
@@ -64,7 +64,9 @@ AliEmcalMCTrackSelector::AliEmcalMCTrackSelector() :
   fEvent(0),
   fMC(0),
   fIsESD(kFALSE),
-  fDisabled(kFALSE)
+  fDisabled(kFALSE),
+  fUseOnlyMeasurable(false),
+  fVecMeasurablePart({22, 211, 321, 2212, 11, 13})
 {
 }
 
@@ -88,7 +90,9 @@ AliEmcalMCTrackSelector::AliEmcalMCTrackSelector(const char *name) :
   fEvent(0),
   fMC(0),
   fIsESD(kFALSE),
-  fDisabled(kFALSE)
+  fDisabled(kFALSE),
+  fUseOnlyMeasurable(false),
+  fVecMeasurablePart({22, 211, 321, 2212, 11, 13})
 {
 }
 
@@ -335,6 +339,8 @@ Bool_t AliEmcalMCTrackSelector::AcceptParticle(AliAODMCParticle* part) const
   if (fChargedMC && part->Charge() == 0) return kFALSE;
 
   if (fOnlyPhysPrim && !part->IsPhysicalPrimary()) return kFALSE;
+  
+  if (fUseOnlyMeasurable && !IsPartMeasurable(partPdgCode)) return kFALSE;
 
   return kTRUE;
 }
@@ -346,6 +352,13 @@ bool AliEmcalMCTrackSelector::IsFromPi0Mother(const AliVParticle &part) const {
   if(!motherparticle) return false;
   if(TMath::Abs(motherparticle->PdgCode()) == kPi0) return true;
   return IsFromPi0Mother(*motherparticle);
+}
+
+bool AliEmcalMCTrackSelector::IsPartMeasurable(const int pdg) const {
+  if(std::find(fVecMeasurablePart.begin(), fVecMeasurablePart.end(), pdg) != fVecMeasurablePart.end()) { 
+    return true;
+  }
+  return false;
 }
 
 AliEmcalMCTrackSelector* AliEmcalMCTrackSelector::AddTaskMCTrackSelector(TString outname, TString nTrackCont, Bool_t nk, Bool_t ch, Double_t etamax, Bool_t physPrim)

--- a/PWG/EMCAL/EMCALtasks/AliEmcalMCTrackSelector.h
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalMCTrackSelector.h
@@ -138,6 +138,27 @@ class AliEmcalMCTrackSelector : public AliAnalysisTaskSE {
 
   void SetIsContainerSpecified(bool isContSpecified)    {fIsContainerSpecified = isContSpecified ; }
 
+  /**
+   * @brief Setter to only use measurable particles in jet definition
+   *
+   * This can be used if the jet definition should not be full or charged jet,
+   * but an alternative definition based on a set of defined particles
+   *
+   * @param useOnlyMeas if true, use only measurable particles
+   */
+  void SetUseOnlyMeasurablePart(bool useOnlyMeas)       {fUseOnlyMeasurable = useOnlyMeas; }
+
+  /**
+   * @brief Give a list of particles considered measurable.
+   *
+   * This can be used if the jet definition should not be full or charged jet,
+   * but an alternative definition based on a set of defined particles.
+   * By default the list contains photons, charged pions, kaons, protons and electrons
+   *
+   * @param vec vector of measruable particles
+   */
+  void SetMeasurableParticles(std::vector<int> vec)     {fVecMeasurablePart = vec; }
+
 
   /**
    * @brief Create new AliEmcalMCTrackSelector task and add it to the analysis manager
@@ -210,6 +231,14 @@ class AliEmcalMCTrackSelector : public AliAnalysisTaskSE {
    */
   bool                      IsFromPi0Mother(const AliVParticle &part) const;
 
+  /**
+   * @brief Check if a particle is measurable, hence if its a photon, charged pion, kaon or proton
+   *
+   * @param pdg PDG code of particle to be checked
+   * @return true if measurable, false if non measurable
+   */
+  bool                      IsPartMeasurable(const int pdg) const;
+
 
   TString                   fParticlesOutName;     ///< name of output particle array
   TString                   fTrackContainerName;   ///< name of input track container
@@ -230,11 +259,13 @@ class AliEmcalMCTrackSelector : public AliAnalysisTaskSE {
   AliMCEvent               *fMC;                   //!<! MC event (ESD)
   Bool_t                    fIsESD;                //!<! ESD or AOD analysis
   Bool_t                    fDisabled;             //!<! Disable task if a problem occurs at initialization
+  bool                      fUseOnlyMeasurable;    ///< flag to switch on using only measurable particles
+  std::vector<int>          fVecMeasurablePart;    ///< list of pdg codes of measurable particles
 
  private:
   AliEmcalMCTrackSelector(const AliEmcalMCTrackSelector&);            // not implemented
   AliEmcalMCTrackSelector &operator=(const AliEmcalMCTrackSelector&); // not implemented
 
-  ClassDef(AliEmcalMCTrackSelector, 6);
+  ClassDef(AliEmcalMCTrackSelector, 7);
 };
 #endif


### PR DESCRIPTION
- As the full jet analysis might be biased by a mismatch of MC to data regarding the pT spectra of "unmeasurable" particles, such as neutrons, K0l, K0s, neutrinos..., an option to add a custom particle list is added
- This is for testing purposes only to study the influence of these particles
- By default photons, charged pions, kaons, protons, electrons and myons are considered measurable. This list can be changed via the SetMeasurableParticles function
- By default, this option si off and the user can activate it via SetUseOnlyMeasurablePart(true)