### PR TITLE
PWGGA/GammaConv: return false and not crash if trigger decision conta…

### DIFF
--- a/PWGGA/GammaConvBase/AliConvEventCuts.cxx
+++ b/PWGGA/GammaConvBase/AliConvEventCuts.cxx
@@ -6057,7 +6057,8 @@ Bool_t AliConvEventCuts::MimicTrigger(AliVEvent *event, Bool_t isMC ){
   if(fMimicTrigger == 2){
     auto triggercont = static_cast<PWG::EMCAL::AliEmcalTriggerDecisionContainer *>(event->FindListObject("EmcalTriggerDecision"));
     if(!triggercont){
-      AliFatal("Trigger decision container not found in event - not possible to select EMCAL triggers");
+      AliError("Trigger decision container not found in event - not possible to select EMCAL triggers");
+      return false;
     } else {
       if( (fSpecialTrigger == 8 || fSpecialTrigger == 10 ) && (fSpecialSubTriggerName.CompareTo("7EG2")==0 ||fSpecialSubTriggerName.CompareTo("8EG2")==0) ){
         if( (triggercont->IsEventSelected("EG2")) || (triggercont->IsEventSelected("DG2")) ) return kTRUE;


### PR DESCRIPTION
…iner not there. There might be no container because trigger decision has its own build in event selection and the event got rejected