### PR TITLE
PWGGA/GammaConv: ptWeights: add possibility to use  integral condition for fitting the local functions

### DIFF
--- a/PWGGA/PWGGAUtils/utils_TH1.h
+++ b/PWGGA/PWGGAUtils/utils_TH1.h
@@ -5,31 +5,60 @@ class TH1;
 
 #include <string>
 
+
 // (helper) class for exponential extrapolation of TH1 histograms
 class TH1_ExponentialInterpolation
 {
     public:    
     TH1_ExponentialInterpolation(std::string const &_id,
-                             TH1 const &theTH1);
+                                 TH1 const &theTH1,
+                                 bool theIntegrate,
+                                 bool theUseXtimesExp);
     ~TH1_ExponentialInterpolation();
 
-    TF1 &GetNewTF1(std::string const &_id);
+    TF1 &GetNewTF1_global(std::string const &_id);
+    
     double Evaluate(double *x, double *);
 
     private:
     std::string id;
-    TH1 *th1; // this will point to a clone of the histo to be extrapolated        
+    TH1 *th1; // this will point to a clone of the histo to be extrapolated    
+    bool integrate;  
+    bool useXtimesExp;  // fits a function of the f(x) = x * exp([0] + [1]*x)
+
+    TF1 *fCache;
 };
 
 class utils_TH1
 {
 public:
 
-    // get a TF1 exponential defined by theTH1 adjacent bin centers to theX
-    static TF1 *GetLocalExponentialTF1(TH1 &theTH1, double theX);
+
+    // get a TF1 exponential defined by:
+    /* 
+    case theIntegrate = false: 
+        - the next two neares bin centers to theX
+        - the two coefficients are calculated analytically from the two bin content values
+    case theIntegrate = true: 
+        - the lower and upper edges of the two nearest bins to theX 
+        - the two coefficients are determined from a fit using the two bins  
+    */
+    static TF1 *GetLocalExponentialTF1(TH1   &theTH1, 
+                                       double theX, 
+                                       bool   theIntegrate, 
+                                       bool   theUseXtimesExp);
     
-    // returns f(theX) with f defined by the exponential that fits theTH1's adjacent bin centers to theX
-    static double LocalExponentialInterpolate(TH1 &theTH1, double theX);
-    
-    static TF1 &GlobalPieceWiseExponentialInterpolation(std::string const &theName, TH1 const &theTH1);
+    static double LocalExponentialInterpolate(TH1   &theTH1, 
+                                              double theX, 
+                                              bool   theIntegrate = false,
+                                              bool   theUseXtimesExp = false);
+    /* 
+    get globally defined TF1 which is either fitted to the bin centers 
+    OR such that the integrals in each in bin agree with their content. 
+    if theUseXtimesExp=true: use f(x) = x * exp([0] + [1]*x). Otherwise f(x) = exp([0] + [1]*x) 
+    */
+    static TF1 &GlobalPieceWiseExponentialInterpolation(std::string const &theName, 
+                                                        TH1 const         &theTH1, 
+                                                        bool               theIntegrate = false,
+                                                        bool               theUseXtimesExp = false);
 };


### PR DESCRIPTION
of utils_TH1::GlobalPieceWiseExponentialInterpolation() and set it as default when calculating weights from variant spectra.