### PR TITLE
 PWG/EMCAL: Fix CrossTalk same cell check

### DIFF
--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEmulateCrosstalk.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEmulateCrosstalk.cxx
@@ -536,7 +536,7 @@ void AliEmcalCorrectionCellEmulateCrosstalk::AddInducedEnergiesToNewCells()
         //printf("\t Check ieta %d, iphi %d\n",ietai,iphii);
 
         // Avoid same cell
-        if ( iphii==0 && ietai == 0) continue;
+        if ( iphii == iphi && ietai == ieta) continue;
 
         // Avoid cells out of SM
         if (  ietai < 0 || ietai >= AliEMCALGeoParams::fgkEMCALCols ||


### PR DESCRIPTION
When inserting a new cell at the end of the cross talk the check to ensure that the same cell is not inducnig to itslef was wrong:
```c++
if ( iphii==0 && ietai == 0) continue;
```
It should be
```c++
if ( iphii == iphi && ietai == ieta) continue;
```

The impact of this bug is unknown. I guess it basically just means that before this fix the cell (0,0) was not allowed to induce energy into a new cell, which is a very specific edge case.