### PR TITLE
Fix: Add AntineutronTask to CMake and LinkDef

### DIFF
--- a/PWGLF/NUCLEX/CMakeLists.txt
+++ b/PWGLF/NUCLEX/CMakeLists.txt
@@ -141,6 +141,7 @@ set(SRCS
   Nuclei/v2/AliAnalysisTaskNucleiv2PbPb18.cxx
   Nuclei/NucleiKine/AliAnalysisTaskNucleiKine.cxx
   Nuclei/NucleiKine/AliAnalysisTaskNucleiKineCor.cxx
+  Nuclei/NeutronCEX/AliAnalysisTaskAntineutron.cxx
   Utils/CODEX/AliAnalysisCODEX.cxx
   Utils/CODEX/AliAnalysisCODEXtask.cxx
   Utils/NanoAOD/AliNanoFilterPID.cxx

--- a/PWGLF/NUCLEX/PWGLFnuclexLinkDef.h
+++ b/PWGLF/NUCLEX/PWGLFnuclexLinkDef.h
@@ -99,7 +99,8 @@
 #pragma link C++ class AliAnalysisTaskPythiaCoalescence+;
 #pragma link C++ class AliAnalysisTaskSimpleCoalescenceHelium3+;
 #pragma link C++ class AliAnalysisTaskSimpleCoalescenceDeuteronInJets+;
-
+/// * Antineutron
+#pragma link C++ class AliAnalysisTaskAntineutron+;
 
 /// * NucleiKine
 #pragma link C++ class AliAnalysisTaskNucleiKine+;


### PR DESCRIPTION
Fix the integration of AliAnalysisTaskAntineutron into AliPhysics

This pull request updates the build system to fully integrate the AliAnalysisTaskAntineutron class, which had been merged earlier without the necessary CMake and LinkDef modifications.

Changes included:

Added AliAnalysisTaskAntineutron.cxx to CMakeLists.txt

Added #pragma link C++ class AliAnalysisTaskAntineutron+; to PWGLFnuclexLinkDef.h

With these changes, the task can now be compiled and used directly from AliPhysics builds.

The class is located in:
PWGLF/NUCLEX/Nuclei/NeutronCEX/