### PR TITLE
AliMCSpectraWeights: bug fixes in CalcMCFractions and FillMCSpectra

### DIFF
--- a/PWG/Tools/AliMCSpectraWeights.cxx
+++ b/PWG/Tools/AliMCSpectraWeights.cxx
@@ -646,10 +646,11 @@ bool AliMCSpectraWeights::CalcMCFractions() {
         //        DebugPCC("\t cent: " << icent << " => " << _multFront << " - "
         //                             << _multBack << "\n");
 
-        auto const _multBin1 =
-        fHistMCGenPrimTrackParticle->GetYaxis()->FindBin(_multFront);
-        auto const _multBbin2 =
-        fHistMCGenPrimTrackParticle->GetYaxis()->FindBin(_multBack);
+        _multFront = round(_multFront);
+        _multBack  = icent>0 ? round(_multBack-1.) : round(_multBack);
+
+        auto const _multBin1  = fHistMCGenPrimTrackParticle->GetYaxis()->FindBin(_multFront);
+        auto const _multBbin2 = fHistMCGenPrimTrackParticle->GetYaxis()->FindBin(_multBack);
 
         for (int ipart = 0; ipart < fNPartTypes;
              ++ipart) { // calculate pt spectra of pi+k+p+Sigma+Rest
@@ -1521,6 +1522,8 @@ void AliMCSpectraWeights::FillMCSpectra(AliMCEvent* mcEvent) {
         return;
     if (mcEvent != fMCEvent) {
         fMCEvent = mcEvent;
+    }
+    if (mcEvent) {
         AliMCSpectraWeights::CountEventMult();
     }
 


### PR DESCRIPTION
Bug fix in CalcMCFractions:
Fix sharing of Nch bin between multiplicity/centrality classes.

Bug fix in FillMCSpectra:
CountEventMult() was not executed if the event address stayed the same between events. This led to problems if the event object is recycled or at least the event object is stored at the same address.