### PR TITLE
PWGGA/GammaConv: Add pT-eta photon weights for added signal gammas

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvV1.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvV1.cxx
@@ -309,7 +309,7 @@ AliAnalysisTaskGammaConvV1::AliAnalysisTaskGammaConvV1(): AliAnalysisTaskSE(),
   fWeightCentrality(NULL),
   fEnableClusterCutsForTrigger(kFALSE),
   fDoMaterialBudgetWeightingOfGammasForTrueMesons(kFALSE),
-  fDoPhotonWeightsFromMesons(kFALSE),
+  fDoPhotonWeights(0),
   tBrokenFiles(NULL),
   fFileNameBroken(NULL),
   fFileWasAlreadyReported(kFALSE),
@@ -681,7 +681,7 @@ AliAnalysisTaskGammaConvV1::AliAnalysisTaskGammaConvV1(const char *name):
   fWeightCentrality(NULL),
   fEnableClusterCutsForTrigger(kFALSE),
   fDoMaterialBudgetWeightingOfGammasForTrueMesons(kFALSE),
-  fDoPhotonWeightsFromMesons(kFALSE),
+  fDoPhotonWeights(0),
   tBrokenFiles(NULL),
   fFileNameBroken(NULL),
   fFileWasAlreadyReported(kFALSE),
@@ -3399,27 +3399,28 @@ void AliAnalysisTaskGammaConvV1::ProcessTruePhotonCandidatesAOD(AliAODConversion
     if (fDoMaterialBudgetWeightingOfGammasForTrueMesons && fiPhotonCut->GetMaterialBudgetWeightsInitialized()) {
       weightMatBudgetGamma = fiPhotonCut->GetMaterialBudgetCorrectingWeightForTrueGamma(TruePhotonCandidate,magField);
     }
-    Float_t photonWeight = GetPhotonWeightFromMeson(Photon);
-    Float_t totalTruePhotonWeight = fWeightJetJetMC*weightMatBudgetGamma*photonWeight;
+    Float_t inclusiveTruePhotonWeight = fWeightJetJetMC*weightMatBudgetGamma;
 
-    fHistoTrueConvGammaPt[fiCut]->Fill(TruePhotonCandidate->Pt(),totalTruePhotonWeight);
+    fHistoTrueConvGammaPt[fiCut]->Fill(TruePhotonCandidate->Pt(),inclusiveTruePhotonWeight);
     if (CheckVectorForDoubleCount(vecDoubleCountTrueConvGammas,posDaughter->GetMother())){
-      fHistoDoubleCountTrueConvGammaRPt[fiCut]->Fill(TruePhotonCandidate->GetConversionRadius(),TruePhotonCandidate->Pt(),totalTruePhotonWeight);
+      fHistoDoubleCountTrueConvGammaRPt[fiCut]->Fill(TruePhotonCandidate->GetConversionRadius(),TruePhotonCandidate->Pt(),inclusiveTruePhotonWeight);
       FillMultipleCountMap(mapMultipleCountTrueConvGammas,posDaughter->GetMother());
     }
     if (fDoPhotonQA > 0 ){
       if (fIsMC < 2){
-        fHistoTrueConvGammaPsiPairPt[fiCut]->Fill(TruePhotonCandidate->GetPsiPair(),TruePhotonCandidate->Pt(),totalTruePhotonWeight);
-        fHistoTrueConvGammaEta[fiCut]->Fill(TruePhotonCandidate->Eta(),totalTruePhotonWeight);
-        fHistoTrueConvGammaR[fiCut]->Fill(TruePhotonCandidate->GetConversionRadius(),totalTruePhotonWeight);
-        fHistoTrueConvGammaRMC[fiCut]->Fill(rConv,totalTruePhotonWeight);
+        fHistoTrueConvGammaPsiPairPt[fiCut]->Fill(TruePhotonCandidate->GetPsiPair(),TruePhotonCandidate->Pt(),inclusiveTruePhotonWeight);
+        fHistoTrueConvGammaEta[fiCut]->Fill(TruePhotonCandidate->Eta(),inclusiveTruePhotonWeight);
+        fHistoTrueConvGammaR[fiCut]->Fill(TruePhotonCandidate->GetConversionRadius(),inclusiveTruePhotonWeight);
+        fHistoTrueConvGammaRMC[fiCut]->Fill(rConv,inclusiveTruePhotonWeight);
       }
-      fHistoTrueConvGammaPtMC[fiCut]->Fill(Photon->Pt(), totalTruePhotonWeight);
+      fHistoTrueConvGammaPtMC[fiCut]->Fill(Photon->Pt(), inclusiveTruePhotonWeight);
     }
-    fHistoTrueGammaPsiPairDeltaPhi[fiCut]->Fill(deltaPhi,TruePhotonCandidate->GetPsiPair(),totalTruePhotonWeight);
+    fHistoTrueGammaPsiPairDeltaPhi[fiCut]->Fill(deltaPhi,TruePhotonCandidate->GetPsiPair(),inclusiveTruePhotonWeight);
 
     Bool_t isPrimary = fiEventCut->IsConversionPrimaryAOD(fInputEvent, Photon, mcProdVtxX, mcProdVtxY, mcProdVtxZ);
     if(isPrimary){
+      Float_t photonWeight = GetPhotonWeight(Photon);
+      Float_t totalTruePhotonWeight = inclusiveTruePhotonWeight*photonWeight;
       // Count just primary MC Gammas as true --> For Ratio esdtruegamma / mcconvgamma
       iPhotonMCInfo = 6;
       fHistoTruePrimaryConvGammaPt[fiCut]->Fill(TruePhotonCandidate->Pt(),totalTruePhotonWeight);
@@ -3431,27 +3432,27 @@ void AliAnalysisTaskGammaConvV1::ProcessTruePhotonCandidatesAOD(AliAODConversion
       if(((AliAODMCParticle*)fAODMCTrackArray->At(Photon->GetMother()))->GetMother() > -1 && ((AliAODMCParticle*)fAODMCTrackArray->At(((AliAODMCParticle*)fAODMCTrackArray->At(Photon->GetMother()))->GetMother()))->GetMother() > -1 ){
         if (((AliAODMCParticle*)fAODMCTrackArray->At(((AliAODMCParticle*)fAODMCTrackArray->At(Photon->GetMother()))->GetMother()))->GetPdgCode() == 310){
             iPhotonMCInfo = 4;
-            fHistoTrueSecondaryConvGammaPt[fiCut]->Fill(TruePhotonCandidate->Pt(),0.,totalTruePhotonWeight);
-            fHistoTrueSecondaryConvGammaMCPt[fiCut]->Fill(Photon->Pt(),0.,totalTruePhotonWeight);
-            fHistoTrueSecondaryConvGammaFromXFromK0sMCPtESDPt[fiCut]->Fill(Photon->Pt(),TruePhotonCandidate->Pt(),totalTruePhotonWeight);
+            fHistoTrueSecondaryConvGammaPt[fiCut]->Fill(TruePhotonCandidate->Pt(),0.,inclusiveTruePhotonWeight);
+            fHistoTrueSecondaryConvGammaMCPt[fiCut]->Fill(Photon->Pt(),0.,inclusiveTruePhotonWeight);
+            fHistoTrueSecondaryConvGammaFromXFromK0sMCPtESDPt[fiCut]->Fill(Photon->Pt(),TruePhotonCandidate->Pt(),inclusiveTruePhotonWeight);
         } else if (((AliAODMCParticle*)fAODMCTrackArray->At(((AliAODMCParticle*)fAODMCTrackArray->At(Photon->GetMother()))->GetMother()))->GetPdgCode() == 130) {
             iPhotonMCInfo = 7;
-            fHistoTrueSecondaryConvGammaPt[fiCut]->Fill(TruePhotonCandidate->Pt(),1.,totalTruePhotonWeight);
-            fHistoTrueSecondaryConvGammaMCPt[fiCut]->Fill(Photon->Pt(),1.,totalTruePhotonWeight);
-            fHistoTrueSecondaryConvGammaFromXFromK0lMCPtESDPt[fiCut]->Fill(Photon->Pt(),TruePhotonCandidate->Pt(),totalTruePhotonWeight);
+            fHistoTrueSecondaryConvGammaPt[fiCut]->Fill(TruePhotonCandidate->Pt(),1.,inclusiveTruePhotonWeight);
+            fHistoTrueSecondaryConvGammaMCPt[fiCut]->Fill(Photon->Pt(),1.,inclusiveTruePhotonWeight);
+            fHistoTrueSecondaryConvGammaFromXFromK0lMCPtESDPt[fiCut]->Fill(Photon->Pt(),TruePhotonCandidate->Pt(),inclusiveTruePhotonWeight);
         } else if (((AliAODMCParticle*)fAODMCTrackArray->At(((AliAODMCParticle*)fAODMCTrackArray->At(Photon->GetMother()))->GetMother()))->GetPdgCode() == 3122) {
             iPhotonMCInfo = 5;
-            fHistoTrueSecondaryConvGammaPt[fiCut]->Fill(TruePhotonCandidate->Pt(),2.,totalTruePhotonWeight);
-            fHistoTrueSecondaryConvGammaMCPt[fiCut]->Fill(Photon->Pt(),2.,totalTruePhotonWeight);
-            fHistoTrueSecondaryConvGammaFromXFromLambdaMCPtESDPt[fiCut]->Fill(Photon->Pt(),TruePhotonCandidate->Pt(),totalTruePhotonWeight);
+            fHistoTrueSecondaryConvGammaPt[fiCut]->Fill(TruePhotonCandidate->Pt(),2.,inclusiveTruePhotonWeight);
+            fHistoTrueSecondaryConvGammaMCPt[fiCut]->Fill(Photon->Pt(),2.,inclusiveTruePhotonWeight);
+            fHistoTrueSecondaryConvGammaFromXFromLambdaMCPtESDPt[fiCut]->Fill(Photon->Pt(),TruePhotonCandidate->Pt(),inclusiveTruePhotonWeight);
         } else if (((AliAODMCParticle*)fAODMCTrackArray->At(((AliAODMCParticle*)fAODMCTrackArray->At(Photon->GetMother()))->GetMother()))->GetPdgCode() == 221) {
             iPhotonMCInfo = 3;
-            fHistoTrueSecondaryConvGammaPt[fiCut]->Fill(TruePhotonCandidate->Pt(),3.,totalTruePhotonWeight);
-            fHistoTrueSecondaryConvGammaMCPt[fiCut]->Fill(Photon->Pt(),3.,totalTruePhotonWeight);
+            fHistoTrueSecondaryConvGammaPt[fiCut]->Fill(TruePhotonCandidate->Pt(),3.,inclusiveTruePhotonWeight);
+            fHistoTrueSecondaryConvGammaMCPt[fiCut]->Fill(Photon->Pt(),3.,inclusiveTruePhotonWeight);
         } else {
     //         if ( !(TMath::Abs(((AliAODMCParticle*)AODMCTrackArray->At(Photon->GetMother()))->GetPdgCode()) == 11 && ((AliAODMCParticle*)AODMCTrackArray->At(((AliAODMCParticle*)AODMCTrackArray->At(Photon->GetMother()))->GetMother()))->GetPdgCode() == 22) ) {
-            fHistoTrueSecondaryConvGammaPt[fiCut]->Fill(TruePhotonCandidate->Pt(),3.,totalTruePhotonWeight);
-            fHistoTrueSecondaryConvGammaMCPt[fiCut]->Fill(Photon->Pt(),3.,totalTruePhotonWeight);
+            fHistoTrueSecondaryConvGammaPt[fiCut]->Fill(TruePhotonCandidate->Pt(),3.,inclusiveTruePhotonWeight);
+            fHistoTrueSecondaryConvGammaMCPt[fiCut]->Fill(Photon->Pt(),3.,inclusiveTruePhotonWeight);
     //         }
         }
       }
@@ -3555,9 +3556,8 @@ void AliAnalysisTaskGammaConvV1::ProcessTruePhotonCandidates(AliAODConversionPho
   if (fDoMaterialBudgetWeightingOfGammasForTrueMesons && fiPhotonCut->GetMaterialBudgetWeightsInitialized()) {
     weightMatBudgetGamma = fiPhotonCut->GetMaterialBudgetCorrectingWeightForTrueGamma(TruePhotonCandidate,magField);
   }
-  Float_t photonWeight = GetPhotonWeightFromMeson(static_cast<AliMCParticle*>(Photon));
-  Float_t totalTruePhotonWeight = fWeightJetJetMC*weightMatBudgetGamma*photonWeight;
-  Float_t qaTruePhotonWeight = weightMatBudgetGamma*photonWeight;
+  Float_t totalTruePhotonWeight = fWeightJetJetMC*weightMatBudgetGamma;
+  Float_t qaTruePhotonWeight = weightMatBudgetGamma;
 
   // cout<< " AM- Material Budget weight Gamma::"<< weightMatBudgetGamma << " "<< TruePhotonCandidate->GetConversionRadius() << endl;
 
@@ -3658,7 +3658,7 @@ void AliAnalysisTaskGammaConvV1::ProcessAODMCParticles(int isCurrentEventSelecte
         
         // returns 0 for non-photons or rejected photons, photon daughters don't play a role
         if(fiPhotonCut->PhotonIsSelectedAODMC(particle,fAODMCTrackArray,kFALSE /*checkForConvertedGamma*/ )){
-          Float_t photonWeight = GetPhotonWeightFromMeson(particle);
+          Float_t photonWeight = GetPhotonWeight(particle);
           Float_t totalPhotonWeight = fWeightJetJetMC*photonWeight;
           fHistoMCAllGammaPt[fiCut]->Fill(particle->Pt(),totalPhotonWeight); // All MC Gamma
           if (fDoPhotonQA > 0) fHistoMCAllGammaMCPtMCEta[fiCut]->Fill(particle->Pt(),particle->Eta(),totalPhotonWeight);
@@ -3704,7 +3704,7 @@ void AliAnalysisTaskGammaConvV1::ProcessAODMCParticles(int isCurrentEventSelecte
               rConv = sqrt( (tmpDaughter->Xv()*tmpDaughter->Xv()) + (tmpDaughter->Yv()*tmpDaughter->Yv()) );
             }
           }
-          Float_t photonWeight = GetPhotonWeightFromMeson(particle);
+          Float_t photonWeight = GetPhotonWeight(particle);
           Float_t totalPhotonWeight = fWeightJetJetMC*photonWeight;
           fHistoMCConvGammaPt[fiCut]->Fill(particle->Pt(),totalPhotonWeight);
           if (fDoPhotonQA > 0) fHistoMCConvGammaMCPtMCEta[fiCut]->Fill(particle->Pt(),particle->Eta(),totalPhotonWeight);
@@ -3956,8 +3956,7 @@ void AliAnalysisTaskGammaConvV1::ProcessMCParticles(int isCurrentEventSelected)
 
       if(!fiPhotonCut->InPlaneOutOfPlaneCut(particle->Phi(),fEventPlaneAngle,kFALSE)) continue;
       if(fiPhotonCut->PhotonIsSelectedMC(particle,fMCEvent,kFALSE)){
-        Float_t photonWeight = GetPhotonWeightFromMeson(particle);
-        Float_t totalPhotonWeight = fWeightJetJetMC*photonWeight;
+        Float_t totalPhotonWeight = fWeightJetJetMC;
         fHistoMCAllGammaPt[fiCut]->Fill(particle->Pt(),totalPhotonWeight); // All MC Gamma
         if (fDoPhotonQA > 0) fHistoMCAllGammaMCPtMCEta[fiCut]->Fill(particle->Pt(),particle->Eta(),totalPhotonWeight);
         if(isCurrentEventSelected == 1){
@@ -3993,8 +3992,7 @@ void AliAnalysisTaskGammaConvV1::ProcessMCParticles(int isCurrentEventSelected)
         }
       }
       if(fiPhotonCut->PhotonIsSelectedMC(particle,fMCEvent,kTRUE)){
-        Float_t photonWeight = GetPhotonWeightFromMeson(particle);
-        Float_t totalPhotonWeight = fWeightJetJetMC*photonWeight;
+        Float_t totalPhotonWeight = fWeightJetJetMC;
         fHistoMCConvGammaPt[fiCut]->Fill(particle->Pt(),totalPhotonWeight);
         if (fDoPhotonQA > 0) fHistoMCConvGammaMCPtMCEta[fiCut]->Fill(particle->Pt(),particle->Eta(),totalPhotonWeight);
         if (fDoPhotonQA > 0 && fIsMC < 2){
@@ -5731,57 +5729,47 @@ void AliAnalysisTaskGammaConvV1::SetLogBinningXTH2(TH2* histoRebin){
 }
 
 //_________________________________________________________________________________
-Float_t AliAnalysisTaskGammaConvV1::GetPhotonWeightFromMeson(AliAODMCParticle* photon)
+Float_t AliAnalysisTaskGammaConvV1::GetPhotonWeight(AliAODMCParticle* photon)
 {
-  if (!fDoPhotonWeightsFromMesons) return 1.;
-  if (!photon || !fAODMCTrackArray || !fMCEvent) return 1.;
-
-  const AliVVertex* primVtxMC = fMCEvent->GetPrimaryVertex();
-  if (!primVtxMC) return 1.;
-
-  Int_t motherLabel = photon->GetMother();
-  if (motherLabel < 0) return 1.;
-
-  AliAODMCParticle* mother = static_cast<AliAODMCParticle*>(fAODMCTrackArray->At(motherLabel));
-  if (!mother) return 1.;
-
-  Int_t motherPdgCode = mother->GetPdgCode();
-  if (motherPdgCode != 111 && motherPdgCode != 221) return 1.;
-  if (mother->Pt() <= 0.005) return 1.;
-
-  Double_t mcProdVtxX = primVtxMC->GetX();
-  Double_t mcProdVtxY = primVtxMC->GetY();
-  Double_t mcProdVtxZ = primVtxMC->GetZ();
-  if (!fiEventCut->IsConversionPrimaryAOD(fInputEvent, mother, mcProdVtxX, mcProdVtxY, mcProdVtxZ)) return 1.;
-
-  return fiEventCut->GetWeightForMeson(motherLabel, 0x0, fInputEvent);
+  if (fDoPhotonWeights == 2) return GetPhotonWeightFromMeson(photon);
+  if (fDoPhotonWeights == 3) return GetPhotonPtEtaWeightForFlatInjectedMesons(photon);
+  return 1.;
 }
 
 //_________________________________________________________________________________
-Float_t AliAnalysisTaskGammaConvV1::GetPhotonWeightFromMeson(AliMCParticle* photon)
+Float_t AliAnalysisTaskGammaConvV1::GetPhotonWeightFromMeson(AliAODMCParticle* photon)
 {
-  if (!fDoPhotonWeightsFromMesons) return 1.;
-  if (!photon || !fMCEvent) return 1.;
-
-  const AliVVertex* primVtxMC = fMCEvent->GetPrimaryVertex();
-  if (!primVtxMC) return 1.;
+  if (!photon || !fAODMCTrackArray || !fMCEvent || !fiEventCut) return 1.;
+  if (photon->GetPdgCode() != 22) return 1.;
 
   Int_t motherLabel = photon->GetMother();
-  if (motherLabel < 0) return 1.;
+  Int_t selectedMesonLabel = -1;
+  Int_t depth = 0;
+  while (motherLabel >= 0 && depth < 20) {
+    AliAODMCParticle* mother = static_cast<AliAODMCParticle*>(fAODMCTrackArray->At(motherLabel));
+    if (!mother) return 1.;
 
-  AliMCParticle* mother = static_cast<AliMCParticle*>(fMCEvent->GetTrack(motherLabel));
-  if (!mother) return 1.;
+    const Int_t motherPdgCode = mother->GetPdgCode();
+    if ((motherPdgCode == 111 || motherPdgCode == 221) && mother->Pt() > 0.005) {
+      selectedMesonLabel = motherLabel;
+    }
 
-  Int_t motherPdgCode = mother->PdgCode();
-  if (motherPdgCode != 111 && motherPdgCode != 221) return 1.;
-  if (mother->Pt() <= 0.005) return 1.;
+    motherLabel = mother->GetMother();
+    ++depth;
+  }
 
-  Double_t mcProdVtxX = primVtxMC->GetX();
-  Double_t mcProdVtxY = primVtxMC->GetY();
-  Double_t mcProdVtxZ = primVtxMC->GetZ();
-  if (!fiEventCut->IsConversionPrimaryESD(fMCEvent, motherLabel, mcProdVtxX, mcProdVtxY, mcProdVtxZ)) return 1.;
+  if (selectedMesonLabel >= 0) return fiEventCut->GetWeightForMeson(selectedMesonLabel, 0x0, fInputEvent);
 
-  return fiEventCut->GetWeightForMeson(motherLabel, fMCEvent, fInputEvent);
+  return 1.;
+}
+
+//_________________________________________________________________________________
+Float_t AliAnalysisTaskGammaConvV1::GetPhotonPtEtaWeightForFlatInjectedMesons(AliAODMCParticle* photon)
+{
+  if (!photon || !fiEventCut) return 1.;
+  if (photon->GetPdgCode() != 22) return 1.;
+
+  return fiEventCut->GetPhotonPtEtaWeightForFlatInjectedMesons(photon->Pt(), photon->Eta());
 }
 
 //_________________________________________________________________________________

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvV1.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvV1.h
@@ -77,7 +77,7 @@ class AliAnalysisTaskGammaConvV1 : public AliAnalysisTaskSE {
                                                                   fClusterCutArray              = CutArray  ;}
 
     void SetDoMaterialBudgetWeightingOfGammasForTrueMesons(Bool_t flag) {fDoMaterialBudgetWeightingOfGammasForTrueMesons = flag;}
-    void SetDoPhotonWeightsFromMesons(Bool_t flag) {fDoPhotonWeightsFromMesons = flag;}
+    void SetDoPhotonWeights(Int_t mode) {fDoPhotonWeights = mode;}
 
     // BG HandlerSettings
     void SetMoveParticleAccordingToVertex(Bool_t flag)            {fMoveParticleAccordingToVertex = flag;}
@@ -88,8 +88,9 @@ class AliAnalysisTaskGammaConvV1 : public AliAnalysisTaskSE {
     void UpdateEventByEventData();
     void SetLogBinningXTH2(TH2* histoRebin);
     Int_t GetSourceClassification(Int_t daughter, Int_t pdgCode);
+    Float_t GetPhotonWeight(AliAODMCParticle* photon);
     Float_t GetPhotonWeightFromMeson(AliAODMCParticle* photon);
-    Float_t GetPhotonWeightFromMeson(AliMCParticle* photon);
+    Float_t GetPhotonPtEtaWeightForFlatInjectedMesons(AliAODMCParticle* photon);
 
     // Additional functions
     Bool_t CheckVectorForDoubleCount(vector<Int_t> &vec, Int_t tobechecked);
@@ -377,7 +378,7 @@ class AliAnalysisTaskGammaConvV1 : public AliAnalysisTaskSE {
     Double_t*                         fWeightCentrality;                          //[fnCuts], weight for centrality flattening
     Bool_t                            fEnableClusterCutsForTrigger;               //enables ClusterCuts for Trigger
     Bool_t                            fDoMaterialBudgetWeightingOfGammasForTrueMesons;
-    Bool_t                            fDoPhotonWeightsFromMesons;                 // enable photon weights from primary pi0/eta mothers
+    Int_t                             fDoPhotonWeights;                          // 0 off, 1 meson weights only, 2 current gamma-from-meson weights, 3 photon pt-eta weights for flat injected mesons
     TTree*                            tBrokenFiles;                               // tree for keeping track of broken files
     TObjString*                       fFileNameBroken;                            // string object for broken file name
     Bool_t                            fFileWasAlreadyReported;                    // to store if the current file was already marked broken
@@ -531,7 +532,7 @@ class AliAnalysisTaskGammaConvV1 : public AliAnalysisTaskSE {
 
     AliAnalysisTaskGammaConvV1(const AliAnalysisTaskGammaConvV1&); // Prevent copy-construction
     AliAnalysisTaskGammaConvV1 &operator=(const AliAnalysisTaskGammaConvV1&); // Prevent assignment
-    ClassDef(AliAnalysisTaskGammaConvV1, 74);
+    ClassDef(AliAnalysisTaskGammaConvV1, 75);
 };
 
 #endif

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvV1_PbPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvV1_PbPb.C
@@ -39,7 +39,7 @@ void AddTask_GammaConvV1_PbPb(
   Int_t     debugLevel                    = 0,        // introducing debug levels for grid running
   // settings for weights
 
-  // FPTW:fileNamePtWeights, FMUW:fileNameMultWeights, FMAW:fileNameMatBudWeights, FEPC:fileNamedEdxPostCalib, FCEF:fileNameCentFlattening, separate with ; NB on FEPC: can be one filename for all cut configs OR one filename per cut config separated by '+'. If no filename at all is given and enableElecDeDxPostCalibration>0 the maps are taken from the OADB. Also ['FMLR:enable/enableP/enableM' -> Machine learning Trees; 'FMLR:config_file.yml' => Apply ML model] 
+  // FPTW:fileNamePtWeights, FGAW:fileNameGammaPtEtaWeights, FMUW:fileNameMultWeights, FMAW:fileNameMatBudWeights, FEPC:fileNamedEdxPostCalib, FCEF:fileNameCentFlattening, separate with ; NB on FEPC: can be one filename for all cut configs OR one filename per cut config separated by '+'. If no filename at all is given and enableElecDeDxPostCalibration>0 the maps are taken from the OADB. Also ['FMLR:enable/enableP/enableM' -> Machine learning Trees; 'FMLR:config_file.yml' => Apply ML model]
  
   TString   fileNameExternalInputs        = "",
   Int_t     acceptedAddedParticles        = 0,        // select which injected particles are to be accepted (defined in terms of MC headers). Specifics depend on the actual MC
@@ -58,7 +58,7 @@ void AddTask_GammaConvV1_PbPb(
   Bool_t    enableChargedPrimary          = kFALSE,
   Bool_t    enablePlotVsCentrality        = kFALSE,
   Bool_t    processAODcheckForV0s         = kFALSE,   // flag for AOD check if V0s contained in AliAODs.root and AliAODGammaConversion.root
-  bool      theUseGetMesonWeightNew       = false,
+  Int_t     theUseGetMesonWeightNew       = 0,        // 0 = off, 1 = new meson weights only, 2 = current gamma-from-meson weights, 3 = photon pt-eta weights for flat injected mesons
   // subwagon config
   TString   additionalTrainConfig         = "0")       // additional counter for trainconfig + special settings
   {
@@ -67,6 +67,7 @@ void AddTask_GammaConvV1_PbPb(
 
   Int_t isHeavyIon                    = 1;
   TString fileNamePtWeights           = cuts.GetSpecialFileNameFromString (fileNameExternalInputs, "FPTW:");
+  TString fileNameGammaPtEtaWeights   = cuts.GetSpecialFileNameFromString (fileNameExternalInputs, "FGAW:");
   TString fileNameMultWeights         = cuts.GetSpecialFileNameFromString (fileNameExternalInputs, "FMUW:");
   TString fileNameMatBudWeights       = cuts.GetSpecialFileNameFromString (fileNameExternalInputs, "FMAW:");
   TString fileNamedEdxPostCalib       = cuts.GetSpecialFileNameFromString (fileNameExternalInputs, "FEPC:");
@@ -202,6 +203,31 @@ void AddTask_GammaConvV1_PbPb(
     cout << "V0Reader: " << V0ReaderName.Data() << " found!!"<< endl;
   }
 
+  if (theUseGetMesonWeightNew == 3) {
+    const Bool_t isAllowedPhotonPtEtaWeightProduction =
+        periodNameV0Reader.BeginsWith("LHC20g10") ||
+        periodNameV0Reader.BeginsWith("LHC24a2")  ||
+        generatorName.BeginsWith("LHC20g10")      ||
+        generatorName.BeginsWith("LHC24a2");
+    if (!isAllowedPhotonPtEtaWeightProduction) {
+      Error(Form("AddTask_GammaConvV1_PbPb_%i", trainConfig),
+            "theUseGetMesonWeightNew=3 is only supported for LHC20g10 and LHC24a2 AddedSignal productions");
+      return;
+    }
+    if (fileNameGammaPtEtaWeights.CompareTo("") == 0) {
+      cout << "ERROR: theUseGetMesonWeightNew=3 requires FGAW:<file> in fileNameExternalInputs" << endl;
+      Error(Form("AddTask_GammaConvV1_PbPb_%i", trainConfig),
+            "theUseGetMesonWeightNew=3 requires FGAW:<file> in fileNameExternalInputs");
+      return;
+    }
+    if (gSystem->AccessPathName(fileNameGammaPtEtaWeights.Data())) {
+      cout << "ERROR: FGAW file not found: " << fileNameGammaPtEtaWeights.Data() << endl;
+      Error(Form("AddTask_GammaConvV1_PbPb_%i", trainConfig),
+            "FGAW file not found: %s", fileNameGammaPtEtaWeights.Data());
+      return;
+    }
+  }
+
   //================================================
   //========= Add task to the ANALYSIS manager =====
   //================================================
@@ -211,7 +237,7 @@ void AddTask_GammaConvV1_PbPb(
   task->SetIsMC(isMC);
   task->SetV0ReaderName(V0ReaderName);
   task->SetLightOutput(enableLightOutput);
-  task->SetDoPhotonWeightsFromMesons(theUseGetMesonWeightNew);
+  task->SetDoPhotonWeights(theUseGetMesonWeightNew);
   if(enableBDT) task->SetFileNameBDT(fileNameBDT.Data());
 
   //****************************************************************************************************
@@ -5352,7 +5378,14 @@ void AddTask_GammaConvV1_PbPb(
     analysisEventCuts[i]->SetV0ReaderName(V0ReaderName);
     if (periodNameV0Reader.CompareTo("") != 0) analysisEventCuts[i]->SetPeriodEnum(periodNameV0Reader);
     analysisEventCuts[i]->SetLightOutput(enableLightOutput);
-    analysisEventCuts[i]->InitializeCutsFromCutString((cuts.GetEventCut(i)).Data());
+    if (theUseGetMesonWeightNew == 3) {
+      analysisEventCuts[i]->SetUsePhotonPtEtaWeightsFromFile(kTRUE, fileNameGammaPtEtaWeights, "hPhotonPtEtaWeight");
+    }
+    if (!analysisEventCuts[i]->InitializeCutsFromCutString((cuts.GetEventCut(i)).Data())) {
+      Error(Form("AddTask_GammaConvV1_PbPb_%i", trainConfig),
+            "Event cut initialization failed for cut %s", (cuts.GetEventCut(i)).Data());
+      return;
+    }
     if (generatorName.CompareTo("LHC14a1b") ==0 || generatorName.CompareTo("LHC14a1c") ==0 ){
       if (acceptedAddedParticles == 1 || acceptedAddedParticles == 4 || acceptedAddedParticles == 12 ) analysisEventCuts[i]->SetAddedSignalPDGCode(111);
       if (acceptedAddedParticles == 2 || acceptedAddedParticles == 5 || acceptedAddedParticles == 13 ) analysisEventCuts[i]->SetAddedSignalPDGCode(221);

--- a/PWGGA/GammaConvBase/AliConvEventCuts.cxx
+++ b/PWGGA/GammaConvBase/AliConvEventCuts.cxx
@@ -156,6 +156,9 @@ AliConvEventCuts::AliConvEventCuts(const char *name,const char *title) :
   fPathTrFGammaReweighting(""),
   fNameHistoReweightingGamma(""),
   fNameDataHistoReweightingGamma(""),
+  fDoPhotonPtEtaWeighting(kFALSE),
+  fPathPhotonPtEtaWeights(""),
+  fNamePhotonPtEtaWeights(""),
   fLabelNamePileupCutTPC(""),
   fHistoEventCuts(NULL),
   fHistoPastFutureBits(NULL),
@@ -182,6 +185,7 @@ AliConvEventCuts::AliConvEventCuts(const char *name,const char *title) :
   fReweightMCHist_interpolate_Eta(NULL),
   hReweightMCHistGamma(NULL),
   hReweightDataHistGamma(NULL),
+  hPhotonPtEtaWeights(NULL),
   fAddedSignalPDGCode(0),
   fPreSelCut(kFALSE),
   fTriggerSelectedManually(kFALSE),
@@ -314,6 +318,9 @@ AliConvEventCuts::AliConvEventCuts(const AliConvEventCuts &ref) :
   fPathTrFGammaReweighting(ref.fPathTrFGammaReweighting),
   fNameHistoReweightingGamma(ref.fNameHistoReweightingGamma),
   fNameDataHistoReweightingGamma(ref.fNameDataHistoReweightingGamma),
+  fDoPhotonPtEtaWeighting(ref.fDoPhotonPtEtaWeighting),
+  fPathPhotonPtEtaWeights(ref.fPathPhotonPtEtaWeights),
+  fNamePhotonPtEtaWeights(ref.fNamePhotonPtEtaWeights),
   fLabelNamePileupCutTPC(ref.fLabelNamePileupCutTPC),
   fHistoEventCuts(NULL),
   fHistoPastFutureBits(NULL),
@@ -340,6 +347,7 @@ AliConvEventCuts::AliConvEventCuts(const AliConvEventCuts &ref) :
   fReweightMCHist_interpolate_Eta(ref.fReweightMCHist_interpolate_Eta),
   hReweightMCHistGamma(ref.hReweightMCHistGamma),
   hReweightDataHistGamma(ref.hReweightDataHistGamma),
+  hPhotonPtEtaWeights(ref.hPhotonPtEtaWeights),
   fAddedSignalPDGCode(ref.fAddedSignalPDGCode),
   fPreSelCut(ref.fPreSelCut),
   fTriggerSelectedManually(ref.fTriggerSelectedManually),
@@ -461,6 +469,13 @@ void AliConvEventCuts::InitCutHistograms(TString name, Bool_t preCut){
   if (hReweightMCHistGamma){
     hReweightMCHistGamma->SetName("MCInputForWeightingGamma");
     fHistograms->Add(hReweightMCHistGamma);
+  }
+  if (hPhotonPtEtaWeights){
+    hPhotonPtEtaWeights->SetName(Form("UsedPhotonPtEtaWeights_%s", GetCutNumber().Data()));
+    hPhotonPtEtaWeights->SetTitle(Form("Used photon pT/eta weights from %s:%s",
+                                       fPathPhotonPtEtaWeights.Data(),
+                                       fNamePhotonPtEtaWeights.Data()));
+    fHistograms->Add(hPhotonPtEtaWeights);
   }
 
   // Persist precomputed bin-wise meson weights (if available).
@@ -1092,6 +1107,53 @@ void AliConvEventCuts::LoadGammaPtReweightingHistosMCFromFile() {
   delete f;
 }
 
+///________________________________________________________________________
+void AliConvEventCuts::LoadPhotonPtEtaWeightsFromFile() {
+
+  AliInfo("Entering loading of photon pT/eta weights");
+  if (!fDoPhotonPtEtaWeighting) return;
+  if (fPathPhotonPtEtaWeights.CompareTo("") == 0 || fNamePhotonPtEtaWeights.CompareTo("") == 0) {
+    AliError("Photon pT/eta weighting enabled, but file path or object name is empty");
+    return;
+  }
+
+  TFile *f = TFile::Open(fPathPhotonPtEtaWeights.Data());
+  if(!f || f->IsZombie()){
+    AliError(Form("file for photon pT/eta weighting %s not found", fPathPhotonPtEtaWeights.Data()));
+    if (f) {
+      f->Close();
+      delete f;
+    }
+    return;
+  }
+
+  TObject *objectPhotonPtEtaWeights = f->Get(fNamePhotonPtEtaWeights.Data());
+  if (!objectPhotonPtEtaWeights) {
+    AliError(Form("%s not found in %s", fNamePhotonPtEtaWeights.Data(), fPathPhotonPtEtaWeights.Data()));
+    f->Close();
+    delete f;
+    return;
+  }
+
+  if (!objectPhotonPtEtaWeights->InheritsFrom(TH2::Class())) {
+    AliError(Form("%s in %s is not a TH2", fNamePhotonPtEtaWeights.Data(), fPathPhotonPtEtaWeights.Data()));
+    f->Close();
+    delete f;
+    return;
+  }
+
+  hPhotonPtEtaWeights = static_cast<TH2*>(objectPhotonPtEtaWeights->Clone(
+      Form("%s_%s", fNamePhotonPtEtaWeights.Data(), GetCutNumber().Data())));
+  if (hPhotonPtEtaWeights) {
+    hPhotonPtEtaWeights->SetDirectory(0);
+    AliInfo(Form("%s has been loaded from %s as TH2 photon pT/eta weights",
+                 fNamePhotonPtEtaWeights.Data(), fPathPhotonPtEtaWeights.Data()));
+  }
+
+  f->Close();
+  delete f;
+}
+
 //________________________________________________________________________
 int AliConvEventCuts::InitializeMapPtWeightsAccessObjects()
 {
@@ -1320,6 +1382,16 @@ Bool_t AliConvEventCuts::InitializeCutsFromCutString(const TString analysisCutSe
   if(fDoReweightHistoMCGamma) {
     AliInfo("Gamma pT Weighting was enabled");
     LoadGammaPtReweightingHistosMCFromFile();
+  }
+
+  if(fDoPhotonPtEtaWeighting) {
+    AliInfo("Photon pT/eta Weighting was enabled");
+    LoadPhotonPtEtaWeightsFromFile();
+    if (!hPhotonPtEtaWeights) {
+      AliError(Form("Photon pT/eta weighting was requested, but %s could not be loaded as TH2 from %s",
+                    fNamePhotonPtEtaWeights.Data(), fPathPhotonPtEtaWeights.Data()));
+      return kFALSE;
+    }
   }
 
   AliInfo(Form("Set Event Cut Number: %s",analysisCutSelection.Data()));
@@ -8213,6 +8285,33 @@ Float_t AliConvEventCuts::GetWeightForMultiplicity(Int_t mult){
   }
 
   return weightMult;
+}
+
+//_________________________________________________________________________
+Float_t AliConvEventCuts::GetPhotonPtEtaWeightForFlatInjectedMesons(Double_t photonPt, Double_t photonEta) const {
+
+  if (!fDoPhotonPtEtaWeighting) return 1.;
+
+  if (!hPhotonPtEtaWeights) return 1.;
+
+  const TAxis *axisPt = hPhotonPtEtaWeights->GetXaxis();
+  const TAxis *axisEta = hPhotonPtEtaWeights->GetYaxis();
+  if (!axisPt || !axisEta) return 1.;
+  if (photonPt < axisPt->GetXmin() || photonPt > axisPt->GetXmax() ||
+      photonEta < axisEta->GetXmin() || photonEta > axisEta->GetXmax()) return 1.;
+
+  Double_t weight = hPhotonPtEtaWeights->Interpolate(photonPt, photonEta);
+  if (weight <= 0.) {
+    const Int_t binPt = axisPt->FindBin(photonPt);
+    const Int_t binEta = axisEta->FindBin(photonEta);
+    if (binPt >= 1 && binPt <= axisPt->GetNbins() &&
+        binEta >= 1 && binEta <= axisEta->GetNbins()) {
+      weight = hPhotonPtEtaWeights->GetBinContent(binPt, binEta);
+    }
+  }
+
+  if (weight <= 0. || !isfinite(weight)) return 1.;
+  return static_cast<Float_t>(weight);
 }
 
 //_________________________________________________________________________

--- a/PWGGA/GammaConvBase/AliConvEventCuts.h
+++ b/PWGGA/GammaConvBase/AliConvEventCuts.h
@@ -28,6 +28,7 @@
 class AliESDEvent;
 class AliAODEvent;
 class TH1F;
+class TH2;
 class TH2F;
 class TProfile;
 class TF1;
@@ -582,6 +583,16 @@ class AliConvEventCuts : public AliAnalysisCuts {
                                                                                       fNameHistoReweightingGamma = histoNameGamma               ;
                                                                                       fNameDataHistoReweightingGamma = histoDataNameGamma       ;
                                                                                     }
+      void    SetUsePhotonPtEtaWeightsFromFile( Bool_t doWeighting=kTRUE,
+                                                 TString path="",
+                                                 TString objectName="")
+                                                                                    {
+                                                                                      AliInfo(Form("enabled photon pT/eta weights from file: %s, object: %s",
+                                                                                                   path.Data(), objectName.Data()));
+                                                                                      fDoPhotonPtEtaWeighting = doWeighting                     ;
+                                                                                      fPathPhotonPtEtaWeights = path                            ;
+                                                                                      fNamePhotonPtEtaWeights = objectName                      ;
+                                                                                    }
 
       void    SetMinFacPtHard(Float_t value)                                        { fMinFacPtHard = value                                     ;
                                                                                       AliInfo(Form("minimum factor between pt hard and jet put to: %2.2f",fMinFacPtHard));
@@ -642,6 +653,7 @@ class AliConvEventCuts : public AliAnalysisCuts {
       Float_t   GetWeightForMesonNew(Int_t index, AliMCEvent *mcEvent, AliVEvent *event = 0x0);
       Float_t   GetWeightForMesonOld(Int_t index, AliMCEvent *mcEvent, AliVEvent *event = 0x0);
       Float_t   GetWeightForGamma( Int_t index, Double_t gammaPTrec, AliMCEvent *mcEvent, AliVEvent *event = 0x0);
+      Float_t   GetPhotonPtEtaWeightForFlatInjectedMesons(Double_t photonPt, Double_t photonEta) const;
       Float_t   GetWeightForHeavyNeutralMeson(Int_t index, AliMCEvent *mcEvent, AliVEvent *event = 0x0);
       Float_t   GetCentrality(AliVEvent *event);
       Int_t     GetEMCalClusterMultiplicity(AliVEvent* event);
@@ -715,6 +727,7 @@ class AliConvEventCuts : public AliAnalysisCuts {
       void    LoadWeightingMultiplicityFromFile ();
       void    LoadReweightingHistosMCFromFile ();
       void    LoadGammaPtReweightingHistosMCFromFile ();
+      void    LoadPhotonPtEtaWeightsFromFile ();
 
       // Event Cuts
       Bool_t    IsCentralitySelected(AliVEvent *event, AliMCEvent *mcEvent);
@@ -841,6 +854,9 @@ class AliConvEventCuts : public AliAnalysisCuts {
       TString                     fPathTrFGammaReweighting;               ///< Path for file used in gamma reweighting
       TString                     fNameHistoReweightingGamma;             ///< Histogram name for reweighting Gamma
       TString                     fNameDataHistoReweightingGamma;         ///< Histogram Data name for reweighting Gamma
+      Bool_t                      fDoPhotonPtEtaWeighting;                ///< Flag for photon pT/eta weighting from external object
+      TString                     fPathPhotonPtEtaWeights;                ///< Path for file used in photon pT/eta weighting
+      TString                     fNamePhotonPtEtaWeights;                ///< Name of TH2 used for photon pT/eta weighting
       TString                     fLabelNamePileupCutTPC;                 //<  Label for NEvents histograms depending on pileup cut used
 
       // Histograms
@@ -869,6 +885,7 @@ class AliConvEventCuts : public AliAnalysisCuts {
       TF1*                        fReweightMCHist_interpolate_Eta;        ///< a tf1 that interpolates the MC Eta spectrum
       TH1D*                       hReweightMCHistGamma;                   ///< histogram MC   input for reweighting Gamma
       TH1D*                       hReweightDataHistGamma;                 ///< histogram data input for reweighting Gamma
+      TH2*                        hPhotonPtEtaWeights;                    ///< photon pT/eta weight map
       Int_t                       fAddedSignalPDGCode;
       Bool_t                      fPreSelCut;                             // Flag for preselection cut used in V0Reader
       Bool_t                      fTriggerSelectedManually;               // Flag for manual trigger selection
@@ -932,7 +949,7 @@ class AliConvEventCuts : public AliAnalysisCuts {
   private:
 
       /// \cond CLASSIMP
-      ClassDef(AliConvEventCuts,102)
+      ClassDef(AliConvEventCuts,103)
       /// \endcond
 };
 


### PR DESCRIPTION
Apply photon pT-eta weights for flat injected added-signal productions while keeping inclusive true-gamma histograms free of photon reweighting.